### PR TITLE
Add samplerExpr to samplers in the descriptor map

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -177,12 +177,13 @@ Then compiling with:
 
 Then `mydescriptormap` will contain:
 
-    sampler,18,descriptorSet,0,binding,0
-    sampler,35,descriptorSet,0,binding,1
+    sampler,18,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_NEAREST|CLK_NORMALIZED_COORDS_FALSE",descriptorSet,0,binding,0
+    sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0
     kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,1,offset,0
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,2,offset,0
     kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0
+
 
 #### Clustering plain-old-data kernel arguments to save descriptors
 
@@ -241,12 +242,13 @@ Compiling with the same sampler map from before:
 
 produces the following descriptor map:
 
-    sampler,18,descriptorSet,0,binding,0
-    sampler,35,descriptorSet,0,binding,1
+    sampler,18,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_NEAREST|CLK_NORMALIZED_COORDS_FALSE",descriptorSet,0,binding,0
+    sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,1,offset,0
     kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,2,offset,0
     kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,2,offset,4
+
 
 TODO(dneto): Give an example using images.
 

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <utility>
+
 namespace llvm {
 // This is against Google C++ style guide.
 class FunctionPass;
@@ -100,7 +103,8 @@ llvm::ModulePass *createReplaceOpenCLBuiltinPass();
 /// @return An LLVM module pass.
 llvm::ModulePass *createSPIRVProducerPass(
     llvm::raw_pwrite_stream &out, llvm::raw_ostream &descriptor_mappings,
-    llvm::ArrayRef<unsigned> samplerMap, bool outputAsm, bool outputCInitList);
+    llvm::ArrayRef<std::pair<unsigned, std::string>> samplerMap, bool outputAsm,
+    bool outputCInitList);
 
 /// Undo LLVM's bitcast instructions with pointer type.
 /// @return An LLVM module pass.


### PR DESCRIPTION
The value is a quoted string containing the sampler literal
initializer expression (with whitespace removed).  The string
expression lists the components in sorted order, for easier
machine processing.

Adding this explicit expression makes it easier to use the descriptor
map since you no longer have to decode the integer value for the sampler.
Instead, it closely matches the expression in the specified samplermap
input file.