### PR TITLE
Fix -mfmt=c

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -390,26 +390,23 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
 
   if (outputCInitList) {
     bool first = true;
-    int word_index = 0;
     std::ostringstream os;
 
-    os << std::hex;
-    auto emit_word = [&os, &word_index, &first](uint32_t word) {
+    auto emit_word = [&os, &first](uint32_t word) {
       if (!first)
-        os << ',';
-      if (word_index > 0)
-        os << ((word_index & 3) ? ' ' : '\n');
-      os << "0x" << word;
-      ++word_index;
+        os << ",\n";
+      os << word;
       first = false;
     };
 
     os << "{";
-    const StringRef str = binaryTempOut.str();
-    for (unsigned i = 0; i < str.size() / 4; i++) {
-      emit_word(uint32_t(str[4 * i]) | (uint32_t(str[4 * i + 1]) << 8) |
-                (uint32_t(str[4 * i + 2]) << 16) |
-                (uint32_t(str[4 * i + 3]) << 24));
+    const std::string str(binaryTempOut.str());
+    for (unsigned i = 0; i < str.size(); i += 4) {
+      const uint32_t a = static_cast<unsigned char>(str[i]);
+      const uint32_t b = static_cast<unsigned char>(str[i + 1]);
+      const uint32_t c = static_cast<unsigned char>(str[i + 2]);
+      const uint32_t d = static_cast<unsigned char>(str[i + 3]);
+      emit_word(a | (b << 8) | (c << 16) | (d << 24));
     }
     os << "}\n";
     out << os.str();

--- a/test/mfmt_c.cl
+++ b/test/mfmt_c.cl
@@ -2,8 +2,11 @@
 // RUN: FileCheck %s < %t.inc
 
 // The first three words in the header.
-// CHECK: {0x7230203, 0x10000, 0x30000,
-// The OpFunctionEnd at the very end.
-// CHECK: 0x10038}
+// CHECK: {119734787,
+// CHECK-NEXT: 65536,
+// CHECK-NEXT: 196608,
+// The OpReturn and OpFunctionEnd at the very end.
+// CHECK: 65789,
+// CHECK-NEXT: 65592}
 
 kernel void foo(global uint *a) {}


### PR DESCRIPTION
Read the characters as unsigned integers before shifting them around.
Also, be sure you don't have a stale reference to the binary
buffer string.

Also changes the format to decimal numbers, one per line.

Fixes https://github.com/google/clspv/issues/23