### PR TITLE
Fix member offsets for storage buffers

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1554,7 +1554,8 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
                                 Inst->getOpcode() != spv::OpExtInstImport;
                        });
 
-      uint32_t ByteOffset = 0;
+      const auto StructLayout = DL.getStructLayout(STy);
+
       for (unsigned MemberIdx = 0; MemberIdx < STy->getNumElements();
            MemberIdx++) {
         // Ops[0] = Structure Type ID
@@ -1578,6 +1579,8 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
         Ops.push_back(DecoOp);
 
         LiteralNum.clear();
+        const auto ByteOffset =
+            uint32_t(StructLayout->getElementOffset(MemberIdx));
         LiteralNum.push_back(ByteOffset);
         SPIRVOperand *ByteOffsetOp =
             new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, LiteralNum);
@@ -1586,10 +1589,6 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
         SPIRVInstruction *DecoInst =
             new SPIRVInstruction(5, spv::OpMemberDecorate, 0 /* No id */, Ops);
         SPIRVInstList.insert(DecoInsertPoint, DecoInst);
-
-        // Update ByteOffset.
-        Type *EleTy = STy->getElementType(MemberIdx);
-        ByteOffset += static_cast<uint32_t>(DL.getTypeSizeInBits(EleTy) / 8);
       }
 
       // Generate OpDecorate.

--- a/test/cluster_pod_args_larger_alignment.cl
+++ b/test/cluster_pod_args_larger_alignment.cl
@@ -1,0 +1,40 @@
+// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
+// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+
+
+// CHECK: OpMemberDecorate [[first_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[first_struct]] Block
+// CHECK: OpMemberDecorate [[podty:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[podty]] 1 Offset 16
+// CHECK: OpMemberDecorate [[st_podty:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[st_podty]] Block
+
+// CHECK: OpDecorate [[Aarg:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[Aarg]] Binding 0
+// CHECK: OpDecorate [[podargs:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[podargs]] Binding 1
+
+// CHECK: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]]
+// CHECK: [[podty]] = OpTypeStruct [[uint]] [[float4]]
+// CHECK: [[st_podty]] = OpTypeStruct [[podty]]
+// CHECK: [[sbptr_st_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_podty]]
+// CHECK: [[sbptr_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[podty]]
+
+// CHECK: [[podargs]] = OpVariable [[sbptr_st_podty]] StorageBuffer
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, uint n, float4 c)
+{
+  A[n] = c.x;
+}


### PR DESCRIPTION
Take alignment into account, by using the DataLayout
for the target.

Also makes it match the descriptormap output, which is already
more correct.

Fixes https://github.com/google/clspv/issues/27