### PR TITLE
Don't emit StorageImageReadWithoutFormat

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2710,18 +2710,8 @@ void SPIRVProducerPass::GenerateModuleInfo() {
                                                 spv::CapabilityFloat64)));
     } else if (auto *STy = dyn_cast<StructType>(Ty)) {
       if (STy->isOpaque()) {
-        if (STy->getName().equals("opencl.image2d_ro_t") ||
-            STy->getName().equals("opencl.image3d_ro_t")) {
-          // Generate OpCapability for read only image type.
-          SPIRVInstList.insert(
-              InsertPoint,
-              new SPIRVInstruction(
-                  2, spv::OpCapability, 0 /* No id */,
-                  new SPIRVOperand(
-                      SPIRVOperandType::NUMBERID,
-                      spv::CapabilityStorageImageReadWithoutFormat)));
-        } else if (STy->getName().equals("opencl.image2d_wo_t") ||
-                   STy->getName().equals("opencl.image3d_wo_t")) {
+        if (STy->getName().equals("opencl.image2d_wo_t") ||
+            STy->getName().equals("opencl.image3d_wo_t")) {
           // Generate OpCapability for write only image type.
           SPIRVInstList.insert(
               InsertPoint,

--- a/test/ImageBuiltins/read_imagef_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float2.cl
@@ -17,8 +17,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 34
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-DAG: OpCapability VariablePointers
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/ImageBuiltins/read_imagef_sampler_float4.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float4.cl
@@ -10,8 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-DAG: OpCapability VariablePointers
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
@@ -10,8 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 41
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-DAG: OpCapability VariablePointers
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
@@ -10,8 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 39
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-DAG: OpCapability VariablePointers
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/SamplerMap/KernelScopeSampler.cl
+++ b/test/SamplerMap/KernelScopeSampler.cl
@@ -10,9 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/SamplerMap/ModuleScopeSampler.cl
+++ b/test/SamplerMap/ModuleScopeSampler.cl
@@ -10,9 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/SamplerMap/TwoModuleScopeSamplers.cl
+++ b/test/SamplerMap/TwoModuleScopeSamplers.cl
@@ -10,9 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 52
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/image2d.cl
+++ b/test/image2d.cl
@@ -10,10 +10,10 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 12
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability StorageImageWriteWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/image2d_read.cl
+++ b/test/image2d_read.cl
@@ -10,9 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 9
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/image3d.cl
+++ b/test/image3d.cl
@@ -10,10 +10,10 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 12
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability StorageImageWriteWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/image3d_read.cl
+++ b/test/image3d_read.cl
@@ -10,9 +10,9 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Bound: 9
 // CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpCapability VariablePointers
+// CHECK-DAG: OpCapability Shader
+// CHECK-NOT OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"


### PR DESCRIPTION
The only image read operation performed is OpImageSampleExplicitLod,
so there is no need to declare the StorageImageReadWithoutFormat
capability.

Fixes https://github.com/google/clspv/issues/5