### PR TITLE
SPIR-V type for i8 always aliases the type for i32

### DIFF
--- a/test/char4_issue15_a.cl
+++ b/test/char4_issue15_a.cl
@@ -1,0 +1,21 @@
+// Test for https://github.com/google/clspv/issues/15
+// Use of <4 x 18> was generating a duplicate of OpTypeInt 32 0.
+
+// In this example, the uint is mentioned before the char4.
+kernel void dup(global uint* A, global char4 *B) {}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK-NOT: OpTypeInt 32 0
+
+// Ensure both buffer types use the same underlying i32
+// CHECK-DAG: OpTypeRuntimeArray [[uint]]
+// CHECK-DAG: OpTypeRuntimeArray [[uint]]
+

--- a/test/char4_issue15_b.cl
+++ b/test/char4_issue15_b.cl
@@ -1,0 +1,21 @@
+// Test for https://github.com/google/clspv/issues/15
+// Use of <4 x 18> was generating a duplicate of OpTypeInt 32 0.
+
+// In this example, the char4 is mentioned before the uint.
+kernel void dup(global char4* A, global uint *B) {}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK-NOT: OpTypeInt 32 0
+
+// Ensure both buffer types use the same underlying i32
+// CHECK-DAG: OpTypeRuntimeArray [[uint]]
+// CHECK-DAG: OpTypeRuntimeArray [[uint]]
+


### PR DESCRIPTION
This is incrementally better than what we have now, but I suspect
we should have remapped the types earlier in the flow, and we should
never see the i8 at this point.

Fixes https://github.com/google/clspv/issues/15