### PR TITLE
Fix generation of <4 x i8> constants

### DIFF
--- a/test/Structs/insert_value_issue_14.cl
+++ b/test/Structs/insert_value_issue_14.cl
@@ -3,6 +3,9 @@
 // of an early return in constant generation when we generate
 // the <4 x i8> constant.
 
+// Also test https://github.com/google/clspv/issues/36 for
+// generation of the <4 x i8> constant including an undef component.
+
 typedef struct {
   int a, b, c, d;
 } S;
@@ -26,5 +29,8 @@ kernel void foo(global S* A, global uchar4* B, int n) {
 
 
 // CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
-// CHECK: [[struct:%[_a-zA-Z0-9]+]] = OpTypeStruct [[uint]] [[uint]] [[uint]] [[uint]]
+// CHECK: [[struct:%[_a-zA-Z0-9]+]] = OpTypeStruct [[uint]] [[uint]] [[uint]]
+// With undef mapping to 0 byte, (undef,1,2,3) maps to 66051.
+// CHECK: [[theconst:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 66051
 // CHECK: [[undef_struct:%[_a-zA-Z0-9]+]] = OpUndef [[struct]]
+// CHECK: OpBitwiseAnd [[uint]] [[theconst]] {{%[_a-zA-Z0-9]+}}

--- a/test/char4_constant.cl
+++ b/test/char4_constant.cl
@@ -1,0 +1,20 @@
+
+// Test for https://github.com/google/clspv/issues/36
+// A <4 x 18> constant was generated incorrectly.
+
+kernel void dup(global uchar4 *B) {
+   *B = (uchar4)(1,128,3,4);
+}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[theconst:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 25166596
+// CHECK-DAG: OpStore {{%[_a-zA-Z0-9]+}} [[theconst]]
+// CHECK-NOT: OpStore

--- a/test/char4_constant_zero.cl
+++ b/test/char4_constant_zero.cl
@@ -1,0 +1,20 @@
+
+// Test for https://github.com/google/clspv/issues/36
+// A <4 x 18> constant was generated incorrectly.
+
+kernel void dup(global uchar4 *B) {
+   *B = (uchar4)(0,0,0,0);
+}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[theconst:%[_a-zA-Z0-9]+]] = OpConstantNull [[uint]]
+// CHECK-DAG: OpStore {{%[_a-zA-Z0-9]+}} [[theconst]]
+// CHECK-NOT: OpStore


### PR DESCRIPTION
Cover both when all components are int constants, or
when some are undef values.

Fixes https://github.com/google/clspv/issues/36