### PR TITLE
Fix insertion into <4 x i8>

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3946,7 +3946,7 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
 
       uint32_t InvMaskID = nextID;
 
-      Inst = new SPIRVInstruction(4, spv::OpLogicalNot, nextID++, Ops);
+      Inst = new SPIRVInstruction(4, spv::OpNot, nextID++, Ops);
       SPIRVInstList.push_back(Inst);
 
       // Apply mask.
@@ -3997,6 +3997,8 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       Op1ID = InsertValID;
       Op1IDOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Op1ID);
       Ops.push_back(Op1IDOp);
+
+      VMap[&I] = nextID;
 
       Inst = new SPIRVInstruction(5, spv::OpBitwiseOr, nextID++, Ops);
       SPIRVInstList.push_back(Inst);
@@ -5795,6 +5797,7 @@ void SPIRVProducerPass::WriteSPIRVAssembly() {
     case spv::OpBitwiseOr:
     case spv::OpBitwiseXor:
     case spv::OpBitwiseAnd:
+    case spv::OpNot:
     case spv::OpShiftLeftLogical:
     case spv::OpShiftRightLogical:
     case spv::OpShiftRightArithmetic:
@@ -6020,6 +6023,7 @@ void SPIRVProducerPass::WriteSPIRVBinary() {
     case spv::OpBitwiseOr:
     case spv::OpBitwiseXor:
     case spv::OpBitwiseAnd:
+    case spv::OpNot:
     case spv::OpShiftLeftLogical:
     case spv::OpShiftRightLogical:
     case spv::OpShiftRightArithmetic:

--- a/test/char4_insert.cl
+++ b/test/char4_insert.cl
@@ -1,0 +1,28 @@
+// Test for https://github.com/google/clspv/issues/15
+
+kernel void foo(global uchar4* A, int n) {
+ *A = (uchar4)(1,2,(uchar)n,4);
+}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[uint3mask:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 16908292
+// CHECK: [[uint255:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 255
+// CHECK: [[uint16:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 16
+
+
+// CHECK: [[load:%[_a-zA-Z0-9]+]] = OpLoad [[uint]] {{%[_0-9a-zA-Z]+}}
+// CHECK: [[conv:%[_a-zA-Z0-9]+]] = OpUConvert [[uint]] [[load]]
+// CHECK: [[shift:%[_a-zA-Z0-9]+]] = OpShiftLeftLogical [[uint]] [[uint255]] [[uint16]]
+// CHECK: [[not:%[_a-zA-Z0-9]+]] = OpNot [[uint]] [[shift]]
+// CHECK: [[and:%[_a-zA-Z0-9]+]] = OpBitwiseAnd [[uint]] [[uint3mask]] [[not]]
+// CHECK: [[shift2:%[_a-zA-Z0-9]+]] = OpShiftLeftLogical [[uint]] [[conv]] [[uint16]]
+// CHECK: [[or:%[_a-zA-Z0-9]+]] = OpBitwiseOr [[uint]] [[and]] [[shift2]]
+// CHECK: OpStore {{%[_0-9a-zA-Z]+}} [[or]]


### PR DESCRIPTION
- Use Not rather than LogicalNot
- Register the last SPIR-V instruction ID for
  the LLVM insertion.

Fixes https://github.com/google/clspv/issues/44