### PR TITLE
Use LLVM's AtomicRMWInst for most of the atomics instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ endif()
 
 # Check if required third-party dependencies exist.
 macro(use_component path)
-  if(NOT IS_DIRECTORY ${path})
-	  message(FATAL_ERROR "Required component '${path}' does not exist! Please run 'python utils/fetch_sources.py' in the '${CMAKE_CURRENT_SOURCE_DIR}' folder.")
+if(NOT IS_DIRECTORY ${path})
+  message(FATAL_ERROR "Required component '${path}' does not exist! Please run 'python utils/fetch_sources.py' in the '${CMAKE_CURRENT_SOURCE_DIR}' folder.")
 endif()
 endmacro()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SPIRV_C_STRINGS_NAMESPACE spv)
 set(SPIRV_C_STRINGS_CMAKE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spirv_c_strings.cmakescript)
 
 add_custom_target(clspv_c_strings
-	DEPENDS ${SPIRV_C_STRINGS_OUTPUT_FILE})
+  DEPENDS ${SPIRV_C_STRINGS_OUTPUT_FILE})
 
 add_custom_command(
   OUTPUT ${SPIRV_C_STRINGS_OUTPUT_FILE}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -48,6 +48,6 @@ add_dependencies(clspv_core clspv_c_strings clspv_glsl)
 
 if (MSVC)
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/SPIRVProducerPass.cpp"
-    PROPERTIES COMPILE_FLAGS "/Wall /WX /wd4710 /wd4820 /wd4625 /wd4626 /wd5026 /wd5027 /wd4061 /wd4711 /wd4996"
+    PROPERTIES COMPILE_FLAGS "/Wall /WX /wd4710 /wd4820 /wd4625 /wd4626 /wd5026 /wd5027 /wd4061 /wd4711 /wd4996 /wd4530 /wd4577"
   )
 endif()


### PR DESCRIPTION
LLVM provides an AtomicRMWInst that satisfies most of the spirv.atomic
'fake' intrinsics we used previously, so lets switch over to use that.
This also allows other languages that aren't coming from a CL
perspective to use AtomicRMWInst and have clspv output the correct
instructions.

I also fixed a bug with the mem_fence replacements - having two maps of
const char* and then comparing if the two pointers matched would compare
the two separate binary blobs of the const char* (EG. their pointers)
which might not match (depending on the linker). Instead I changed it to
a std::map where the second element is a std::tuple.

Lastly, MSVC would complain with SPIRVProducerPass so I fixed all the warnings-as-errors that were produced.