### PR TITLE
OpSelect: vectorize bool condition for vector operands

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -228,4 +228,12 @@ llvm::ModulePass *createUndoTruncatedSwitchConditionPass();
 /// is a very limited resource.  Vulkan requires a minimum of 4 StorageBuffer
 /// arguments (maxPerStageDescriptorStorageBuffers), which is very easy to reach.
 llvm::ModulePass *createClusterPodKernelArgumentsPass();
+
+/// Splat select scalar condition with vector data operands.
+/// @return An LLVM module pass.
+///
+/// Converts a select with scalar bool argument but vector operands so that
+/// the bool condition is converted into a bool vector with as many elements
+/// as the operands.
+llvm::ModulePass *createSplatSelectConditionPass();
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplacePointerBitcastPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SimplifyPointerBitcastPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatArgPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/SplatSelectCondition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoBoolPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoByvalPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoGetElementPtrConstantExprPass.cpp

--- a/lib/SplatSelectCondition.cpp
+++ b/lib/SplatSelectCondition.cpp
@@ -1,0 +1,80 @@
+// Copyright 2017 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/raw_ostream.h>
+
+using namespace llvm;
+
+#define DEBUG_TYPE "splatselectcond"
+
+namespace {
+struct SplatSelectConditionPass : public ModulePass {
+  static char ID;
+  SplatSelectConditionPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+};
+} // namespace
+
+char SplatSelectConditionPass::ID = 0;
+static RegisterPass<SplatSelectConditionPass>
+    X("SplatSelectCond", "Splat Select Condition Pass");
+
+namespace clspv {
+llvm::ModulePass *createSplatSelectConditionPass() {
+  return new SplatSelectConditionPass();
+}
+} // namespace clspv
+
+
+bool SplatSelectConditionPass::runOnModule(Module &M) {
+  bool Changed = false;
+
+  SmallVector<SelectInst *, 16> WorkList;
+  for (Function &F : M) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (SelectInst *sel = dyn_cast<SelectInst>(&I)) {
+          auto cond = sel->getCondition();
+          if (cond->getType()->isIntegerTy(1)) {
+            Type *valueTy = sel->getTrueValue()->getType();
+            if (valueTy->isVectorTy()) {
+              WorkList.push_back(sel);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (WorkList.size() == 0)
+    return Changed;
+
+  IRBuilder<> Builder(WorkList.front());
+
+  for (SelectInst *sel : WorkList) {
+    Changed = true;
+    auto cond = sel->getCondition();
+    auto numElems = sel->getTrueValue()->getType()->getVectorNumElements();
+    Builder.SetInsertPoint(sel);
+    auto splat = Builder.CreateVectorSplat(numElems, cond);
+    sel->setCondition(splat);
+  }
+
+  return Changed;
+}

--- a/test/opselect_float2.cl
+++ b/test/opselect_float2.cl
@@ -1,0 +1,90 @@
+// Test https://github.com/google/clspv/issues/65
+// OpSelect with vector data operands must use vector bool selector.
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* A, int c)
+{
+  *A = c ? (float2)(1.0,2.0) : (float2)(3.0,4.0);
+}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 34
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
+// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
+
+// CHECK: OpDecorate %[[ARG0_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 8
+// CHECK: OpMemberDecorate %[[ARG0_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[ARG0_STRUCT_TYPE_ID]] Block
+
+// CHECK: OpMemberDecorate %[[s_uint:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[s_uint]] Block
+
+// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
+// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+
+// CHECK: %[[float:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[float2:[a-zA-Z0-9_]*]] = OpTypeVector %[[float]] 2
+
+
+// For the A argument:
+// CHECK: %[[ARG0_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[float2]]
+// CHECK: %[[ARG0_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[float2]]
+// CHECK: %[[ARG0_STRUCT_TYPE_ID]] = OpTypeStruct %[[ARG0_DYNAMIC_ARRAY_TYPE_ID]]
+// CHECK: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG0_STRUCT_TYPE_ID]]
+
+// For the n argument:
+// CHECK: %[[uint:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK: %[[s_uint]] = OpTypeStruct %[[uint]]
+// CHECK: %[[ptr_s_uint:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[s_uint]]
+// CHECK: %[[ptr_uint:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[uint]]
+
+
+// CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
+// CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
+// CHECK: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK: %[[bool2:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 2
+
+// CHECK: %[[uint_0:[a-zA-Z0-9_]*]] = OpConstant %[[uint]] 0
+// CHECK: %[[undef:[a-zA-Z0-9_]*]] = OpUndef %[[bool2]]
+// CHECK: %[[float_3:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 3
+// CHECK: %[[float_4:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 4
+// CHECK: %[[v2_3_4:[a-zA-Z0-9_]*]] = OpConstantComposite %[[float2]] %[[float_3]] %[[float_4]]
+// CHECK: %[[float_1:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 1
+// CHECK: %[[float_2:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 2
+// CHECK: %[[v2_1_2:[a-zA-Z0-9_]*]] = OpConstantComposite %[[float2]] %[[float_1]] %[[float_2]]
+
+
+// CHECK: %[[ARG0_ID]] = OpVariable %[[ARG0_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG1_ID]] = OpVariable %[[ptr_s_uint]] StorageBuffer
+
+
+// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
+// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[ARG0_GLOBAL_POINTER_TYPE_ID]] %[[ARG0_ID]] %[[uint_0]] %[[uint_0]]
+// CHECK: %[[n_ptr:[a-zA-Z0-9_]*]] = OpAccessChain %[[ptr_uint]] %[[ARG1_ID]] %[[uint_0]]
+
+// CHECK: %[[n:[a-zA-Z0-9_]*]] = OpLoad %[[uint]] %[[n_ptr]]
+// CHECK: %[[eq:[a-zA-Z0-9_]*]] = OpIEqual %[[BOOL_TYPE_ID]] %[[n]] %[[uint_0]]
+
+// CHECK: %[[eq_vec0:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[bool2]] %[[eq]] %[[undef]] 0
+// CHECK: %[[eq_splat:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[bool2]] %[[eq_vec0]] %[[undef]] 0 0
+
+// CHECK: %[[sel:[a-zA-Z0-9_]*]] = OpSelect %[[float2]] %[[eq_splat]] %[[v2_3_4]] %[[v2_1_2]]
+// CHECK: OpStore %[[A_ACCESS_CHAIN_ID]] %[[sel]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -750,6 +750,7 @@ int main(const int argc, const char *const argv[]) {
   pm.add(clspv::createSimplifyPointerBitcastPass());
   pm.add(clspv::createReplacePointerBitcastPass());
   pm.add(clspv::createUndoTranslateSamplerFoldPass());
+  pm.add(clspv::createSplatSelectConditionPass());
   pm.add(clspv::createSPIRVProducerPass(
       bufferedOutStream, descriptor_map_out, SamplerMapEntries,
       OutputAssembly.getValue(), OutputFormat == "c"));


### PR DESCRIPTION
For an OpSelect with vector data operands, the condition
must be a bool vector with the same number of elements.
In this way SPIR-V is a slightly more restrictive than
LLVM IR.

Fixes https://github.com/google/clspv/issues/65