### PR TITLE
By default, reuse descriptor sets across kernels

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -107,7 +107,12 @@ denote that the shaders can interact with their data.
 The default way to map an OpenCL C language kernel to a Vulkan SPIR-V compute
 shader is as follows:
 
-- Each kernel is assigned a corresponding descriptor set, such that the first
+- If a sampler map file is specified, all literal samplers use descriptor set _0_.
+- By default, all kernels in the translation unit use the same descriptor set
+  number, either _0_ or _1_.  (They use 1 if a sampler map is specified.)
+  **This is new default behaviour**.
+  - Use option `-distinct-kernel-descriptor-sets` to get the old behaviour,
+  where each kernel is assigned its own descriptor set number, such that the first
   kernel has descriptor set _0_, and each subsequent kernel is an increment of
   _1_ from the previous.
 - Each argument within each kernel is assigned a binding in that kernel's
@@ -131,9 +136,9 @@ shader is as follows:
 
 #### Descriptor map
 
-The compiler can tell you what descriptor set and bindings are used for kernel
-arguemnts.  Use option `-descriptormap` to name a file that should contain
-the mapping information.
+The compiler can tell you what descriptor set and bindings are used for samplers
+in the sampler map and kernel arguments.
+Use option `-descriptormap` to name a file that should contain the mapping information.
 
 Example:
 
@@ -238,7 +243,10 @@ will produce the following in `myclusteredmap`:
     kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,2,offset,4
 
 If `foo` were the second kernel in the translation unit, then its arguments
-would use descriptor set 1.
+would also use descriptor set 0.
+If `foo` were the second kernel in the translation unit _and_ option
+`-distinct-kernel-descriptor-sets` is used, then its arguments would
+use descriptor set 1.
 
 Compiling with the same sampler map from before:
 

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -23,7 +23,7 @@
 // CHECK: OpDecorate %[[UINT_ARG0_STRUCT_TYPE_ID]] Block
 // CHECK: OpDecorate %[[FOO_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[FOO_ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 1
+// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[BAR_ARG0_ID]] Binding 0
 // CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK: %[[UINT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_TYPE_ID]]

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -25,7 +25,7 @@
 // CHECK: OpDecorate %[[BUILTIN_ID:[a-zA-Z0-9_]*]] BuiltIn WorkgroupSize
 // CHECK: OpDecorate %[[FOO_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[FOO_ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 1
+// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[BAR_ARG0_ID]] Binding 0
 // CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK: %[[UINT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_TYPE_ID]]

--- a/test/descriptor_set_default.cl
+++ b/test/descriptor_set_default.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpDecorate [[A:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[A]] Binding 0
+// CHECK: OpDecorate [[foo_pod:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[foo_pod]] Binding 1
+
+// CHECK: OpDecorate [[B:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[B]] Binding 0
+// CHECK: OpDecorate [[bar_pod:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[bar_pod]] Binding 1
+
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+
+// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0
+// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP-NOT: kernel
+
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, uint n, float4 c)
+{
+  A[n] = c.x;
+}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(global float* B, uint m)
+{
+  B[m] *= 2.0;
+}

--- a/test/descriptor_set_distinct.cl
+++ b/test/descriptor_set_distinct.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t.map -distinct-kernel-descriptor-sets
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpDecorate [[A:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[A]] Binding 0
+// CHECK: OpDecorate [[foo_pod:%[a-zA-Z0-9]+]] DescriptorSet 0
+// CHECK: OpDecorate [[foo_pod]] Binding 1
+
+// CHECK: OpDecorate [[B:%[a-zA-Z0-9]+]] DescriptorSet 1
+// CHECK: OpDecorate [[B]] Binding 0
+// CHECK: OpDecorate [[bar_pod:%[a-zA-Z0-9]+]] DescriptorSet 1
+// CHECK: OpDecorate [[bar_pod]] Binding 1
+
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+
+// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,1,binding,0,offset,0
+// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,1,binding,1,offset,0
+// MAP-NOT: kernel
+
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, uint n, float4 c)
+{
+  A[n] = c.x;
+}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(global float* B, uint m)
+{
+  B[m] *= 2.0;
+}


### PR DESCRIPTION
Use option -distinct-kernel-descriptor-sets to retain old behaviour