### PR TITLE
Change argType to argKind in descriptormap file

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -153,10 +153,10 @@ Consider this example:
 
 It generates the following descriptor map:
 
-    kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argType,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argType,pod
-    kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argType,buffer
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argType,pod
+    kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+    kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,buffer
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod
 
 For kernel arguments, the fields are:
 - `kernel` to indicate a kernel argument
@@ -172,7 +172,7 @@ For kernel arguments, the fields are:
 - `offset`
 - The byte offset inside the storage buffer where you should write the argument value.
   This will always be zero, unless you cluster plain-old-data kernel arguments. (See below.)
-- `argType`
+- `argKind`
 - a string describing the kind of argument, one of:
   - `buffer` - OpenCL buffer
   - `pod` - Plain Old Data, e.g. a scalar, vector, or structure
@@ -195,10 +195,10 @@ Then `mydescriptormap` will contain:
 
     sampler,18,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_NEAREST|CLK_NORMALIZED_COORDS_FALSE",descriptorSet,0,binding,0
     sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
-    kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argType,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argType,pod
-    kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argType,buffer
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argType,pod
+    kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod
+    kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,buffer
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,pod
 
 
 #### Clustering plain-old-data kernel arguments to save descriptors
@@ -244,10 +244,10 @@ That is, compiling as follows:
 
 will produce the following in `myclusteredmap`:
 
-    kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argType,buffer
-    kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argType,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,2,offset,0,argType,pod
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,2,offset,4,argType,pod
+    kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+    kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,buffer
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,2,offset,0,argKind,pod
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,2,offset,4,argKind,pod
 
 If `foo` were the second kernel in the translation unit, then its arguments
 would also use descriptor set 0.
@@ -263,10 +263,10 @@ produces the following descriptor map:
 
     sampler,18,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_NEAREST|CLK_NORMALIZED_COORDS_FALSE",descriptorSet,0,binding,0
     sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
-    kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argType,buffer
-    kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,1,offset,0,argType,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,2,offset,0,argType,pod
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,2,offset,4,argType,pod
+    kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+    kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,1,offset,0,argKind,buffer
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,2,offset,0,argKind,pod
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,2,offset,4,argKind,pod
 
 
 TODO(dneto): Give an example using images.

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -21,7 +21,7 @@ using namespace llvm;
 
 namespace clspv {
 
-const char *GetArgTypeForType(Type *type) {
+const char *GetArgKindForType(Type *type) {
   if (type->isPointerTy()) {
     auto pointeeTy = type->getPointerElementType();
     if (auto structTy = dyn_cast<StructType>(pointeeTy)) {

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CLSPV_LIB_ARGTYPE_H_
-#define CLSPV_LIB_ARGTYPE_H_
+#ifndef CLSPV_LIB_ARGKIND_H_
+#define CLSPV_LIB_ARGKIND_H_
 
 #include <llvm/IR/Type.h>
 
 namespace clspv {
 
 // Maps an LLVM type for a kernel argument to an argument
-// type suitable for a descriptor map.  The result is one of:
+// kind suitable for a descriptor map.  The result is one of:
 //   buffer
 //   pod
 //   ro_image
 //   wo_image
 //   sampler
-const char *GetArgTypeForType(llvm::Type *type);
+const char *GetArgKindForType(llvm::Type *type);
 
 } // namespace clspv
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(clspv_core STATIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/ArgType.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -36,7 +36,7 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/raw_ostream.h>
 
-#include "ArgType.h"
+#include "ArgKind.h"
 
 using namespace llvm;
 
@@ -96,8 +96,8 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
       // this is the byte offset within the POD arguments struct.
       unsigned offset;
       // Argument type.  Same range of values as the result of
-      // clspv::GetArgTypeForType.
-      const char* arg_type;
+      // clspv::GetArgKindForType.
+      const char* arg_kind;
     };
 
     // In OpenCL, kernel arguments are either pointers or POD. A composite with
@@ -114,7 +114,7 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
         PtrArgTys.push_back(ArgTy);
         RemapInfo.push_back({std::string(Arg.getName()), arg_index,
                              unsigned(RemapInfo.size()), 0u,
-                             clspv::GetArgTypeForType(ArgTy)});
+                             clspv::GetArgKindForType(ArgTy)});
       } else {
         PodArgTys.push_back(ArgTy);
       }
@@ -141,7 +141,7 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
           RemapInfo.push_back(
               {std::string(Arg.getName()), arg_index, num_pointer_args,
                unsigned(StructLayout->getElementOffset(pod_index++)),
-               clspv::GetArgTypeForType(ArgTy)});
+               clspv::GetArgKindForType(ArgTy)});
         }
         arg_index++;
       }
@@ -197,7 +197,7 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.new_index));
         auto *offset =
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.offset));
-        auto *argtype_md = MDString::get(Context, arg_mapping.arg_type);
+        auto *argtype_md = MDString::get(Context, arg_mapping.arg_kind);
         auto *arg_md = MDNode::get(
             Context, {name_md, old_index_md, new_index_md, offset, argtype_md});
         mappings.push_back(arg_md);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -37,7 +37,7 @@
 #include <clspv/spirv_c_strings.hpp>
 #include <clspv/spirv_glsl.hpp>
 
-#include "ArgType.h"
+#include "ArgKind.h"
 
 #include <list>
 #include <iomanip>
@@ -2544,12 +2544,12 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
             dyn_extract<ConstantInt>(arg_node->getOperand(2))->getZExtValue();
         const auto offset =
             dyn_extract<ConstantInt>(arg_node->getOperand(3))->getZExtValue();
-        const auto argType =
+        const auto argKind =
             dyn_cast<MDString>(arg_node->getOperand(4))->getString();
         descriptorMapOut << "kernel," << F.getName() << ",arg," << name
                          << ",argOrdinal," << old_index << ",descriptorSet,"
                          << DescriptorSetIdx << ",binding," << new_index
-                         << ",offset," << offset << ",argType," << argType
+                         << ",offset," << offset << ",argKind," << argKind
                          << "\n";
       }
     }
@@ -2566,8 +2566,8 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
         descriptorMapOut << "kernel," << F.getName() << ",arg," << Arg.getName()
                          << ",argOrdinal," << BindingIdx << ",descriptorSet,"
                          << DescriptorSetIdx << ",binding," << BindingIdx
-                         << ",offset,0,argType,"
-                         << clspv::GetArgTypeForType(Arg.getType()) << "\n";
+                         << ",offset,0,argKind,"
+                         << clspv::GetArgKindForType(Arg.getType()) << "\n";
       }
 
       // Ops[0] = Target ID

--- a/test/descriptor_map_argtype.cl
+++ b/test/descriptor_map_argtype.cl
@@ -6,20 +6,20 @@
 // RUN: clspv %s -o %t.spv -descriptormap=%t.cluster.map -cluster-pod-kernel-args 
 // RUN: FileCheck -check-prefix=CLUSTER %s < %t.cluster.map
 
-// CHECK: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argType,buffer
-// CHECK-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argType,ro_image
-// CHECK-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argType,wo_image
-// CHECK-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argType,sampler
-// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argType,pod
-// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argType,pod
+// CHECK: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// CHECK-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
+// CHECK-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
+// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod
+// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argKind,pod
 // CHECK-NOT: foo
 
-// CLUSTER: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argType,buffer
-// CLUSTER-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argType,ro_image
-// CLUSTER-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argType,wo_image
-// CLUSTER-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argType,sampler
-// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argType,pod
-// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,4,offset,4,argType,pod
+// CLUSTER: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// CLUSTER-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
+// CLUSTER-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
+// CLUSTER-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
+// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod
+// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,4,offset,4,argKind,pod
 // CLUSTER-NOT: foo
 
 kernel void foo(global int *A, read_only image2d_t RO, write_only image2d_t WO,


### PR DESCRIPTION
argKind is better because it doesn't have the connotation of providing OpenCL C type information.
It's a reduction of that.