### PR TITLE
Hide loads from constant memory from instcombine

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -236,4 +236,18 @@ llvm::ModulePass *createClusterPodKernelArgumentsPass();
 /// the bool condition is converted into a bool vector with as many elements
 /// as the operands.
 llvm::ModulePass *createSplatSelectConditionPass();
+
+/// Hide loads from __constant address space.
+/// @return An LLVM module pass.
+///
+/// Wrap the result of a load from __constant address space.  This prevents
+/// the instcombine pass from generating selects over pointer-to-constant.
+/// See https://github.com/google/clspv/issues/71
+llvm::ModulePass *createHideConstantLoadsPass();
+
+/// Unhide loads from __constant address space.
+/// @return An LLVM module pass.
+///
+/// Unwrap the result of a load from __constant address space.
+llvm::ModulePass *createUnhideConstantLoadsPass();
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/OpenCLInlinerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SPIRVProducerPass.cpp

--- a/lib/HideConstantLoadsPass.cpp
+++ b/lib/HideConstantLoadsPass.cpp
@@ -1,0 +1,193 @@
+// Copyright 2017 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <clspv/AddressSpace.h>
+
+using namespace llvm;
+using std::string;
+
+#define DEBUG_TYPE "hideconstantloads"
+
+
+namespace {
+
+const char* kWrapFunctionPrefix = "clspv.wrap_constant_load.";
+
+class HideConstantLoadsPass : public ModulePass {
+ public:
+  static char ID;
+  HideConstantLoadsPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+
+ private:
+   // Return the name for the wrap function for the given type.
+   string &WrapFunctionNameForType(Type *type) {
+     auto where = function_for_type_.find(type);
+     if (where == function_for_type_.end()) {
+       // Insert it.
+       auto &result = function_for_type_[type] =
+           string(kWrapFunctionPrefix) +
+           std::to_string(function_for_type_.size());
+       return result;
+     } else {
+       return where->second;
+     }
+   }
+
+   // Maps a loaded type to the name of the wrap function for that type.
+   DenseMap<Type *, string> function_for_type_;
+};
+} // namespace
+
+char HideConstantLoadsPass::ID = 0;
+static RegisterPass<HideConstantLoadsPass>
+    X("HideConstantLoads", "Hide loads from __constant memory");
+
+namespace clspv {
+llvm::ModulePass *createHideConstantLoadsPass() {
+  return new HideConstantLoadsPass();
+}
+} // namespace clspv
+
+
+bool HideConstantLoadsPass::runOnModule(Module &M) {
+  bool Changed = false;
+
+  SmallVector<LoadInst *, 16> WorkList;
+  for (Function &F : M) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (LoadInst *load = dyn_cast<LoadInst>(&I)) {
+          if (clspv::AddressSpace::Constant == load->getPointerAddressSpace()) {
+            WorkList.push_back(load);
+          }
+        }
+      }
+    }
+  }
+
+  if (WorkList.size() == 0) {
+    return Changed;
+  }
+
+  for (LoadInst *load : WorkList) {
+    Changed = true;
+
+    auto loadedTy = load->getType();
+
+    // The wrap function conceptually maps the loaded value to itself.
+    const string& fn_name = WrapFunctionNameForType(loadedTy);
+    Function* fn = M.getFunction(fn_name);
+    if (!fn) {
+      // Make the function.
+      FunctionType* fnTy = FunctionType::get(loadedTy, {loadedTy}, false);
+      auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
+      fn = cast<Function>(fn_constant);
+      fn->addFnAttr(Attribute::ReadOnly);
+      fn->addFnAttr(Attribute::ReadNone);
+    }
+
+    // Wrap the load
+    auto call = CallInst::Create(fn, {load});
+    call->insertAfter(load);
+
+    // Replace other uses of the load with the result of the wrap call.
+    {
+      SmallVector<User *, 16> ToReplaceIn;
+      for (auto &use : load->uses()) {
+        User *user = use.getUser();
+        ToReplaceIn.push_back(user);
+      }
+      for (auto *user : ToReplaceIn) {
+        if (dyn_cast<CallInst>(user) != call) {
+          user->replaceUsesOfWith(load, call);
+        }
+      }
+    }
+  }
+
+  return Changed;
+}
+
+namespace {
+class UnhideConstantLoadsPass : public ModulePass {
+ public:
+  static char ID;
+  UnhideConstantLoadsPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+
+ private:
+
+   // Maps a loaded type to the name of the wrap function for that type.
+   DenseMap<Type *, string> function_for_type_;
+};
+
+} // namespace
+
+char UnhideConstantLoadsPass::ID = 0;
+static RegisterPass<UnhideConstantLoadsPass>
+    X2("UnhideConstantLoads", "Unhide loads from __constant memory");
+
+namespace clspv {
+llvm::ModulePass *createUnhideConstantLoadsPass() {
+  return new UnhideConstantLoadsPass();
+}
+} // namespace clspv
+
+bool UnhideConstantLoadsPass::runOnModule(Module &M) {
+  bool Changed = false;
+
+  SmallVector<Function *, 16> WorkList;
+  for (auto& F : M.getFunctionList()) {
+    if (F.getName().startswith(kWrapFunctionPrefix)) {
+      WorkList.push_back(&F);
+    }
+  }
+
+  if (WorkList.size() == 0)
+    return Changed;
+
+  SmallVector<CallInst *, 16> RemoveList;
+  for (auto* F : WorkList) {
+    for (auto& use : F->uses()) {
+      if (auto* call = dyn_cast<CallInst>(use.getUser())) {
+        assert(call->getNumArgOperands() == 1);
+        auto* load = call->getArgOperand(0);
+        call->replaceAllUsesWith(load);
+        RemoveList.push_back(call);
+      }
+    }
+  }
+  for (auto* call : RemoveList) {
+    call->eraseFromParent();
+  }
+  for (auto* F : WorkList) {
+    F->eraseFromParent();
+  }
+
+  return Changed;
+}

--- a/test/ProgramScopeConstants/select_between_constant_load.cl
+++ b/test/ProgramScopeConstants/select_between_constant_load.cl
@@ -1,0 +1,116 @@
+// Ensure that instcombine does not convert a selection between
+// loads into a selection between the pointer and then loading
+// from that pointer.
+// https://github.com/google/clspv/issues/71
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+__constant float kFirst[3] = {1.0f, 2.0f, 3.0f};
+__constant float kSecond[3] = {10.0f, 11.0f, 12.0f};
+
+kernel void foo(global float *A, int c, int i) {
+  *A = c == 0 ? kFirst[i] : kSecond[i];
+}
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 61
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_41:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_31:%[a-zA-Z0-9_]+]] SpecId 0
+// CHECK: OpDecorate [[_32:%[a-zA-Z0-9_]+]] SpecId 1
+// CHECK: OpDecorate [[_33:%[a-zA-Z0-9_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4:%[a-zA-Z0-9_]+]] Block
+// CHECK: OpMemberDecorate [[__struct_7:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_7:%[a-zA-Z0-9_]+]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_38:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_38:%[a-zA-Z0-9_]+]] Binding 0
+// CHECK: OpDecorate [[_39:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_39:%[a-zA-Z0-9_]+]] Binding 1
+// CHECK: OpDecorate [[_40:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_40:%[a-zA-Z0-9_]+]] Binding 2
+// CHECK: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float:%[a-zA-Z0-9_]+]]
+// CHECK: [[__runtimearr_float:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[_float:%[a-zA-Z0-9_]+]]
+// CHECK: [[__struct_4:%[a-zA-Z0-9_]+]] = OpTypeStruct [[__runtimearr_float:%[a-zA-Z0-9_]+]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4:%[a-zA-Z0-9_]+]]
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__struct_7:%[a-zA-Z0-9_]+]] = OpTypeStruct [[_uint:%[a-zA-Z0-9_]+]]
+// CHECK: [[__ptr_StorageBuffer__struct_7:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_7:%[a-zA-Z0-9_]+]]
+// CHECK: [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_uint:%[a-zA-Z0-9_]+]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_11:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void:%[a-zA-Z0-9_]+]]
+// CHECK: [[_bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK: [[_uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[_uint:%[a-zA-Z0-9_]+]] 3
+// CHECK: [[__arr_float_uint_3:%[a-zA-Z0-9_]+]] = OpTypeArray [[_float:%[a-zA-Z0-9_]+]] [[_uint_3:%[a-zA-Z0-9_]+]]
+// CHECK: [[__ptr_Private__arr_float_uint_3:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[__arr_float_uint_3:%[a-zA-Z0-9_]+]]
+// CHECK: [[__ptr_Private_float:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_float:%[a-zA-Z0-9_]+]]
+// CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint:%[a-zA-Z0-9_]+]] 3
+// CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint:%[a-zA-Z0-9_]+]]
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint:%[a-zA-Z0-9_]+]] 0
+// CHECK: [[_20:%[a-zA-Z0-9_]+]] = OpUndef [[_float:%[a-zA-Z0-9_]+]]
+// CHECK: [[_false:%[a-zA-Z0-9_]+]] = OpConstantFalse [[_bool:%[a-zA-Z0-9_]+]]
+// CHECK: [[_true:%[a-zA-Z0-9_]+]] = OpConstantTrue [[_bool:%[a-zA-Z0-9_]+]]
+// CHECK: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 1
+// CHECK: [[_float_2:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 2
+// CHECK: [[_float_3:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 3
+// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpConstantComposite [[__arr_float_uint_3:%[a-zA-Z0-9_]+]] [[_float_1:%[a-zA-Z0-9_]+]] [[_float_2:%[a-zA-Z0-9_]+]] [[_float_3:%[a-zA-Z0-9_]+]]
+// CHECK: [[_float_10:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 10
+// CHECK: [[_float_11:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 11
+// CHECK: [[_float_12:%[a-zA-Z0-9_]+]] = OpConstant [[_float:%[a-zA-Z0-9_]+]] 12
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpConstantComposite [[__arr_float_uint_3:%[a-zA-Z0-9_]+]] [[_float_10:%[a-zA-Z0-9_]+]] [[_float_11:%[a-zA-Z0-9_]+]] [[_float_12:%[a-zA-Z0-9_]+]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpSpecConstant [[_uint:%[a-zA-Z0-9_]+]] 1
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpSpecConstant [[_uint:%[a-zA-Z0-9_]+]] 1
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpSpecConstant [[_uint:%[a-zA-Z0-9_]+]] 1
+// CHECK: [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] = OpSpecConstantComposite [[_v3uint:%[a-zA-Z0-9_]+]] [[_31:%[a-zA-Z0-9_]+]] [[_32:%[a-zA-Z0-9_]+]] [[_33:%[a-zA-Z0-9_]+]]
+// CHECK: [[_35:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] Private [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]]
+// CHECK: [[_36:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private__arr_float_uint_3:%[a-zA-Z0-9_]+]] Private [[_26:%[a-zA-Z0-9_]+]]
+// CHECK: [[_37:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private__arr_float_uint_3:%[a-zA-Z0-9_]+]] Private [[_30:%[a-zA-Z0-9_]+]]
+// CHECK: [[_38:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] StorageBuffer
+// CHECK: [[_39:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_StorageBuffer__struct_7:%[a-zA-Z0-9_]+]] StorageBuffer
+// CHECK: [[_40:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_StorageBuffer__struct_7:%[a-zA-Z0-9_]+]] StorageBuffer
+// CHECK: [[_41:%[a-zA-Z0-9_]+]] = OpFunction [[_void:%[a-zA-Z0-9_]+]] None [[_11:%[a-zA-Z0-9_]+]]
+// CHECK: [[_42:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_43:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] [[_38:%[a-zA-Z0-9_]+]] [[_uint_0:%[a-zA-Z0-9_]+]] [[_uint_0:%[a-zA-Z0-9_]+]]
+// CHECK: [[_44:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] [[_39:%[a-zA-Z0-9_]+]] [[_uint_0:%[a-zA-Z0-9_]+]]
+// CHECK: [[_45:%[a-zA-Z0-9_]+]] = OpLoad [[_uint:%[a-zA-Z0-9_]+]] [[_44:%[a-zA-Z0-9_]+]]
+// CHECK: [[_46:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] [[_40:%[a-zA-Z0-9_]+]] [[_uint_0:%[a-zA-Z0-9_]+]]
+// CHECK: [[_47:%[a-zA-Z0-9_]+]] = OpLoad [[_uint:%[a-zA-Z0-9_]+]] [[_46:%[a-zA-Z0-9_]+]]
+// CHECK: [[_48:%[a-zA-Z0-9_]+]] = OpIEqual [[_bool:%[a-zA-Z0-9_]+]] [[_45:%[a-zA-Z0-9_]+]] [[_uint_0:%[a-zA-Z0-9_]+]]
+// CHECK: [[_49:%[a-zA-Z0-9_]+]] = OpLogicalNot [[_bool:%[a-zA-Z0-9_]+]] [[_48:%[a-zA-Z0-9_]+]]
+// CHECK: OpSelectionMerge [[_53:%[a-zA-Z0-9_]+]] None
+// CHECK: OpBranchConditional [[_49:%[a-zA-Z0-9_]+]] [[_50:%[a-zA-Z0-9_]+]] [[_53:%[a-zA-Z0-9_]+]]
+// CHECK: [[_50:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_51:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_Private_float:%[a-zA-Z0-9_]+]] [[_37:%[a-zA-Z0-9_]+]] [[_47:%[a-zA-Z0-9_]+]]
+// CHECK: [[_52:%[a-zA-Z0-9_]+]] = OpLoad [[_float:%[a-zA-Z0-9_]+]] [[_51:%[a-zA-Z0-9_]+]]
+// CHECK: OpBranch [[_53:%[a-zA-Z0-9_]+]]
+// CHECK: [[_53:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_55:%[a-zA-Z0-9_]+]] = OpPhi [[_bool:%[a-zA-Z0-9_]+]] [[_false:%[a-zA-Z0-9_]+]] [[_50:%[a-zA-Z0-9_]+]] [[_true:%[a-zA-Z0-9_]+]] [[_42:%[a-zA-Z0-9_]+]]
+// CHECK: [[_54:%[a-zA-Z0-9_]+]] = OpPhi [[_float:%[a-zA-Z0-9_]+]] [[_52:%[a-zA-Z0-9_]+]] [[_50:%[a-zA-Z0-9_]+]] [[_20:%[a-zA-Z0-9_]+]] [[_42:%[a-zA-Z0-9_]+]]
+// CHECK: OpSelectionMerge [[_56:%[a-zA-Z0-9_]+]] None
+// CHECK: OpBranchConditional [[_55:%[a-zA-Z0-9_]+]] [[_58:%[a-zA-Z0-9_]+]] [[_56:%[a-zA-Z0-9_]+]]
+// CHECK: [[_56:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_57:%[a-zA-Z0-9_]+]] = OpPhi [[_float:%[a-zA-Z0-9_]+]] [[_54:%[a-zA-Z0-9_]+]] [[_53:%[a-zA-Z0-9_]+]] [[_60:%[a-zA-Z0-9_]+]] [[_58:%[a-zA-Z0-9_]+]]
+// CHECK: OpStore [[_43:%[a-zA-Z0-9_]+]] [[_57:%[a-zA-Z0-9_]+]]
+// CHECK: OpReturn
+// CHECK: [[_58:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_59:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_Private_float:%[a-zA-Z0-9_]+]] [[_36:%[a-zA-Z0-9_]+]] [[_47:%[a-zA-Z0-9_]+]]
+// CHECK: [[_60:%[a-zA-Z0-9_]+]] = OpLoad [[_float:%[a-zA-Z0-9_]+]] [[_59:%[a-zA-Z0-9_]+]]
+// CHECK: OpBranch [[_56:%[a-zA-Z0-9_]+]]
+// CHECK: OpFunctionEnd

--- a/test/spvasm2checks.pl
+++ b/test/spvasm2checks.pl
@@ -1,0 +1,47 @@
+#!/usr/bin/perl -w
+
+# Copyright 2017 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Convert a SPIR-V assembly listing into a list of FileCheck check assertions.
+
+use strict;
+
+# Key is a defined id.
+my %id = ();
+
+while(<>) {
+  chomp;
+  my $line = $_;
+  $line =~ s/^\s+//;
+  $line =~ s/\s+$//;
+  my @words = split(/\s+/, $line);
+  my @parts = qw(// CHECK:);
+  foreach my $word (@words) {
+    if ($word =~ m/^%(.*)/) {
+      my $name = $1;
+      if (defined $id{$name}) {
+	# This is a first use
+	push @parts, "[[_$name]]"
+      } else {
+	# This is a definition.  Write a match rule
+	push @parts, "[[_$name:%[a-zA-Z0-9_]+]]"
+      }
+    } else {
+      # Not an Id.  Emit it verbatim
+      push @parts, $word;
+    }
+  }
+  print join(' ', @parts), "\n";
+}


### PR DESCRIPTION
    
    Prevent instcombine from generating selects over pointer-to-constant
    which turn into OpSelect over pointer-to-Private which is invalid
    even with VariablePointers.
    
    We prevent it by temporarily wrapping the loads from constant
    memory via an opaque function.  After all instcombines have been
    run, unwrap those loads again.
