### PR TITLE
Report call to unknown function

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5348,6 +5348,14 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
         Ops.push_back(ResTyIDOp);
 
         uint32_t CalleeID = VMap[Callee];
+        if (CalleeID == 0) {
+          errs() << "Can't translate function call.  Missing builtin? "
+                 << Callee->getName() << " in: " << *Call << "\n";
+          // TODO(dneto): Can we error out?  Enabling this llvm_unreachable
+          // causes an infinite loop.  Instead, go ahead and generate
+          // the bad function call.  A validator will catch the 0-Id.
+          // llvm_unreachable("Can't translate function call");
+        }
 
         SPIRVOperand *CalleeIDOp =
             new SPIRVOperand(SPIRVOperandType::NUMBERID, CalleeID);


### PR DESCRIPTION
The compiler doesn't error out, but will emit a call to a function
with id 0.  I don't know how to error out from within the code
generator.

This will make it easier to debug the case where we are missing
support for a builtin.