### PR TITLE
Enable LoadStoreVectorizer

### DIFF
--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -743,6 +743,8 @@ int main(const int argc, const char *const argv[]) {
   pm.add(clspv::createReplacePointerBitcastPass());
   pm.add(clspv::createUndoTranslateSamplerFoldPass());
   pm.add(clspv::createSplatSelectConditionPass());
+  pm.add(llvm::createLoadStoreVectorizerPass());
+  
   pm.add(clspv::createSPIRVProducerPass(
       binaryStream, descriptor_map_out, SamplerMapEntries,
       OutputAssembly.getValue(), OutputFormat == "c"));


### PR DESCRIPTION
Both the AMDGPU and NVPTX backends enable this because it's a huge performance increase on their respective GPUs.

For properly aligned types this can coalesce loads and stores together, something the Nvidia driver typically doesn't do when fed raw SPIR-V (the AMD driver does, however, do this).

Improves code-gen for this particular code sample:
```
struct __attribute__((aligned(16))) asdf
{
  int k0;
  int k1;
  int k2;
  int k3;
};

__kernel void myTest(__global struct asdf *jasper)
{
  jasper[0].k0 = 0;
  jasper[0].k1 = 1;
  jasper[0].k2 = 2;
  jasper[0].k3 = 3;
}
```

After we perform only one 16 byte vector store:
```
define spir_kernel void @myTest(%struct.asdf addrspace(1)* nocapture %jasper) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
entry:
  %k0 = getelementptr inbounds %struct.asdf, %struct.asdf addrspace(1)* %jasper, i32 0, i32 0
  %0 = bitcast i32 addrspace(1)* %k0 to <4 x i32> addrspace(1)*
  store <4 x i32> <i32 0, i32 1, i32 2, i32 3>, <4 x i32> addrspace(1)* %0, align 16
  ret void
}
```

Before we used to perform 4 4byte float stores:
```
define spir_kernel void @myTest(%struct.asdf addrspace(1)* nocapture %jasper) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
entry:
  %k0 = getelementptr inbounds %struct.asdf, %struct.asdf addrspace(1)* %jasper, i32 0, i32 0
  store i32 0, i32 addrspace(1)* %k0, align 16
  %k1 = getelementptr inbounds %struct.asdf, %struct.asdf addrspace(1)* %jasper, i32 0, i32 1
  store i32 1, i32 addrspace(1)* %k1, align 4
  %k2 = getelementptr inbounds %struct.asdf, %struct.asdf addrspace(1)* %jasper, i32 0, i32 2
  store i32 2, i32 addrspace(1)* %k2, align 8
  %k3 = getelementptr inbounds %struct.asdf, %struct.asdf addrspace(1)* %jasper, i32 0, i32 3
  store i32 3, i32 addrspace(1)* %k3, align 4
  ret void
}
```