### PR TITLE
Cluster pod kernel args: Inline the inner function by default

### DIFF
--- a/test/ImageBuiltins/read_imagef_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float2.cl
@@ -98,27 +98,70 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 }
 
 // In a second round, check -cluster-pod-kernel-args
-// CLUSTER: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
-// CLUSTER: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CLUSTER: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
-// CLUSTER: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 2D 0 0 0 1 Unknown
-// CLUSTER: [[vec2:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
-// CLUSTER: [[st_vec2:%[a-zA-Z0-9_]+]] = OpTypeStruct [[vec2]]
-// CLUSTER: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CLUSTER: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
-// CLUSTER: [[void_fn:%[a-zA-Z0-9_]+]] = OpTypeFunction [[void]]
-// CLUSTER: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
 
-// CLUSTER: [[fooinner:%[a-zA-A0-9]+]] = OpFunction [[void]] None
+// CLUSTER: ; SPIR-V
+// CLUSTER: ; Version: 1.0
+// CLUSTER: ; Generator: Codeplay; 0
+// CLUSTER: ; Bound: 36
+// CLUSTER: ; Schema: 0
+// CLUSTER: OpCapability Shader
+// CLUSTER: OpCapability VariablePointers
+// CLUSTER: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CLUSTER: OpExtension "SPV_KHR_variable_pointers"
+// CLUSTER: OpMemoryModel Logical GLSL450
+// CLUSTER: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"
+// CLUSTER: OpExecutionMode [[_26]] LocalSize 1 1 1
+// CLUSTER: OpSource OpenCL_C 120
+// CLUSTER: OpDecorate [[__runtimearr_v4float:%[a-zA-Z0-9_]+]] ArrayStride 16
+// CLUSTER: OpMemberDecorate [[__struct_9:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpDecorate [[__struct_9]] Block
+// CLUSTER: OpMemberDecorate [[__struct_12:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpMemberDecorate [[__struct_13:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpDecorate [[__struct_13]] Block
+// CLUSTER: OpDecorate [[_22:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_22]] Binding 0
+// CLUSTER: OpDecorate [[_23:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_23]] Binding 1
+// CLUSTER: OpDecorate [[_23]] NonWritable
+// CLUSTER: OpDecorate [[_24:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_24]] Binding 2
+// CLUSTER: OpDecorate [[_25:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_25]] Binding 3
+// CLUSTER: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CLUSTER: [[_2:%[a-zA-Z0-9_]+]] = OpTypeSampler
+// CLUSTER: [[__ptr_UniformConstant_2:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[_2]]
+// CLUSTER: [[_4:%[a-zA-Z0-9_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CLUSTER: [[__ptr_UniformConstant_4:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[_4]]
+// CLUSTER: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CLUSTER: [[__ptr_StorageBuffer_v4float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CLUSTER: [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CLUSTER: [[__struct_9]] = OpTypeStruct [[__runtimearr_v4float]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_9:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CLUSTER: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
+// CLUSTER: [[__struct_12]] = OpTypeStruct [[_v2float]]
+// CLUSTER: [[__struct_13]] = OpTypeStruct [[__struct_12]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_13:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_12:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CLUSTER: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CLUSTER: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CLUSTER: [[_18:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CLUSTER: [[_19:%[a-zA-Z0-9_]+]] = OpTypeSampledImage [[_4]]
+// CLUSTER: [[_float_0:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0
+// CLUSTER: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CLUSTER: [[_22]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CLUSTER: [[_23]] = OpVariable [[__ptr_UniformConstant_4]] UniformConstant
+// CLUSTER: [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CLUSTER: [[_25]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
+// CLUSTER: [[_26]] = OpFunction [[_void]] None [[_18]]
+// CLUSTER: [[_27:%[a-zA-Z0-9_]+]] = OpLabel
+// CLUSTER: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_2]] [[_22]]
+// CLUSTER: [[_29:%[a-zA-Z0-9_]+]] = OpLoad [[_4]] [[_23]]
+// CLUSTER: [[_30:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_24]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_31:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_12]] [[_25]] [[_uint_0]]
+// CLUSTER: [[_32:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_12]] [[_31]]
+// CLUSTER: [[_33:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]] [[_32]] 0
+// CLUSTER: [[_34:%[a-zA-Z0-9_]+]] = OpSampledImage [[_19]] [[_29]] [[_28]]
+// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_34]] [[_33]] Lod [[_float_0]]
+// CLUSTER: OpStore [[_30]] [[_35]]
+// CLUSTER: OpReturn
 // CLUSTER: OpFunctionEnd
-
-// Match the wrapper kernel function.
-// CLUSTER: [[foo]] = OpFunction [[void]] None [[void_fn]]
-// CLUSTER-NEXT: OpLabel
-// CLUSTER-NEXT: [[sampler_val:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]]
-// CLUSTER-NEXT: [[image_val:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
-// CLUSTER-NEXT: [[a_base:%[a-zA-Z0-9_]+]] = OpAccessChain %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} [[zero]] [[zero]]
-// CLUSTER-NEXT: [[podargs_base:%[a-zA-Z0-9_]+]] = OpAccessChain %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} [[zero]]
-// CLUSTER-NEXT: [[podargs:%[a-zA-Z0-9_]+]] = OpLoad [[st_vec2]] [[podargs_base]]
-// CLUSTER-NEXT: [[vec2_val:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[vec2]] [[podargs]] 0
-// CLUSTER-NEXT: = OpFunctionCall [[void]] [[fooinner]] [[sampler_val]] [[image_val]] [[vec2_val]] [[a_base]]

--- a/test/cluster_pod_args_globals_scalars.cl
+++ b/test/cluster_pod_args_globals_scalars.cl
@@ -5,85 +5,62 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 37
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
-// CHECK: OpExecutionMode [[foo]] LocalSize 1 1 1
-
-// CHECK: OpDecorate [[rtarr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpMemberDecorate [[st_rtarr_float:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[st_rtarr_float:%[a-zA-Z0-9_]+]] Block
-
-// CHECK: OpMemberDecorate [[podty:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[podty]] 1 Offset 4
-// CHECK: OpMemberDecorate [[st_podty:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[st_podty]] Block
-
-// CHECK: OpDecorate [[A:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[A]] Binding 0
-// CHECK: OpDecorate [[B:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[B]] Binding 1
-// CHECK: OpDecorate [[podargs:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[podargs]] Binding 2
-// CHECK: OpDecorate [[sbptr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-
-// CHECK: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK: [[sbptr_float]] = OpTypePointer StorageBuffer [[float]]
-// CHECK: [[rtarr_float]] = OpTypeRuntimeArray [[float]]
-// CHECK: [[st_rtarr_float]] = OpTypeStruct [[rtarr_float]]
-// CHECK: [[sbptr_st_rtarr_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_rtarr_float]]
-
-// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CHECK: [[podty]] = OpTypeStruct [[float]] [[uint]]
-// CHECK: [[st_podty]] = OpTypeStruct [[podty]]
-// CHECK: [[sbptr_st_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_podty]]
-// CHECK: [[sbptr_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[podty]]
-
-// CHECK: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
-// CHECK: [[void_fn:%[a-zA-Z0-9_]+]] = OpTypeFunction [[void]]
-// CHECK: [[fooinner_fnty:%[a-zA-Z0-9_]+]] = OpTypeFunction [[void]] [[sbptr_float]] [[float]] [[sbptr_float]] [[uint]]
-// CHECK: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
-
-// CHECK: [[A]] = OpVariable [[sbptr_st_rtarr_float]] StorageBuffer
-// CHECK: [[B]] = OpVariable [[sbptr_st_rtarr_float]] StorageBuffer
-// CHECK: [[podargs]] = OpVariable [[sbptr_st_podty]] StorageBuffer
-
-// The inner function.
-// CHECK: [[fooinner:%[a-zA-Z0-9_]+]] = OpFunction [[void]] None [[fooinner_fnty]]
-// CHECK: [[Aparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[sbptr_float]]
-// CHECK: [[fparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[float]]
-// CHECK: [[Bparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[sbptr_float]]
-// CHECK: [[nparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[uint]]
-// CHECK: [[fooinner_entry:%[a-zA-Z0-9_]+]] = OpLabel
-// CHECK: [[B_n:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[sbptr_float]] [[Bparm]] [[nparm]]
-// CHECK: [[Bval:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[B_n]]
-// CHECK: [[sum:%[a-zA-Z0-9_]+]] = OpFAdd [[float]] [[Bval]] [[fparm]]
-// CHECK: [[A_n:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[sbptr_float]] [[Aparm]] [[nparm]]
-// CHECK: OpStore [[A_n]] [[sum]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
-
-// The wrapper kernel.
-// CHECK: [[foo]] = OpFunction [[void]] None [[void_fn]]
-// CHECK: [[foo_entry:%[a-zA-Z0-9_]+]] = OpLabel
-// CHECK: [[A_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[sbptr_float]] [[A]] [[zero]] [[zero]]
-// CHECK: [[B_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[sbptr_float]] [[B]] [[zero]] [[zero]]
-// CHECK: [[podargs_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[sbptr_podty]] [[podargs]] [[zero]]
-// CHECK: [[podargs_val:%[a-zA-Z0-9_]+]] = OpLoad [[podty]] [[podargs_base]]
-// CHECK: [[f:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] [[podargs_val]] 0
-// CHECK: [[n:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uint]] [[podargs_val]] 1
-// CHECK: [[callresult:%[a-zA-Z0-9_]+]] = OpFunctionCall [[void]] [[fooinner]] [[A_base]] [[f]] [[B_base]] [[n]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
-
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, float f, global float* B, uint n)
 {
   A[n] = B[n] + f;
 }
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 27
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_17:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpExecutionMode [[_17]] LocalSize 1 1 1
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_7:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_7]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_8:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_8]] Block
+// CHECK: OpDecorate [[_14:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_14]] Binding 0
+// CHECK: OpDecorate [[_15:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_15]] Binding 1
+// CHECK: OpDecorate [[_16:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_16]] Binding 2
+// CHECK: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__struct_7]] = OpTypeStruct [[_float]] [[_uint]]
+// CHECK: [[__struct_8]] = OpTypeStruct [[__struct_7]]
+// CHECK: [[__ptr_StorageBuffer__struct_8:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
+// CHECK: [[__ptr_StorageBuffer__struct_7:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_12:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_14]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_15]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_16]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
+// CHECK: [[_17]] = OpFunction [[_void]] None [[_12]]
+// CHECK: [[_18:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_19:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_7]] [[_16]] [[_uint_0]]
+// CHECK: [[_20:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_7]] [[_19]]
+// CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_20]] 0
+// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_20]] 1
+// CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_15]] [[_uint_0]] [[_22]]
+// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_23]]
+// CHECK: [[_25:%[a-zA-Z0-9_]+]] = OpFAdd [[_float]] [[_21]] [[_24]]
+// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_14]] [[_uint_0]] [[_22]]
+// CHECK: OpStore [[_26]] [[_25]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/cluster_pod_args_locals_scalars.cl
+++ b/test/cluster_pod_args_locals_scalars.cl
@@ -5,95 +5,69 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 41
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
-// CHECK: OpExecutionMode [[foo]] LocalSize 1 1 1
-
-// CHECK: OpDecorate [[rtarr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpMemberDecorate [[st_rtarr_float:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[st_rtarr_float]] Block
-
-// CHECK: OpDecorate [[rtarr_float_0:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpMemberDecorate [[st_rtarr_float_0:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[st_rtarr_float_0]] Block
-
-// CHECK: OpMemberDecorate [[podty:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[podty]] 1 Offset 4
-// CHECK: OpMemberDecorate [[st_podty:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[st_podty]] Block
-
-// CHECK: OpDecorate [[A:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[A]] Binding 0
-// CHECK: OpDecorate [[B:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[B]] Binding 1
-// CHECK: OpDecorate [[podargs:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[podargs]] Binding 2
-// CHECK: OpDecorate [[sbptr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-
-// CHECK: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK: [[sbptr_float]] = OpTypePointer StorageBuffer [[float]]
-// CHECK: [[rtarr_float]] = OpTypeRuntimeArray [[float]]
-
-// CHECK: [[st_rtarr_float]] = OpTypeStruct [[rtarr_float]]
-// CHECK: [[sbptr_st_rtarr_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_rtarr_float]]
-
-// CHECK: [[wgptr_float:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[float]]
-// CHECK: [[rtarr_float_0]] = OpTypeRuntimeArray [[float]]
-// CHECK: [[st_rtarr_float_0]] = OpTypeStruct [[rtarr_float_0]]
-// CHECK: [[wgptr_st_rtarr_float_0:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[st_rtarr_float_0]]
-
-// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CHECK: [[podty]] = OpTypeStruct [[float]] [[uint]]
-// CHECK: [[st_podty]] = OpTypeStruct [[podty]]
-// CHECK: [[sbptr_st_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_podty]]
-// CHECK: [[sbptr_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[podty]]
-
-// CHECK: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
-// CHECK: [[void_fn:%[a-zA-Z0-9_]+]] = OpTypeFunction [[void]]
-// CHECK: [[fooinner_fnty:%[a-zA-Z0-9_]+]] = OpTypeFunction [[void]] [[sbptr_float]] [[float]] [[wgptr_float]] [[uint]]
-// CHECK: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
-
-// CHECK: [[A:%[a-zA-Z0-9_]+]] = OpVariable [[sbptr_st_rtarr_float]] StorageBuffer
-// CHECK: [[B:%[a-zA-Z0-9_]+]] = OpVariable [[wgptr_st_rtarr_float_0]] Workgroup
-// CHECK: [[podargs:%[a-zA-Z0-9_]+]] = OpVariable [[sbptr_st_podty]] StorageBuffer
-
-// The inner function.
-// CHECK: [[fooinner:%[a-zA-Z0-9_]+]] = OpFunction [[void]] None [[fooinner_fnty]]
-// CHECK: [[Aparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[sbptr_float]]
-// CHECK: [[fparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[float]]
-// CHECK: [[Bparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[wgptr_float]]
-// CHECK: [[nparm:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[uint]]
-// CHECK: [[fooinner_entry:%[a-zA-Z0-9_]+]] = OpLabel
-// CHECK: [[B_n:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[wgptr_float]] [[Bparm]] [[nparm]]
-// CHECK: [[Bval:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[B_n]]
-// CHECK: [[sum:%[a-zA-Z0-9_]+]] = OpFAdd [[float]] [[Bval]] [[fparm]]
-// CHECK: [[A_n:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[sbptr_float]] [[Aparm]] [[nparm]]
-// CHECK: OpStore [[A_n]] [[sum]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
-
-// The wrapper kernel.
-// CHECK: [[foo]] = OpFunction [[void]] None [[void_fn]]
-// CHECK: [[foo_entry:%[a-zA-Z0-9_]+]] = OpLabel
-// CHECK: [[A_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[sbptr_float]] [[A]] [[zero]] [[zero]]
-// CHECK: [[B_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[wgptr_float]] [[B]] [[zero]] [[zero]]
-// CHECK: [[podargs_base:%[a-zA-Z0-9_]+]] = OpAccessChain [[sbptr_podty]] [[podargs]] [[zero]]
-// CHECK: [[podargs_val:%[a-zA-Z0-9_]+]] = OpLoad [[podty]] [[podargs_base]]
-// CHECK: [[f:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] [[podargs_val]] 0
-// CHECK: [[n:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uint]] [[podargs_val]] 1
-// CHECK: [[callresult:%[a-zA-Z0-9_]+]] = OpFunctionCall [[void]] [[fooinner]] [[A_base]] [[f]] [[B_base]] [[n]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
-
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, float f, local float* B, uint n)
 {
   A[n] = B[n] + f;
 }
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 31
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_21:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpExecutionMode [[_21]] LocalSize 1 1 1
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpDecorate [[__runtimearr_float_0:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_8:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_8]] Block
+// CHECK: OpMemberDecorate [[__struct_11:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_11]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_12:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_12]] Block
+// CHECK: OpDecorate [[_18:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_18]] Binding 0
+// CHECK: OpDecorate [[_19:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 1
+// CHECK: OpDecorate [[_20:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_20]] Binding 2
+// CHECK: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__ptr_Workgroup_float:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[_float]]
+// CHECK: [[__runtimearr_float_0]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_8]] = OpTypeStruct [[__runtimearr_float_0]]
+// CHECK: [[__ptr_Workgroup__struct_8:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[__struct_8]]
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__struct_11]] = OpTypeStruct [[_float]] [[_uint]]
+// CHECK: [[__struct_12]] = OpTypeStruct [[__struct_11]]
+// CHECK: [[__ptr_StorageBuffer__struct_12:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CHECK: [[__ptr_StorageBuffer__struct_11:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_16:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_19]] = OpVariable [[__ptr_Workgroup__struct_8]] Workgroup
+// CHECK: [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
+// CHECK: [[_21]] = OpFunction [[_void]] None [[_16]]
+// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_11]] [[_20]] [[_uint_0]]
+// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_11]] [[_23]]
+// CHECK: [[_25:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_24]] 0
+// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_24]] 1
+// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_19]] [[_uint_0]] [[_26]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_27]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFAdd [[_float]] [[_25]] [[_28]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_18]] [[_uint_0]] [[_26]]
+// CHECK: OpStore [[_30]] [[_29]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd


### PR DESCRIPTION
Use option -no-inline-pod to avoid inlining, i.e. get the old
behaviour.  But it's deprecated.