### PR TITLE
Reuse kernel arg variables for StorageBuffers

### DIFF
--- a/lib/\
+++ b/lib/\
@@ -339,10 +339,6 @@ private:
   // This mimics what Glslang does, and that's what drivers are used to.
   uint32_t WorkgroupSizeValueID;
   uint32_t WorkgroupSizeVarID;
-
-  // What module-scope variables already have had their binding information
-  // emitted?
-  DenseSet<Value*> GVarWithEmittedBindingInfo;
 };
 
 char SPIRVProducerPass::ID;
@@ -823,11 +819,9 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
       // Make a new variable if there was none for this type, or if we can
       // reuse one created for a different function but not yet reused for
       // the current function, *and* the binding is the same.
-      // Always make a new variable if we're forcing distinct descriptor sets.
       GlobalVariable *GV = nullptr;
       auto which_set = GVarsForType.find(GVTy);
-      if (IsSamplerType || IsImageType || which_set == GVarsForType.end() ||
-          distinct_kernel_descriptor_sets) {
+      if (IsSamplerType || IsImageType || which_set == GVarsForType.end()) {
         GV = make_gvar();
       } else {
         auto &set = which_set->second;
@@ -2695,12 +2689,6 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
                          << ",offset,0,argKind,"
                          << clspv::GetArgKindForType(Arg.getType()) << "\n";
       }
-
-      if (GVarWithEmittedBindingInfo.count(NewGV)) {
-        BindingIdx++;
-        continue;
-      }
-      GVarWithEmittedBindingInfo.insert(NewGV);
 
       // Ops[0] = Target ID
       // Ops[1] = Decoration (DescriptorSet)

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -5,70 +5,6 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 45
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpEntryPoint GLCompute %[[BAR_ID:[a-zA-Z0-9_]*]] "bar"
-// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 42 13 5
-// CHECK: OpExecutionMode %[[BAR_ID]] LocalSize 42 13 5
-// CHECK: OpDecorate %[[UINT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 4
-// CHECK: OpMemberDecorate %[[UINT_ARG0_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[UINT_ARG0_STRUCT_TYPE_ID]] Block
-// CHECK: OpDecorate %[[FOO_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[FOO_ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID]] Binding 0
-// CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK: %[[UINT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_TYPE_ID]]
-// CHECK: %[[UINT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[UINT_TYPE_ID]]
-// CHECK: %[[UINT_ARG0_STRUCT_TYPE_ID]] = OpTypeStruct %[[UINT_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK: %[[UINT_ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_ARG0_STRUCT_TYPE_ID]]
-// CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK: %[[UINT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
-// CHECK: %[[UINT3_PRIVATE_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer Private %[[UINT3_TYPE_ID]]
-// CHECK: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
-// CHECK: %[[CONSTANT_13_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 13
-// CHECK: %[[CONSTANT_5_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 5
-// CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
-// CHECK: %[[CONSTANT_3_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 3
-// CHECK: %[[BUILTIN_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT3_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_13_ID]] %[[CONSTANT_5_ID]]
-// CHECK: %[[BUILTIN_VAR_FOR_FOO_ID:[a-zA-Z0-9_]*]] = OpVariable %[[UINT3_PRIVATE_POINTER_TYPE_ID]] Private %[[BUILTIN_ID]]
-// CHECK: %[[FOO_ARG0_ID]] = OpVariable %[[UINT_ARG0_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[BAR_ARG0_ID]] = OpVariable %[[UINT_ARG0_POINTER_TYPE_ID]] StorageBuffer
-
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL1_ID:[a-zA-Z0-9_]*]] = OpLabel
-
-// CHECK: %[[ACCESS_CHAIN0_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: [[hack0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp0:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack0]] 0
-// CHECK: OpStore %[[ACCESS_CHAIN0_ID]] [[foo_comp0]]
-
-// CHECK: [[hack1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp1:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack1]] 1
-// CHECK: %[[ACCESS_CHAIN1_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_1_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN1_ID]] [[foo_comp1]]
-
-// CHECK: [[hack2:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp2:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack2]] 2
-// CHECK: %[[ACCESS_CHAIN2_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_2_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN2_ID]] [[foo_comp2]]
-
-// CHECK: %[[ACCESS_CHAIN3_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_3_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN3_ID]] %[[CONSTANT_1_ID]]
-
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel __attribute__((reqd_work_group_size(42, 13, 5))) foo(global uint* a)
 {
@@ -78,30 +14,6 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) foo(global uint* a)
   a[3] = get_local_size(3);
 }
 
-// CHECK: %[[BAR_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL1_ID:[a-zA-Z0-9_]*]] = OpLabel
-
-// CHECK: %[[BAR_ACCESS_CHAIN0_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: [[hack3:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp0:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack3]] 0
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN0_ID]] [[bar_comp0]]
-
-// CHECK: [[hack4:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp1:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack4]] 1
-// CHECK: %[[BAR_ACCESS_CHAIN1_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_1_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN1_ID]] [[bar_comp1]]
-
-// CHECK: [[hack5:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp2:%[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack5]] 2
-// CHECK: %[[BAR_ACCESS_CHAIN2_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_2_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN2_ID]] [[bar_comp2]]
-
-// CHECK: %[[BAR_ACCESS_CHAIN3_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_3_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN3_ID]] %[[CONSTANT_1_ID]]
-
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
-
 void kernel __attribute__((reqd_work_group_size(42, 13, 5))) bar(global uint* a)
 {
   a[0] = get_local_size(0);
@@ -109,3 +21,82 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) bar(global uint* a)
   a[2] = get_local_size(2);
   a[3] = get_local_size(3);
 }
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 44
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_20:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpEntryPoint GLCompute [[_32:%[a-zA-Z0-9_]+]] "bar"
+// CHECK: OpExecutionMode [[_20]] LocalSize 42 13 5
+// CHECK: OpExecutionMode [[_32]] LocalSize 42 13 5
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[__runtimearr_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_19:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 0
+// CHECK: OpDecorate [[_19]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 0
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_7:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_42:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 42
+// CHECK: [[_uint_13:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 13
+// CHECK: [[_uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 5
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_42]] [[_uint_13]] [[_uint_5]]
+// CHECK: [[_18:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_20]] = OpFunction [[_void]] None [[_7]]
+// CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_23]] 0
+// CHECK: OpStore [[_22]] [[_24]]
+// CHECK: [[_25:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_25]] 1
+// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_27]] [[_26]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_28]] 2
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_30]] [[_29]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_31]] [[_uint_1]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+// CHECK: [[_32]] = OpFunction [[_void]] None [[_7]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_35:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_36:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_35]] 0
+// CHECK: OpStore [[_34]] [[_36]]
+// CHECK: [[_37:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_38:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_37]] 1
+// CHECK: [[_39:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_39]] [[_38]]
+// CHECK: [[_40:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_41:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_40]] 2
+// CHECK: [[_42:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_42]] [[_41]]
+// CHECK: [[_43:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_43]] [[_uint_1]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -5,72 +5,6 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 45
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpEntryPoint GLCompute %[[BAR_ID:[a-zA-Z0-9_]*]] "bar"
-// CHECK: OpDecorate %[[BUILTIN_X_ID:[a-zA-Z0-9_]*]] SpecId 0
-// CHECK: OpDecorate %[[BUILTIN_Y_ID:[a-zA-Z0-9_]*]] SpecId 1
-// CHECK: OpDecorate %[[BUILTIN_Z_ID:[a-zA-Z0-9_]*]] SpecId 2
-// CHECK: OpDecorate %[[UINT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 4
-// CHECK: OpMemberDecorate %[[UINT_ARG0_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[UINT_ARG0_STRUCT_TYPE_ID]] Block
-// CHECK: OpDecorate %[[BUILTIN_ID:[a-zA-Z0-9_]*]] BuiltIn WorkgroupSize
-// CHECK: OpDecorate %[[FOO_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[FOO_ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[BAR_ARG0_ID]] Binding 0
-// CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK: %[[UINT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_TYPE_ID]]
-// CHECK: %[[UINT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[UINT_TYPE_ID]]
-// CHECK: %[[UINT_ARG0_STRUCT_TYPE_ID]] = OpTypeStruct %[[UINT_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK: %[[UINT_ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT_ARG0_STRUCT_TYPE_ID]]
-// CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK: %[[UINT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
-// CHECK: %[[UINT3_PRIVATE_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer Private %[[UINT3_TYPE_ID]]
-// CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
-// CHECK: %[[CONSTANT_3_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 3
-// CHECK: %[[BUILTIN_X_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[BUILTIN_Y_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[BUILTIN_Z_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[BUILTIN_ID]] = OpSpecConstantComposite %[[UINT3_TYPE_ID]] %[[BUILTIN_X_ID]] %[[BUILTIN_Y_ID]] %[[BUILTIN_Z_ID]]
-// CHECK: %[[BUILTIN_VAR_ID:[a-zA-Z0-9_]*]] = OpVariable %[[UINT3_PRIVATE_POINTER_TYPE_ID]] Private %[[BUILTIN_ID]]
-// CHECK: %[[FOO_ARG0_ID]] = OpVariable %[[UINT_ARG0_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[BAR_ARG0_ID]] = OpVariable %[[UINT_ARG0_POINTER_TYPE_ID]] StorageBuffer
-
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL1_ID:[a-zA-Z0-9_]*]] = OpLabel
-
-// CHECK: %[[ACCESS_CHAIN0_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: [[hack0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp0:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack0]] 0
-// CHECK: OpStore %[[ACCESS_CHAIN0_ID]] [[foo_comp0]]
-
-// CHECK: [[hack1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp1:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack1]] 1
-// CHECK: %[[ACCESS_CHAIN1_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_1_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN1_ID]] [[foo_comp1]]
-
-// CHECK: [[hack2:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[foo_comp2:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack2]] 2
-// CHECK: %[[ACCESS_CHAIN2_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_2_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN2_ID]] [[foo_comp2]]
-
-// CHECK: %[[ACCESS_CHAIN3_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[FOO_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_3_ID]]
-// CHECK: OpStore %[[ACCESS_CHAIN3_ID]] %[[CONSTANT_1_ID]]
-
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel foo(global uint* a)
 {
@@ -80,29 +14,6 @@ void kernel foo(global uint* a)
   a[3] = get_local_size(3);
 }
 
-// CHECK: %[[BAR_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL1_ID:[a-zA-Z0-9_]*]] = OpLabel
-
-// CHECK: %[[BAR_ACCESS_CHAIN0_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: [[hack3:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp0:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack3]] 0
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN0_ID]] [[bar_comp0]]
-
-// CHECK: [[hack4:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp1:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack4]] 1
-// CHECK: %[[BAR_ACCESS_CHAIN1_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_1_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN1_ID]] [[bar_comp1]]
-
-// CHECK: [[hack5:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %[[UINT3_TYPE_ID]] %[[BUILTIN_ID]] %[[BUILTIN_ID]]
-// CHECK: [[bar_comp2:%[a-zA-Z0-9_]+]] = OpCompositeExtract %[[UINT_TYPE_ID]] [[hack5]] 2
-// CHECK: %[[BAR_ACCESS_CHAIN2_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_2_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN2_ID]] [[bar_comp2]]
-
-// CHECK: %[[BAR_ACCESS_CHAIN3_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[BAR_ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_3_ID]]
-// CHECK: OpStore %[[BAR_ACCESS_CHAIN3_ID]] %[[CONSTANT_1_ID]]
-
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel bar(global uint* a)
 {
@@ -111,3 +22,83 @@ void kernel bar(global uint* a)
   a[2] = get_local_size(2);
   a[3] = get_local_size(3);
 }
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 44
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_20:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpEntryPoint GLCompute [[_32:%[a-zA-Z0-9_]+]] "bar"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_14:%[a-zA-Z0-9_]+]] SpecId 0
+// CHECK: OpDecorate [[_15:%[a-zA-Z0-9_]+]] SpecId 1
+// CHECK: OpDecorate [[_16:%[a-zA-Z0-9_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_19:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 0
+// CHECK: OpDecorate [[_19]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 0
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_7:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_14]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_15]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_14]] [[_15]] [[_16]]
+// CHECK: [[_18:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_20]] = OpFunction [[_void]] None [[_7]]
+// CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_23]] 0
+// CHECK: OpStore [[_22]] [[_24]]
+// CHECK: [[_25:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_25]] 1
+// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_27]] [[_26]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_28]] 2
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_30]] [[_29]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_31]] [[_uint_1]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+// CHECK: [[_32]] = OpFunction [[_void]] None [[_7]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_35:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_36:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_35]] 0
+// CHECK: OpStore [[_34]] [[_36]]
+// CHECK: [[_37:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_38:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_37]] 1
+// CHECK: [[_39:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_39]] [[_38]]
+// CHECK: [[_40:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
+// CHECK: [[_41:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_40]] 2
+// CHECK: [[_42:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_42]] [[_41]]
+// CHECK: [[_43:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_43]] [[_uint_1]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/descriptor_set_default.cl
+++ b/test/descriptor_set_default.cl
@@ -9,8 +9,8 @@
 // CHECK: OpDecorate [[foo_pod:%[a-zA-Z0-9]+]] DescriptorSet 0
 // CHECK: OpDecorate [[foo_pod]] Binding 1
 
-// CHECK: OpDecorate [[B:%[a-zA-Z0-9]+]] DescriptorSet 0
-// CHECK: OpDecorate [[B]] Binding 0
+// B reuses the variable for A, and hence its bindings.
+
 // CHECK: OpDecorate [[bar_pod:%[a-zA-Z0-9]+]] DescriptorSet 0
 // CHECK: OpDecorate [[bar_pod]] Binding 1
 

--- a/test/reuse_kernel_arg_var.cl
+++ b/test/reuse_kernel_arg_var.cl
@@ -1,0 +1,262 @@
+// Reuse the module-scope variables we make for kernel arguments, to
+// the maximum extent possible.
+
+kernel void foo(global float* A, global float *B, global int* C, global float* D, float f, float g) {
+  *A = f + g;
+  *B = 0.0f;
+  *C = 12;
+  *D = f;
+}
+
+kernel void bar(global float* R, global float* S, global float* T, float x, float y) {
+  *R = x * y;
+  *S = x / y;
+  *T = x;
+}
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
+// RUN: FileCheck -check-prefix=CLUSTER %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck -check-prefix=CLUSTER %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// In the default case:
+//   R should reuse the var for A
+//   S should reuse the var for B
+//   T cannot reuse the var for C because of type mismatch
+//   T cannot reuse the var for D because of binding mismatch
+//   x cannot reuse a var because of binding mismatch
+//   y should reuse the var for f
+
+// In the cluster-pod-kernel-args case:
+//   C should reuse the var for A
+//   D should reuse the var for B
+//   T cannot reuse the var for C because of type mismatch
+//   T cannot reuse the var for D because of binding mismatch
+//   {x, y} cannot reuse the var for {f, g} because of binding mismatch
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 55
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_33:%[a-zA-Z0-9_]+]] "foo"
+// CHECK: OpEntryPoint GLCompute [[_44:%[a-zA-Z0-9_]+]] "bar"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_20:%[a-zA-Z0-9_]+]] SpecId 0
+// CHECK: OpDecorate [[_21:%[a-zA-Z0-9_]+]] SpecId 1
+// CHECK: OpDecorate [[_22:%[a-zA-Z0-9_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpDecorate [[__runtimearr_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_9:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_9]] Block
+// CHECK: OpMemberDecorate [[__struct_11:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_11]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_25:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_25]] Binding 0
+// CHECK: OpDecorate [[_26:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_26]] Binding 1
+// CHECK: OpDecorate [[_27:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_27]] Binding 2
+// CHECK: OpDecorate [[_28:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_28]] Binding 3
+// CHECK: OpDecorate [[_29:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_29]] Binding 4
+// CHECK: OpDecorate [[_30:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_30]] Binding 5
+// CHECK: OpDecorate [[_31:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_31]] Binding 2
+// CHECK: OpDecorate [[_32:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_32]] Binding 3
+// CHECK: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_9]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_9:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CHECK: [[__struct_11]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_11:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
+// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK: [[_14:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_float_0:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0
+// CHECK: [[_uint_12:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 12
+// CHECK: [[_20]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_21]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_20]] [[_21]] [[_22]]
+// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_25]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_26]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_29]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
+// CHECK: [[_30]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
+// CHECK: [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_32]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
+// CHECK: [[_33]] = OpFunction [[_void]] None [[_14]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_35:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_25]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_36:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_37:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_27]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_38:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_39:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]]
+// CHECK: [[_40:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_39]]
+// CHECK: [[_41:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_30]] [[_uint_0]]
+// CHECK: [[_42:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_41]]
+// CHECK: [[_43:%[a-zA-Z0-9_]+]] = OpFAdd [[_float]] [[_40]] [[_42]]
+// CHECK: OpStore [[_35]] [[_43]]
+// CHECK: OpStore [[_36]] [[_float_0]]
+// CHECK: OpStore [[_37]] [[_uint_12]]
+// CHECK: OpStore [[_38]] [[_40]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+// CHECK: [[_44]] = OpFunction [[_void]] None [[_14]]
+// CHECK: [[_45:%[a-zA-Z0-9_]+]] = OpLabel
+// CHECK: [[_46:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_25]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_47:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_48:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_31]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_49:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_32]] [[_uint_0]]
+// CHECK: [[_50:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_49]]
+// CHECK: [[_51:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]]
+// CHECK: [[_52:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_51]]
+// CHECK: [[_53:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_50]] [[_52]]
+// CHECK: OpStore [[_46]] [[_53]]
+// CHECK: [[_54:%[a-zA-Z0-9_]+]] = OpFDiv [[_float]] [[_50]] [[_52]]
+// CHECK: OpStore [[_47]] [[_54]]
+// CHECK: OpStore [[_48]] [[_50]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+
+
+// CLUSTER: ; SPIR-V
+// CLUSTER: ; Version: 1.0
+// CLUSTER: ; Generator: Codeplay; 0
+// CLUSTER: ; Bound: 56
+// CLUSTER: ; Schema: 0
+// CLUSTER: OpCapability Shader
+// CLUSTER: OpCapability VariablePointers
+// CLUSTER: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CLUSTER: OpExtension "SPV_KHR_variable_pointers"
+// CLUSTER: OpMemoryModel Logical GLSL450
+// CLUSTER: OpEntryPoint GLCompute [[_34:%[a-zA-Z0-9_]+]] "foo"
+// CLUSTER: OpEntryPoint GLCompute [[_45:%[a-zA-Z0-9_]+]] "bar"
+// CLUSTER: OpSource OpenCL_C 120
+// CLUSTER: OpDecorate [[_22:%[a-zA-Z0-9_]+]] SpecId 0
+// CLUSTER: OpDecorate [[_23:%[a-zA-Z0-9_]+]] SpecId 1
+// CLUSTER: OpDecorate [[_24:%[a-zA-Z0-9_]+]] SpecId 2
+// CLUSTER: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CLUSTER: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpDecorate [[__struct_4]] Block
+// CLUSTER: OpDecorate [[__runtimearr_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CLUSTER: OpMemberDecorate [[__struct_9:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpDecorate [[__struct_9]] Block
+// CLUSTER: OpMemberDecorate [[__struct_11:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpMemberDecorate [[__struct_11]] 1 Offset 4
+// CLUSTER: OpMemberDecorate [[__struct_12:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CLUSTER: OpDecorate [[__struct_12]] Block
+// CLUSTER: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CLUSTER: OpDecorate [[_27:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_27]] Binding 0
+// CLUSTER: OpDecorate [[_28:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_28]] Binding 1
+// CLUSTER: OpDecorate [[_29:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_29]] Binding 2
+// CLUSTER: OpDecorate [[_30:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_30]] Binding 3
+// CLUSTER: OpDecorate [[_31:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_31]] Binding 4
+// CLUSTER: OpDecorate [[_32:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_32]] Binding 2
+// CLUSTER: OpDecorate [[_33:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CLUSTER: OpDecorate [[_33]] Binding 3
+// CLUSTER: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CLUSTER: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CLUSTER: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CLUSTER: [[__struct_4]] = OpTypeStruct [[__runtimearr_float]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CLUSTER: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CLUSTER: [[__ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CLUSTER: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CLUSTER: [[__struct_9]] = OpTypeStruct [[__runtimearr_uint]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_9:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CLUSTER: [[__struct_11]] = OpTypeStruct [[_float]] [[_float]]
+// CLUSTER: [[__struct_12]] = OpTypeStruct [[__struct_11]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_12:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CLUSTER: [[__ptr_StorageBuffer__struct_11:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
+// CLUSTER: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CLUSTER: [[_16:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
+// CLUSTER: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
+// CLUSTER: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
+// CLUSTER: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CLUSTER: [[_float_0:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0
+// CLUSTER: [[_uint_12:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 12
+// CLUSTER: [[_22]] = OpSpecConstant [[_uint]] 1
+// CLUSTER: [[_23]] = OpSpecConstant [[_uint]] 1
+// CLUSTER: [[_24]] = OpSpecConstant [[_uint]] 1
+// CLUSTER: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_22]] [[_23]] [[_24]]
+// CLUSTER: [[_26:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CLUSTER: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CLUSTER: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CLUSTER: [[_29]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CLUSTER: [[_30]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CLUSTER: [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
+// CLUSTER: [[_32]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CLUSTER: [[_33]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
+// CLUSTER: [[_34]] = OpFunction [[_void]] None [[_16]]
+// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpLabel
+// CLUSTER: [[_36:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_37:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_38:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_29]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_39:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_30]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_40:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_11]] [[_31]] [[_uint_0]]
+// CLUSTER: [[_41:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_11]] [[_40]]
+// CLUSTER: [[_42:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_41]] 0
+// CLUSTER: [[_43:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_41]] 1
+// CLUSTER: [[_44:%[a-zA-Z0-9_]+]] = OpFAdd [[_float]] [[_42]] [[_43]]
+// CLUSTER: OpStore [[_36]] [[_44]]
+// CLUSTER: OpStore [[_37]] [[_float_0]]
+// CLUSTER: OpStore [[_38]] [[_uint_12]]
+// CLUSTER: OpStore [[_39]] [[_42]]
+// CLUSTER: OpReturn
+// CLUSTER: OpFunctionEnd
+// CLUSTER: [[_45]] = OpFunction [[_void]] None [[_16]]
+// CLUSTER: [[_46:%[a-zA-Z0-9_]+]] = OpLabel
+// CLUSTER: [[_47:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_48:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_49:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_32]] [[_uint_0]] [[_uint_0]]
+// CLUSTER: [[_50:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_11]] [[_33]] [[_uint_0]]
+// CLUSTER: [[_51:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_11]] [[_50]]
+// CLUSTER: [[_52:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_51]] 0
+// CLUSTER: [[_53:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_51]] 1
+// CLUSTER: [[_54:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_52]] [[_53]]
+// CLUSTER: OpStore [[_47]] [[_54]]
+// CLUSTER: [[_55:%[a-zA-Z0-9_]+]] = OpFDiv [[_float]] [[_52]] [[_53]]
+// CLUSTER: OpStore [[_48]] [[_55]]
+// CLUSTER: OpStore [[_49]] [[_52]]
+// CLUSTER: OpReturn
+// CLUSTER: OpFunctionEnd


### PR DESCRIPTION
We can reuse such a variable if:
 - it is of the same type
 - it was last used for a different function

Fixes https://github.com/google/clspv/issues/103