### PR TITLE
Remove the cland dependency from the check-spirv target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,6 @@ add_custom_target(check-spirv
     --path ${LLVM_BINARY_DIR}/bin
     --path ${SPIRV_TOOLS_BINARY_DIR}/
     --path ${CLSPV_BINARY_DIR}/bin
-  DEPENDS clang clspv spirv-as spirv-dis spirv-val FileCheck not
+  DEPENDS clspv spirv-as spirv-dis spirv-val FileCheck not
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
This avoids building the whole clang target hierarchy. It trims
the number of additional targets to build from ~1400 to ~70.