### PR TITLE
Rewrite inserts

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -255,7 +255,12 @@ llvm::ModulePass *createUnhideConstantLoadsPass();
 /// @return An LLVM module pass.
 ///
 /// Rewrite a chain of insertvalue instructions that cover all
-/// members of a vector of struct, so that it becomes a single
-/// new builtin corresponding to an OpCompositeConstruct.
+/// members of a struct, so that it becomes a single new builtin
+/// corresponding to an OpCompositeConstruct.  Only affects 
+/// insertvalue instructions with a single index operand.
+///
+/// Also, if -hack-inserts option is used, then also rewrite
+/// chains of insertvalue instructions that only cover some but
+/// not all of a struct.
 llvm::ModulePass *createRewriteInsertsPass();
 }

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -250,4 +250,12 @@ llvm::ModulePass *createHideConstantLoadsPass();
 ///
 /// Unwrap the result of a load from __constant address space.
 llvm::ModulePass *createUnhideConstantLoadsPass();
+
+/// Rewrite insertvalue instructions.
+/// @return An LLVM module pass.
+///
+/// Rewrite a chain of insertvalue instructions that cover all
+/// members of a vector of struct, so that it becomes a single
+/// new builtin corresponding to an OpCompositeConstruct.
+llvm::ModulePass *createRewriteInsertsPass();
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplaceLLVMIntrinsicsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplaceOpenCLBuiltinPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplacePointerBitcastPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/RewriteInsertsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SimplifyPointerBitcastPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatSelectCondition.cpp

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -1,0 +1,181 @@
+// Copyright 2017 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/raw_ostream.h>
+
+using namespace llvm;
+using std::string;
+
+#define DEBUG_TYPE "collapsecompositeinserts"
+
+
+namespace {
+
+const char* kCompositeConstructFunctionPrefix = "clspv.composite_construct.";
+
+class RewriteInsertsPass : public ModulePass {
+ public:
+  static char ID;
+  RewriteInsertsPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+
+ private:
+   using InsertionVector = SmallVector<InsertValueInst *, 4>;
+
+   // If this is the tail of a chain of InsertValueInst instructions
+   // that covers the entire composite, then return a small vector
+   // containing the insertion instructions, in member order.
+   // Otherwise returns nullptr.  Only handle insertions into structs,
+   // not into arrays.
+   InsertionVector *CompleteInsertionChain(InsertValueInst *iv) {
+     if (iv->getNumIndices() == 1) {
+       if (auto *structTy = dyn_cast<StructType>(iv->getType())) {
+         auto numElems = structTy->getNumElements();
+         // Only handle single-index insertions.
+         unsigned index = iv->getIndices()[0];
+         if (index + 1u != numElems) {
+           // Not the last in the chain.
+           return nullptr;
+         }
+         InsertionVector candidates(numElems, nullptr);
+         for (unsigned i = index;
+              iv->getNumIndices() == 1 && i == iv->getIndices()[0]; --i) {
+           // iv inserts the i'th member
+           candidates[i] = iv;
+
+           if (i == 0) {
+             // We're done!
+             return new InsertionVector(candidates);
+           }
+
+           if (InsertValueInst *agg =
+                   dyn_cast<InsertValueInst>(iv->getAggregateOperand())) {
+             iv = agg;
+           } else {
+             // The chain is broken.
+             break;
+           }
+         }
+       }
+     }
+     return nullptr;
+   }
+
+   // Return the name for the wrap function for the given type.
+   string &WrapFunctionNameForType(Type *type) {
+     auto where = function_for_type_.find(type);
+     if (where == function_for_type_.end()) {
+       // Insert it.
+       auto &result = function_for_type_[type] =
+           string(kCompositeConstructFunctionPrefix) +
+           std::to_string(function_for_type_.size());
+       return result;
+     } else {
+       return where->second;
+     }
+   }
+
+   // Maps a loaded type to the name of the wrap function for that type.
+   DenseMap<Type *, string> function_for_type_;
+};
+} // namespace
+
+char RewriteInsertsPass::ID = 0;
+static RegisterPass<RewriteInsertsPass>
+    X("RewriteInserts",
+      "Rewrite chains of insertvalue to as composite-construction");
+
+namespace clspv {
+llvm::ModulePass *createRewriteInsertsPass() {
+  return new RewriteInsertsPass();
+}
+} // namespace clspv
+
+bool RewriteInsertsPass::runOnModule(Module &M) {
+  bool Changed = false;
+
+  SmallVector<InsertionVector *, 16> WorkList;
+  for (Function &F : M) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (InsertValueInst *iv = dyn_cast<InsertValueInst>(&I)) {
+          if (InsertionVector *insertions = CompleteInsertionChain(iv)) {
+            WorkList.push_back(insertions);
+          }
+        }
+      }
+    }
+  }
+
+  if (WorkList.size() == 0) {
+    return Changed;
+  }
+
+  for (InsertionVector *insertions : WorkList) {
+    Changed = true;
+
+    // Gather the member values and types.
+    SmallVector<Value*, 4> values;
+    SmallVector<Type*, 4> types;
+    for (InsertValueInst* insert : *insertions) {
+      Value* value = insert->getInsertedValueOperand();
+      values.push_back(value);
+      types.push_back(value->getType());
+    }
+
+    Type* resultTy = insertions->back()->getType();
+
+    // Get or create the composite construct function definition.
+    const string& fn_name = WrapFunctionNameForType(resultTy);
+    Function* fn = M.getFunction(fn_name);
+    if (!fn) {
+      // Make the function.
+      FunctionType* fnTy = FunctionType::get(resultTy, types, false);
+      auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
+      fn = cast<Function>(fn_constant);
+      fn->addFnAttr(Attribute::ReadOnly);
+      fn->addFnAttr(Attribute::ReadNone);
+    }
+
+    // Replace the chain.
+    auto call = CallInst::Create(fn, values);
+    call->insertAfter(insertions->back());
+    insertions->back()->replaceAllUsesWith(call);
+
+    // Remove the insertions if we can.  Go from the tail back to
+    // the head, since the tail uses the previous insertion, etc.
+    for (auto iter = insertions->rbegin(), end = insertions->rend();
+         iter != end; ++iter) {
+      InsertValueInst *insertion = *iter;
+      if (!insertion->hasNUsesOrMore(1)) {
+        insertion->eraseFromParent();
+      }
+    }
+
+    delete insertions;
+  }
+
+  return Changed;
+}

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 #include <string>
+#include <utility>
 
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/UniqueVector.h>
 #include <llvm/IR/Attributes.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -27,8 +31,14 @@
 using namespace llvm;
 using std::string;
 
-#define DEBUG_TYPE "collapsecompositeinserts"
+#define DEBUG_TYPE "rewriteinserts"
 
+static llvm::cl::opt<bool> hack_inserts(
+    "hack-inserts", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Avoid all single-index OpCompositInsert instructions "
+        "into struct types by using complete composite construction and "
+        "extractions"));
 
 namespace {
 
@@ -43,6 +53,55 @@ class RewriteInsertsPass : public ModulePass {
 
  private:
    using InsertionVector = SmallVector<InsertValueInst *, 4>;
+
+   // Replaces chains of insertions that cover the entire value.
+   // Such a change always reduces the number of instructions, so
+   // we always perform these.  Returns true if the module was modified.
+   bool ReplaceCompleteInsertionChains(Module &M);
+
+   // Replaces all InsertValue instructions, even if they aren't part
+   // of a complete insetion chain.  Returns true if the module was modified.
+   bool ReplacePartialInsertions(Module &M);
+
+   // Load |values| and |chain| with the members of the struct value produced
+   // by a chain of InsertValue instructions ending with |iv|, and following
+   // the aggregate operand.  Return the start of the chain: the aggregate
+   // value which is not an InsertValue instruction, or an InsertValue
+   // instruction which inserts a component that is replaced later in the
+   // chain.  The |values| vector will match the order of struct members and
+   // is initialized to all nullptr members.  The |chain| vector will list
+   // the chain of InsertValue instructions, listed in the order we discover
+   // them, e.g. begining with |iv|.
+   Value *LoadValuesEndingWithInsertion(InsertValueInst *iv,
+                                        std::vector<Value *> *values,
+                                        InsertionVector *chain) {
+     auto *structTy = dyn_cast<StructType>(iv->getType());
+     assert(structTy);
+     const auto numElems = structTy->getNumElements();
+
+     // Walk backward from the tail to an instruction we don't want to
+     // replace.
+     Value *frontier = iv;
+     while (auto *insertion = dyn_cast<InsertValueInst>(frontier)) {
+       chain->push_back(insertion);
+       // Only handle single-index insertions.
+       if (insertion->getNumIndices() == 1) {
+         // Try to replace this one.
+
+         unsigned index = insertion->getIndices()[0];
+         assert(index < numElems);
+         if ((*values)[index] != nullptr) {
+           // We already have a value for this slot.  Stop now.
+           break;
+         }
+         (*values)[index] = insertion->getInsertedValueOperand();
+         frontier = insertion->getAggregateOperand();
+       } else {
+         break;
+       }
+     }
+     return frontier;
+   }
 
    // If this is the tail of a chain of InsertValueInst instructions
    // that covers the entire composite, then return a small vector
@@ -83,6 +142,7 @@ class RewriteInsertsPass : public ModulePass {
      return nullptr;
    }
 
+
    // Return the name for the wrap function for the given type.
    string &WrapFunctionNameForType(Type *type) {
      auto where = function_for_type_.find(type);
@@ -95,6 +155,23 @@ class RewriteInsertsPass : public ModulePass {
      } else {
        return where->second;
      }
+   }
+
+   // Get or create the composite construct function definition.
+   Function *GetConstructFunction(Module &M, StructType *constructed_type) {
+     // Get or create the composite construct function definition.
+     const string &fn_name = WrapFunctionNameForType(constructed_type);
+     Function *fn = M.getFunction(fn_name);
+     if (!fn) {
+       // Make the function.
+       FunctionType *fnTy = FunctionType::get(
+           constructed_type, constructed_type->elements(), false);
+       auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
+       fn = cast<Function>(fn_constant);
+       fn->addFnAttr(Attribute::ReadOnly);
+       fn->addFnAttr(Attribute::ReadNone);
+     }
+     return fn;
    }
 
    // Maps a loaded type to the name of the wrap function for that type.
@@ -114,6 +191,16 @@ llvm::ModulePass *createRewriteInsertsPass() {
 } // namespace clspv
 
 bool RewriteInsertsPass::runOnModule(Module &M) {
+  bool Changed = ReplaceCompleteInsertionChains(M);
+
+  if (hack_inserts) {
+    Changed |= ReplacePartialInsertions(M);
+  }
+
+  return Changed;
+}
+
+bool RewriteInsertsPass::ReplaceCompleteInsertionChains(Module &M) {
   bool Changed = false;
 
   SmallVector<InsertionVector *, 16> WorkList;
@@ -145,19 +232,8 @@ bool RewriteInsertsPass::runOnModule(Module &M) {
       types.push_back(value->getType());
     }
 
-    Type* resultTy = insertions->back()->getType();
-
-    // Get or create the composite construct function definition.
-    const string& fn_name = WrapFunctionNameForType(resultTy);
-    Function* fn = M.getFunction(fn_name);
-    if (!fn) {
-      // Make the function.
-      FunctionType* fnTy = FunctionType::get(resultTy, types, false);
-      auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
-      fn = cast<Function>(fn_constant);
-      fn->addFnAttr(Attribute::ReadOnly);
-      fn->addFnAttr(Attribute::ReadNone);
-    }
+    StructType *resultTy = cast<StructType>(insertions->back()->getType());
+    Function *fn = GetConstructFunction(M, resultTy);
 
     // Replace the chain.
     auto call = CallInst::Create(fn, values);
@@ -175,6 +251,122 @@ bool RewriteInsertsPass::runOnModule(Module &M) {
     }
 
     delete insertions;
+  }
+
+  return Changed;
+}
+
+bool RewriteInsertsPass::ReplacePartialInsertions(Module &M) {
+  bool Changed = false;
+
+  // First find candidates.  Collect all InsertValue instructions
+  // into struct type, but track their interdependencies.  To minimize
+  // the number of new instructions, generate a construction for each
+  // tail of an insertion chain.
+
+  UniqueVector<InsertValueInst *> insertions;
+  for (Function &F : M) {
+    for (BasicBlock &BB : F) {
+      for (Instruction &I : BB) {
+        if (InsertValueInst *iv = dyn_cast<InsertValueInst>(&I)) {
+          if (iv->getType()->isStructTy()) {
+            insertions.insert(iv);
+          }
+        }
+      }
+    }
+  }
+
+  // Now count how many times each InsertValue is used by another InsertValue.
+  // The |num_uses| vector is indexed by the unique id that |insertions|
+  // assigns to it.
+  std::vector<unsigned> num_uses(insertions.size() + 1);
+  // Count from the user's perspective.
+  for (InsertValueInst *insertion : insertions) {
+    if (auto *agg =
+            dyn_cast<InsertValueInst>(insertion->getAggregateOperand())) {
+      ++(num_uses[insertions.idFor(agg)]);
+    }
+  }
+
+  // Proceed in rounds.  Each round rewrites any chains ending with an
+  // insertion that is not used by another insertion.
+
+  // Get the first list of insertion tails.
+  InsertionVector WorkList;
+  for (InsertValueInst *insertion : insertions) {
+    if (num_uses[insertions.idFor(insertion)] == 0) {
+      WorkList.push_back(insertion);
+    }
+  }
+
+  // This records insertions in the order they should be removed.
+  // In this list, an insertion preceds any insertions it uses.
+  // (This is post-dominance order.)
+  InsertionVector ordered_candidates_for_removal;
+
+  // Proceed in rounds.
+  while (WorkList.size()) {
+    Changed = true;
+
+    // Record the list of tails for the next round.
+    InsertionVector NextRoundWorkList;
+
+    for (InsertValueInst *insertion : WorkList) {
+      // Rewrite |insertion|.
+
+      StructType *resultTy = cast<StructType>(insertion->getType());
+
+      const unsigned num_members = resultTy->getNumElements();
+      std::vector<Value*> members(num_members, nullptr);
+      InsertionVector chain;
+      // Gather the member values.  Walk backward from the insertion.
+      Value *base = LoadValuesEndingWithInsertion(insertion, &members, &chain);
+
+      // Populate remaining entries in |values| by extracting elements
+      // from |base|.  Only make a new extractvalue instruction if we can't
+      // make a constant or undef.  New instructions are inserted before
+      // the insertion we plan to remove.
+      for (unsigned i = 0; i < num_members; ++i) {
+        if (!members[i]) {
+          Type *memberTy = resultTy->getTypeAtIndex(i);
+          if (isa<UndefValue>(base)) {
+            members[i] = UndefValue::get(memberTy);
+          } else if (const auto *caz = dyn_cast<ConstantAggregateZero>(base)) {
+            members[i] = caz->getElementValue(i);
+          } else if (const auto *ca = dyn_cast<ConstantAggregate>(base)) {
+            members[i] = ca->getOperand(i);
+          } else {
+            members[i] = ExtractValueInst::Create(base, {i}, "", insertion);
+          }
+        }
+      }
+
+      // Create the call.  It's dominated by any extractions we've just
+      // created.
+      Function *construct_fn = GetConstructFunction(M, resultTy);
+      auto *call = CallInst::Create(construct_fn, members, "", insertion);
+
+      // Disconnect this insertion.  We'll remove it later.
+      insertion->replaceAllUsesWith(call);
+
+      // Trace backward through the chain, removing uses and deleting where
+      // we can.  Stop at the first element that has a remaining use.
+      for (auto* chainElem : chain) {
+        if (chainElem->hasNUsesOrMore(1)) {
+          unsigned &use_count = num_uses[insertions.idFor(chainElem)];
+          assert(use_count > 0);
+          --use_count;
+          if (use_count == 0) {
+            NextRoundWorkList.push_back(chainElem);
+          }
+          break;
+        } else {
+          chainElem->eraseFromParent();
+        }
+      }
+    }
+    WorkList = std::move(NextRoundWorkList);
   }
 
   return Changed;

--- a/test/Structs/insert_value_issue_14.cl
+++ b/test/Structs/insert_value_issue_14.cl
@@ -2,6 +2,7 @@
 // An undef for an aggregate was not being generated because
 // of an early return in constant generation when we generate
 // the <4 x i8> constant.
+// UPDATE: Rewriting constant composites makes the OpUndef struct go away.
 
 // Also test https://github.com/google/clspv/issues/36 for
 // generation of the <4 x i8> constant including an undef component.
@@ -30,7 +31,10 @@ kernel void foo(global S* A, global uchar4* B, int n) {
 
 // CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
 // CHECK: [[struct:%[_a-zA-Z0-9]+]] = OpTypeStruct [[uint]] [[uint]] [[uint]]
+
 // With undef mapping to 0 byte, (undef,1,2,3) maps to 66051.
 // CHECK: [[theconst:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 66051
-// CHECK: [[undef_struct:%[_a-zA-Z0-9]+]] = OpUndef [[struct]]
+
+// no longer checked: [[undef_struct:%[_a-zA-Z0-9]+]] = OpUndef [[struct]]
+
 // CHECK: OpBitwiseAnd [[uint]] [[theconst]] {{%[_a-zA-Z0-9]+}}

--- a/test/composite_construct.cl
+++ b/test/composite_construct.cl
@@ -1,0 +1,113 @@
+// Test rewriting complete sets of insertions into a struct.
+// The rewrite is done by default.
+
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(float a) {
+  S result;
+  // This entire chain of insertions is replaced by a single 
+  // OpCompositeConstruct
+  result.a = a;
+  result.c = a+2.0f;
+  result.b = a+1.0f;
+  result.d = a+3.0f;
+  return result;
+}
+
+kernel void foo(global S* data, float f) {
+  *data = boo(f);
+}
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 49
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_22:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_23:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_27]] Binding 0
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_28]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_float_3:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 3
+// CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_22]] [[_23]] [[_24]]
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_float]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_2]]
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_1]]
+// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_3]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_30]] [[_33]] [[_32]] [[_34]]
+// CHECK: OpReturnValue [[_35]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_36]] = OpFunction [[_void]] None [[_11]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_29]] [[_39]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 0
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 1
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 2
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 3
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_45]] [[_41]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_46]] [[_42]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_47]] [[_43]]
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_48]] [[_44]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/composite_construct_varying.cl
+++ b/test/composite_construct_varying.cl
@@ -1,0 +1,113 @@
+// RUN: clspv %s -S -o %t.spvasm -hack-inserts
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -hack-inserts
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(S in) {
+  in.a = 0.0f;
+  in.c = 2.0f;
+  in.b = 1.0f;
+  in.d = 3.0f;
+  return in;
+}
+
+
+kernel void foo(global S* data, float f) {
+  data[0] = boo(data[1]);
+}
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 54
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_25:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_26:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_29:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_29]] Binding 0
+// CHECK: OpDecorate [[_30:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_30]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[__struct_2]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_float_3:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 3
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_2]] [[_float_0]] [[_float_1]] [[_float_2]] [[_float_3]]
+// CHECK: [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_25]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_26]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_24]] [[_25]] [[_26]]
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_29]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_30]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__struct_2]]
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: OpReturnValue [[_23]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_34]] = OpFunction [[_void]] None [[_10]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_1]] [[_uint_0]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_36]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_1]] [[_uint_1]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_1]] [[_uint_2]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_40]]
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_1]] [[_uint_3]]
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_42]]
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_37]] [[_39]] [[_41]] [[_43]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_31]] [[_44]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 0
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 1
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 2
+// CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 3
+// CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_50]] [[_46]]
+// CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_51]] [[_47]]
+// CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_52]] [[_48]]
+// CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_53]] [[_49]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/hack_inserts_constant.cl
+++ b/test/hack_inserts_constant.cl
@@ -1,0 +1,113 @@
+// Test the -hack-inserts option.
+// Check that we can remove partial chains of insertvalue
+// to avoid OpCompositeInsert entirely.
+
+// RUN: clspv %s -S -o %t.spvasm -hack-inserts
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -hack-inserts
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(float a) {
+  S result = {10.0f, 11.0f, 12.0f, 13.0f};
+  result.c = a+2.0f;
+  result.b = a+1.0f;
+  // Skip filling in result.a, result.d
+  return result;
+}
+
+
+kernel void foo(global S* data, float f) {
+  *data = boo(f);
+}
+
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 49
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_23:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_25:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_28]] Binding 0
+// CHECK: OpDecorate [[_29:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_29]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_float_10:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 10
+// CHECK: [[_float_13:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 13
+// CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_25]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_23]] [[_24]] [[_25]]
+// CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_29]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_float]]
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_31]] [[_float_2]]
+// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_31]] [[_float_1]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_float_10]] [[_34]] [[_33]] [[_float_13]]
+// CHECK: OpReturnValue [[_35]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_36]] = OpFunction [[_void]] None [[_11]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_30]] [[_39]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 0
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 1
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 2
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_40]] 3
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_45]] [[_41]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_46]] [[_42]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_47]] [[_43]]
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_48]] [[_44]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/hack_inserts_undef.cl
+++ b/test/hack_inserts_undef.cl
@@ -1,0 +1,111 @@
+// Test the -hack-inserts option.
+// Check that we can remove partial chains of insertvalue
+// to avoid OpCompositeInsert entirely.
+
+// RUN: clspv %s -S -o %t.spvasm -hack-inserts
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -hack-inserts
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(float a) {
+  S result;
+  result.a = a;
+  result.c = a+2.0f;
+  result.b = a+1.0f;
+  // Skip filling in result.d
+  return result;
+}
+
+
+kernel void foo(global S* data, float f) {
+  *data = boo(f);
+}
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 48
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_22:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_23:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_27]] Binding 0
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_28]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpUndef [[_float]]
+// CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_22]] [[_23]] [[_24]]
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_float]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_2]]
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_1]]
+// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_30]] [[_33]] [[_32]] [[_21]]
+// CHECK: OpReturnValue [[_34]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_35]] = OpFunction [[_void]] None [[_11]]
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_37]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_29]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 0
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 1
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 2
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 3
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_44]] [[_40]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_45]] [[_41]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_46]] [[_42]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_47]] [[_43]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/hack_inserts_varying.cl
+++ b/test/hack_inserts_varying.cl
@@ -1,0 +1,116 @@
+// Test the -hack-inserts option.
+// Check that we can remove partial chains of insertvalue
+// to avoid OpCompositeInsert entirely.
+
+// RUN: clspv %s -S -o %t.spvasm -hack-inserts
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -hack-inserts
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(S in) {
+  in.c = 2.0f;
+  in.b = 1.0f;
+  return in;
+}
+
+
+kernel void foo(global S* data, float f) {
+  data[0] = boo(data[1]);
+}
+
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 54
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_21:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_22:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_23:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_26:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_26]] Binding 0
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_27]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[__struct_2]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_21]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_21]] [[_22]] [[_23]]
+// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_26]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__struct_2]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_29]] 3
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_29]] 0
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_32]] [[_float_1]] [[_float_2]] [[_31]]
+// CHECK: OpReturnValue [[_33]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_34]] = OpFunction [[_void]] None [[_10]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_1]] [[_uint_0]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_36]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_1]] [[_uint_1]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_1]] [[_uint_2]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_40]]
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_1]] [[_uint_3]]
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_42]]
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_37]] [[_39]] [[_41]] [[_43]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_28]] [[_44]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 0
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 1
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 2
+// CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_45]] 3
+// CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_50]] [[_46]]
+// CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_51]] [[_47]]
+// CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_52]] [[_48]]
+// CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_53]] [[_49]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/hack_inserts_zero.cl
+++ b/test/hack_inserts_zero.cl
@@ -1,0 +1,111 @@
+// Test the -hack-inserts option.
+// Check that we can remove partial chains of insertvalue
+// to avoid OpCompositeInsert entirely.
+
+// RUN: clspv %s -S -o %t.spvasm -hack-inserts
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -hack-inserts
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+typedef struct { float a, b, c, d; } S;
+
+S boo(float a) {
+  S result = {0.0f}; // Produces const-aggregate-zero
+  result.a = a;
+  result.c = a+2.0f;
+  result.b = a+1.0f;
+  // Skip filling in result.d
+  return result;
+}
+
+
+kernel void foo(global S* data, float f) {
+  *data = boo(f);
+}
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 48
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_22:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_23:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_2]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_2]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_2]] 3 Offset 12
+// CHECK: OpDecorate [[__runtimearr__struct_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_27]] Binding 0
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_28]] Binding 1
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_2]] = OpTypeStruct [[_float]] [[_float]] [[_float]] [[_float]]
+// CHECK: [[__runtimearr__struct_2]] = OpTypeRuntimeArray [[__struct_2]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr__struct_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[__struct_2]] [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_22]] [[_23]] [[_24]]
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_27]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_28]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpFunction [[__struct_2]] Const [[_12]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_float]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_2]]
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_30]] [[_float_1]]
+// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[__struct_2]] [[_30]] [[_33]] [[_32]] [[_float_0]]
+// CHECK: OpReturnValue [[_34]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_35]] = OpFunction [[_void]] None [[_11]]
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_28]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_37]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpFunctionCall [[__struct_2]] [[_29]] [[_38]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 0
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 1
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 2
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_39]] 3
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_0]]
+// CHECK: OpStore [[_44]] [[_40]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_1]]
+// CHECK: OpStore [[_45]] [[_41]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_2]]
+// CHECK: OpStore [[_46]] [[_42]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_27]] [[_uint_0]] [[_uint_0]] [[_uint_3]]
+// CHECK: OpStore [[_47]] [[_43]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -743,6 +743,7 @@ int main(const int argc, const char *const argv[]) {
   pm.add(clspv::createReplacePointerBitcastPass());
   pm.add(clspv::createUndoTranslateSamplerFoldPass());
   pm.add(clspv::createSplatSelectConditionPass());
+  pm.add(clspv::createRewriteInsertsPass());
   pm.add(clspv::createSPIRVProducerPass(
       binaryStream, descriptor_map_out, SamplerMapEntries,
       OutputAssembly.getValue(), OutputFormat == "c"));


### PR DESCRIPTION
Rewrite insertions into structs to avoid OpCompositeInsert

By default: replace chains of OpCompositeInsert that cover all members of the struct.  Only rewrites cases where where the insertion replaces a top-level member of the struct (i.e. only has one indexing operand).  It also only recognizes the pattern where the members are inserted in index order.  This is turned on by default since this always makes the code smaller.

With option -hack-inserts, generalize rewrite *partial* chains, i.e. those that don't cover the entire struct.  This is a little more aggressive in that members don't have to be inserted in order.