### PR TITLE
Cluster constants

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -71,7 +71,8 @@ following way:
 - If the argument to the kernel is a constant or global pointer type, the
   matching Vulkan descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`.
 - If the argument to the kernel is a plain-old-data type, the matching Vulkan
-  descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`.
+  descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER` by default.
+  If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
 
 Note: If `-cluster-pod-kernel-args` is used, then all plain-old-data kernel
 arguments are collected into a single structure to be passed in to the compute
@@ -175,7 +176,8 @@ For kernel arguments, the fields are:
 - `argKind`
 - a string describing the kind of argument, one of:
   - `buffer` - OpenCL buffer
-  - `pod` - Plain Old Data, e.g. a scalar, vector, or structure
+  - `pod` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a storage buffer.
+  - `pod_ubo` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a uniform buffer.
   - `ro_image` - Read-only image
   - `wo_image` - Write-only image
   - `sampler` - Sampler
@@ -200,6 +202,16 @@ Then `mydescriptormap` will contain:
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,buffer
     kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,pod
 
+#### Sending in plain-old-data kernel arguments in uniform buffers
+
+Normally plan-old-data arguments are passed into the kernel via a storage buffer.
+Use option `-pod-ubo` to pass these parameters in via a uniform buffer.  These can
+be faster to read in the shader.
+
+When option `-pod-ubo` is used, the descriptor map list the `argKind` of a plain-old-data
+argument as `pod_ubo` rather than the default of `pod`.
+
+TODO(dneto):  A push-constant might even be faster, but space is very limited.
 
 #### Clustering plain-old-data kernel arguments to save descriptors
 

--- a/include/clspv/AddressSpace.h
+++ b/include/clspv/AddressSpace.h
@@ -20,7 +20,8 @@ enum Type {
   Constant,          // OpenCL constant memory.
   Local,             // OpenCL local memory.
   Input,             // Vulkan input memory.
-  UniformConstant,   // Vulkan uniform memory.
+  Uniform,           // Vulkan uniform memory.
+  UniformConstant,   // Vulkan uniform constant memory.
   ModuleScopePrivate // Vulkan private memory.
 };
 }

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -31,6 +31,11 @@ bool HackInserts();
 // TODO(dneto): Remove this eventually when drivers are fixed.
 bool HackUndef();
 
+// Returns true if module-scope constants are to be collected into a single
+// storage buffer.  The binding for that buffer, and its intialization data
+// are given in the descriptor map file.
+bool ModuleConstantsInStorageBuffer();
+
 // Returns true if POD kernel arguments should be passed in via uniform buffers.
 bool PodArgsInUniformBuffer();
 

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -1,0 +1,42 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace clspv {
+namespace Option {
+
+// Returns true if code generation can use SPV_KHR_16bit_storage.
+bool F16BitStorage();
+
+// Returns true if each kernel must use its own descriptor set for all arguments.
+bool DistinctKernelDescriptorSets();
+
+// Returns true if code generation should avoid single-index OpCompositeInsert
+// instructions into struct types.  Use complete OpCompositeConstruct instead.
+// TODO(dneto): Remove this eventually when drivers are fixed.
+bool HackInserts();
+
+// Returns true if numeric scalar and vector Undef values should be replaced
+// with OpConstantNull.  Works around a driver bug.
+// TODO(dneto): Remove this eventually when drivers are fixed.
+bool HackUndef();
+
+// Returns true if POD kernel arguments should be passed in via uniform buffers.
+bool PodArgsInUniformBuffer();
+
+// Returns true if SPIR-V IDs for functions should be emitted to stderr during
+// code generation.
+bool ShowIDs();
+
+} // namespace Option
+} // namespace clspv

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -221,6 +221,14 @@ llvm::ModulePass *createUndoTranslateSamplerFoldPass();
 /// malformed types" that would make this pass redundant.
 llvm::ModulePass *createUndoTruncatedSwitchConditionPass();
 
+/// Cluster module-scope __constant variables.
+/// @return An LLVM module pass.
+///
+/// Replace all live module-scope __constant variables by a single such variable
+/// of struct type.  Assumes none of the constants contain pointers.  Eliminates
+/// any dead module-scope __constant variables.
+llvm::ModulePass *createClusterModuleScopeConstantVars();
+
 /// Cluster plain-old-data kernel arguments into a single struct argument.
 /// @return An LLVM module pass.
 ///

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ClusterConstants.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/OpenCLInlinerPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Option.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SPIRVProducerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ReorderBasicBlocksPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplaceLLVMIntrinsicsPass.cpp

--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -1,0 +1,143 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Cluster module-scope __constant variables.  But only if option
+// ModuleScopeConstantsInUniformBuffer is true.
+
+#include <cassert>
+
+#include <llvm/ADT/UniqueVector.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include "clspv/AddressSpace.h"
+#include "clspv/Option.h"
+
+#include "ArgKind.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "clusterconstants"
+
+namespace {
+struct ClusterModuleScopeConstantVars : public ModulePass {
+  static char ID;
+  ClusterModuleScopeConstantVars() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+};
+
+} // namespace
+
+char ClusterModuleScopeConstantVars::ID = 0;
+static RegisterPass<ClusterModuleScopeConstantVars>
+    X("ClusterModuleScopeConstantVars",
+      "Cluster module-scope __constant variables");
+
+namespace clspv {
+llvm::ModulePass *createClusterModuleScopeConstantVars() {
+  return new ClusterModuleScopeConstantVars();
+}
+} // namespace clspv
+
+bool ClusterModuleScopeConstantVars::runOnModule(Module &M) {
+  bool Changed = false;
+  LLVMContext &Context = M.getContext();
+
+  SmallVector<GlobalVariable *, 8> global_constants;
+  UniqueVector<Constant *> initializers;
+  SmallVector<GlobalVariable *, 8> dead_global_constants;
+  for (GlobalVariable &GV : M.globals()) {
+    if (GV.hasInitializer() && GV.getType()->getPointerAddressSpace() ==
+                                   clspv::AddressSpace::Constant) {
+      // Only keep live __constant variables.
+      if (GV.use_empty()) {
+        dead_global_constants.push_back(&GV);
+      } else {
+        global_constants.push_back(&GV);
+        initializers.insert(GV.getInitializer());
+      }
+    }
+  }
+
+  for (GlobalVariable *GV : dead_global_constants) {
+    Changed = true;
+    GV->eraseFromParent();
+  }
+
+  if (global_constants.size() > 1 ||
+      (global_constants.size() == 1 &&
+       !global_constants[0]->getType()->isStructTy())) {
+
+    Changed = true;
+
+    // Make the struct type.
+    SmallVector<Type *, 8> types;
+    types.reserve(initializers.size());
+    for (Value *init : initializers) {
+      Type *ty = init->getType();
+      types.push_back(ty);
+    }
+    StructType *type = StructType::get(Context, types);
+
+    // Make the global variable.
+    SmallVector<Constant *, 8> initializers_as_vec(initializers.begin(),
+                                                   initializers.end());
+    Constant *clustered_initializer =
+        ConstantStruct::get(type, initializers_as_vec);
+    GlobalVariable *clustered_gv = new GlobalVariable(
+        M, type, true, GlobalValue::InternalLinkage, clustered_initializer,
+        "clspv.clustered_constants", nullptr,
+        GlobalValue::ThreadLocalMode::NotThreadLocal,
+        clspv::AddressSpace::Constant);
+    assert(clustered_gv);
+
+    // Replace uses of the other globals with references to the members of the
+    // clustered constant.
+    IRBuilder<> Builder(Context);
+    Value *zero = Builder.getInt32(0);
+    for (GlobalVariable *GV : global_constants) {
+      SmallVector<User *, 8> users(GV->users());
+      for (User *user : users) {
+        if (GV == user) {
+          // This is the original global variable declaration.  Skip it.
+        } else if (auto *inst = dyn_cast<Instruction>(user)) {
+          unsigned index = initializers.idFor(GV->getInitializer()) - 1;
+          Instruction *gep = GetElementPtrInst::CreateInBounds(
+              clustered_gv, {zero, Builder.getInt32(index)}, "", inst);
+          user->replaceUsesOfWith(GV, gep);
+        } else {
+          errs() << "Don't know how to handle updating user of __constant: "
+                 << *user << "\n";
+          llvm_unreachable("Unhandled case replacing a user of __constant");
+        }
+      }
+    }
+
+    // Remove the old constants.
+    for (GlobalVariable *GV : global_constants) {
+      GV->eraseFromParent();
+    }
+  }
+
+  return Changed;
+}

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -44,12 +44,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "clusterpodkernelargs"
 
-// TODO(dneto): Remove this after experimentation.
-static llvm::cl::opt<bool> no_inline_pod_fn(
-    "no-inline-pod-inner-function", llvm::cl::init(false),
-    llvm::cl::desc("DEPRECATED. Avoid inlining the inner function created by "
-                   "clustering pod kernel args"));
-
 namespace {
 struct ClusterPodKernelArgumentsPass : public ModulePass {
   static char ID;
@@ -260,11 +254,10 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
     Builder.CreateRetVoid();
   }
 
-  if (!no_inline_pod_fn) {
-    for (CallInst *C : CallList) {
-      InlineFunctionInfo info;
-      Changed |= InlineFunction(C, info);
-    }
+  // Inline the inner function.  It's cleaner to do this.
+  for (CallInst *C : CallList) {
+    InlineFunctionInfo info;
+    Changed |= InlineFunction(C, info);
   }
 
   return Changed;

--- a/lib/ConstantEmitter.cpp
+++ b/lib/ConstantEmitter.cpp
@@ -1,0 +1,143 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ConstantEmitter.h"
+
+#include <cassert>
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace llvm;
+
+namespace clspv {
+
+void ConstantEmitter::Emit(Constant *c) {
+  AlignTo(Layout.getABITypeAlignment(c->getType()));
+  if (auto i = dyn_cast<ConstantInt>(c)) {
+    EmitInt(i);
+  } else if (auto f = dyn_cast<ConstantFP>(c)) {
+    EmitFP(f);
+  } else if (auto st = dyn_cast<ConstantStruct>(c)) {
+    EmitStruct(st);
+  } else if (auto ag = dyn_cast<ConstantArray>(c)) {
+    EmitAggregate(ag);
+  } else if (auto ag = dyn_cast<ConstantVector>(c)) {
+    EmitAggregate(ag);
+  } else if (auto cds = dyn_cast<ConstantDataSequential>(c)) {
+    EmitDataSequential(cds);
+  } else if (auto ag = dyn_cast<ConstantAggregate>(c)) {
+    EmitAggregate(ag);
+  } else if (auto ag = dyn_cast<ConstantAggregateZero>(c)) {
+    EmitAggregateZero(ag);
+  } else {
+    errs() << "Don't know how to emit " << *c << " with value id "
+           << int(c->getValueID()) << " compared to " << int(Value::ConstantVectorVal)
+           << "\n";
+    llvm_unreachable("Unhandled constant");
+  }
+}
+
+void ConstantEmitter::EmitZeroes(size_t n) {
+  for (size_t i = 0; i < n; ++i) {
+    Out << "00";
+    ++Offset;
+  }
+}
+
+void ConstantEmitter::AlignTo(size_t alignment) {
+  size_t overflow = Offset % alignment;
+  if (overflow) {
+    const size_t padding = alignment - overflow;
+    EmitZeroes(padding);
+  }
+  assert(0 == (Offset % alignment));
+}
+
+void ConstantEmitter::EmitStruct(ConstantStruct *c) {
+  const StructLayout *sl = Layout.getStructLayout(c->getType());
+  AlignTo(sl->getAlignment()); // Might be redundant.
+  const size_t BaseOffset = Offset;
+  for (unsigned i = 0; i < c->getNumOperands(); ++i) {
+    EmitZeroes(sl->getElementOffset(i) - (Offset - BaseOffset));
+    Emit(c->getOperand(i));
+  }
+  EmitZeroes(sl->getSizeInBytes() - (Offset - BaseOffset));
+}
+
+void ConstantEmitter::EmitDataSequential(ConstantDataSequential *c) {
+  for (unsigned i = 0; i < c->getNumElements(); ++i) {
+    // The elements will align themselves.
+    Constant *elem = c->getElementAsConstant(i);
+    Emit(elem);
+  }
+}
+
+void ConstantEmitter::EmitAggregate(ConstantAggregate *c) {
+  for (unsigned i = 0; i < c->getNumOperands(); ++i) {
+    // The elements will align themselves.
+    Emit(c->getOperand(i));
+  }
+}
+
+void ConstantEmitter::EmitAggregateZero(ConstantAggregateZero *c) {
+  if (StructType *sty = dyn_cast<StructType>(c->getType())) {
+
+    const StructLayout *sl = Layout.getStructLayout(sty);
+    AlignTo(sl->getAlignment()); // Might be redundant.
+    const size_t BaseOffset = Offset;
+    for (unsigned i = 0; i < c->getNumElements(); ++i) {
+      EmitZeroes(sl->getElementOffset(i) - (Offset - BaseOffset));
+      Emit(c->getElementValue(i));
+    }
+    EmitZeroes(sl->getSizeInBytes() - (Offset - BaseOffset));
+
+  } else {
+    for (unsigned i = 0; i < c->getNumElements(); ++i) {
+      // The elements will align themselves.
+      Emit(c->getElementValue(i));
+    }
+  }
+}
+
+void ConstantEmitter::EmitInt(ConstantInt *c) {
+  EmitRaw(c->getBitWidth(), c->getValue().getRawData());
+}
+
+void ConstantEmitter::EmitFP(ConstantFP *c) {
+  APInt asInt = c->getValueAPF().bitcastToAPInt();
+  EmitRaw(asInt.getBitWidth(), asInt.getRawData());
+}
+
+void ConstantEmitter::EmitRaw(unsigned num_bits, const uint64_t *data) {
+  unsigned num_bytes = (num_bits + 7) / 8;
+  while (num_bytes) {
+    uint64_t word = *data++;
+    for (int i = 0; i < 8 && num_bytes; --num_bytes, ++i) {
+      EmitByte(word & 0xff);
+      word = (word >> 8);
+    }
+  }
+}
+
+void ConstantEmitter::EmitByte(size_t byte) {
+  static const char hex[] = "0123456789abcdef";
+  Out << hex[(byte & 0xf0) >> 4] << hex[byte & 0xf];
+  ++Offset;
+}
+
+} // namespace clspv

--- a/lib/ConstantEmitter.h
+++ b/lib/ConstantEmitter.h
@@ -1,0 +1,66 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_LIB_CONSTANT_EMITTER_H
+#define CLSPV_LIB_CONSTANT_EMITTER_H
+
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace clspv {
+
+// A Constant value emitter.  Emit the bytes of a constant as if it were
+// laid out in memory, converted to hexadecimal.
+class ConstantEmitter {
+public:
+  ConstantEmitter(const llvm::DataLayout &DL, llvm::raw_ostream &out)
+      : Layout(DL), Out(out), Offset(0) {}
+
+  void Emit(llvm::Constant *c);
+
+private:
+  // Emit |n| zeroes.
+  void EmitZeroes(size_t n);
+  // Emit just enough zeros to align to the given alignment.
+  void AlignTo(size_t alignment);
+
+  void EmitStruct(llvm::ConstantStruct *c);
+  // ConstantDataSequential is an LLVM optimization for smallish numeric
+  // arrays and vectors.
+  void EmitDataSequential(llvm::ConstantDataSequential *c);
+  // Aggregate covers both Array and (general) Vector
+  void EmitAggregate(llvm::ConstantAggregate *c);
+  void EmitAggregateZero(llvm::ConstantAggregateZero *c);
+  void EmitInt(llvm::ConstantInt *c);
+  void EmitFP(llvm::ConstantFP *c);
+
+  // Emit bytes representing the first num_bits bits from the
+  // array at |data|.
+  void EmitRaw(unsigned num_bits, const uint64_t* data);
+
+  // Emit a byte as a hex number to the output stream.
+  void EmitByte(size_t byte);
+
+  const llvm::DataLayout &Layout;
+  // The output stream.
+  llvm::raw_ostream &Out;
+  // Offset into the memory layout in memory.
+  size_t Offset;
+};
+
+} // namespace clspv
+
+#endif

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -56,6 +56,13 @@ llvm::cl::opt<bool>
     pod_ubo("pod-ubo", llvm::cl::init(false),
             llvm::cl::desc("POD kernel arguments are in uniform buffers"));
 
+llvm::cl::opt<bool> module_constants_in_storage_buffer(
+    "module-constants-in-storage-buffer", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Module-scope __constants are collected into a single storage buffer.  "
+        "The binding and initialization data are reported in the descriptor "
+        "map."));
+
 llvm::cl::opt<bool> show_ids("show-ids", llvm::cl::init(false),
                              llvm::cl::desc("Show SPIR-V IDs for functions"));
 
@@ -68,6 +75,7 @@ bool DistinctKernelDescriptorSets() { return distinct_kernel_descriptor_sets; }
 bool F16BitStorage() { return f16bit_storage; }
 bool HackInserts() { return hack_inserts; }
 bool HackUndef() { return hack_undef; }
+bool ModuleConstantsInStorageBuffer() { return module_constants_in_storage_buffer; }
 bool PodArgsInUniformBuffer() { return pod_ubo; }
 bool ShowIDs() { return show_ids; }
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -1,0 +1,75 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This translation unit defines all Clspv command line option variables.
+
+#include <llvm/Support/CommandLine.h>
+
+namespace {
+// By default, reuse the same descriptor set number for all arguments.
+// To turn that off, use -distinct-kernel-descriptor-sets
+llvm::cl::opt<bool> distinct_kernel_descriptor_sets(
+    "distinct-kernel-descriptor-sets", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Each kernel uses its own descriptor set for its arguments"));
+
+// TODO(dneto): As per Neil Henning suggestion, might not need this if
+// you can trace the pointer back far enough to see that it's 32-bit
+// aligned.  However, even in the vstore_half case, you'll probably get
+// better performance if you can rely on SPV_KHR_16bit_storage since in
+// the alternate case you're using a (relaxed) atomic, and therefore
+// have to write through to the cache.
+llvm::cl::opt<bool> f16bit_storage(
+    "f16bit_storage", llvm::cl::init(false),
+    llvm::cl::desc("Assume the target supports SPV_KHR_16bit_storage"));
+
+llvm::cl::opt<bool> hack_inserts(
+    "hack-inserts", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Avoid all single-index OpCompositInsert instructions "
+        "into struct types by using complete composite construction and "
+        "extractions"));
+
+// Some drivers don't like to see constant composite values constructed
+// from scalar Undef values.  Replace numeric scalar and vector Undef with
+// corresponding OpConstantNull.  We need to keep Undef for image values,
+// for example.  In the LLVM domain, image values are passed as pointer to
+// struct.
+// See https://github.com/google/clspv/issues/95
+llvm::cl::opt<bool> hack_undef(
+    "hack-undef", llvm::cl::init(false),
+    llvm::cl::desc("Use OpConstantNull instead of OpUndef for floating point, "
+                   "integer, or vectors of them"));
+
+llvm::cl::opt<bool>
+    pod_ubo("pod-ubo", llvm::cl::init(false),
+            llvm::cl::desc("POD kernel arguments are in uniform buffers"));
+
+llvm::cl::opt<bool> show_ids("show-ids", llvm::cl::init(false),
+                             llvm::cl::desc("Show SPIR-V IDs for functions"));
+
+} // namespace
+
+namespace clspv {
+namespace Option {
+
+bool DistinctKernelDescriptorSets() { return distinct_kernel_descriptor_sets; }
+bool F16BitStorage() { return f16bit_storage; }
+bool HackInserts() { return hack_inserts; }
+bool HackUndef() { return hack_undef; }
+bool PodArgsInUniformBuffer() { return pod_ubo; }
+bool ShowIDs() { return show_ids; }
+
+} // namespace Option
+} // namespace clspv

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -28,17 +28,12 @@
 #include <llvm/Pass.h>
 #include <llvm/Support/raw_ostream.h>
 
+#include "clspv/Option.h"
+
 using namespace llvm;
 using std::string;
 
 #define DEBUG_TYPE "rewriteinserts"
-
-static llvm::cl::opt<bool> hack_inserts(
-    "hack-inserts", llvm::cl::init(false),
-    llvm::cl::desc(
-        "Avoid all single-index OpCompositInsert instructions "
-        "into struct types by using complete composite construction and "
-        "extractions"));
 
 namespace {
 
@@ -193,7 +188,7 @@ llvm::ModulePass *createRewriteInsertsPass() {
 bool RewriteInsertsPass::runOnModule(Module &M) {
   bool Changed = ReplaceCompleteInsertionChains(M);
 
-  if (hack_inserts) {
+  if (clspv::Option::HackInserts()) {
     Changed |= ReplacePartialInsertions(M);
   }
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -325,6 +325,7 @@ private:
   // in these two variables.  We only ever do a vector load from it, and
   // when we see one of those, substitute just the value of the intializer.
   // This mimics what Glslang does, and that's what drivers are used to.
+  // TODO(dneto): Remove this once drivers are fixed.
   uint32_t WorkgroupSizeValueID;
   uint32_t WorkgroupSizeVarID;
 
@@ -4492,6 +4493,7 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
     // When we're loading from the special variable holding the WorkgroupSize
     // builtin value, use an OpBitWiseAnd of the value's ID rather than
     // generating a load.
+    // TODO(dneto): Remove this awful hack once drivers are fixed.
     if (PointerID == WorkgroupSizeVarID) {
       // Generate a bitwise-and of the original value with itself.
       // We should have been able to get away with just an OpCopyObject,

--- a/test/PointerAccessChains/pointer_index_in_called_function.cl
+++ b/test/PointerAccessChains/pointer_index_in_called_function.cl
@@ -8,6 +8,7 @@
 
 // CHECK: OpDecorate [[rtarr_struct:%[a-zA-Z0-9_]+]] ArrayStride 48
 // CHECK: OpDecorate [[rtarr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpDecorate [[arr_12_float:%[a-zA-Z0-9_]+]] ArrayStride 4
 // This is the one we really want:
 // CHECK: OpDecorate [[ptr_sb_float:%[a-zA-Z0-9_]+]] ArrayStride 4
 

--- a/test/PointerAccessChains/pointer_index_is_constant_1.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_1.cl
@@ -27,6 +27,7 @@
 // CHECK: OpDecorate %[[ARG0_ID]] Binding 0
 // CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+// CHECK-NEXT: OpDecorate %[[CONSTANT_ARRAY_TYPE_ID:[a-zA-Z0-9_]+]] ArrayStride 4
 // CHECK-NEXT: OpDecorate %[[FLOAT_POINTER_TYPE_ID:[a-zA-Z0-9_]+]] ArrayStride 4
 // CHECK: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK: %[[FLOAT_POINTER_TYPE_ID]] = OpTypePointer StorageBuffer %[[FLOAT_TYPE_ID]]
@@ -35,7 +36,7 @@
 // CHECK: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG0_STRUCT_TYPE_ID]]
 // CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK: %[[CONSTANT_128_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 128
-// CHECK: %[[CONSTANT_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeArray %[[FLOAT_TYPE_ID]] %[[CONSTANT_128_ID]]
+// CHECK: %[[CONSTANT_ARRAY_TYPE_ID]] = OpTypeArray %[[FLOAT_TYPE_ID]] %[[CONSTANT_128_ID]]
 // CHECK: %[[THING_TYPE_ID]] = OpTypeStruct %[[CONSTANT_ARRAY_TYPE_ID]]
 // CHECK: %[[THING_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[THING_TYPE_ID]]
 // CHECK: %[[ARG1_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[THING_TYPE_ID]]

--- a/test/ProgramScopeConstants/constant_array_with_function_call.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call.cl
@@ -23,6 +23,7 @@
 // CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[ARG0_ID]] Binding 0
 
+// CHECK: OpDecorate %[[B_TYPE_ID:[a-zA-Z0-9_]+]] ArrayStride 4
 // CHECK-NOT: OpDecorate %{{[a-zA-Z0-9_]+}} ArrayStride
 
 // CHECK: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
@@ -35,7 +36,7 @@
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 
 // CHECK: %[[CONSTANT_4_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4
-// CHECK: %[[B_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeArray %[[UINT_TYPE_ID]] %[[CONSTANT_4_ID]]
+// CHECK: %[[B_TYPE_ID]] = OpTypeArray %[[UINT_TYPE_ID]] %[[CONSTANT_4_ID]]
 // CHECK: %[[B_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer Private %[[B_TYPE_ID]]
 // CHECK: %[[UINT_PRIVATE_POINTER_TYPE_ID:[a-zA-Z0-9_]+]] = OpTypePointer Private %[[UINT_TYPE_ID]]
 

--- a/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
@@ -1,0 +1,94 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+constant uint b[4] = {42, 13, 0, 5};
+
+uint bar(constant uint* a)
+{
+  return a[get_local_id(0)];
+}
+
+void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
+{
+  *a = bar(b);
+}
+
+
+// MAP: constant,descriptorSet,0,binding,0,kind,buffer,hexbytes,2a0000000d0000000000000005000000
+// MAP-NEXT: kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 39
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo" [[_gl_LocalInvocationID:%[0-9a-zA-Z_]+]]
+// CHECK: OpExecutionMode [[_33]] LocalSize 4 1 1
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[_gl_LocalInvocationID]] BuiltIn LocalInvocationId
+// CHECK: OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_24]] Binding 0
+// CHECK: OpDecorate [[_25:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_25]] Binding 0
+// CHECK: OpDecorate [[__arr_uint_uint_4:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpDecorate [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_7:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_uint_4:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 4
+// CHECK: [[__arr_uint_uint_4]] = OpTypeArray [[_uint]] [[_uint_4]]
+// CHECK: [[__struct_10]] = OpTypeStruct [[__arr_uint_uint_4]]
+// CHECK: [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK: [[__ptr_StorageBuffer__arr_uint_uint_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__arr_uint_uint_4]]
+// CHECK: [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_uint]] [[__ptr_StorageBuffer_uint]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Input_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Input [[_v3uint]]
+// CHECK: [[__ptr_Input_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Input [[_uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
+// CHECK: [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
+// CHECK: [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_4]] [[_uint_42]] [[_uint_13]] [[_uint_0]] [[_uint_5]]
+// CHECK: [[_22:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_10]] [[_21]]
+// CHECK: [[_gl_LocalInvocationID]] = OpVariable [[__ptr_Input_v3uint]] Input
+// CHECK: [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK: [[_25]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpFunction [[_uint]] Pure [[_13]]
+// CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Input_uint]] [[_gl_LocalInvocationID]] [[_uint_0]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_29]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_uint]] [[_27]] [[_30]]
+// CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_31]]
+// CHECK: OpReturnValue [[_32]]
+// CHECK: OpFunctionEnd
+// CHECK: [[_33]] = OpFunction [[_void]] None [[_7]]
+// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_25]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__arr_uint_uint_4]] [[_24]] [[_uint_0]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_36]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_uint]] [[_26]] [[_37]]
+// CHECK: OpStore [[_35]] [[_38]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -1,0 +1,105 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  char c;
+  uint a;
+  float f;
+} Foo;
+__constant Foo ppp[3] = {{'a', 0x1234abcd, 1.0}, {'b', 0xffffffff, 1.5}, {0}};
+
+kernel void foo(global uint* A, uint i) { *A = ppp[i].a; }
+
+// MAP: constant,descriptorSet,0,binding,0,kind,buffer,hexbytes,61000000cdab34120000803f62000000ffffffff0000c03f000000000000000000000000
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod
+
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 48
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_40:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_32:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_33:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_34:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpMemberDecorate [[__struct_11:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_11]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_11]] 2 Offset 8
+// CHECK: OpMemberDecorate [[__struct_14:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_37:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_37]] Binding 0
+// CHECK: OpDecorate [[_38:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_38]] Binding 0
+// CHECK: OpDecorate [[_39:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_39]] Binding 1
+// CHECK: OpDecorate [[__arr__struct_11_uint_3:%[0-9a-zA-Z_]+]] ArrayStride 12
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_9:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__struct_11]] = OpTypeStruct [[_uint]] [[_uint]] [[_float]]
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[__arr__struct_11_uint_3]] = OpTypeArray [[__struct_11]] [[_uint_3]]
+// CHECK: [[__struct_14]] = OpTypeStruct [[__arr__struct_11_uint_3]]
+// CHECK: [[__ptr_StorageBuffer__struct_14:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_14]]
+// CHECK: [[__ptr_StorageBuffer__arr__struct_11_uint_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__arr__struct_11_uint_3]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_97:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 97
+// CHECK: [[_uint_305441741:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 305441741
+// CHECK: [[_float_1:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_11]] [[_uint_97]] [[_uint_305441741]] [[_float_1]]
+// CHECK: [[_uint_98:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 98
+// CHECK: [[_uint_4294967295:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 4294967295
+// CHECK: [[_float_1_5:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 1.5
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_11]] [[_uint_98]] [[_uint_4294967295]] [[_float_1_5]]
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpConstantNull [[__struct_11]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr__struct_11_uint_3]] [[_24]] [[_28]] [[_29]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_14]] [[_30]]
+// CHECK: [[_32]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_33]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_34]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_32]] [[_33]] [[_34]]
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_37]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_38]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_39]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_40]] = OpFunction [[_void]] None [[_9]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_38]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_39]] [[_uint_0]]
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_43]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__arr__struct_11_uint_3]] [[_37]] [[_uint_0]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_45]] [[_44]] [[_uint_1]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_46]]
+// CHECK: OpStore [[_42]] [[_47]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -1,0 +1,93 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Proves ConstantDataVector and ConstantArray work.
+
+__constant uint ppp[2][3] = {{1,2,3}, {5}};
+
+kernel void foo(global uint* A, uint i) { *A = ppp[i][i]; }
+
+// MAP: constant,descriptorSet,0,binding,0,kind,buffer,hexbytes,010000000200000003000000050000000000000000000000
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 42
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_26:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpMemberDecorate [[__struct_14:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_31:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_31]] Binding 0
+// CHECK: OpDecorate [[_32:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_32]] Binding 0
+// CHECK: OpDecorate [[_33:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_33]] Binding 1
+// CHECK: OpDecorate [[__arr_uint_uint_3:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpDecorate [[__arr__arr_uint_uint_3_uint_2:%[0-9a-zA-Z_]+]] ArrayStride 12
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_9:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[__arr_uint_uint_3]] = OpTypeArray [[_uint]] [[_uint_3]]
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[__arr__arr_uint_uint_3_uint_2]] = OpTypeArray [[__arr_uint_uint_3]] [[_uint_2]]
+// CHECK: [[__struct_14]] = OpTypeStruct [[__arr__arr_uint_uint_3_uint_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_14:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_14]]
+// CHECK: [[__ptr_StorageBuffer__arr__arr_uint_uint_3_uint_2:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__arr__arr_uint_uint_3_uint_2]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_3]] [[_uint_1]] [[_uint_2]] [[_uint_3]]
+// CHECK: [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_3]] [[_uint_5]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr__arr_uint_uint_3_uint_2]] [[_21]] [[_23]]
+// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_14]] [[_24]]
+// CHECK: [[_26]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_27]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_28]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_26]] [[_27]] [[_28]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_32]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_33]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_34]] = OpFunction [[_void]] None [[_9]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_32]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_37]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__arr__arr_uint_uint_3_uint_2]] [[_31]] [[_uint_0]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_39]] [[_38]] [[_38]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_40]]
+// CHECK: OpStore [[_36]] [[_41]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -1,0 +1,95 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Proves ConstantDataVector and ConstantArray work.
+
+__constant uint3 ppp[2] = {(uint3)(1,2,3), (uint3)(5)};
+
+kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
+
+
+
+// MAP: constant,descriptorSet,0,binding,0,kind,buffer,hexbytes,0100000002000000030000000000000005000000050000000500000000000000
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 43
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_26:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpMemberDecorate [[__struct_13:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_31:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_31]] Binding 0
+// CHECK: OpDecorate [[_32:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_32]] Binding 0
+// CHECK: OpDecorate [[_33:%[0-9a-zA-Z_]+]] DescriptorSet 1
+// CHECK: OpDecorate [[_33]] Binding 1
+// CHECK: OpDecorate [[__arr_v3uint_uint_2:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_9:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK: [[__arr_v3uint_uint_2]] = OpTypeArray [[_v3uint]] [[_uint_2]]
+// CHECK: [[__struct_13]] = OpTypeStruct [[__arr_v3uint_uint_2]]
+// CHECK: [[__ptr_StorageBuffer__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
+// CHECK: [[__ptr_StorageBuffer__arr_v3uint_uint_2:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__arr_v3uint_uint_2]]
+// CHECK: [[__ptr_StorageBuffer_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v3uint]]
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v3uint]] [[_uint_1]] [[_uint_2]] [[_uint_3]]
+// CHECK: [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v3uint]] [[_uint_5]] [[_uint_5]] [[_uint_5]]
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_v3uint_uint_2]] [[_21]] [[_23]]
+// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__struct_13]] [[_24]]
+// CHECK: [[_26]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_27]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_28]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_26]] [[_27]] [[_28]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
+// CHECK: [[_32]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_33]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_34]] = OpFunction [[_void]] None [[_9]]
+// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_32]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_37]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__arr_v3uint_uint_2]] [[_31]] [[_uint_0]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v3uint]] [[_39]] [[_38]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_v3uint]] [[_40]]
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_41]] 0
+// CHECK: OpStore [[_36]] [[_42]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
@@ -1,0 +1,69 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uint* A, uint i) { A[i] = 0; }
+
+// MAP-NOT: constant,descriptorSet
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NOT: constant,descriptorSet
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NOT: constant,descriptorSet
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 25
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_13:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_14:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_15:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_4:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_4]] Block
+// CHECK: OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_6]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_18:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_18]] Binding 0
+// CHECK: OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 1
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
+// CHECK: [[__struct_6]] = OpTypeStruct [[_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_9:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_13]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_14]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_15]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_13]] [[_14]] [[_15]]
+// CHECK: [[_17:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_18]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
+// CHECK: [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_20]] = OpFunction [[_void]] None [[_9]]
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_22:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]]
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_22]]
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_18]] [[_uint_0]] [[_23]]
+// CHECK: OpStore [[_24]] [[_uint_0]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/pod_in_ubo.cl
+++ b/test/pod_in_ubo.cl
@@ -1,0 +1,76 @@
+kernel void foo(int k, global int *A, int b) { *A = k + b; }
+
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -pod-ubo
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -pod-ubo
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+// MAP: kernel,foo,arg,k,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,pod_ubo
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo
+
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 30
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_14:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_15:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_16:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpMemberDecorate [[__struct_2:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_2]] Block
+// CHECK: OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_7]] Block
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_19]] Binding 0
+// CHECK: OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_20]] Binding 1
+// CHECK: OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_21]] Binding 2
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__struct_2]] = OpTypeStruct [[_uint]]
+// CHECK: [[__ptr_Uniform__struct_2:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_2]]
+// CHECK: [[__ptr_Uniform_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[_uint]]
+// CHECK: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK: [[__struct_7]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK: [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_14]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_15]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_14]] [[_15]] [[_16]]
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_19]] = OpVariable [[__ptr_Uniform__struct_2]] Uniform
+// CHECK: [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK: [[_21]] = OpVariable [[__ptr_Uniform__struct_2]] Uniform
+// CHECK: [[_22]] = OpFunction [[_void]] None [[_10]]
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Uniform_uint]] [[_19]] [[_uint_0]]
+// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_24]]
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Uniform_uint]] [[_21]] [[_uint_0]]
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_27]]
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_28]] [[_25]]
+// CHECK: OpStore [[_26]] [[_29]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -27,8 +27,9 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 
-#include <clspv/Passes.h>
-#include <clspv/opencl_builtins_header.h>
+#include "clspv/Option.h"
+#include "clspv/Passes.h"
+#include "clspv/opencl_builtins_header.h"
 
 #include <numeric>
 #include <string>
@@ -742,6 +743,11 @@ int main(const int argc, const char *const argv[]) {
   pm.add(clspv::createSimplifyPointerBitcastPass());
   pm.add(clspv::createReplacePointerBitcastPass());
   pm.add(clspv::createUndoTranslateSamplerFoldPass());
+
+  if (clspv::Option::ModuleConstantsInStorageBuffer()) {
+    pm.add(clspv::createClusterModuleScopeConstantVars());
+  }
+
   pm.add(clspv::createSplatSelectConditionPass());
   pm.add(clspv::createRewriteInsertsPass());
   pm.add(clspv::createSPIRVProducerPass(


### PR DESCRIPTION
Add -pod-ubo : put plain-old-data arguments in uniform buffers instead of storage buffers.  This could be faster.

Add -module-constants-in-storage-buffer:  Big change enabled by new option.
  - Don't use Private variables for __constant data
  - Module-scope constants are collected into a single storage buffer
  - That storage buffer must be initialized by the host to contain the right initialization data by the time the pipeline executes
  - The initialization data is emitted to the descriptor map along with the descriptor set and binding
This is more correct, fixing variable-pointers validation for cases where pointer-to-constant was being dereferenced inside a function.