### PR TITLE
Support pointer-to-local kernel arguments

### DIFF
--- a/docs/\
+++ b/docs/\
@@ -111,7 +111,7 @@ shader is as follows:
 - If a sampler map file is specified, all literal samplers use descriptor set _0_.
 - By default, all kernels in the translation unit use the same descriptor set
   number, either _0_, _1_, or _2_.  (The particular value depends on whether
-  a sampler map is used, and how `__constant` variables are mapped.)
+  a sampler map and how `__constant` variables are mapped.)
   **This is new default behaviour**.
   - Use option `-distinct-kernel-descriptor-sets` to get the old behaviour,
   where each kernel is assigned its own descriptor set number, such that the first
@@ -217,11 +217,6 @@ For kernel arguments of type pointer-to-local, the fields are:
   `SpecId` decoration on the integer constant that specficies the array size.
   (This number is always at least 3 so that specialization IDs 0, 1, and 2 can
   be use for the workgroup size dimensions along `x`, `y`, and `z`.)
-
-Notes: Each pointer-to-local argument is assigned its own array type and
-specialization constant to size the array.  Unless you override the
-array size specialization constant at pipeline creation time, the array will
-only have one element.
 
 If a sampler map is used, then samplers use descriptor set 0 and kernel descriptor
 set numbers start at 1.  For example, if the sampler map file is `mysamplermap`

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -94,6 +94,38 @@ private:
   SmallVector<uint32_t, 4> LiteralNum;
 };
 
+class SPIRVOperandList {
+public:
+  SPIRVOperandList() {}
+  SPIRVOperandList(const SPIRVOperandList& other) = delete;
+  SPIRVOperandList(SPIRVOperandList&& other) {
+    contents_ = std::move(other.contents_);
+    other.contents_.clear();
+  }
+  SPIRVOperandList(ArrayRef<SPIRVOperand *> init)
+      : contents_(init.begin(), init.end()) {}
+  operator ArrayRef<SPIRVOperand *>() { return contents_; }
+  void push_back(SPIRVOperand *op) { contents_.push_back(op); }
+  void clear() { contents_.clear();}
+  size_t size() const { return contents_.size(); }
+  SPIRVOperand *&operator[](size_t i) { return contents_[i]; }
+
+private:
+  SmallVector<SPIRVOperand *,8> contents_;
+};
+
+SPIRVOperandList &operator<<(SPIRVOperandList &list, SPIRVOperand *elem) {
+  list.push_back(elem);
+  return list;
+}
+
+SPIRVOperand* MkNum(uint32_t num) {
+  return new SPIRVOperand(LITERAL_INTEGER, num);
+}
+SPIRVOperand* MkId(uint32_t id) {
+  return new SPIRVOperand(NUMBERID, id);
+}
+
 struct SPIRVInstruction {
   explicit SPIRVInstruction(uint16_t WCount, spv::Op Opc, uint32_t ResID,
                             ArrayRef<SPIRVOperand *> Ops)
@@ -113,7 +145,6 @@ private:
 };
 
 struct SPIRVProducerPass final : public ModulePass {
-  typedef std::vector<SPIRVOperand *> SPIRVOperandList;
   typedef DenseMap<Type *, uint32_t> TypeMapType;
   typedef UniqueVector<Type *> TypeList;
   typedef DenseMap<Value *, uint32_t> ValueMapType;
@@ -134,6 +165,7 @@ struct SPIRVProducerPass final : public ModulePass {
         binaryTempOut(binaryTempUnderlyingVector), binaryOut(&out),
         descriptorMapOut(descriptor_map_out), outputAsm(outputAsm),
         outputCInitList(outputCInitList), patchBoundOffset(0), nextID(1),
+        nextSpecID(3),
         OpExtInstImportID(0), HasVariablePointers(false), SamplerTy(nullptr),
         WorkgroupSizeValueID(0), WorkgroupSizeVarID(0),
         NextDescriptorSetIndex(0) {}
@@ -194,7 +226,7 @@ struct SPIRVProducerPass final : public ModulePass {
     return TypesNeedingArrayStride;
   }
 
-  void GenerateLLVMIRInfo(Module &M);
+  void GenerateLLVMIRInfo(Module &M, const DataLayout &DL);
   bool FindExtInst(Module &M);
   void FindTypePerGlobalVar(GlobalVariable &GV);
   void FindTypePerFunc(Function &F);
@@ -210,10 +242,11 @@ struct SPIRVProducerPass final : public ModulePass {
   // allocated sequentially starting with the current value of nextID, and
   // with a type following its subtypes.  Also updates nextID to just beyond
   // the last generated ID.
-  void GenerateSPIRVTypes(const DataLayout &DL);
+  void GenerateSPIRVTypes(LLVMContext& context, const DataLayout &DL);
   void GenerateSPIRVConstants();
   void GenerateModuleInfo(Module &M);
   void GenerateGlobalVar(GlobalVariable &GV);
+  void GenerateWorkgroupVars();
   void GenerateSamplers(Module &M);
   void GenerateFuncPrologue(Function &F);
   void GenerateFuncBody(Function &F);
@@ -288,6 +321,9 @@ private:
   const bool outputCInitList; // If true, output look like {0x7023, ... , 5}
   uint64_t patchBoundOffset;
   uint32_t nextID;
+  // The next specialization constant ID to be used.  Spec ID values 0, 1, 2
+  // are reserved for the workgroup size elements.
+  uint32_t nextSpecID;
 
   // Maps an LLVM Value pointer to the corresponding SPIR-V Id.
   TypeMapType TypeMap;
@@ -343,11 +379,39 @@ private:
   // emitted?
   DenseSet<Value*> GVarWithEmittedBindingInfo;
 
+  // An ordered list of the kernel arguments of type pointer-to-local.
+  using LocalArgList = SmallVector<const Argument*, 8>;
+  LocalArgList LocalArgs;
+  // Information about a pointer-to-local argument.
+  struct LocalArgInfo {
+    // The SPIR-V ID of the array variable.
+    uint32_t variable_id;
+    // The element type of the
+    Type* elem_type;
+    // The ID of the array type.
+    uint32_t array_size_id;
+    // The ID of the array type.
+    uint32_t array_type_id;
+    // The ID of the pointer to the array type.
+    uint32_t ptr_array_type_id;
+    // The ID of the pointer to the first element of the array.
+    uint32_t first_elem_ptr_id;
+    // The specialization constant ID of the array size.
+    int spec_id;
+  };
+  // A mapping from a pointer-to-local argument value to a LocalArgInfo value.
+  DenseMap<const Argument*, LocalArgInfo> LocalArgMap;
+
   // The next descriptor set index to use.
   uint32_t NextDescriptorSetIndex;
+
+  // A mapping from pointer-to-local argument to a specialization constant ID
+  // for that argument's array size.  This is generated from AllocatArgSpecIds.
+  ArgIdMapType ArgSpecIdMap;
 };
 
 char SPIRVProducerPass::ID;
+
 }
 
 namespace clspv {
@@ -363,11 +427,15 @@ createSPIRVProducerPass(raw_pwrite_stream &out, raw_ostream &descriptor_map_out,
 bool SPIRVProducerPass::runOnModule(Module &module) {
   binaryOut = outputCInitList ? &binaryTempOut : &out;
 
+  ArgSpecIdMap = AllocateArgSpecIds(module);
+
   // SPIR-V always begins with its header information
   outputHeader();
 
+  const DataLayout &DL = module.getDataLayout();
+
   // Gather information from the LLVM IR that we require.
-  GenerateLLVMIRInfo(module);
+  GenerateLLVMIRInfo(module, DL);
 
   // If we are using a sampler map, find the type of the sampler.
   if (0 < getSamplerMap().size()) {
@@ -403,14 +471,20 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
     }
   }
 
+  // Find types related to pointer-to-local arguments.
+  for (auto& arg_spec_id_pair : ArgSpecIdMap) {
+    const Argument* arg = arg_spec_id_pair.first;
+    FindType(arg->getType());
+    FindType(arg->getType()->getPointerElementType());
+  }
+
   // If there are extended instructions, generate OpExtInstImport.
   if (FindExtInst(module)) {
     GenerateExtInstImport();
   }
 
   // Generate SPIRV instructions for types.
-  const DataLayout &DL = module.getDataLayout();
-  GenerateSPIRVTypes(DL);
+  GenerateSPIRVTypes(module.getContext(), DL);
 
   // Generate SPIRV constants.
   GenerateSPIRVConstants();
@@ -424,6 +498,7 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
   for (GlobalVariable &GV : module.globals()) {
     GenerateGlobalVar(GV);
   }
+  GenerateWorkgroupVars();
 
   // Generate SPIRV instructions for each function.
   for (Function &F : module) {
@@ -548,14 +623,13 @@ void SPIRVProducerPass::patchHeader() {
   }
 }
 
-void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
+void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M, const DataLayout &DL) {
   // This function generates LLVM IR for function such as global variable for
   // argument, constant and pointer type for argument access. These information
   // is artificial one because we need Vulkan SPIR-V output. This function is
   // executed ahead of FindType and FindConstant.
   ValueToValueMapTy &ArgGVMap = getArgumentGVMap();
   LLVMContext &Context = M.getContext();
-  const DataLayout &DL = M.getDataLayout();
 
   // Map for avoiding to generate struct type with same fields.
   DenseMap<Type *, Type *> ArgTyMap;
@@ -570,90 +644,95 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
   };
 
   // Collect global constant variables.
-  SmallVector<GlobalVariable *, 8> GVList;
-  SmallVector<GlobalVariable *, 8> DeadGVList;
-  for (GlobalVariable &GV : M.globals()) {
-    if (GV.getType()->getAddressSpace() == AddressSpace::Constant) {
-      if (GV.use_empty()) {
-        DeadGVList.push_back(&GV);
-      } else {
-        GVList.push_back(&GV);
+  {
+    SmallVector<GlobalVariable *, 8> GVList;
+    SmallVector<GlobalVariable *, 8> DeadGVList;
+    for (GlobalVariable &GV : M.globals()) {
+      if (GV.getType()->getAddressSpace() == AddressSpace::Constant) {
+        if (GV.use_empty()) {
+          DeadGVList.push_back(&GV);
+        } else {
+          GVList.push_back(&GV);
+        }
       }
     }
-  }
 
-  // Remove dead global variables.
-  for (auto GV : DeadGVList) {
-    GV->eraseFromParent();
-  }
-  DeadGVList.clear();
-
-  if (clspv::Option::ModuleConstantsInStorageBuffer()) {
-    // For now, we only support a single storage buffer.
-    if (GVList.size() > 0) {
-      assert(GVList.size() == 1);
-      const auto *GV = GVList[0];
-      const size_t constants_byte_size =
-          (DL.getTypeSizeInBits(GV->getInitializer()->getType())) / 8;
-      const size_t kConstantMaxSize = 65536;
-      if (constants_byte_size > kConstantMaxSize) {
-        outs() << "Max __constant capacity of " << kConstantMaxSize
-               << " bytes exceeded: " << constants_byte_size << " bytes used\n";
-        llvm_unreachable("Max __constant capacity exceeded");
-      }
+    // Remove dead global __constant variables.
+    for (auto GV : DeadGVList) {
+      GV->eraseFromParent();
     }
-  } else {
-    // Change global constant variable's address space to ModuleScopePrivate.
-    auto &GlobalConstFuncTyMap = getGlobalConstFuncTypeMap();
-    for (auto GV : GVList) {
-      // Create new gv with ModuleScopePrivate address space.
-      Type *NewGVTy = GV->getType()->getPointerElementType();
-      GlobalVariable *NewGV = new GlobalVariable(
-          M, NewGVTy, false, GV->getLinkage(), GV->getInitializer(), "",
-          nullptr, GV->getThreadLocalMode(), AddressSpace::ModuleScopePrivate);
-      NewGV->takeName(GV);
+    DeadGVList.clear();
 
-      const SmallVector<User *, 8> GVUsers(GV->user_begin(), GV->user_end());
-      SmallVector<User *, 8> CandidateUsers;
+    if (clspv::Option::ModuleConstantsInStorageBuffer()) {
+      // For now, we only support a single storage buffer.
+      if (GVList.size() > 0) {
+        assert(GVList.size() == 1);
+        const auto *GV = GVList[0];
+        const size_t constants_byte_size =
+            (DL.getTypeSizeInBits(GV->getInitializer()->getType())) / 8;
+        const size_t kConstantMaxSize = 65536;
+        if (constants_byte_size > kConstantMaxSize) {
+          outs() << "Max __constant capacity of " << kConstantMaxSize
+                 << " bytes exceeded: " << constants_byte_size
+                 << " bytes used\n";
+          llvm_unreachable("Max __constant capacity exceeded");
+        }
+      }
+    } else {
+      // Change global constant variable's address space to ModuleScopePrivate.
+      auto &GlobalConstFuncTyMap = getGlobalConstFuncTypeMap();
+      for (auto GV : GVList) {
+        // Create new gv with ModuleScopePrivate address space.
+        Type *NewGVTy = GV->getType()->getPointerElementType();
+        GlobalVariable *NewGV = new GlobalVariable(
+            M, NewGVTy, false, GV->getLinkage(), GV->getInitializer(), "",
+            nullptr, GV->getThreadLocalMode(),
+            AddressSpace::ModuleScopePrivate);
+        NewGV->takeName(GV);
 
-      auto record_called_function_type_as_user =
-          [&GlobalConstFuncTyMap](Value *gv, CallInst *call) {
-            // Find argument index.
-            unsigned index = 0;
-            for (unsigned i = 0; i < call->getNumArgOperands(); i++) {
-              if (gv == call->getOperand(i)) {
-                // TODO(dneto): Should we break here?
-                index = i;
+        const SmallVector<User *, 8> GVUsers(GV->user_begin(), GV->user_end());
+        SmallVector<User *, 8> CandidateUsers;
+
+        auto record_called_function_type_as_user =
+            [&GlobalConstFuncTyMap](Value *gv, CallInst *call) {
+              // Find argument index.
+              unsigned index = 0;
+              for (unsigned i = 0; i < call->getNumArgOperands(); i++) {
+                if (gv == call->getOperand(i)) {
+                  // TODO(dneto): Should we break here?
+                  index = i;
+                }
+              }
+
+              // Record function type with global constant.
+              GlobalConstFuncTyMap[call->getFunctionType()] =
+                  std::make_pair(call->getFunctionType(), index);
+            };
+
+        for (User *GVU : GVUsers) {
+          if (CallInst *Call = dyn_cast<CallInst>(GVU)) {
+            record_called_function_type_as_user(GV, Call);
+          } else if (GetElementPtrInst *GEP =
+                         dyn_cast<GetElementPtrInst>(GVU)) {
+            // Check GEP users.
+            for (User *GEPU : GEP->users()) {
+              if (CallInst *GEPCall = dyn_cast<CallInst>(GEPU)) {
+                record_called_function_type_as_user(GEP, GEPCall);
               }
             }
-
-            // Record function type with global constant.
-            GlobalConstFuncTyMap[call->getFunctionType()] =
-                std::make_pair(call->getFunctionType(), index);
-          };
-
-      for (User *GVU : GVUsers) {
-        if (CallInst *Call = dyn_cast<CallInst>(GVU)) {
-          record_called_function_type_as_user(GV, Call);
-        } else if (GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(GVU)) {
-          // Check GEP users.
-          for (User *GEPU : GEP->users()) {
-            if (CallInst *GEPCall = dyn_cast<CallInst>(GEPU)) {
-              record_called_function_type_as_user(GEP, GEPCall);
-            }
           }
+
+          CandidateUsers.push_back(GVU);
         }
 
-        CandidateUsers.push_back(GVU);
-      }
+        for (User *U : CandidateUsers) {
+          // Update users of gv with new gv.
+          U->replaceUsesOfWith(GV, NewGV);
+        }
 
-      for (User *U : CandidateUsers) {
-        // Update users of gv with new gv.
-        U->replaceUsesOfWith(GV, NewGV);
+        // Delete original gv.
+        GV->eraseFromParent();
       }
-
-      // Delete original gv.
-      GV->eraseFromParent();
     }
   }
 
@@ -666,7 +745,6 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
   }
 
 
-
   // Map kernel functions to their ordinal number in the compilation unit.
   UniqueVector<Function*> KernelOrdinal;
 
@@ -674,7 +752,7 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
   // order.
   UniqueVector<GlobalVariable*> KernelArgVarOrdinal;
 
-  // For each kernel argument type, record the kernel arg global variables
+  // For each kernel argument type, record the kernel arg global resource variables
   // generated for that type, the function in which that variable was most
   // recently used, and the binding number it took.  For reproducibility,
   // we track things by ordinal number (rather than pointer), and we use a
@@ -799,6 +877,9 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
           }
         }
       }
+      const bool IsPointerToLocal = IsLocalPtr(ArgTy);
+      // Can't both be pointer-to-local and (sampler or image).
+      assert(!((IsSamplerType || IsImageType) && IsPointerToLocal));
 
       // Determine the address space for the module-scope variable.
       unsigned AddrSpace = AddressSpace::Global;
@@ -824,6 +905,17 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
 
       if (IsSamplerType || IsImageType) {
         GVTy = TmpArgTy;
+      } else if (IsPointerToLocal) {
+        assert(ArgTy == TmpArgTy);
+        auto spec_id = ArgSpecIdMap[&Arg];
+        assert(spec_id > 0);
+        LocalArgMap[&Arg] =
+            LocalArgInfo{nextID,     ArgTy->getPointerElementType(),
+                         nextID + 1, nextID + 2,
+                         nextID + 3, nextID + 4,
+                         spec_id};
+        LocalArgs.push_back(&Arg);
+        nextID += 5;
       } else if (ArgTyMap.count(TmpArgTy)) {
         // If there are arguments handled previously, use its type.
         GVTy = ArgTyMap[TmpArgTy];
@@ -837,60 +929,63 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M) {
         ArgTyMap[TmpArgTy] = STy;
       }
 
-      // In order to build type map between llvm type and spirv id, LLVM
-      // global variable is needed. It has llvm type and other instructions
-      // can access it with its type.
-      //
-      // Reuse a global variable if it was created for a different entry point.
+      if (!IsPointerToLocal) {
+        // In order to build type map between llvm type and spirv id, LLVM
+        // global variable is needed. It has llvm type and other instructions
+        // can access it with its type.
+        //
+        // Reuse a global variable if it was created for a different entry
+        // point.
 
-      // Returns a new global variable for this kernel argument, and remembers
-      // it in KernelArgVarOrdinal.
-      auto make_gvar = [&]() {
-        auto result = new GlobalVariable(
-            M, GVTy, false, GlobalValue::ExternalLinkage, UndefValue::get(GVTy),
-            F.getName() + ".arg." + std::to_string(Idx), nullptr,
-            GlobalValue::ThreadLocalMode::NotThreadLocal, AddrSpace);
-        KernelArgVarOrdinal.insert(result);
-        return result;
-      };
+        // Returns a new global variable for this kernel argument, and remembers
+        // it in KernelArgVarOrdinal.
+        auto make_gvar = [&]() {
+          auto result = new GlobalVariable(
+              M, GVTy, false, GlobalValue::ExternalLinkage,
+              UndefValue::get(GVTy),
+              F.getName() + ".arg." + std::to_string(Idx), nullptr,
+              GlobalValue::ThreadLocalMode::NotThreadLocal, AddrSpace);
+          KernelArgVarOrdinal.insert(result);
+          return result;
+        };
 
-      // Make a new variable if there was none for this type, or if we can
-      // reuse one created for a different function but not yet reused for
-      // the current function, *and* the binding is the same.
-      // Always make a new variable if we're forcing distinct descriptor sets.
-      GlobalVariable *GV = nullptr;
-      auto which_set = GVarsForType.find(GVTy);
-      if (IsSamplerType || IsImageType || which_set == GVarsForType.end() ||
-          clspv::Option::DistinctKernelDescriptorSets()) {
-        GV = make_gvar();
-      } else {
-        auto &set = which_set->second;
-        // Reuse a variable if it was associated with a different function.
-        for (auto iter = set.begin(), end = set.end();
-             iter != end; ++iter) {
-          const unsigned fn_ordinal = std::get<0>(*iter);
-          const unsigned binding = std::get<1>(*iter);
-          if (fn_ordinal != KernelOrdinal.idFor(&F) && binding == Idx) {
-            GV = KernelArgVarOrdinal[std::get<2>(*iter)];
-            // Remove it from the set.  We'll add it back later.
-            set.erase(iter);
-            break;
+        // Make a new variable if there was none for this type, or if we can
+        // reuse one created for a different function but not yet reused for
+        // the current function, *and* the binding is the same.
+        // Always make a new variable if we're forcing distinct descriptor sets.
+        GlobalVariable *GV = nullptr;
+        auto which_set = GVarsForType.find(GVTy);
+        if (IsSamplerType || IsImageType || which_set == GVarsForType.end() ||
+            clspv::Option::DistinctKernelDescriptorSets()) {
+          GV = make_gvar();
+        } else {
+          auto &set = which_set->second;
+          // Reuse a variable if it was associated with a different function.
+          for (auto iter = set.begin(), end = set.end(); iter != end; ++iter) {
+            const unsigned fn_ordinal = std::get<0>(*iter);
+            const unsigned binding = std::get<1>(*iter);
+            if (fn_ordinal != KernelOrdinal.idFor(&F) && binding == Idx) {
+              GV = KernelArgVarOrdinal[std::get<2>(*iter)];
+              // Remove it from the set.  We'll add it back later.
+              set.erase(iter);
+              break;
+            }
+          }
+          if (!GV) {
+            GV = make_gvar();
           }
         }
-        if (!GV) {
-          GV = make_gvar();
-        }
+        assert(GV);
+        GVarsForType[GVTy].insert(std::make_tuple(
+            KernelOrdinal.idFor(&F), Idx, KernelArgVarOrdinal.idFor(GV)));
+
+        // Generate type info for argument global variable.
+        FindType(GV->getType());
+
+        ArgGVMap[&Arg] = GV;
+
+        Idx++;
       }
-      assert(GV);
-      GVarsForType[GVTy].insert(std::make_tuple(KernelOrdinal.idFor(&F), Idx,
-                                                KernelArgVarOrdinal.idFor(GV)));
-
-      // Generate type info for argument global variable.
-      FindType(GV->getType());
-
-      ArgGVMap[&Arg] = GV;
-
-      Idx++;
 
       // Generate pointer type of argument type for OpAccessChain of argument.
       if (!Arg.use_empty()) {
@@ -1457,7 +1552,7 @@ void SPIRVProducerPass::GenerateExtInstImport() {
   SPIRVInstList.push_back(Inst);
 }
 
-void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
+void SPIRVProducerPass::GenerateSPIRVTypes(LLVMContext& Context, const DataLayout &DL) {
   SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
   ValueMapType &VMap = getValueMap();
   ValueMapType &AllocatedVMap = getAllocatedValueMap();
@@ -1736,6 +1831,7 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
 
         // Check OpTypeRuntimeArray.
         if (isa<PointerType>(EleTy)) {
+          // TODO(dneto): Isn't this a straight lookup instead of a loop?
           for (auto ArgGV : ArgGVMap) {
             Type *ArgTy = ArgGV.first->getType();
             if (ArgTy == EleTy) {
@@ -1974,8 +2070,8 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
           new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER,
                            Ty->getVectorNumElements())};
 
-      SPIRVInstList.push_back(
-          new SPIRVInstruction(4, spv::OpTypeVector, nextID++, Ops));
+      SPIRVInstruction* inst = new SPIRVInstruction(4, spv::OpTypeVector, nextID++, Ops);
+      SPIRVInstList.push_back(inst);
       break;
     }
     case Type::VoidTyID: {
@@ -1993,11 +2089,7 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
       SPIRVOperandList Ops;
 
       // Find SPIRV instruction for return type
-      uint32_t RetTyID = lookupType(FTy->getReturnType());
-
-      SPIRVOperand *RetTyOp =
-          new SPIRVOperand(SPIRVOperandType::NUMBERID, RetTyID);
-      Ops.push_back(RetTyOp);
+      Ops << MkId(lookupType(FTy->getReturnType()));
 
       // Find SPIRV instructions for parameter types
       for (unsigned k = 0; k < FTy->getNumParams(); k++) {
@@ -2011,10 +2103,7 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
           }
         }
 
-        uint32_t ParamTyID = lookupType(ParamTy);
-        SPIRVOperand *ParamTyOp =
-            new SPIRVOperand(SPIRVOperandType::NUMBERID, ParamTyID);
-        Ops.push_back(ParamTyOp);
+        Ops << MkId(lookupType(ParamTy));
       }
 
       // Return type id is included in operand list.
@@ -2039,10 +2128,7 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
     SPIRVOperandList Ops;
 
     Type *ImgTy = ImageType.first;
-    uint32_t ImgTyID = TypeMap[ImgTy];
-    SPIRVOperand *ImgTyOp =
-        new SPIRVOperand(SPIRVOperandType::NUMBERID, ImgTyID);
-    Ops.push_back(ImgTyOp);
+    Ops << MkId(TypeMap[ImgTy]);
 
     // Update OpImageTypeMap.
     ImageType.second = nextID;
@@ -2050,6 +2136,34 @@ void SPIRVProducerPass::GenerateSPIRVTypes(const DataLayout &DL) {
     SPIRVInstruction *Inst =
         new SPIRVInstruction(3, spv::OpTypeSampledImage, nextID++, Ops);
     SPIRVInstList.push_back(Inst);
+  }
+
+  // Generate types for pointer-to-local arguments.
+  for (auto* arg : LocalArgs) {
+
+    LocalArgInfo& arg_info = LocalArgMap[arg];
+
+    // Generate the spec constant.
+    SPIRVOperandList Ops;
+    Ops << MkId(lookupType(Type::getInt32Ty(Context))) << MkNum(1);
+    SPIRVInstList.push_back(new SPIRVInstruction(4, spv::OpSpecConstant,
+                                                 arg_info.array_size_id, Ops));
+
+
+    // Generate the array type.
+    Ops.clear();
+    // The element type must have been created.
+    uint32_t elem_ty_id = lookupType(arg_info.elem_type);
+    assert(elem_ty_id);
+    Ops << MkId(elem_ty_id) << MkId(arg_info.array_size_id);
+
+    SPIRVInstList.push_back(
+        new SPIRVInstruction(4, spv::OpTypeArray, arg_info.array_type_id, Ops));
+
+    Ops.clear();
+    Ops << MkNum(spv::StorageClassWorkgroup) << MkId(arg_info.array_type_id);
+    SPIRVInstList.push_back(
+        new SPIRVInstruction(4, spv::OpTypePointer, arg_info.ptr_array_type_id, Ops));
   }
 }
 
@@ -2596,12 +2710,8 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
   // GIDOps[1] : Storage Class
   SPIRVOperandList Ops;
 
-  Ops.push_back(new SPIRVOperand(SPIRVOperandType::NUMBERID, lookupType(Ty)));
-
   const auto AS = PTy->getAddressSpace();
-
-  spv::StorageClass StorageClass = GetStorageClass(AS);
-  Ops.push_back(new SPIRVOperand(SPIRVOperandType::NUMBERID, StorageClass));
+  Ops << MkId(lookupType(Ty)) << MkNum(GetStorageClass(AS));
 
   if (GV.hasInitializer()) {
     InitializerID = VMap[GV.getInitializer()];
@@ -2614,8 +2724,7 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
   if (0 != InitializerID) {
     if (!module_scope_constant_external_init) {
       // Emit the ID of the intiializer as part of the variable definition.
-      Ops.push_back(
-          new SPIRVOperand(SPIRVOperandType::NUMBERID, InitializerID));
+      Ops << MkId(InitializerID);
     }
   }
   const uint32_t var_id = nextID++;
@@ -2710,12 +2819,30 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
                                     spv::DecorationDescriptorSet));
     DOps.push_back(
         new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, descriptor_set));
-    SPIRVInstList.insert(DecoInsertPoint, 
+    SPIRVInstList.insert(DecoInsertPoint,
         new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, DOps));
   }
 }
 
+void SPIRVProducerPass::GenerateWorkgroupVars() {
+  SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
+  for (auto* arg : LocalArgs) {
+    const auto& info = LocalArgMap[arg];
+
+    // Generate OpVariable.
+    //
+    // GIDOps[0] : Result Type ID
+    // GIDOps[1] : Storage Class
+    SPIRVOperandList Ops;
+    Ops << MkId(info.ptr_array_type_id) << MkNum(spv::StorageClassWorkgroup);
+
+    SPIRVInstList.push_back(
+        new SPIRVInstruction(4, spv::OpVariable, info.variable_id, Ops));
+  }
+}
+
 void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
+  const DataLayout &DL = F.getParent()->getDataLayout();
   SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
   ValueMapType &VMap = getValueMap();
   EntryPointVecType &EntryPoints = getEntryPointVec();
@@ -2755,9 +2882,14 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
     // Emit descriptor map entries, if there was explicit metadata
     // attached.
     if (ArgMap) {
+      // The binding number is the new argument index minus the number
+      // pointer-to-local arguments.  Do this adjustment here rather than
+      // adding yet another data member to the metadata for each argument.
+      int num_ptr_local = 0;
+
       for (const auto &arg : ArgMap->operands()) {
         const MDNode *arg_node = dyn_cast<MDNode>(arg.get());
-        assert(arg_node->getNumOperands() == 5);
+        assert(arg_node->getNumOperands() == 6);
         const auto name =
             dyn_cast<MDString>(arg_node->getOperand(0))->getString();
         const auto old_index =
@@ -2766,138 +2898,175 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
             dyn_extract<ConstantInt>(arg_node->getOperand(2))->getZExtValue();
         const auto offset =
             dyn_extract<ConstantInt>(arg_node->getOperand(3))->getZExtValue();
-        const auto argKind =
-            dyn_cast<MDString>(arg_node->getOperand(4))->getString();
-        descriptorMapOut << "kernel," << F.getName() << ",arg," << name
-                         << ",argOrdinal," << old_index << ",descriptorSet,"
-                         << DescriptorSetIdx << ",binding," << new_index
-                         << ",offset," << offset << ",argKind,"
-                         << remap_arg_kind(argKind) << "\n";
+        const auto argKind = remap_arg_kind(
+            dyn_cast<MDString>(arg_node->getOperand(4))->getString());
+        const auto spec_id =
+            dyn_extract<ConstantInt>(arg_node->getOperand(5))->getSExtValue();
+        if (spec_id > 0) {
+          num_ptr_local++;
+          FunctionType *fTy =
+              cast<FunctionType>(F.getType()->getPointerElementType());
+          descriptorMapOut
+              << "kernel," << F.getName() << ",arg," << name << ",argOrdinal,"
+              << old_index << ",argKind," << argKind << ",arrayElemSize,"
+              << DL.getTypeAllocSize(
+                     fTy->getParamType(new_index)->getPointerElementType())
+              << ",arrayNumElemSpecId," << spec_id << "\n";
+        } else {
+          descriptorMapOut << "kernel," << F.getName() << ",arg," << name
+                           << ",argOrdinal," << old_index << ",descriptorSet,"
+                           << DescriptorSetIdx << ",binding,"
+                           << (new_index - num_ptr_local) << ",offset,"
+                           << offset << ",argKind," << argKind << "\n";
+        }
       }
     }
 
     uint32_t BindingIdx = 0;
+    uint32_t arg_index = 0;
     for (auto &Arg : F.args()) {
-      Value *NewGV = ArgGVMap[&Arg];
-      VMap[&Arg] = VMap[NewGV];
-      ArgGVIDMap[&Arg] = VMap[&Arg];
+      // Always use a binding, unless it's pointer-to-local.
+      const bool uses_binding = !IsLocalPtr(Arg.getType());
 
       // Emit a descriptor map entry for this arg, in case there was no explicit
       // kernel arg mapping metadata.
+      auto argKind = remap_arg_kind(clspv::GetArgKindForType(Arg.getType()));
       if (!ArgMap) {
-        descriptorMapOut << "kernel," << F.getName() << ",arg," << Arg.getName()
-                         << ",argOrdinal," << BindingIdx << ",descriptorSet,"
-                         << DescriptorSetIdx << ",binding," << BindingIdx
-                         << ",offset,0,argKind,"
-                         << remap_arg_kind(
-                                clspv::GetArgKindForType(Arg.getType()))
-                         << "\n";
+        if (uses_binding) {
+          descriptorMapOut << "kernel," << F.getName() << ",arg,"
+                           << Arg.getName() << ",argOrdinal," << arg_index
+                           << ",descriptorSet," << DescriptorSetIdx
+                           << ",binding," << BindingIdx << ",offset,0,argKind,"
+                           << argKind << "\n";
+        } else {
+          descriptorMapOut << "kernel," << F.getName() << ",arg,"
+                           << Arg.getName() << ",argOrdinal," << arg_index
+                           << ",argKind," << argKind << ",arrayElemSize,"
+                           << DL.getTypeAllocSize(
+                                  Arg.getType()->getPointerElementType())
+                           << ",arrayNumElemSpecId," << ArgSpecIdMap[&Arg]
+                           << "\n";
+        }
       }
 
-      if (GVarWithEmittedBindingInfo.count(NewGV)) {
-        BindingIdx++;
-        continue;
-      }
-      GVarWithEmittedBindingInfo.insert(NewGV);
+      if (uses_binding) {
+        Value *NewGV = ArgGVMap[&Arg];
+        VMap[&Arg] = VMap[NewGV];
+        ArgGVIDMap[&Arg] = VMap[&Arg];
 
-      // Ops[0] = Target ID
-      // Ops[1] = Decoration (DescriptorSet)
-      // Ops[2] = LiteralNumber according to Decoration
-      SPIRVOperandList Ops;
+        if (0 == GVarWithEmittedBindingInfo.count(NewGV)) {
+          // Generate a new global variable for this argument.
+          GVarWithEmittedBindingInfo.insert(NewGV);
 
-      SPIRVOperand *ArgIDOp =
-          new SPIRVOperand(SPIRVOperandType::NUMBERID, VMap[&Arg]);
-      Ops.push_back(ArgIDOp);
+          SPIRVOperandList Ops;
+          SPIRVOperand *ArgIDOp = nullptr;
 
-      spv::Decoration Deco = spv::DecorationDescriptorSet;
-      SPIRVOperand *DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
-      Ops.push_back(DecoOp);
+          if (uses_binding) {
+            // Ops[0] = Target ID
+            // Ops[1] = Decoration (DescriptorSet)
+            // Ops[2] = LiteralNumber according to Decoration
 
-      std::vector<uint32_t> LiteralNum;
-      LiteralNum.push_back(DescriptorSetIdx);
-      SPIRVOperand *DescSet =
-          new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, LiteralNum);
-      Ops.push_back(DescSet);
+            ArgIDOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, VMap[&Arg]);
+            Ops.push_back(ArgIDOp);
 
-      SPIRVInstruction *DescDecoInst =
-          new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops);
-      SPIRVInstList.insert(DecoInsertPoint, DescDecoInst);
+            spv::Decoration Deco = spv::DecorationDescriptorSet;
+            SPIRVOperand *DecoOp =
+                new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
+            Ops.push_back(DecoOp);
 
-      // Ops[0] = Target ID
-      // Ops[1] = Decoration (Binding)
-      // Ops[2] = LiteralNumber according to Decoration
-      Ops.clear();
+            std::vector<uint32_t> LiteralNum;
+            LiteralNum.push_back(DescriptorSetIdx);
+            SPIRVOperand *DescSet =
+                new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, LiteralNum);
+            Ops.push_back(DescSet);
 
-      Ops.push_back(ArgIDOp);
+            SPIRVInstruction *DescDecoInst =
+                new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops);
+            SPIRVInstList.insert(DecoInsertPoint, DescDecoInst);
 
-      Deco = spv::DecorationBinding;
-      DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
-      Ops.push_back(DecoOp);
+            // Ops[0] = Target ID
+            // Ops[1] = Decoration (Binding)
+            // Ops[2] = LiteralNumber according to Decoration
+            Ops.clear();
 
-      LiteralNum.clear();
-      LiteralNum.push_back(BindingIdx++);
-      SPIRVOperand *Binding =
-          new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, LiteralNum);
-      Ops.push_back(Binding);
+            Ops.push_back(ArgIDOp);
 
-      SPIRVInstruction *BindDecoInst =
-          new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops);
-      SPIRVInstList.insert(DecoInsertPoint, BindDecoInst);
+            Deco = spv::DecorationBinding;
+            DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
+            Ops.push_back(DecoOp);
 
-      // Handle image type argument.
-      bool HasReadOnlyImageType = false;
-      bool HasWriteOnlyImageType = false;
-      if (PointerType *ArgPTy = dyn_cast<PointerType>(Arg.getType())) {
-        if (StructType *STy = dyn_cast<StructType>(ArgPTy->getElementType())) {
-          if (STy->isOpaque()) {
-            if (STy->getName().equals("opencl.image2d_ro_t") ||
-                STy->getName().equals("opencl.image3d_ro_t")) {
-              HasReadOnlyImageType = true;
-            } else if (STy->getName().equals("opencl.image2d_wo_t") ||
-                       STy->getName().equals("opencl.image3d_wo_t")) {
-              HasWriteOnlyImageType = true;
+            LiteralNum.clear();
+            LiteralNum.push_back(BindingIdx);
+            SPIRVOperand *Binding =
+                new SPIRVOperand(SPIRVOperandType::LITERAL_INTEGER, LiteralNum);
+            Ops.push_back(Binding);
+
+            SPIRVInstruction *BindDecoInst =
+                new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops);
+            SPIRVInstList.insert(DecoInsertPoint, BindDecoInst);
+          }
+
+          // Handle image type argument.
+          bool HasReadOnlyImageType = false;
+          bool HasWriteOnlyImageType = false;
+          if (PointerType *ArgPTy = dyn_cast<PointerType>(Arg.getType())) {
+            if (StructType *STy =
+                    dyn_cast<StructType>(ArgPTy->getElementType())) {
+              if (STy->isOpaque()) {
+                if (STy->getName().equals("opencl.image2d_ro_t") ||
+                    STy->getName().equals("opencl.image3d_ro_t")) {
+                  HasReadOnlyImageType = true;
+                } else if (STy->getName().equals("opencl.image2d_wo_t") ||
+                           STy->getName().equals("opencl.image3d_wo_t")) {
+                  HasWriteOnlyImageType = true;
+                }
+              }
             }
           }
+
+          if (HasReadOnlyImageType || HasWriteOnlyImageType) {
+            // Ops[0] = Target ID
+            // Ops[1] = Decoration (NonReadable or NonWritable)
+            Ops.clear();
+
+            auto *ArgIDOp =
+                new SPIRVOperand(SPIRVOperandType::NUMBERID, VMap[&Arg]);
+            Ops.push_back(ArgIDOp);
+
+            auto Deco = spv::DecorationNonReadable;
+            if (HasReadOnlyImageType) {
+              Deco = spv::DecorationNonWritable;
+            }
+            auto *DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
+            Ops.push_back(DecoOp);
+
+            auto *DescDecoInst =
+                new SPIRVInstruction(3, spv::OpDecorate, 0 /* No id */, Ops);
+            SPIRVInstList.insert(DecoInsertPoint, DescDecoInst);
+          }
+
+          // Handle const address space.
+          if (uses_binding && NewGV->getType()->getPointerAddressSpace() ==
+                                  AddressSpace::Constant) {
+            // Ops[0] = Target ID
+            // Ops[1] = Decoration (NonWriteable)
+            Ops.clear();
+
+            assert(ArgIDOp);
+            Ops.push_back(ArgIDOp);
+
+            auto Deco = spv::DecorationNonWritable;
+            auto *DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
+            Ops.push_back(DecoOp);
+
+            auto *BindDecoInst =
+                new SPIRVInstruction(3, spv::OpDecorate, 0 /* No id */, Ops);
+            SPIRVInstList.insert(DecoInsertPoint, BindDecoInst);
+          }
         }
+        BindingIdx++;
       }
-
-      if (HasReadOnlyImageType || HasWriteOnlyImageType) {
-        // Ops[0] = Target ID
-        // Ops[1] = Decoration (NonReadable or NonWritable)
-        Ops.clear();
-
-        ArgIDOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, VMap[&Arg]);
-        Ops.push_back(ArgIDOp);
-
-        Deco = spv::DecorationNonReadable;
-        if (HasReadOnlyImageType) {
-          Deco = spv::DecorationNonWritable;
-        }
-        DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
-        Ops.push_back(DecoOp);
-
-        DescDecoInst =
-            new SPIRVInstruction(3, spv::OpDecorate, 0 /* No id */, Ops);
-        SPIRVInstList.insert(DecoInsertPoint, DescDecoInst);
-      }
-
-      // Handle const address space.
-      if (NewGV->getType()->getPointerAddressSpace() ==
-          AddressSpace::Constant) {
-        // Ops[0] = Target ID
-        // Ops[1] = Decoration (NonWriteable)
-        Ops.clear();
-
-        Ops.push_back(ArgIDOp);
-
-        Deco = spv::DecorationNonWritable;
-        DecoOp = new SPIRVOperand(SPIRVOperandType::NUMBERID, Deco);
-        Ops.push_back(DecoOp);
-
-        BindDecoInst =
-            new SPIRVInstruction(3, spv::OpDecorate, 0 /* No id */, Ops);
-        SPIRVInstList.insert(DecoInsertPoint, BindDecoInst);
-      }
+      arg_index++;
     }
   }
 
@@ -3375,6 +3544,21 @@ void SPIRVProducerPass::GenerateInstForArg(Function &F) {
       continue;
     }
 
+    Type *ArgTy = Arg.getType();
+    if (IsLocalPtr(ArgTy)) {
+      // Generate OpAccessChain to point to the first element of the array.
+      const LocalArgInfo &info = LocalArgMap[&Arg];
+      VMap[&Arg] = info.first_elem_ptr_id;
+
+      SPIRVOperandList Ops;
+      uint32_t zeroId = VMap[ConstantInt::get(Type::getInt32Ty(Context), 0)];
+      Ops << MkId(lookupType(ArgTy)) << MkId(info.variable_id) << MkId(zeroId);
+      SPIRVInstList.push_back(new SPIRVInstruction(
+          5, spv::OpAccessChain, info.first_elem_ptr_id, Ops));
+
+      continue;
+    }
+
     // Check the type of users of arguments.
     bool HasOnlyGEPUse = true;
     for (auto *U : Arg.users()) {
@@ -3383,8 +3567,6 @@ void SPIRVProducerPass::GenerateInstForArg(Function &F) {
         break;
       }
     }
-
-    Type *ArgTy = Arg.getType();
 
     if (PointerType *PTy = dyn_cast<PointerType>(ArgTy)) {
       if (StructType *STy = dyn_cast<StructType>(PTy->getElementType())) {
@@ -5772,10 +5954,9 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
 }
 
 void SPIRVProducerPass::HandleDeferredDecorations(const DataLayout &DL) {
-  // Insert ArrayStride decorations on pointer types, due to OpPtrAccessChain
-  // instructions we generated earlier.
-  if (getTypesNeedingArrayStride().empty())
+  if (getTypesNeedingArrayStride().empty() && LocalArgs.empty()) {
     return;
+  }
 
   SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
 
@@ -5795,6 +5976,8 @@ void SPIRVProducerPass::HandleDeferredDecorations(const DataLayout &DL) {
                      }
                    });
 
+  // Insert ArrayStride decorations on pointer types, due to OpPtrAccessChain
+  // instructions we generated earlier.
   for (auto *type : getTypesNeedingArrayStride()) {
     Type *elemTy = nullptr;
     if (auto *ptrTy = dyn_cast<PointerType>(type)) {
@@ -5824,6 +6007,16 @@ void SPIRVProducerPass::HandleDeferredDecorations(const DataLayout &DL) {
     SPIRVInstruction *DecoInst =
         new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops);
     SPIRVInstList.insert(DecoInsertPoint, DecoInst);
+  }
+
+  // Emit SpecId decorations targeting the array size value.
+  for (const Argument *arg : LocalArgs) {
+    const LocalArgInfo &arg_info = LocalArgMap[arg];
+    SPIRVOperandList Ops;
+    Ops << MkId(arg_info.array_size_id) << MkNum(spv::DecorationSpecId)
+        << MkNum(arg_info.spec_id);
+    SPIRVInstList.insert(DecoInsertPoint,
+        new SPIRVInstruction(4, spv::OpDecorate, 0 /* No id */, Ops));
   }
 }
 
@@ -6580,7 +6773,7 @@ void SPIRVProducerPass::WriteSPIRVBinary() {
   SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
 
   for (auto Inst : SPIRVInstList) {
-    SPIRVOperandList Ops = Inst->getOperands();
+    SPIRVOperandList Ops{Inst->getOperands()};
     spv::Op Opcode = static_cast<spv::Op>(Inst->getOpcode());
 
     switch (Opcode) {

--- a/test/cluster_pod_args_locals_scalars.cl
+++ b/test/cluster_pod_args_locals_scalars.cl
@@ -1,73 +1,81 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
+// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
 // RUN: FileCheck %s < %t.spvasm
-// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck %s < %t2.map -check-prefix=MAP
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, float f, local float* B, uint n)
 {
   A[n] = B[n] + f;
 }
+
+
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,B,argOrdinal,2,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,3,descriptorSet,0,binding,1,offset,4,argKind,pod
+// MAP-NOT: kernel
+
+
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 31
+// CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
 // CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute [[_21:%[a-zA-Z0-9_]+]] "foo"
-// CHECK: OpExecutionMode [[_21]] LocalSize 1 1 1
+// CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpExecutionMode [[_22]] LocalSize 1 1 1
 // CHECK: OpSource OpenCL_C 120
-// CHECK: OpDecorate [[__runtimearr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpMemberDecorate [[__struct_4:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[__struct_4]] Block
-// CHECK: OpDecorate [[__runtimearr_float_0:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpMemberDecorate [[__struct_8:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[__struct_8]] Block
-// CHECK: OpMemberDecorate [[__struct_11:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[__struct_11]] 1 Offset 4
-// CHECK: OpMemberDecorate [[__struct_12:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[__struct_12]] Block
-// CHECK: OpDecorate [[_18:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[_18]] Binding 0
-// CHECK: OpDecorate [[_19:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[_19]] Binding 1
-// CHECK: OpDecorate [[_20:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[_20]] Binding 2
-// CHECK: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_9:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_9]] Block
+// CHECK: OpMemberDecorate [[__struct_12:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_12]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_13:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_13]] Block
+// CHECK: OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_20]] Binding 0
+// CHECK: OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_21]] Binding 1
+// CHECK: OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
 // CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
-// CHECK: [[__struct_4]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK: [[__ptr_StorageBuffer__struct_4:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
-// CHECK: [[__ptr_Workgroup_float:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[_float]]
-// CHECK: [[__runtimearr_float_0]] = OpTypeRuntimeArray [[_float]]
-// CHECK: [[__struct_8]] = OpTypeStruct [[__runtimearr_float_0]]
-// CHECK: [[__ptr_Workgroup__struct_8:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[__struct_8]]
-// CHECK: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CHECK: [[__struct_11]] = OpTypeStruct [[_float]] [[_uint]]
-// CHECK: [[__struct_12]] = OpTypeStruct [[__struct_11]]
-// CHECK: [[__ptr_StorageBuffer__struct_12:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
-// CHECK: [[__ptr_StorageBuffer__struct_11:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
-// CHECK: [[_void:%[a-zA-Z0-9_]+]] = OpTypeVoid
-// CHECK: [[_16:%[a-zA-Z0-9_]+]] = OpTypeFunction [[_void]]
-// CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_18]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
-// CHECK: [[_19]] = OpVariable [[__ptr_Workgroup__struct_8]] Workgroup
-// CHECK: [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
-// CHECK: [[_21]] = OpFunction [[_void]] None [[_16]]
-// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpLabel
-// CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_11]] [[_20]] [[_uint_0]]
-// CHECK: [[_24:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_11]] [[_23]]
-// CHECK: [[_25:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_24]] 0
-// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_24]] 1
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_19]] [[_uint_0]] [[_26]]
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_float]] [[_27]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFAdd [[_float]] [[_25]] [[_28]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_18]] [[_uint_0]] [[_26]]
-// CHECK: OpStore [[_30]] [[_29]]
+// CHECK: [[__struct_9]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[__struct_12]] = OpTypeStruct [[_float]] [[_uint]]
+// CHECK: [[__struct_13]] = OpTypeStruct [[__struct_12]]
+// CHECK: [[__ptr_StorageBuffer__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
+// CHECK: [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_17:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
+// CHECK: [[_2]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
+// CHECK: [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK: [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
+// CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
+// CHECK: [[_22]] = OpFunction [[_void]] None [[_17]]
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_uint_0]]
+// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_12]] [[_21]] [[_uint_0]]
+// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpLoad [[__struct_12]] [[_24]]
+// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_25]] 0
+// CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_25]] 1
+// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_Workgroup_float]] [[_5]] [[_27]]
+// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_28]]
+// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_26]] [[_29]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_27]]
+// CHECK: OpStore [[_31]] [[_30]]
 // CHECK: OpReturn
 // CHECK: OpFunctionEnd

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -1,0 +1,109 @@
+// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: clspv %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck %s < %t2.map -check-prefix=MAP
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct S {
+  int a; int b;
+} S;
+
+kernel void foo(local float *L, global float* A, float f, S local* LS, constant float* C, float g ) {
+ *A = *L + *C + f + g;
+}
+
+// MAP: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,LS,argOrdinal,3,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
+// MAP-NEXT: kernel,foo,arg,C,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod
+// MAP-NOT: kernel
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 49
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_27:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_28:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_29:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_14:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_14]] Block
+// CHECK: OpMemberDecorate [[__struct_16:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_16]] Block
+// CHECK: OpMemberDecorate [[__struct_24:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_24]] 1 Offset 4
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_32:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_32]] Binding 0
+// CHECK: OpDecorate [[_33:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_33]] Binding 1
+// CHECK: OpDecorate [[_34:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_34]] Binding 2
+// CHECK: OpDecorate [[_34]] NonWritable
+// CHECK: OpDecorate [[_35:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_35]] Binding 3
+// CHECK: OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3
+// CHECK: OpDecorate [[_7:%[0-9a-zA-Z_]+]] SpecId 4
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_14]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_14:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_14]]
+// CHECK: [[__struct_16]] = OpTypeStruct [[_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_16:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_16]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[__struct_24]] = OpTypeStruct [[_uint]] [[_uint]]
+// CHECK: [[__ptr_Workgroup__struct_24:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__struct_24]]
+// CHECK: [[_2]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
+// CHECK: [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]
+// CHECK: [[_7]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[__arr__struct_24_7:%[0-9a-zA-Z_]+]] = OpTypeArray [[__struct_24]] [[_7]]
+// CHECK: [[__ptr_Workgroup__arr__struct_24_7:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr__struct_24_7]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_27]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_28]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_29]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_27]] [[_28]] [[_29]]
+// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_32]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_33]] = OpVariable [[__ptr_StorageBuffer__struct_16]] StorageBuffer
+// CHECK: [[_34]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_35]] = OpVariable [[__ptr_StorageBuffer__struct_16]] StorageBuffer
+// CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
+// CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr__struct_24_7]] Workgroup
+// CHECK: [[_36]] = OpFunction [[_void]] None [[_20]]
+// CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_uint_0]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_32]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_33]] [[_uint_0]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_39]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_34]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_35]] [[_uint_0]]
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_42]]
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_5]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_41]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_44]] [[_45]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_46]] [[_40]]
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_47]] [[_43]]
+// CHECK: OpStore [[_38]] [[_48]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -1,0 +1,110 @@
+// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck %s < %t2.map -check-prefix=MAP
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct S {
+  int a; int b;
+} S;
+
+kernel void foo(local float *L, global float* A, S local* LS, constant float* C, float f, float g ) {
+ *A = *L + *C + f + g;
+}
+
+// MAP: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,LS,argOrdinal,2,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
+// MAP-NEXT: kernel,foo,arg,C,argOrdinal,3,descriptorSet,0,binding,1,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,2,offset,4,argKind,pod
+// MAP-NOT: kernel
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 50
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute [[_37:%[0-9a-zA-Z_]+]] "foo"
+// CHECK: OpSource OpenCL_C 120
+// CHECK: OpDecorate [[_29:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK: OpDecorate [[_30:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK: OpDecorate [[_31:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK: OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK: OpMemberDecorate [[__struct_14:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_14]] Block
+// CHECK: OpMemberDecorate [[__struct_16:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_16]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_17:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_17]] Block
+// CHECK: OpMemberDecorate [[__struct_26:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_26]] 1 Offset 4
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK: OpDecorate [[_34:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_34]] Binding 0
+// CHECK: OpDecorate [[_35:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_35]] Binding 1
+// CHECK: OpDecorate [[_35]] NonWritable
+// CHECK: OpDecorate [[_36:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[_36]] Binding 2
+// CHECK: OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3
+// CHECK: OpDecorate [[_7:%[0-9a-zA-Z_]+]] SpecId 4
+// CHECK: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK: [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK: [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK: [[__struct_14]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK: [[__ptr_StorageBuffer__struct_14:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_14]]
+// CHECK: [[__struct_16]] = OpTypeStruct [[_float]] [[_float]]
+// CHECK: [[__struct_17]] = OpTypeStruct [[__struct_16]]
+// CHECK: [[__ptr_StorageBuffer__struct_17:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_17]]
+// CHECK: [[__ptr_StorageBuffer__struct_16:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_16]]
+// CHECK: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK: [[_22:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK: [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
+// CHECK: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK: [[__struct_26]] = OpTypeStruct [[_uint]] [[_uint]]
+// CHECK: [[__ptr_Workgroup__struct_26:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__struct_26]]
+// CHECK: [[_2]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
+// CHECK: [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]
+// CHECK: [[_7]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[__arr__struct_26_7:%[0-9a-zA-Z_]+]] = OpTypeArray [[__struct_26]] [[_7]]
+// CHECK: [[__ptr_Workgroup__arr__struct_26_7:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr__struct_26_7]]
+// CHECK: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_29]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_30]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_31]] = OpSpecConstant [[_uint]] 1
+// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_29]] [[_30]] [[_31]]
+// CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK: [[_34]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_35]] = OpVariable [[__ptr_StorageBuffer__struct_14]] StorageBuffer
+// CHECK: [[_36]] = OpVariable [[__ptr_StorageBuffer__struct_17]] StorageBuffer
+// CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
+// CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr__struct_26_7]] Workgroup
+// CHECK: [[_37]] = OpFunction [[_void]] None [[_22]]
+// CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK: [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_uint_0]]
+// CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_34]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_35]] [[_uint_0]] [[_uint_0]]
+// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_16]] [[_36]] [[_uint_0]]
+// CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpLoad [[__struct_16]] [[_41]]
+// CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_42]] 0
+// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_42]] 1
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_5]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_40]]
+// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_45]] [[_46]]
+// CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_43]] [[_47]]
+// CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_44]] [[_48]]
+// CHECK: OpStore [[_39]] [[_49]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd


### PR DESCRIPTION
- Descriptor map says it's a local, not a buffer.
- Don't allocate a binding for such variables.
- Maps to OpVariable in Workgroup storge of type OpTypeArray
- Array size is an integer specialization constant, with SpecId unique
  to that integer.
- Document pointer-to-local kernel args
- Add tests

- Refactor SPIRVOperandList into its own class
  Add a shift operator to add operands to the list.
  Add MkId and MkNum helpers to make operands.