### PR TITLE
Add -hack-initializers to work around a driver bug

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -21,6 +21,14 @@ bool F16BitStorage();
 // Returns true if each kernel must use its own descriptor set for all arguments.
 bool DistinctKernelDescriptorSets();
 
+// Returns true if we should apply a workaround to make get_global_size(i)
+// with non-constant i work on certain drivers.  The workaround is for the
+// value of the workgroup size is written to a special compiler-generated
+// variable right at the start of each kernel, rather than relying on the
+// variable intializer to take effect.
+// TODO(dneto): Remove this eventually when drivers are fixed.
+bool HackInitializers();
+
 // Returns true if code generation should avoid single-index OpCompositeInsert
 // instructions into struct types.  Use complete OpCompositeConstruct instead.
 // TODO(dneto): Remove this eventually when drivers are fixed.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -34,6 +34,14 @@ llvm::cl::opt<bool> f16bit_storage(
     "f16bit_storage", llvm::cl::init(false),
     llvm::cl::desc("Assume the target supports SPV_KHR_16bit_storage"));
 
+llvm::cl::opt<bool> hack_initializers(
+    "hack-initializers", llvm::cl::init(false),
+    llvm::cl::desc(
+        "At the start of each kernel, explicitly write the initializer "
+        "value for a compiler-generated variable containing the workgroup "
+        "size. Required by some drivers to make the get_global_size builtin "
+        "function work when used with non-constant dimension index."));
+
 llvm::cl::opt<bool> hack_inserts(
     "hack-inserts", llvm::cl::init(false),
     llvm::cl::desc(
@@ -73,6 +81,7 @@ namespace Option {
 
 bool DistinctKernelDescriptorSets() { return distinct_kernel_descriptor_sets; }
 bool F16BitStorage() { return f16bit_storage; }
+bool HackInitializers() { return hack_initializers; }
 bool HackInserts() { return hack_inserts; }
 bool HackUndef() { return hack_undef; }
 bool ModuleConstantsInStorageBuffer() { return module_constants_in_storage_buffer; }

--- a/test/get_global_size_hack_initializers.cl
+++ b/test/get_global_size_hack_initializers.cl
@@ -1,6 +1,6 @@
-// RUN: clspv %s -S -o %t.spvasm
+// RUN: clspv %s -S -o %t.spvasm -hack-initializers
 // RUN: FileCheck %s < %t.spvasm
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -hack-initializers
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
@@ -54,6 +54,8 @@
 
 // CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
 // CHECK-NEXT: %[[LABEL1_ID:[a-zA-Z0-9_]*]] = OpLabel
+// This is new, caused by -hack-initializers
+// CHECK-NEXT: OpStore %[[WORKGROUP_SIZE_VAR_ID]] %[[WORKGROUP_SIZE_ID]]
 // CHECK-NEXT: %[[ACCESS_CHAIN1_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT_GLOBAL_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]]
 // CHECK-NEXT: %[[LOAD1_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_TYPE_ID]] %[[ACCESS_CHAIN1_ID]]
 // CHECK-NEXT: %[[RESULT_ID:[a-zA-Z0-9_]*]] = OpFunctionCall %[[UINT_TYPE_ID]] %[[GET_GLOBAL_SIZE_ID:[a-zA-Z0-9_]*]] %[[LOAD1_ID]]


### PR DESCRIPTION
Use -hack-initializers to work around driver bugs that cause the
get_global_size builtin function to return the wrong value if used with
a non-constant dimension argument.

The underlying issue is that SPIR-V Private variable initializers may
not take effect.  The workaround is to start every kernel with an
explicit store to write the initializer value.  This is only required
for a compiler-generated variable that stores the workgroup size, only
used to implement the get_global_size builtin.