### PR TITLE
Tests: Reduce number of digits to match

### DIFF
--- a/test/MathBuiltins/float2_acospi.cl
+++ b/test/MathBuiltins/float2_acospi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float2* A, float2 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float2_asinpi.cl
+++ b/test/MathBuiltins/float2_asinpi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float2* A, float2 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float2_atan2pi.cl
+++ b/test/MathBuiltins/float2_atan2pi.cl
@@ -51,7 +51,7 @@ void kernel foo(global float2* A, float2 y, float2 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float2_exp10.cl
+++ b/test/MathBuiltins/float2_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float2_half_exp10.cl
+++ b/test/MathBuiltins/float2_half_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float2_native_exp10.cl
+++ b/test/MathBuiltins/float2_native_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float3_acospi.cl
+++ b/test/MathBuiltins/float3_acospi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float3_asinpi.cl
+++ b/test/MathBuiltins/float3_asinpi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float3_atan2pi.cl
+++ b/test/MathBuiltins/float3_atan2pi.cl
@@ -51,7 +51,7 @@ void kernel foo(global float3* A, float3 y, float3 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float3_exp10.cl
+++ b/test/MathBuiltins/float3_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float3_half_exp10.cl
+++ b/test/MathBuiltins/float3_half_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float3_native_exp10.cl
+++ b/test/MathBuiltins/float3_native_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float4_acospi.cl
+++ b/test/MathBuiltins/float4_acospi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float4* A, float4 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float4_asinpi.cl
+++ b/test/MathBuiltins/float4_asinpi.cl
@@ -49,7 +49,7 @@ void kernel foo(global float4* A, float4 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float4_atan2pi.cl
+++ b/test/MathBuiltins/float4_atan2pi.cl
@@ -51,7 +51,7 @@ void kernel foo(global float4* A, float4 y, float4 x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_19]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float4_exp10.cl
+++ b/test/MathBuiltins/float4_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float4_half_exp10.cl
+++ b/test/MathBuiltins/float4_half_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float4_native_exp10.cl
+++ b/test/MathBuiltins/float4_native_exp10.cl
@@ -34,7 +34,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer

--- a/test/MathBuiltins/float_acospi.cl
+++ b/test/MathBuiltins/float_acospi.cl
@@ -48,7 +48,7 @@ void kernel foo(global float* A, float x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_17]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float_asinpi.cl
+++ b/test/MathBuiltins/float_asinpi.cl
@@ -48,7 +48,7 @@ void kernel foo(global float* A, float x)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_17]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float_atan2pi.cl
+++ b/test/MathBuiltins/float_atan2pi.cl
@@ -50,7 +50,7 @@ void kernel foo(global float* A, float x, float y)
 // CHECK: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK: [[__ptr_Private_v3uint:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.31831
+// CHECK: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_17]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_18]] = OpSpecConstant [[_uint]] 1

--- a/test/MathBuiltins/float_exp10.cl
+++ b/test/MathBuiltins/float_exp10.cl
@@ -33,7 +33,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 

--- a/test/MathBuiltins/float_half_exp10.cl
+++ b/test/MathBuiltins/float_half_exp10.cl
@@ -33,7 +33,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 

--- a/test/MathBuiltins/float_native_exp10.cl
+++ b/test/MathBuiltins/float_native_exp10.cl
@@ -33,7 +33,7 @@
 // CHECK: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
 // CHECK: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
 // CHECK: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.30259
+// CHECK: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
 // CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 // CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
 


### PR DESCRIPTION
The SPIRV-Tools disassembler recently started printing
more digits in floating point numbers, to better reproduce
values.

This change accommodates both old and new SPIRV-Tools by truncating
the specified floating point digits to match.