### PR TITLE
Current descriptor set index maintained in named metadata

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterConstants.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp

--- a/lib/DescriptorCounter.cpp
+++ b/lib/DescriptorCounter.cpp
@@ -1,0 +1,74 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include "DescriptorCounter.h"
+
+#include <cassert>
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+namespace {
+
+// We keep the current counter in a named metadata node in the module.
+// It looks likk this:
+//
+// !"clspv.descriptor.index" = !{!3}
+// !3 = !{i32 0}
+static const char *kMetadataName = "clspv.descriptor.index";
+
+} // namespace
+
+namespace clspv {
+
+int GetCurrentDescriptorIndex(llvm::Module *M) {
+  auto *md = M->getOrInsertNamedMetadata(kMetadataName);
+  if (md->getNumOperands() == 0) {
+    auto &ctx = M->getContext();
+    IRBuilder<> Builder(ctx);
+    ConstantInt *ci = Builder.getInt32(0);
+    auto *val = ConstantAsMetadata::get(ci);
+    md->addOperand(MDNode::get(ctx, val));
+    return 0;
+  }
+  assert(md->getNumOperands() == 1);
+  MDNode *operand = md->getOperand(0);
+  assert(operand);
+  assert(operand->getNumOperands() == 1);
+  ConstantInt *ci = mdconst::dyn_extract<ConstantInt>(operand->getOperand(0));
+  assert(ci);
+  const int value = ci->getSExtValue();
+  return value;
+}
+
+int TakeDescriptorIndex(llvm::Module *M) {
+  const int old_value = GetCurrentDescriptorIndex(M);
+  auto *md = M->getNamedMetadata(kMetadataName);
+  assert(md);
+  assert(md->getNumOperands() == 1);
+
+  auto &ctx = M->getContext();
+  IRBuilder<> Builder(ctx);
+  md->setOperand(0, MDNode::get(ctx, ConstantAsMetadata::get(
+                                         Builder.getInt32(old_value + 1))));
+  return old_value;
+}
+
+} // namespace clspv

--- a/lib/DescriptorCounter.h
+++ b/lib/DescriptorCounter.h
@@ -1,0 +1,31 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_LIB_DESCRIPTOR_COUNTER_H_
+#define CLSPV_LIB_DESCRIPTOR_COUNTER_H_
+
+#include "llvm/IR/Module.h"
+
+namespace clspv {
+
+// Returns the current descriptor index for the module.  The first one is 0.
+int GetCurrentDescriptorIndex(llvm::Module *M);
+
+// Get the current descriptor index and increment it internally
+// so that we never get this one again.  The first one is 0.
+int TakeDescriptorIndex(llvm::Module* M);
+
+} // namespace clspv
+
+#endif


### PR DESCRIPTION
It's in module-scope metadata with name "clspv.descriptor.index"

This will make it easier to allocate descriptor sets in different parts
of the compiler.