### PR TITLE
Direct Resource Access optimization

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -21,9 +21,9 @@ bool F16BitStorage();
 // Returns true if each kernel must use its own descriptor set for all arguments.
 bool DistinctKernelDescriptorSets();
 
-// Returns true if the compiler should try to use direct buffer accesses
+// Returns true if the compiler should try to use direct resource accesses
 // within helper functions instead of passing pointers via function arguments.
-bool DirectBufferAccess();
+bool DirectResourceAccess();
 
 // Returns true if we should avoid sharing resource variables for images
 // and samplers.  Use this to avoid one difference between the old and new

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -22,7 +22,7 @@ class ModulePass;
 class raw_pwrite_stream;
 class raw_ostream;
 template <typename T> class ArrayRef;
-}
+} // namespace llvm
 
 namespace clspv {
 /// Define the work-item builtins that OpenCL has.
@@ -254,7 +254,8 @@ llvm::ModulePass *createClusterModuleScopeConstantVars();
 ///
 /// The idea is to save on the number of StorageBuffer (SSBO) arguments, as that
 /// is a very limited resource.  Vulkan requires a minimum of 4 StorageBuffer
-/// arguments (maxPerStageDescriptorStorageBuffers), which is very easy to reach.
+/// arguments (maxPerStageDescriptorStorageBuffers), which is very easy to
+/// reach.
 llvm::ModulePass *createClusterPodKernelArgumentsPass();
 
 /// Splat select scalar condition with vector data operands.
@@ -302,4 +303,15 @@ llvm::ModulePass *createRewriteInsertsPass();
 /// the appropriately typed pointers.
 llvm::ModulePass *createAllocateDescriptorsPass(
     llvm::ArrayRef<std::pair<unsigned, std::string>> samplerMap);
-}
+
+/// Direct Resource Access
+/// @return An LLVM module pass.
+///
+/// For kernel arguments that map to resource variabls (descriptors),
+/// try to avoid passing them by pointer down into helper functions.
+/// Find and exploit commonality among callees of each helper function.
+/// Assumes descriptors have been allocated and mapped to function
+/// calls of the form @clspv.resource.var.*.
+llvm::ModulePass *createDirectResourceAccessPass();
+
+} // namespace clspv

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -416,7 +416,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
   DenseMap<int, unsigned> all_kernels_binding_for_arg_index;
 
   // Maps a function to the list of set and binding to use, per argument.
-  // For an argument that does no use a descriptor, its set and binding are
+  // For an argument that does not use a descriptor, its set and binding are
   // both the kUnallocated value.
   DenseMap<Function *, SmallVector<std::pair<unsigned, unsigned>, 3>>
       set_and_binding_pairs_for_function;
@@ -634,9 +634,10 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           //  binding
           //  arg kind
           //  arg index
+          //  discriminant index
           Type *i32 = Builder.getInt32Ty();
           FunctionType *fnTy =
-              FunctionType::get(ptrTy, {i32, i32, i32, i32}, false);
+              FunctionType::get(ptrTy, {i32, i32, i32, i32, i32}, false);
           var_fn = cast<Function>(M.getOrInsertFunction(fn_name, fnTy));
         }
 
@@ -646,8 +647,11 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         auto *binding_arg = Builder.getInt32(binding);
         auto *arg_kind_arg = Builder.getInt32(unsigned(arg_kind));
         auto *arg_index_arg = Builder.getInt32(arg_index);
-        auto *call = Builder.CreateCall(
-            var_fn, {set_arg, binding_arg, arg_kind_arg, arg_index_arg});
+        auto *discriminant_index_arg =
+            Builder.getInt32(discriminants_list[arg_index].index);
+        auto *call =
+            Builder.CreateCall(var_fn, {set_arg, binding_arg, arg_kind_arg,
+                                        arg_index_arg, discriminant_index_arg});
 
         Value *replacement = nullptr;
         Value *zero = Builder.getInt32(0);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DirectResourceAccessPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -1,0 +1,325 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <climits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/UniqueVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "clspv/Option.h"
+#include "clspv/Passes.h"
+
+#include "ArgKind.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "directresourceaccess"
+
+namespace {
+
+cl::opt<bool> ShowDRA("show-dra", cl::init(false), cl::Hidden,
+                      cl::desc("Show direct resource access details"));
+
+using SamplerMapType = llvm::ArrayRef<std::pair<unsigned, std::string>>;
+
+class DirectResourceAccessPass final : public ModulePass {
+public:
+  static char ID;
+  DirectResourceAccessPass() : ModulePass(ID) {}
+  bool runOnModule(Module &M) override;
+
+private:
+  // Return the functions reachable from entry point functions, where
+  // callers appear before callees.  OpenCL C does not permit recursion
+  // or function or pointers, so this is always well defined.  The ordering
+  // should be reproducible from one run to the next.
+  UniqueVector<Function *> CallGraphOrderedFunctions(Module &);
+
+  // For each kernel argument that will map to a resource variable (descriptor),
+  // try to rewrite the uses of the argument as a direct access of the resource.
+  // We can only do this if all the callees of the function use the same
+  // resource access value for that argument.  Returns true if the module
+  // changed.
+  bool RewriteResourceAccesses(Function *fn);
+
+  // Rewrite uses of this resrouce-based arg if all the callers pass in the
+  // same resource access.  Returns true if the module changed.
+  bool RewriteAccessesForArg(Function *fn, int arg_index, Argument &arg);
+};
+} // namespace
+
+char DirectResourceAccessPass::ID = 0;
+static RegisterPass<DirectResourceAccessPass> X("DirectResourceAccessPass",
+                                                "Direct resource access");
+
+namespace clspv {
+ModulePass *createDirectResourceAccessPass() {
+  return new DirectResourceAccessPass();
+}
+} // namespace clspv
+
+namespace {
+bool DirectResourceAccessPass::runOnModule(Module &M) {
+  bool Changed = false;
+
+  if (clspv::Option::DirectResourceAccess()) {
+    auto ordered_functions = CallGraphOrderedFunctions(M);
+    for (auto *fn : ordered_functions) {
+      Changed |= RewriteResourceAccesses(fn);
+    }
+  }
+
+  return Changed;
+}
+
+UniqueVector<Function *>
+DirectResourceAccessPass::CallGraphOrderedFunctions(Module &M) {
+  // Use a topological sort.
+
+  // Make an ordered list of all functions having bodies, with kernel entry
+  // points listed first.
+  UniqueVector<Function *> functions;
+  SmallVector<Function *, 10> entry_points;
+  for (Function &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
+      functions.insert(&F);
+      entry_points.push_back(&F);
+    }
+  }
+  // Add the remaining functions.
+  for (Function &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
+      functions.insert(&F);
+    }
+  }
+
+  // This will be a complete set of reveresed edges, i.e. with all pairs
+  // of (callee, caller).
+  using Edge = std::pair<unsigned, unsigned>;
+  auto make_edge = [&functions](Function *callee, Function *caller) {
+    return std::pair<unsigned, unsigned>{functions.idFor(callee),
+                                         functions.idFor(caller)};
+  };
+  std::set<Edge> reverse_edges;
+  // Map each function to the functions it calls, and populate |reverse_edges|.
+  std::map<Function *, SmallVector<Function *, 3>> calls_functions;
+  for (Function *callee : functions) {
+    for (auto &use : callee->uses()) {
+      if (auto *call = dyn_cast<CallInst>(use.getUser())) {
+        Function *caller = call->getParent()->getParent();
+        calls_functions[caller].push_back(callee);
+        reverse_edges.insert(make_edge(callee, caller));
+      }
+    }
+  }
+  // Sort the callees in module-order.  This helps us produce a deterministic
+  // result.
+  for (auto &pair : calls_functions) {
+    auto &callees = pair.second;
+    std::sort(callees.begin(), callees.end(),
+              [&functions](Function *lhs, Function *rhs) {
+                return functions.idFor(lhs) < functions.idFor(rhs);
+              });
+  }
+
+  // Use Kahn's algorithm for topoological sort.
+  UniqueVector<Function *> result;
+  SmallVector<Function *, 10> work_list(entry_points.begin(),
+                                        entry_points.end());
+  while (!work_list.empty()) {
+    Function *caller = work_list.back();
+    work_list.pop_back();
+    result.insert(caller);
+    auto &callees = calls_functions[caller];
+    for (auto *callee : callees) {
+      reverse_edges.erase(make_edge(callee, caller));
+      auto lower_bound = reverse_edges.lower_bound(make_edge(callee, nullptr));
+      if (lower_bound == reverse_edges.end() ||
+          lower_bound->first != functions.idFor(callee)) {
+        // Callee has no other unvisited callers.
+        work_list.push_back(callee);
+      }
+    }
+  }
+  // If reverse_edges is not empty then there was a cycle.  But we don't care
+  // about that erroneous case.
+
+  if (ShowDRA) {
+    outs() << "DRA: Ordered functions:\n";
+    for (Function *fun : result) {
+      outs() << "DRA:   " << fun->getName() << "\n";
+    }
+  }
+  return result;
+}
+
+bool DirectResourceAccessPass::RewriteResourceAccesses(Function *fn) {
+  bool Changed = false;
+  int arg_index = 0;
+  for (Argument &arg : fn->args()) {
+    switch (clspv::GetArgKindForType(arg.getType())) {
+    case clspv::ArgKind::Buffer:
+    case clspv::ArgKind::ReadOnlyImage:
+    case clspv::ArgKind::WriteOnlyImage:
+    case clspv::ArgKind::Sampler:
+      Changed |= RewriteAccessesForArg(fn, arg_index, arg);
+      break;
+    }
+    arg_index++;
+  }
+  return Changed;
+}
+
+bool DirectResourceAccessPass::RewriteAccessesForArg(Function *fn,
+                                                     int arg_index,
+                                                     Argument &arg) {
+  bool Changed = false;
+  if (fn->use_empty()) {
+    return false;
+  }
+
+  // We can convert a parameter to a direct resource access if it is
+  // either a direct call to a clspv.resource.var.* or if it a GEP of
+  // such a thing (where the GEP can only have zero indices).
+  struct ParamInfo {
+    // The resource-access builtin function.  (@clspv.resource.var.*)
+    Function *var_fn;
+    // The descriptor set.
+    uint32_t set;
+    // The binding.
+    uint32_t binding;
+    // If the parameter is a GEP, then this is the number of zero-indices
+    // the GEP used.
+    unsigned num_gep_zeroes;
+    // An example call fitting
+    CallInst *sample_call;
+  };
+  // The common valid parameter info across all the callers seen soo far.
+
+  bool seen_one = false;
+  ParamInfo common;
+  // Tries to merge the given parameter info into |common|.  If it is the first
+  // time we've tried, then save it.  Returns true if there is no conflict.
+  auto merge_param_info = [&seen_one, &common](const ParamInfo &pi) {
+    if (!seen_one) {
+      common = pi;
+      seen_one = true;
+      return true;
+    }
+    return pi.var_fn == common.var_fn && pi.set == common.set &&
+           pi.binding == common.binding &&
+           pi.num_gep_zeroes == common.num_gep_zeroes;
+  };
+
+  for (auto &use : fn->uses()) {
+    if (auto *caller = dyn_cast<CallInst>(use.getUser())) {
+      Value *value = caller->getArgOperand(arg_index);
+      // We care about two cases:
+      //     - a direct call to clspv.resource.var.*
+      //     - a GEP with only zero indices, where the base pointer is
+
+      // Unpack GEPs with zeros, if we can.  Rewrite |value| as we go along.
+      unsigned num_gep_zeroes = 0;
+      for (auto *gep = dyn_cast<GetElementPtrInst>(value); gep;
+           gep = dyn_cast<GetElementPtrInst>(value)) {
+        if (!gep->hasAllZeroIndices()) {
+          return false;
+        }
+        num_gep_zeroes += gep->getNumIndices();
+        value = gep->getPointerOperand();
+      }
+      if (auto *call = dyn_cast<CallInst>(value)) {
+        // If the call is a call to a @clspv.resource.var.* function, then try
+        // to merge it, assuming the given number of GEP zero-indices so far.
+        if (call->getCalledFunction()->getName().startswith(
+                "clspv.resource.var.")) {
+          const auto set = uint32_t(
+              dyn_cast<ConstantInt>(call->getOperand(0))->getZExtValue());
+          const auto binding = uint32_t(
+              dyn_cast<ConstantInt>(call->getOperand(1))->getZExtValue());
+          if (!merge_param_info({call->getCalledFunction(), set, binding,
+                                 num_gep_zeroes, call})) {
+            return false;
+          }
+        } else {
+          // A call but not to a resource access builtin function.
+          return false;
+        }
+      } else {
+        // Not a call.
+        return false;
+      }
+    } else {
+      // There isn't enough commonality.  Bail out without changing anything.
+      return false;
+    }
+  }
+  if (ShowDRA) {
+    if (seen_one) {
+      outs() << "DRA:  Rewrite " << fn->getName() << " arg " << arg_index << " "
+             << arg.getName() << ": " << common.var_fn->getName() << " ("
+             << common.set << "," << common.binding
+             << ") zeroes: " << common.num_gep_zeroes << "\n";
+    }
+  }
+
+  // Now rewrite the argument, using the info in |common|.
+
+  Changed = true;
+  IRBuilder<> Builder(fn->getParent()->getContext());
+  auto *zero = Builder.getInt32(0);
+  Builder.SetInsertPoint(fn->getEntryBlock().getFirstNonPHI());
+
+  // Create the call.
+  SmallVector<Value *, 8> args(common.sample_call->arg_begin(),
+                               common.sample_call->arg_end());
+  Value *replacement = Builder.CreateCall(common.var_fn, args);
+  if (ShowDRA) {
+    outs() << "DRA:    Replace: call " << *replacement << "\n";
+  }
+  if (common.num_gep_zeroes) {
+    SmallVector<Value *, 3> zeroes;
+    for (unsigned i = 0; i < common.num_gep_zeroes; i++) {
+      zeroes.push_back(zero);
+    }
+    replacement = Builder.CreateGEP(replacement, zeroes);
+    if (ShowDRA) {
+      outs() << "DRA:    Replace: gep  " << *replacement << "\n";
+    }
+  }
+  arg.replaceAllUsesWith(replacement);
+
+  return Changed;
+}
+
+} // namespace

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -18,20 +18,23 @@
 
 namespace {
 
-// Should the compiler try to use direct buffer accesses within helper
+// Should the compiler try to use direct resource accesses within helper
 // functions instead of passing pointers via function arguments?
-llvm::cl::opt<bool> direct_buffer_access(
-    "direct-buffer-access", llvm::cl::init(false),
+llvm::cl::opt<bool> no_direct_resource_access(
+    "no-dra", llvm::cl::init(false),
     llvm::cl::desc(
-        "Helper functions access buffers directly instead of by pointers "
-        "in function arguments"));
+        "No Direct Resource Access: Avoid rewriting helper functions "
+        "to access resources directly instead of by pointers "
+        "in function arguments.  Affects kernel arguments of type "
+        "pointer-to-global, pointer-to-constant, image, and sampler."));
 
 // By default, reuse the same descriptor set number for all arguments.
 // To turn that off, use -distinct-kernel-descriptor-sets
 llvm::cl::opt<bool> distinct_kernel_descriptor_sets(
     "distinct-kernel-descriptor-sets", llvm::cl::init(false),
     llvm::cl::desc(
-        "Each kernel uses its own descriptor set for its arguments"));
+        "Each kernel uses its own descriptor set for its arguments. "
+        "Turns off direct-resource-access optimizations."));
 
 // TODO(dneto): As per Neil Henning suggestion, might not need this if
 // you can trace the pointer back far enough to see that it's 32-bit
@@ -95,7 +98,9 @@ llvm::cl::opt<bool> show_ids("show-ids", llvm::cl::init(false),
 namespace clspv {
 namespace Option {
 
-bool DirectBufferAccess() { return direct_buffer_access; }
+bool DirectResourceAccess() {
+  return !(no_direct_resource_access || distinct_kernel_descriptor_sets);
+}
 bool DistinctKernelDescriptorSets() { return distinct_kernel_descriptor_sets; }
 bool F16BitStorage() { return f16bit_storage; }
 bool HackDistinctImageSampler() { return hack_dis; }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2919,6 +2919,9 @@ void SPIRVProducerPass::GenerateWorkgroupVars() {
 
 void SPIRVProducerPass::GenerateDescriptorMapInfo(const DataLayout &DL,
                                                   Function &F) {
+  if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
+    return;
+  }
   // Gather the list of resources that are used by this function's arguments.
   auto &resource_var_at_index = FunctionToResourceVarsMap[&F];
 

--- a/test/DirectResourceAccess/common_global_into_helper.cl
+++ b/test/DirectResourceAccess/common_global_into_helper.cl
@@ -1,0 +1,115 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+
+//      MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NONE: kernel
+
+
+
+float core(global float *arr, int n) {
+  return arr[n];
+}
+
+float apple(global float *arr, int n) {
+  return core(arr, n) + core(arr, n+1);
+}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, int n)
+{
+  A[0] = apple(A, n);
+}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(global float* B, uint m)
+{
+  B[0] = apple(B, m) + apple(B, m+2);
+}
+
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 48
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_39:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpExecutionMode [[_33]] LocalSize 1 1 1
+// CHECK:  OpExecutionMode [[_39]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_3]] Block
+// CHECK:  OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_6]] Block
+// CHECK:  OpDecorate [[_16:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_16]] Binding 0
+// CHECK:  OpDecorate [[_17:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_17]] Binding 1
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__struct_6]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_9:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer_float]] [[_uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_16]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_17]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK:  [[_18:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_12]]
+// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_float]]
+// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_16]] [[_uint_0]] [[_20]]
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_22]]
+// CHECK:  OpReturnValue [[_23]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_12]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_float]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_16]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_18]] [[_28]] [[_26]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_26]] [[_uint_1]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_18]] [[_28]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_29]] [[_31]]
+// CHECK:  OpReturnValue [[_32]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_33]] = OpFunction [[_void]] None [[_9]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_16]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_17]] [[_uint_0]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_36]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_24]] [[_35]] [[_37]]
+// CHECK:  OpStore [[_35]] [[_38]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_39]] = OpFunction [[_void]] None [[_9]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_16]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_17]] [[_uint_0]]
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_42]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_24]] [[_41]] [[_43]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_43]] [[_uint_2]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_24]] [[_41]] [[_45]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_44]] [[_46]]
+// CHECK:  OpStore [[_41]] [[_47]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/constant_arg.cl
+++ b/test/DirectResourceAccess/constant_arg.cl
@@ -1,0 +1,110 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+void core(global int *A, int n, constant int *B) { A[n] = B[n + 2]; }
+
+void apple(constant int *B, global int *A, int n) { core(A, n + 1, B); }
+
+kernel void foo(global int *A, int n, constant int *B) { apple(B, A, n); }
+
+kernel void bar(global int *A, int n, constant int *B) { apple(B, A, n); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 57
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_43:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_50:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_17:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_3]] Block
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_5]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 0
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 2
+// CHECK:  OpDecorate [[_23]] NonWritable
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_24]] Binding 1
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_8:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[_uint]] [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[__ptr_StorageBuffer_uint]] [[_uint]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_17]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_18]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_19]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_17]] [[_18]] [[_19]]
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_5]] StorageBuffer
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_10]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_27]] [[_uint_2]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_31]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_27]]
+// CHECK:  OpStore [[_33]] [[_32]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_11]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_37]] [[_uint_1]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_25]] [[_39]] [[_41]] [[_40]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_43]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_46]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_34]] [[_48]] [[_45]] [[_47]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_50]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// CHECK:  [[_54:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_53]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_34]] [[_55]] [[_52]] [[_54]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/global_arg.cl
+++ b/test/DirectResourceAccess/global_arg.cl
@@ -1,0 +1,109 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+void core(global int *A, int n, global int *B) { A[n] = B[n + 2]; }
+
+void apple(global int *B, global int *A, int n) { core(A, n + 1, B); }
+
+kernel void foo(global int *A, int n, global int *B) { apple(B, A, n); }
+
+kernel void bar(global int *A, int n, global int *B) { apple(B, A, n); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 57
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_43:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_50:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_17:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_3]] Block
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_5]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 0
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 2
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_24]] Binding 1
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_8:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[_uint]] [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_11:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[__ptr_StorageBuffer_uint]] [[_uint]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_17]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_18]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_19]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_17]] [[_18]] [[_19]]
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_5]] StorageBuffer
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_10]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_27]] [[_uint_2]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_31]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_27]]
+// CHECK:  OpStore [[_33]] [[_32]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_11]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_37]] [[_uint_1]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_25]] [[_39]] [[_41]] [[_40]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_43]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_46]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_34]] [[_48]] [[_45]] [[_47]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_50]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// CHECK:  [[_54:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_53]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_34]] [[_55]] [[_52]] [[_54]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/inconsistent_kernel_args_global.cl
+++ b/test/DirectResourceAccess/inconsistent_kernel_args_global.cl
@@ -1,0 +1,101 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void apple(global int *B, global int *A, int n) { A[n] = B[n + 2]; }
+
+// foo and bar differ in the second argument, so we can't do the optimization there.
+
+kernel void foo(global int *A, global int *B, int n) { apple(B, A, n); }
+
+kernel void bar(global int *A, int n, global int *B) { apple(B, A, n); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 48
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_41:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_15:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_16:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_17:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_3]] Block
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_5]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_20]] Binding 0
+// CHECK:  OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_21]] Binding 1
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 2
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 1
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_24]] Binding 2
+// CHECK:  OpDecorate [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_8:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_uint]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[__ptr_StorageBuffer_uint]] [[_uint]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_15]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_16]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_17]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_15]] [[_16]] [[_17]]
+// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_5]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_5]] StorageBuffer
+// CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_10]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_28]] [[_uint_2]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_uint]] [[_26]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_31]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_20]] [[_uint_0]] [[_28]]
+// CHECK:  OpStore [[_33]] [[_32]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_34]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_21]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_38]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_25]] [[_37]] [[_36]] [[_39]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_41]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_44]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_25]] [[_46]] [[_43]] [[_45]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/local_arg.cl
+++ b/test/DirectResourceAccess/local_arg.cl
@@ -1,0 +1,116 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+void core(global int *A, int n, local int *B) { A[n] = B[n + 2]; }
+
+void apple(local int *B, global int *A, int n) { core(A, n + 1, B); }
+
+kernel void foo(global int *A, int n, local int *B) { apple(B, A, n); }
+
+kernel void bar(global int *A, int n, local int *B) { apple(B, A, n); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 64
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_52:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_58:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_28:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_29:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_30:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_13:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_13]] Block
+// CHECK:  OpMemberDecorate [[__struct_15:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_15]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_33:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_33]] Binding 0
+// CHECK:  OpDecorate [[_34:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_34]] Binding 1
+// CHECK:  OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3
+// CHECK:  OpDecorate [[_7:%[0-9a-zA-Z_]+]] SpecId 4
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK:  [[__struct_13]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
+// CHECK:  [[__struct_15]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_15:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_15]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_18:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[__ptr_Workgroup_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_uint]]
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[_uint]] [[__ptr_Workgroup_uint]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_Workgroup_uint]] [[__ptr_StorageBuffer_uint]] [[_uint]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_2]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[__arr_uint_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_uint]] [[_2]]
+// CHECK:  [[__ptr_Workgroup__arr_uint_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_uint_2]]
+// CHECK:  [[_7]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[__arr_uint_7:%[0-9a-zA-Z_]+]] = OpTypeArray [[_uint]] [[_7]]
+// CHECK:  [[__ptr_Workgroup__arr_uint_7:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_uint_7]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_28]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_29]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_30]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_28]] [[_29]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_33]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
+// CHECK:  [[_34]] = OpVariable [[__ptr_StorageBuffer__struct_15]] StorageBuffer
+// CHECK:  [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_uint_2]] Workgroup
+// CHECK:  [[_6:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_uint_7]] Workgroup
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_21]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_Workgroup_uint]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_37]] [[_uint_2]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_Workgroup_uint]] [[_38]] [[_40]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_41]]
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]] [[_37]]
+// CHECK:  OpStore [[_43]] [[_42]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_22]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_Workgroup_uint]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_47]] [[_uint_1]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_35]] [[_49]] [[_50]] [[_45]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_52]] = OpFunction [[_void]] None [[_18]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_uint]] [[_1]] [[_uint_0]]
+// CHECK:  [[_54:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_34]] [[_uint_0]]
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_55]]
+// CHECK:  [[_57:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_44]] [[_5]] [[_54]] [[_56]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_58]] = OpFunction [[_void]] None [[_18]]
+// CHECK:  [[_59:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_10:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_uint]] [[_6]] [[_uint_0]]
+// CHECK:  [[_60:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_33]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_61:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_34]] [[_uint_0]]
+// CHECK:  [[_62:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_61]]
+// CHECK:  [[_63:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_44]] [[_10]] [[_60]] [[_62]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/partial_access_chain_global.cl
+++ b/test/DirectResourceAccess/partial_access_chain_global.cl
@@ -1,0 +1,96 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Kernel |bar| does a non-trivial access chain before calling the helper.
+
+void apple(global int *A, global int *B, int n) { A[n] = B[n + 2]; }
+
+kernel void foo(global int *A, global int *B, int n) { apple(A, B, n); }
+
+kernel void bar(global int *A, global int *B, int n) { apple(A + 1, B, n); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 47
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_40:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_16:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_17:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_3]] Block
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_5]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_21]] Binding 1
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 0
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 2
+// CHECK:  OpDecorate [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
+// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_8:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_uint]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_10:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[__ptr_StorageBuffer_uint]] [[__ptr_StorageBuffer_uint]] [[_uint]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
+// CHECK:  [[_16]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_17]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_18]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_16]] [[_17]] [[_18]]
+// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_5]] StorageBuffer
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_10]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_uint]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_27]] [[_uint_2]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_21]] [[_uint_0]] [[_29]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_uint]] [[_25]] [[_27]]
+// CHECK:  OpStore [[_32]] [[_31]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_33]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_21]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_37]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_24]] [[_35]] [[_36]] [[_38]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_40]] = OpFunction [[_void]] None [[_8]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_21]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_23]] [[_uint_0]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_43]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_22]] [[_uint_0]] [[_uint_1]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_24]] [[_45]] [[_42]] [[_44]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/ro_image2_sampler_args.cl
+++ b/test/DirectResourceAccess/ro_image2_sampler_args.cl
@@ -1,0 +1,134 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+float4 core(read_only image2d_t im, float2 coord, sampler_t s) {
+  return read_imagef(im, s, coord);
+}
+
+void apple(read_only image2d_t im, sampler_t s, float2 coord, global float4 *A) {
+    *A = core(im, coord, s); }
+
+kernel void foo(float2 coord, sampler_t s, read_only image2d_t im, global float4* A) {
+    apple(im, s, 2 * coord, A); }
+kernel void bar(float2 coord, sampler_t s, read_only image2d_t im, global float4* A) {
+    apple(im, s, 3 * coord, A); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 75
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_57:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_66:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_29:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_30:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_31:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_8]] Block
+// CHECK:  OpMemberDecorate [[__struct_11:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_11]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_34:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_34]] Binding 1
+// CHECK:  OpDecorate [[_35:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_35]] Binding 2
+// CHECK:  OpDecorate [[_35]] NonWritable
+// CHECK:  OpDecorate [[_36:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_36]] Binding 3
+// CHECK:  OpDecorate [[_37:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_37]] Binding 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeSampler
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CHECK:  [[__ptr_UniformConstant_4:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_4]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_8]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
+// CHECK:  [[_v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 2
+// CHECK:  [[__struct_11]] = OpTypeStruct [[_v2float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_11:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_14:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__ptr_StorageBuffer_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v2float]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_18:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_v4float]] [[_4]] [[_v2float]] [[_2]]
+// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_4]] [[_2]] [[_v2float]] [[__ptr_StorageBuffer_v4float]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v2float]] [[_float_2]] [[_float_2]]
+// CHECK:  [[_float_3:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 3
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v2float]] [[_float_3]] [[_float_3]]
+// CHECK:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK:  [[_29]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_30]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_31]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_29]] [[_30]] [[_31]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_34]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_35]] = OpVariable [[__ptr_UniformConstant_4]] UniformConstant
+// CHECK:  [[_36]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
+// CHECK:  [[_37]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunction [[_v4float]] Pure [[_18]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2float]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_34]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_35]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpSampledImage [[_22]] [[_44]] [[_43]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_45]] [[_40]] Lod [[_float_0]]
+// CHECK:  OpReturnValue [[_46]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_19]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2float]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_v4float]]
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_36]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_54:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_34]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_35]]
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_38]] [[_55]] [[_50]] [[_54]]
+// CHECK:  OpStore [[_53]] [[_56]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_57]] = OpFunction [[_void]] None [[_14]]
+// CHECK:  [[_58:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_59:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2float]] [[_37]] [[_uint_0]]
+// CHECK:  [[_60:%[0-9a-zA-Z_]+]] = OpLoad [[_v2float]] [[_59]]
+// CHECK:  [[_61:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_34]]
+// CHECK:  [[_62:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_35]]
+// CHECK:  [[_63:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_36]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_64:%[0-9a-zA-Z_]+]] = OpFMul [[_v2float]] [[_60]] [[_25]]
+// CHECK:  [[_65:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_47]] [[_62]] [[_61]] [[_64]] [[_63]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_66]] = OpFunction [[_void]] None [[_14]]
+// CHECK:  [[_67:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_68:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2float]] [[_37]] [[_uint_0]]
+// CHECK:  [[_69:%[0-9a-zA-Z_]+]] = OpLoad [[_v2float]] [[_68]]
+// CHECK:  [[_70:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_34]]
+// CHECK:  [[_71:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_35]]
+// CHECK:  [[_72:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_36]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_73:%[0-9a-zA-Z_]+]] = OpFMul [[_v2float]] [[_69]] [[_27]]
+// CHECK:  [[_74:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_47]] [[_71]] [[_70]] [[_73]] [[_72]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/ro_image3_sampler_args.cl
+++ b/test/DirectResourceAccess/ro_image3_sampler_args.cl
@@ -1,0 +1,132 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+float4 core(read_only image3d_t im, float4 coord, sampler_t s) {
+  return read_imagef(im, s, coord);
+}
+
+void apple(read_only image3d_t im, sampler_t s, float4 coord, global float4 *A) {
+    *A = core(im, coord, s); }
+
+kernel void foo(float4 coord, sampler_t s, read_only image3d_t im, global float4* A) {
+    apple(im, s, 2 * coord, A); }
+kernel void bar(float4 coord, sampler_t s, read_only image3d_t im, global float4* A) {
+    apple(im, s, 3 * coord, A); }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 73
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_55:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_64:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_27:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_28:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_29:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_8]] Block
+// CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_10]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_32:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_32]] Binding 1
+// CHECK:  OpDecorate [[_33:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_33]] Binding 2
+// CHECK:  OpDecorate [[_33]] NonWritable
+// CHECK:  OpDecorate [[_34:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_34]] Binding 3
+// CHECK:  OpDecorate [[_35:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_35]] Binding 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeSampler
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK:  [[__ptr_UniformConstant_4:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_4]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_8]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_v4float]] [[_4]] [[_v4float]] [[_2]]
+// CHECK:  [[_17:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_4]] [[_2]] [[_v4float]] [[__ptr_StorageBuffer_v4float]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_float_2:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 2
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v4float]] [[_float_2]] [[_float_2]] [[_float_2]] [[_float_2]]
+// CHECK:  [[_float_3:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 3
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v4float]] [[_float_3]] [[_float_3]] [[_float_3]] [[_float_3]]
+// CHECK:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK:  [[_27]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_28]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_29]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_27]] [[_28]] [[_29]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_32]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_33]] = OpVariable [[__ptr_UniformConstant_4]] UniformConstant
+// CHECK:  [[_34]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
+// CHECK:  [[_35]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpFunction [[_v4float]] Pure [[_16]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_32]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_33]]
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpSampledImage [[_20]] [[_42]] [[_41]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_43]] [[_38]] Lod [[_float_0]]
+// CHECK:  OpReturnValue [[_44]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_17]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer_v4float]]
+// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_34]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_32]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_33]]
+// CHECK:  [[_54:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_36]] [[_53]] [[_48]] [[_52]]
+// CHECK:  OpStore [[_51]] [[_54]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_55]] = OpFunction [[_void]] None [[_13]]
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_57:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_35]] [[_uint_0]]
+// CHECK:  [[_58:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_57]]
+// CHECK:  [[_59:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_32]]
+// CHECK:  [[_60:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_33]]
+// CHECK:  [[_61:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_34]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_62:%[0-9a-zA-Z_]+]] = OpFMul [[_v4float]] [[_58]] [[_23]]
+// CHECK:  [[_63:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_45]] [[_60]] [[_59]] [[_62]] [[_61]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_64]] = OpFunction [[_void]] None [[_13]]
+// CHECK:  [[_65:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_66:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_35]] [[_uint_0]]
+// CHECK:  [[_67:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_66]]
+// CHECK:  [[_68:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_32]]
+// CHECK:  [[_69:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_33]]
+// CHECK:  [[_70:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_34]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_71:%[0-9a-zA-Z_]+]] = OpFMul [[_v4float]] [[_67]] [[_25]]
+// CHECK:  [[_72:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_45]] [[_69]] [[_68]] [[_71]] [[_70]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/wo_image2_args.cl
+++ b/test/DirectResourceAccess/wo_image2_args.cl
@@ -1,0 +1,125 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Just for fun, swap arguments in the helpers.
+
+void core(float4 a, write_only image2d_t im, int2 coord) {
+  write_imagef(im, coord, a);
+}
+
+void apple(write_only image2d_t im, int2 coord, float4 a) {
+   core(a, im, coord);
+}
+
+kernel void foo(int2 coord, write_only image2d_t im, float4 a) {
+  apple(im, 2 * coord, a);
+}
+
+kernel void bar(int2 coord, write_only image2d_t im, float4 a) {
+  apple(im, 3 * coord, a);
+}
+
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 63
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability StorageImageWriteWithoutFormat
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_45:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_54:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_25:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_26:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_6]] Block
+// CHECK:  OpMemberDecorate [[__struct_9:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_9]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_29:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_29]] Binding 1
+// CHECK:  OpDecorate [[_29]] NonReadable
+// CHECK:  OpDecorate [[_30:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_30]] Binding 0
+// CHECK:  OpDecorate [[_31:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_31]] Binding 2
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK:  [[__struct_6]] = OpTypeStruct [[_v2uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__struct_9]] = OpTypeStruct [[_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_v2uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v2uint]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_15:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_v4float]] [[_2]] [[_v2uint]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_2]] [[_v2uint]] [[_v4float]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v2uint]] [[_uint_1]] [[_uint_1]]
+// CHECK:  [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v2uint]] [[_uint_3]] [[_uint_3]]
+// CHECK:  [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_25]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_26]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_24]] [[_25]] [[_26]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_29]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_30]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK:  [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_15]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2uint]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  OpImageWrite [[_37]] [[_35]] [[_33]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_16]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2uint]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_32]] [[_41]] [[_43]] [[_40]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_45]] = OpFunction [[_void]] None [[_12]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_30]] [[_uint_0]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpLoad [[_v2uint]] [[_47]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_31]] [[_uint_0]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_50]]
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_v2uint]] [[_48]] [[_21]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_38]] [[_49]] [[_52]] [[_51]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_54]] = OpFunction [[_void]] None [[_12]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_30]] [[_uint_0]]
+// CHECK:  [[_57:%[0-9a-zA-Z_]+]] = OpLoad [[_v2uint]] [[_56]]
+// CHECK:  [[_58:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_59:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_31]] [[_uint_0]]
+// CHECK:  [[_60:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_59]]
+// CHECK:  [[_61:%[0-9a-zA-Z_]+]] = OpIMul [[_v2uint]] [[_57]] [[_23]]
+// CHECK:  [[_62:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_38]] [[_58]] [[_61]] [[_60]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/DirectResourceAccess/wo_image3_args.cl
+++ b/test/DirectResourceAccess/wo_image3_args.cl
@@ -1,0 +1,126 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void core(float4 a, write_only image3d_t im, int4 coord) {
+  write_imagef(im, coord, a);
+}
+
+void apple(write_only image3d_t im, int4 coord, float4 a) {
+   core(a, im, coord);
+}
+
+kernel void foo(int4 coord, write_only image3d_t im, float4 a) {
+  apple(im, 2 * coord, a);
+}
+
+kernel void bar(int4 coord, write_only image3d_t im, float4 a) {
+  apple(im, 3 * coord, a);
+}
+
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 63
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability StorageImageWriteWithoutFormat
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_45:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpEntryPoint GLCompute [[_54:%[0-9a-zA-Z_]+]] "bar"
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] SpecId 0
+// CHECK:  OpDecorate [[_25:%[0-9a-zA-Z_]+]] SpecId 1
+// CHECK:  OpDecorate [[_26:%[0-9a-zA-Z_]+]] SpecId 2
+// CHECK:  OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_6]] Block
+// CHECK:  OpMemberDecorate [[__struct_9:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_9]] Block
+// CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:  OpDecorate [[_29:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_29]] Binding 1
+// CHECK:  OpDecorate [[_29]] NonReadable
+// CHECK:  OpDecorate [[_30:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_30]] Binding 0
+// CHECK:  OpDecorate [[_31:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_31]] Binding 2
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
+// CHECK:  [[__struct_6]] = OpTypeStruct [[_v4uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__struct_9]] = OpTypeStruct [[_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_12:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_v4uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4uint]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_15:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_v4float]] [[_2]] [[_v4uint]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_2]] [[_v4uint]] [[_v4float]]
+// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v4uint]] [[_uint_1]] [[_uint_1]] [[_uint_1]] [[_uint_1]]
+// CHECK:  [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpConstantComposite [[_v4uint]] [[_uint_3]] [[_uint_3]] [[_uint_3]] [[_uint_3]]
+// CHECK:  [[_24]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_25]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_26]] = OpSpecConstant [[_uint]] 1
+// CHECK:  [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_24]] [[_25]] [[_26]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private_v3uint]] Private [[_gl_WorkGroupSize]]
+// CHECK:  [[_29]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_30]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK:  [[_31]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_15]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4uint]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  OpImageWrite [[_37]] [[_35]] [[_33]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_16]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4uint]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_32]] [[_41]] [[_43]] [[_40]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_45]] = OpFunction [[_void]] None [[_12]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4uint]] [[_30]] [[_uint_0]]
+// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpLoad [[_v4uint]] [[_47]]
+// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_31]] [[_uint_0]]
+// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_50]]
+// CHECK:  [[_52:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_v4uint]] [[_48]] [[_21]]
+// CHECK:  [[_53:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_38]] [[_49]] [[_52]] [[_51]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_54]] = OpFunction [[_void]] None [[_12]]
+// CHECK:  [[_55:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_56:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4uint]] [[_30]] [[_uint_0]]
+// CHECK:  [[_57:%[0-9a-zA-Z_]+]] = OpLoad [[_v4uint]] [[_56]]
+// CHECK:  [[_58:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_29]]
+// CHECK:  [[_59:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_31]] [[_uint_0]]
+// CHECK:  [[_60:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_59]]
+// CHECK:  [[_61:%[0-9a-zA-Z_]+]] = OpIMul [[_v4uint]] [[_57]] [[_23]]
+// CHECK:  [[_62:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_38]] [[_58]] [[_61]] [[_60]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
@@ -5,97 +5,100 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 41
-// CHECK: ; Schema: 0
-// CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
 
-// CHECK: OpMemberDecorate %[[ARG2_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG2_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG3_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
 
-// CHECK: OpMemberDecorate %[[ARG3_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG3_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
 
-// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
-// CHECK: OpDecorate %[[ARG1_ID]] NonWritable
 
-// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
 
-// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
 
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[SAMPLER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeSampler
-// CHECK-DAG: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[SAMPLER_TYPE_ID]]
-// CHECK-DAG: %[[READ_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[FLOAT_TYPE_ID]] 2D 0 0 0 1 Unknown
-// CHECK-DAG: %[[ARG1_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[READ_ONLY_IMAGE_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT2_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
-// CHECK-DAG: %[[ARG2_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT2_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG2_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT2_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK-DAG: %[[FLOAT4_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_STRUCT_TYPE_ID]] = OpTypeStruct %[[ARG3_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG3_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK-DAG: %[[BAR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[FLOAT4_TYPE_ID]] %[[SAMPLER_TYPE_ID]] %[[READ_ONLY_IMAGE_TYPE_ID]] %[[FLOAT2_TYPE_ID]]
 
-// CHECK-DAG: %[[SAMPLED_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeSampledImage %[[READ_ONLY_IMAGE_TYPE_ID]]
 
-// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK-DAG: %[[FP_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0
 
-// CHECK: %[[ARG0_ID]] = OpVariable %[[ARG0_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG1_ID]] = OpVariable %[[ARG1_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG2_ID]] = OpVariable %[[ARG2_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[ARG3_ID]] = OpVariable %[[ARG3_POINTER_TYPE_ID]] StorageBuffer
 
-// CHECK: %[[BAR_ID:[a-zA-Z0-9_]*]] = OpFunction %[[FLOAT4_TYPE_ID]] Pure %[[BAR_TYPE_ID]]
-// CHECK: %[[S_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[SAMPLER_TYPE_ID]]
-// CHECK: %[[I_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[READ_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[FLOAT2_TYPE_ID]]
-// CHECK: %[[BAR_LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[SAMPLED_IMAGE_ID:[a-zA-Z0-9_]*]] = OpSampledImage %[[SAMPLED_IMAGE_TYPE_ID]] %[[I_ID]] %[[S_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpImageSampleExplicitLod %[[FLOAT4_TYPE_ID]] %[[SAMPLED_IMAGE_ID]] %[[C_ID]] Lod %[[FP_CONSTANT_0_ID]]
-// CHECK: OpReturnValue %[[OP_ID]]
-// CHECK: OpFunctionEnd
 
 float4 bar(sampler_t s, read_only image2d_t i, float2 c)
 {
   return read_imagef(i, s, c);
 }
 
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[S_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[SAMPLER_TYPE_ID]] %[[ARG0_ID]]
-// CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[READ_ONLY_IMAGE_TYPE_ID]] %[[ARG1_ID]]
-// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT2_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT2_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
-// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT4_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[CALL_ID:[a-zA-Z0-9_]*]] = OpFunctionCall %[[FLOAT4_TYPE_ID]] %[[BAR_ID]] %[[S_LOAD_ID]] %[[I_LOAD_ID]] %[[C_LOAD_ID]]
-// CHECK: OpStore %[[A_ACCESS_CHAIN_ID]] %[[CALL_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read_only image2d_t i, float2 c, global float4* a)
 {
   *a = bar(s, i, c);
 }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 43
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpExecutionMode [[_35]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_11:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_11]] Block
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 0
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 1
+// CHECK:  OpDecorate [[_23]] NonWritable
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_24]] Binding 2
+// CHECK:  OpDecorate [[_25:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_25]] Binding 3
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeSampler
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CHECK:  [[__ptr_UniformConstant_4:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_4]]
+// CHECK:  [[_v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 2
+// CHECK:  [[__struct_7]] = OpTypeStruct [[_v2float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_11]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_11:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_11]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_14:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__ptr_StorageBuffer_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v2float]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_18:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_v4float]] [[_2]] [[_4]] [[_v2float]]
+// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK:  [[_22]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_23]] = OpVariable [[__ptr_UniformConstant_4]] UniformConstant
+// CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK:  [[_25]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunction [[_v4float]] Pure [[_18]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2float]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_23]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_22]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpSampledImage [[_19]] [[_31]] [[_32]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_33]] [[_29]] Lod [[_float_0]]
+// CHECK:  OpReturnValue [[_34]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_35]] = OpFunction [[_void]] None [[_14]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_22]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_23]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2float]] [[_24]] [[_uint_0]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpLoad [[_v2float]] [[_39]]
+// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_25]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_26]] [[_37]] [[_38]] [[_40]]
+// CHECK:  OpStore [[_41]] [[_42]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
@@ -5,95 +5,98 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 39
-// CHECK: ; Schema: 0
-// CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK-NOT: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
 
-// CHECK: OpMemberDecorate %[[ARG2_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG2_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG3_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
 
-// CHECK: OpMemberDecorate %[[ARG3_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG3_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
 
-// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
-// CHECK: OpDecorate %[[ARG1_ID]] NonWritable
 
-// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
 
-// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
 
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[SAMPLER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeSampler
-// CHECK-DAG: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[SAMPLER_TYPE_ID]]
-// CHECK-DAG: %[[READ_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[FLOAT_TYPE_ID]] 3D 0 0 0 1 Unknown
-// CHECK-DAG: %[[ARG1_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[READ_ONLY_IMAGE_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK-DAG: %[[ARG2_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG2_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT4_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_STRUCT_TYPE_ID]] = OpTypeStruct %[[ARG3_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK-DAG: %[[ARG3_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG3_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK-DAG: %[[BAR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[FLOAT4_TYPE_ID]] %[[SAMPLER_TYPE_ID]] %[[READ_ONLY_IMAGE_TYPE_ID]] %[[FLOAT4_TYPE_ID]]
 
-// CHECK-DAG: %[[SAMPLED_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeSampledImage %[[READ_ONLY_IMAGE_TYPE_ID]]
 
-// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
-// CHECK-DAG: %[[FP_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0
 
-// CHECK: %[[ARG0_ID]] = OpVariable %[[ARG0_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG1_ID]] = OpVariable %[[ARG1_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG2_ID]] = OpVariable %[[ARG2_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[ARG3_ID]] = OpVariable %[[ARG3_POINTER_TYPE_ID]] StorageBuffer
 
-// CHECK: %[[BAR_ID:[a-zA-Z0-9_]*]] = OpFunction %[[FLOAT4_TYPE_ID]] Pure %[[BAR_TYPE_ID]]
-// CHECK: %[[S_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[SAMPLER_TYPE_ID]]
-// CHECK: %[[I_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[READ_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[FLOAT4_TYPE_ID]]
-// CHECK: %[[BAR_LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[SAMPLED_IMAGE_ID:[a-zA-Z0-9_]*]] = OpSampledImage %[[SAMPLED_IMAGE_TYPE_ID]] %[[I_ID]] %[[S_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpImageSampleExplicitLod %[[FLOAT4_TYPE_ID]] %[[SAMPLED_IMAGE_ID]] %[[C_ID]] Lod %[[FP_CONSTANT_0_ID]]
-// CHECK: OpReturnValue %[[OP_ID]]
-// CHECK: OpFunctionEnd
 
 float4 bar(sampler_t s, read_only image3d_t i, float4 c)
 {
   return read_imagef(i, s, c);
 }
 
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[S_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[SAMPLER_TYPE_ID]] %[[ARG0_ID]]
-// CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[READ_ONLY_IMAGE_TYPE_ID]] %[[ARG1_ID]]
-// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT4_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
-// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT4_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[CALL_ID:[a-zA-Z0-9_]*]] = OpFunctionCall %[[FLOAT4_TYPE_ID]] %[[BAR_ID]] %[[S_LOAD_ID]] %[[I_LOAD_ID]] %[[C_LOAD_ID]]
-// CHECK: OpStore %[[A_ACCESS_CHAIN_ID]] %[[CALL_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read_only image3d_t i, float4 c, global float4* a)
 {
   *a = bar(s, i, c);
 }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 41
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpExecutionMode [[_33]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_10]] Block
+// CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_20]] Binding 0
+// CHECK:  OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_21]] Binding 1
+// CHECK:  OpDecorate [[_21]] NonWritable
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 2
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 3
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeSampler
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK:  [[__ptr_UniformConstant_4:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_4]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__struct_7]] = OpTypeStruct [[_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_v4float]] [[_2]] [[_4]] [[_v4float]]
+// CHECK:  [[_17:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
+// CHECK:  [[_20]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_21]] = OpVariable [[__ptr_UniformConstant_4]] UniformConstant
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunction [[_v4float]] Pure [[_16]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_4]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_21]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_20]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpSampledImage [[_17]] [[_29]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_31]] [[_27]] Lod [[_float_0]]
+// CHECK:  OpReturnValue [[_32]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_33]] = OpFunction [[_void]] None [[_13]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_20]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpLoad [[_4]] [[_21]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_22]] [[_uint_0]]
+// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_37]]
+// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_24]] [[_35]] [[_36]] [[_38]]
+// CHECK:  OpStore [[_39]] [[_40]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
@@ -5,85 +5,89 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 34
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
 
-// CHECK: OpMemberDecorate %[[ARG1_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG1_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG2_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
 
-// CHECK: OpMemberDecorate %[[ARG2_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG2_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[ARG0_ID]] NonReadable
 
-// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
 
-// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
 
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[WRITE_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[FLOAT_TYPE_ID]] 2D 0 0 0 2 Unknown
-// CHECK-DAG: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK-DAG: %[[UINT2_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 2
-// CHECK-DAG: %[[ARG1_STRUCT_TYPE_ID]] = OpTypeStruct %[[UINT2_TYPE_ID]]
-// CHECK-DAG: %[[ARG1_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG1_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[UINT2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT2_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK-DAG: %[[FLOAT4_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_STRUCT_TYPE_ID]] = OpTypeStruct %[[ARG2_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG2_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK-DAG: %[[BAR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]] %[[WRITE_ONLY_IMAGE_TYPE_ID]] %[[UINT2_TYPE_ID]] %[[FLOAT4_TYPE_ID]]
 
-// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 
-// CHECK: %[[ARG0_ID]] = OpVariable %[[ARG0_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG1_ID]] = OpVariable %[[ARG1_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[ARG2_ID]] = OpVariable %[[ARG2_POINTER_TYPE_ID]] StorageBuffer
 
-// CHECK: %[[BAR_ID:[a-zA-Z0-9_]*]] = OpFunction %[[VOID_TYPE_ID]] None %[[BAR_TYPE_ID]]
-// CHECK: %[[I_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[UINT2_TYPE_ID]]
-// CHECK: %[[A_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[FLOAT4_TYPE_ID]]
-// CHECK: %[[BAR_LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: OpImageWrite %[[I_ID]] %[[C_ID]] %[[A_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void bar(write_only image2d_t i, int2 c, float4 a)
 {
   write_imagef(i, c, a);
 }
 
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]] %[[ARG0_ID]]
-// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT2_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT2_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
-// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT4_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
-// CHECK: %[[CALL_ID:[a-zA-Z0-9_]*]] = OpFunctionCall %[[VOID_TYPE_ID]] %[[BAR_ID]] %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2d_t i, int2 c, global float4* a)
 {
   bar(i, c, *a);
 }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 35
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability StorageImageWriteWithoutFormat
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpExecutionMode [[_27]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_6]] Block
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_10]] Block
+// CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_18]] Binding 0
+// CHECK:  OpDecorate [[_18]] NonReadable
+// CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_19]] Binding 1
+// CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_20]] Binding 2
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK:  [[__struct_6]] = OpTypeStruct [[_v2uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_v2uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v2uint]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_2]] [[_v2uint]] [[_v4float]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_18]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_16]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2uint]]
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_18]]
+// CHECK:  OpImageWrite [[_26]] [[_23]] [[_24]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_27]] = OpFunction [[_void]] None [[_13]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_18]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_19]] [[_uint_0]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpLoad [[_v2uint]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_32]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_21]] [[_29]] [[_31]] [[_33]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
@@ -7,85 +7,89 @@
 
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
 
-// CHECK: ; SPIR-V
-// CHECK: ; Version: 1.0
-// CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 34
-// CHECK: ; Schema: 0
-// CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
-// CHECK: OpMemoryModel Logical GLSL450
-// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
-// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
 
-// CHECK: OpMemberDecorate %[[ARG1_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG1_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG2_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
 
-// CHECK: OpMemberDecorate %[[ARG2_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
-// CHECK: OpDecorate %[[ARG2_STRUCT_TYPE_ID]] Block
 
-// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
-// CHECK: OpDecorate %[[ARG0_ID]] NonReadable
 
-// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
 
-// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
-// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
 
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[WRITE_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[FLOAT_TYPE_ID]] 3D 0 0 0 2 Unknown
-// CHECK-DAG: %[[ARG0_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer UniformConstant %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
-// CHECK-DAG: %[[ARG1_STRUCT_TYPE_ID]] = OpTypeStruct %[[UINT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG1_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG1_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[UINT4_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[UINT4_TYPE_ID]]
-// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK-DAG: %[[FLOAT4_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT4_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_STRUCT_TYPE_ID]] = OpTypeStruct %[[ARG2_DYNAMIC_ARRAY_TYPE_ID]]
-// CHECK-DAG: %[[ARG2_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[ARG2_STRUCT_TYPE_ID]]
-// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
-// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
-// CHECK-DAG: %[[BAR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]] %[[WRITE_ONLY_IMAGE_TYPE_ID]] %[[UINT4_TYPE_ID]] %[[FLOAT4_TYPE_ID]]
 
-// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 
-// CHECK: %[[ARG0_ID]] = OpVariable %[[ARG0_POINTER_TYPE_ID]] UniformConstant
-// CHECK: %[[ARG1_ID]] = OpVariable %[[ARG1_POINTER_TYPE_ID]] StorageBuffer
-// CHECK: %[[ARG2_ID]] = OpVariable %[[ARG2_POINTER_TYPE_ID]] StorageBuffer
 
-// CHECK: %[[BAR_ID:[a-zA-Z0-9_]*]] = OpFunction %[[VOID_TYPE_ID]] None %[[BAR_TYPE_ID]]
-// CHECK: %[[I_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[UINT4_TYPE_ID]]
-// CHECK: %[[A_ID:[a-zA-Z0-9_]*]] = OpFunctionParameter %[[FLOAT4_TYPE_ID]]
-// CHECK: %[[BAR_LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: OpImageWrite %[[I_ID]] %[[C_ID]] %[[A_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void bar(write_only image3d_t i, int4 c, float4 a)
 {
   write_imagef(i, c, a);
 }
 
-// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
-// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
-// CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]] %[[ARG0_ID]]
-// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[UINT4_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT4_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
-// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT4_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
-// CHECK: %[[CALL_ID:[a-zA-Z0-9_]*]] = OpFunctionCall %[[VOID_TYPE_ID]] %[[BAR_ID]] %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image3d_t i, int4 c, global float4* a)
 {
   bar(i, c, *a);
 }
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 35
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability StorageImageWriteWithoutFormat
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpExecutionMode [[_27]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_6:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_6]] Block
+// CHECK:  OpDecorate [[__runtimearr_v4float:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_10]] Block
+// CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_18]] Binding 0
+// CHECK:  OpDecorate [[_18]] NonReadable
+// CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_19]] Binding 1
+// CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_20]] Binding 2
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_2:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK:  [[__ptr_UniformConstant_2:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[_2]]
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
+// CHECK:  [[__struct_6]] = OpTypeStruct [[_v4uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[__runtimearr_v4float]] = OpTypeRuntimeArray [[_v4float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_v4float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer_v4uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4uint]]
+// CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]] [[_2]] [[_v4uint]] [[_v4float]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_18]] = OpVariable [[__ptr_UniformConstant_2]] UniformConstant
+// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpFunction [[_void]] None [[_16]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_2]]
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4uint]]
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_18]]
+// CHECK:  OpImageWrite [[_26]] [[_23]] [[_24]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_27]] = OpFunction [[_void]] None [[_13]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_2]] [[_18]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4uint]] [[_19]] [[_uint_0]]
+// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpLoad [[_v4uint]] [[_30]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v4float]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]] [[_32]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_void]] [[_21]] [[_29]] [[_31]] [[_33]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd

--- a/test/PointerAccessChains/pointer_deref.cl
+++ b/test/PointerAccessChains/pointer_deref.cl
@@ -41,49 +41,49 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  OpEntryPoint GLCompute [[_26:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_26]] LocalSize 1 1 1
 // CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] ArrayStride 512
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
 // CHECK:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__struct_3]] Block
-// CHECK:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__runtimearr__struct_8:%[0-9a-zA-Z_]+]] ArrayStride 512
 // CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK:  OpDecorate [[__struct_10]] Block
 // CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_19]] Binding 0
+// CHECK:  OpDecorate [[_19]] Binding 1
 // CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_20]] Binding 1
+// CHECK:  OpDecorate [[_20]] Binding 0
 // CHECK:  OpDecorate [[__arr_float_uint_128:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
-// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK:  [[_uint_128:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 128
 // CHECK:  [[__arr_float_uint_128]] = OpTypeArray [[_float]] [[_uint_128]]
-// CHECK:  [[__struct_8]] = OpTypeStruct [[__arr_float_uint_128]]
-// CHECK:  [[__runtimearr__struct_8]] = OpTypeRuntimeArray [[__struct_8]]
-// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr__struct_8]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[__arr_float_uint_128]]
+// CHECK:  [[__runtimearr__struct_5]] = OpTypeRuntimeArray [[__struct_5]]
+// CHECK:  [[__struct_7]] = OpTypeStruct [[__runtimearr__struct_5]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_float]]
 // CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
 // CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
 // CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
-// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
 // CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_16]]
-// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_22]] [[_uint_0]] [[_uint_5]]
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_19]] [[_uint_0]] [[_uint_0]] [[_uint_0]] [[_uint_5]]
 // CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_24]]
 // CHECK:  OpReturnValue [[_25]]
 // CHECK:  OpFunctionEnd
 // CHECK:  [[_26]] = OpFunction [[_void]] None [[_13]]
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_19]] [[_uint_0]] [[_uint_0]]
-// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_8]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_5]] [[_19]] [[_uint_0]] [[_uint_0]]
 // CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_21]] [[_29]]
 // CHECK:  OpStore [[_28]] [[_30]]
 // CHECK:  OpReturn

--- a/test/PointerAccessChains/pointer_index_in_called_function.cl
+++ b/test/PointerAccessChains/pointer_index_in_called_function.cl
@@ -5,22 +5,14 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -S -o %t.spvasm -no-dra
+// RUN: FileCheck %s < %t.spvasm -check-prefix=NODRA
+// RUN: clspv %s -o %t.spv -no-dra
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: OpDecorate [[rtarr_struct:%[a-zA-Z0-9_]+]] ArrayStride 48
-// CHECK: OpDecorate [[rtarr_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-// CHECK: OpDecorate [[arr_12_float:%[a-zA-Z0-9_]+]] ArrayStride 4
-// This is the one we really want:
-// CHECK: OpDecorate [[ptr_sb_float:%[a-zA-Z0-9_]+]] ArrayStride 4
 
-// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct
-// CHECK-DAG: [[ptr_sb_struct:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[struct]]
-// CHECK-DAG: [[ptr_sb_float]] = OpTypePointer StorageBuffer [[float]]
-// CHECK-DAG: [[rtarr_float]] = OpTypeRuntimeArray [[float]]
-
-// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
-// CHECK-DAG: [[uint_7:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 7
 
 typedef struct {
   float x[12];
@@ -30,13 +22,157 @@ float bar(global Thing* a, int n) {
   return a[n].x[7];
 }
 
-// CHECK: = OpFunction [[float]]
-// CHECK-NEXT: [[param_a:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[ptr_sb_struct]]
-// CHECK-NEXT: [[param_n:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[uint]]
-// CHECK-NEXT: OpLabel
-// CHECK-NEXT: = OpPtrAccessChain [[ptr_sb_float]] [[param_a]] [[param_n]] [[uint_0]] [[uint_7]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
 foo(global Thing* a, global float *b, int n) {
   *b = bar(a, n);
 }
+
+// Direct-resource-access optimization converts to straight OpAccessChain
+
+// CHECK:  ; SPIR-V
+// CHECK:  ; Version: 1.0
+// CHECK:  ; Generator: Codeplay; 0
+// CHECK:  ; Bound: 38
+// CHECK:  ; Schema: 0
+// CHECK:  OpCapability Shader
+// CHECK:  OpCapability VariablePointers
+// CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// CHECK:  OpExtension "SPV_KHR_variable_pointers"
+// CHECK:  OpMemoryModel Logical GLSL450
+// CHECK:  OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"
+// CHECK:  OpExecutionMode [[_31]] LocalSize 1 1 1
+// CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] ArrayStride 48
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
+// CHECK:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_10]] Block
+// CHECK:  OpMemberDecorate [[__struct_12:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_12]] Block
+// CHECK:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_22]] Binding 0
+// CHECK:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_23]] Binding 1
+// CHECK:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// CHECK:  OpDecorate [[_24]] Binding 2
+// CHECK:  OpDecorate [[__arr_float_uint_12:%[0-9a-zA-Z_]+]] ArrayStride 4
+// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK:  [[_uint_12:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 12
+// CHECK:  [[__arr_float_uint_12]] = OpTypeArray [[_float]] [[_uint_12]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[__arr_float_uint_12]]
+// CHECK:  [[__runtimearr__struct_5]] = OpTypeRuntimeArray [[__struct_5]]
+// CHECK:  [[__struct_7]] = OpTypeStruct [[__runtimearr__struct_5]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CHECK:  [[__struct_12]] = OpTypeStruct [[_uint]]
+// CHECK:  [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK:  [[_15:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_5]] [[_uint]]
+// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK:  [[_uint_7:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 7
+// CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_19]]
+// CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_5]]
+// CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_22]] [[_uint_0]] [[_27]] [[_uint_0]] [[_uint_7]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_29]]
+// CHECK:  OpReturnValue [[_30]]
+// CHECK:  OpFunctionEnd
+// CHECK:  [[_31]] = OpFunction [[_void]] None [[_15]]
+// CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpLabel
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_5]] [[_22]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_23]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_35]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_25]] [[_33]] [[_36]]
+// CHECK:  OpStore [[_34]] [[_37]]
+// CHECK:  OpReturn
+// CHECK:  OpFunctionEnd
+
+
+
+// NODRA:  ; SPIR-V
+// NODRA:  ; Version: 1.0
+// NODRA:  ; Generator: Codeplay; 0
+// NODRA:  ; Bound: 38
+// NODRA:  ; Schema: 0
+// NODRA:  OpCapability Shader
+// NODRA:  OpCapability VariablePointers
+// NODRA:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// NODRA:  OpExtension "SPV_KHR_variable_pointers"
+// NODRA:  OpMemoryModel Logical GLSL450
+// NODRA:  OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"
+// NODRA:  OpExecutionMode [[_31]] LocalSize 1 1 1
+// NODRA:  OpSource OpenCL_C 120
+// NODRA:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] ArrayStride 48
+// NODRA:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__struct_7]] Block
+// NODRA:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__struct_10]] Block
+// NODRA:  OpMemberDecorate [[__struct_12:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__struct_12]] Block
+// NODRA:  OpDecorate [[_22:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// NODRA:  OpDecorate [[_22]] Binding 0
+// NODRA:  OpDecorate [[_23:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// NODRA:  OpDecorate [[_23]] Binding 1
+// NODRA:  OpDecorate [[_24:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// NODRA:  OpDecorate [[_24]] Binding 2
+// NODRA:  OpDecorate [[__arr_float_uint_12:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  OpDecorate [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// NODRA:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// NODRA:  [[_uint_12:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 12
+// NODRA:  [[__arr_float_uint_12]] = OpTypeArray [[_float]] [[_uint_12]]
+// NODRA:  [[__struct_5]] = OpTypeStruct [[__arr_float_uint_12]]
+// NODRA:  [[__runtimearr__struct_5]] = OpTypeRuntimeArray [[__struct_5]]
+// NODRA:  [[__struct_7]] = OpTypeStruct [[__runtimearr__struct_5]]
+// NODRA:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// NODRA:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// NODRA:  [[__struct_10]] = OpTypeStruct [[__runtimearr_float]]
+// NODRA:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// NODRA:  [[__struct_12]] = OpTypeStruct [[_uint]]
+// NODRA:  [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// NODRA:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// NODRA:  [[_15:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// NODRA:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// NODRA:  [[__ptr_StorageBuffer_float]] = OpTypePointer StorageBuffer [[_float]]
+// NODRA:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// NODRA:  [[_19:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_5]] [[_uint]]
+// NODRA:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// NODRA:  [[_uint_7:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 7
+// NODRA:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
+// NODRA:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// NODRA:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_12]] StorageBuffer
+// NODRA:  [[_25:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_19]]
+// NODRA:  [[_26:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_5]]
+// NODRA:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_uint]]
+// NODRA:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// NODRA:  [[_29:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_float]] [[_26]] [[_27]] [[_uint_0]] [[_uint_7]]
+// NODRA:  [[_30:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_29]]
+// NODRA:  OpReturnValue [[_30]]
+// NODRA:  OpFunctionEnd
+// NODRA:  [[_31]] = OpFunction [[_void]] None [[_15]]
+// NODRA:  [[_32:%[0-9a-zA-Z_]+]] = OpLabel
+// NODRA:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_5]] [[_22]] [[_uint_0]] [[_uint_0]]
+// NODRA:  [[_34:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_23]] [[_uint_0]] [[_uint_0]]
+// NODRA:  [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_24]] [[_uint_0]]
+// NODRA:  [[_36:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_35]]
+// NODRA:  [[_37:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_25]] [[_33]] [[_36]]
+// NODRA:  OpStore [[_34]] [[_37]]
+// NODRA:  OpReturn
+// NODRA:  OpFunctionEnd

--- a/test/PointerAccessChains/pointer_index_is_constant_0.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_0.cl
@@ -41,49 +41,49 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  OpEntryPoint GLCompute [[_26:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_26]] LocalSize 1 1 1
 // CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] ArrayStride 512
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
 // CHECK:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__struct_3]] Block
-// CHECK:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__runtimearr__struct_8:%[0-9a-zA-Z_]+]] ArrayStride 512
 // CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK:  OpDecorate [[__struct_10]] Block
 // CHECK:  OpDecorate [[_19:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_19]] Binding 0
+// CHECK:  OpDecorate [[_19]] Binding 1
 // CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_20]] Binding 1
+// CHECK:  OpDecorate [[_20]] Binding 0
 // CHECK:  OpDecorate [[__arr_float_uint_128:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
-// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK:  [[_uint_128:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 128
 // CHECK:  [[__arr_float_uint_128]] = OpTypeArray [[_float]] [[_uint_128]]
-// CHECK:  [[__struct_8]] = OpTypeStruct [[__arr_float_uint_128]]
-// CHECK:  [[__runtimearr__struct_8]] = OpTypeRuntimeArray [[__struct_8]]
-// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr__struct_8]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[__arr_float_uint_128]]
+// CHECK:  [[__runtimearr__struct_5]] = OpTypeRuntimeArray [[__struct_5]]
+// CHECK:  [[__struct_7]] = OpTypeStruct [[__runtimearr__struct_5]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_float]]
 // CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
 // CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
 // CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
-// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
 // CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_16]]
-// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_22]] [[_uint_0]] [[_uint_5]]
+// CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_19]] [[_uint_0]] [[_uint_0]] [[_uint_0]] [[_uint_5]]
 // CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_24]]
 // CHECK:  OpReturnValue [[_25]]
 // CHECK:  OpFunctionEnd
 // CHECK:  [[_26]] = OpFunction [[_void]] None [[_13]]
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_19]] [[_uint_0]] [[_uint_0]]
-// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_8]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_5]] [[_19]] [[_uint_0]] [[_uint_0]]
 // CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_21]] [[_29]]
 // CHECK:  OpStore [[_28]] [[_30]]
 // CHECK:  OpReturn

--- a/test/PointerAccessChains/pointer_index_is_constant_1.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_1.cl
@@ -5,15 +5,18 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -S -o %t.spvasm -no-dra
+// RUN: FileCheck %s < %t.spvasm -check-prefix=NODRA
+// RUN: clspv %s -o %t.spv -no-dra
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 
 struct Thing
 {
   float a[128];
 };
-
-
-
-
 
 
 float bar(global struct Thing* a)
@@ -26,6 +29,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 {
   *a = bar(b);
 }
+
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
@@ -39,52 +43,116 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_27]] LocalSize 1 1 1
 // CHECK:  OpSource OpenCL_C 120
+// CHECK:  OpMemberDecorate [[__struct_5:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] ArrayStride 512
+// CHECK:  OpMemberDecorate [[__struct_7:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:  OpDecorate [[__struct_7]] Block
 // CHECK:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__struct_3]] Block
-// CHECK:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:  OpDecorate [[__runtimearr__struct_8:%[0-9a-zA-Z_]+]] ArrayStride 512
 // CHECK:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK:  OpDecorate [[__struct_10]] Block
 // CHECK:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_20]] Binding 0
+// CHECK:  OpDecorate [[_20]] Binding 1
 // CHECK:  OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
-// CHECK:  OpDecorate [[_21]] Binding 1
+// CHECK:  OpDecorate [[_21]] Binding 0
 // CHECK:  OpDecorate [[__arr_float_uint_128:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  OpDecorate [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
-// CHECK:  [[__struct_3]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK:  [[_uint_128:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 128
 // CHECK:  [[__arr_float_uint_128]] = OpTypeArray [[_float]] [[_uint_128]]
-// CHECK:  [[__struct_8]] = OpTypeStruct [[__arr_float_uint_128]]
-// CHECK:  [[__runtimearr__struct_8]] = OpTypeRuntimeArray [[__struct_8]]
-// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr__struct_8]]
+// CHECK:  [[__struct_5]] = OpTypeStruct [[__arr_float_uint_128]]
+// CHECK:  [[__runtimearr__struct_5]] = OpTypeRuntimeArray [[__struct_5]]
+// CHECK:  [[__struct_7]] = OpTypeStruct [[__runtimearr__struct_5]]
+// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// CHECK:  [[__struct_10]] = OpTypeStruct [[__runtimearr_float]]
 // CHECK:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
 // CHECK:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
-// CHECK:  [[__ptr_StorageBuffer_float]] = OpTypePointer StorageBuffer [[_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
-// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
+// CHECK:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
+// CHECK:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
 // CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_16]]
-// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_8]]
+// CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_5]]
 // CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_float]] [[_23]] [[_uint_1]] [[_uint_0]] [[_uint_5]]
+// CHECK:  [[_25:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_uint_1]] [[_uint_0]] [[_uint_5]]
 // CHECK:  [[_26:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_25]]
 // CHECK:  OpReturnValue [[_26]]
 // CHECK:  OpFunctionEnd
 // CHECK:  [[_27]] = OpFunction [[_void]] None [[_13]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_uint_0]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_8]] [[_21]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_21]] [[_uint_0]] [[_uint_0]]
+// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_5]] [[_20]] [[_uint_0]] [[_uint_0]]
 // CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_22]] [[_30]]
 // CHECK:  OpStore [[_29]] [[_31]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd
+
+
+
+// NODRA:  ; SPIR-V
+// NODRA:  ; Version: 1.0
+// NODRA:  ; Generator: Codeplay; 0
+// NODRA:  ; Bound: 32
+// NODRA:  ; Schema: 0
+// NODRA:  OpCapability Shader
+// NODRA:  OpCapability VariablePointers
+// NODRA:  OpExtension "SPV_KHR_storage_buffer_storage_class"
+// NODRA:  OpExtension "SPV_KHR_variable_pointers"
+// NODRA:  OpMemoryModel Logical GLSL450
+// NODRA:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
+// NODRA:  OpExecutionMode [[_27]] LocalSize 1 1 1
+// NODRA:  OpSource OpenCL_C 120
+// NODRA:  OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  OpMemberDecorate [[__struct_3:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__struct_3]] Block
+// NODRA:  OpMemberDecorate [[__struct_8:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__runtimearr__struct_8:%[0-9a-zA-Z_]+]] ArrayStride 512
+// NODRA:  OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// NODRA:  OpDecorate [[__struct_10]] Block
+// NODRA:  OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// NODRA:  OpDecorate [[_20]] Binding 0
+// NODRA:  OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
+// NODRA:  OpDecorate [[_21]] Binding 1
+// NODRA:  OpDecorate [[__arr_float_uint_128:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  OpDecorate [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] ArrayStride 4
+// NODRA:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// NODRA:  [[__runtimearr_float]] = OpTypeRuntimeArray [[_float]]
+// NODRA:  [[__struct_3]] = OpTypeStruct [[__runtimearr_float]]
+// NODRA:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// NODRA:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// NODRA:  [[_uint_128:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 128
+// NODRA:  [[__arr_float_uint_128]] = OpTypeArray [[_float]] [[_uint_128]]
+// NODRA:  [[__struct_8]] = OpTypeStruct [[__arr_float_uint_128]]
+// NODRA:  [[__runtimearr__struct_8]] = OpTypeRuntimeArray [[__struct_8]]
+// NODRA:  [[__struct_10]] = OpTypeStruct [[__runtimearr__struct_8]]
+// NODRA:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// NODRA:  [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
+// NODRA:  [[_13:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// NODRA:  [[__ptr_StorageBuffer_float]] = OpTypePointer StorageBuffer [[_float]]
+// NODRA:  [[__ptr_StorageBuffer__struct_8:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
+// NODRA:  [[_16:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_float]] [[__ptr_StorageBuffer__struct_8]]
+// NODRA:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// NODRA:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// NODRA:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// NODRA:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
+// NODRA:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// NODRA:  [[_22:%[0-9a-zA-Z_]+]] = OpFunction [[_float]] Pure [[_16]]
+// NODRA:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[__ptr_StorageBuffer__struct_8]]
+// NODRA:  [[_24:%[0-9a-zA-Z_]+]] = OpLabel
+// NODRA:  [[_25:%[0-9a-zA-Z_]+]] = OpPtrAccessChain [[__ptr_StorageBuffer_float]] [[_23]] [[_uint_1]] [[_uint_0]] [[_uint_5]]
+// NODRA:  [[_26:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_25]]
+// NODRA:  OpReturnValue [[_26]]
+// NODRA:  OpFunctionEnd
+// NODRA:  [[_27]] = OpFunction [[_void]] None [[_13]]
+// NODRA:  [[_28:%[0-9a-zA-Z_]+]] = OpLabel
+// NODRA:  [[_29:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_uint_0]]
+// NODRA:  [[_30:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_8]] [[_21]] [[_uint_0]] [[_uint_0]]
+// NODRA:  [[_31:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_float]] [[_22]] [[_30]]
+// NODRA:  OpStore [[_29]] [[_31]]
+// NODRA:  OpReturn
+// NODRA:  OpFunctionEnd

--- a/test/ResourceVar/pointer_to_constant_arg_into_helper_fn.cl
+++ b/test/ResourceVar/pointer_to_constant_arg_into_helper_fn.cl
@@ -1,6 +1,0 @@
-// Have to preserve the address space of pointer-to-constant.
-// RUN: clspv %s
-void helper(global int* A, constant int* B) { *A = *B; }
-
-kernel void foo(global int* A, constant int* B) { helper(A, B); }
-

--- a/test/spvasm2checks.pl
+++ b/test/spvasm2checks.pl
@@ -64,6 +64,7 @@ while(<>) {
       push @parts, $word;
     }
   }
+  $is_type_or_constant = 0;
   my $first = ($is_type_or_constant ? '// CHECK-DAG: ' : '// CHECK: ');
   print join(' ', $first, @parts), "\n";
 }

--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -768,6 +768,7 @@ int main(const int argc, const char *const argv[]) {
 
   pm.add(clspv::createAllocateDescriptorsPass(SamplerMapEntries));
   pm.add(llvm::createVerifierPass());
+  pm.add(clspv::createDirectResourceAccessPass());
   // Replacing pointer bitcasts can leave some trivial GEPs
   // that are easy to remove.  Also replace GEPs of GEPS
   // left by replacing indirect buffer accesses.


### PR DESCRIPTION
Where possible, convert helper function accesses to resource variables
into direct accesses of that resource variable.  This happens under
the following conditions:

- Affects kernel arguments of the following type, which are converted
  to resource variables that are associated with Vulkan descriptors:
   - pointer-to-global
   - pointer-to-constant
   - image
   - sampler
- All callees of the helper function are using the same resource
  variable. (E.g. Generally, same kernel argument index and same type.)
- The base pointer of the resource is passed in (directly, without
  modification or sub-object access chain)

Use option -no-dra to disable this optimization.

Use of -distinct-kernel-descriptor-sets disables this optimiztaion.

List of commits included
------------------------

1.
Resource var call also saves discriminant index

This is more conveneint and explicit than trying to pick
off the pointer type or get the last component of the function
name.

2.
Compute call-level ordering of reachable functions via
Kahn's topological sort algorithm.

3.
Descriptor map should only get info for kernels

4.
Update tests.
In two cases, also verify the old behaviour via -no-dra

5.
spvasm2checks: Don't emit CHECK-DAG