### PR TITLE
Fix -Wparentheses warnings

### DIFF
--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -160,7 +160,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
 
       GetElementPtrInst *GEP = nullptr;
       Value *OrgGEPIdx = nullptr;
-      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
+      if ((GEP = dyn_cast<GetElementPtrInst>(BitCastUser))) {
         OrgGEPIdx = GEP->getOperand(1);
 
         // Build new src/dst address index.
@@ -806,7 +806,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
 
       GetElementPtrInst *GEP = nullptr;
       Value *OrgGEPIdx = nullptr;
-      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
+      if ((GEP = dyn_cast<GetElementPtrInst>(BitCastUser))) {
         IRBuilder<> Builder(GEP);
 
         // Build new src/dst address.


### PR DESCRIPTION
Resolves

```
[911/1316] Building CXX object lib/CMakeFiles/clspv_core.dir/ReplacePointerBitcastPass.cpp.o
../lib/ReplacePointerBitcastPass.cpp:163:15: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/ReplacePointerBitcastPass.cpp:163:15: note: place parentheses around the assignment to silence this warning
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
              ^
          (                                             )
../lib/ReplacePointerBitcastPass.cpp:163:15: note: use '==' to turn this assignment into an equality comparison
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
              ^
              ==
../lib/ReplacePointerBitcastPass.cpp:809:15: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/ReplacePointerBitcastPass.cpp:809:15: note: place parentheses around the assignment to silence this warning
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
              ^
          (                                             )
../lib/ReplacePointerBitcastPass.cpp:809:15: note: use '==' to turn this assignment into an equality comparison
      if (GEP = dyn_cast<GetElementPtrInst>(BitCastUser)) {
              ^
              ==
2 warnings generated.
```