### PR TITLE
Extend RewriteInsertPass to handle complete vector chains.

### DIFF
--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -154,6 +154,14 @@ class RewriteInsertsPass : public ModulePass {
    // containing the insertion instructions, in member order.
    // Otherwise returns nullptr.  Only handle insertions into vectors.
    InsertionVector *CompleteInsertionChain(InsertElementInst *ie) {
+     // Don't handle i8 vectors. Only <4 x i8> is supported and it is
+     // translated as i32.  Only handle single-index insertions.
+     if (auto vec_ty = dyn_cast<VectorType>(ie->getType())) {
+       if (vec_ty->getVectorElementType() == Type::getInt8Ty(ie->getContext())) {
+         return nullptr;
+       }
+     }
+
      // Only handle single-index insertions.
      if (ie->getNumOperands() == 3) {
        auto numElems = GetNumElements(ie->getType());

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -371,7 +371,6 @@ bool RewriteInsertsPass::ReplacePartialInsertions(Module &M) {
     // Record the list of tails for the next round.
     InsertionVector NextRoundWorkList;
 
-    //for (InsertValueInst *insertion : WorkList) {
     for (Instruction *inst : WorkList) {
       InsertValueInst *insertion = cast<InsertValueInst>(inst);
       // Rewrite |insertion|.

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -47,7 +47,7 @@ class RewriteInsertsPass : public ModulePass {
   bool runOnModule(Module &M) override;
 
  private:
-   using InsertionVector = SmallVector<InsertValueInst *, 4>;
+   using InsertionVector = SmallVector<Instruction *, 4>;
 
    // Replaces chains of insertions that cover the entire value.
    // Such a change always reduces the number of instructions, so
@@ -98,11 +98,23 @@ class RewriteInsertsPass : public ModulePass {
      return frontier;
    }
 
+   // Returns the number of elements in the struct or array.
+   unsigned GetNumElements(Type *type) {
+     // CompositeType doesn't implement getNumElements(), but its inheritors
+     // do.
+     if (auto *struct_ty = dyn_cast<StructType>(type)) {
+       return struct_ty->getNumElements();
+     } else if (auto *seq_ty = dyn_cast<SequentialType>(type)) {
+       return seq_ty->getNumElements();
+     }
+     return 0;
+   }
+
+
    // If this is the tail of a chain of InsertValueInst instructions
    // that covers the entire composite, then return a small vector
    // containing the insertion instructions, in member order.
-   // Otherwise returns nullptr.  Only handle insertions into structs,
-   // not into arrays.
+   // Otherwise returns nullptr. 
    InsertionVector *CompleteInsertionChain(InsertValueInst *iv) {
      if (iv->getNumIndices() == 1) {
        auto numElems = GetNumElements(iv->getType());
@@ -137,6 +149,48 @@ class RewriteInsertsPass : public ModulePass {
      return nullptr;
    }
 
+   // If this is the tail of a chain of InsertElementInst instructions
+   // that covers the entire vector, then return a small vector
+   // containing the insertion instructions, in member order.
+   // Otherwise returns nullptr.  Only handle insertions into vectors.
+   InsertionVector *CompleteInsertionChain(InsertElementInst *ie) {
+     // Only handle single-index insertions.
+     if (ie->getNumOperands() == 3) {
+       auto numElems = GetNumElements(ie->getType());
+       if (numElems != 0) {
+         if (auto *const_value = dyn_cast<ConstantInt>(ie->getOperand(2))) {
+           uint64_t index = const_value->getZExtValue();
+           if (index + 1u != numElems) {
+             // Not the last in the chain.
+             return nullptr;
+           }
+           InsertionVector candidates(numElems, nullptr);
+           Value *value = ie;
+           uint64_t i = index;
+           while (auto *insert = dyn_cast<InsertElementInst>(value)) {
+             if (insert->getNumOperands() != 3) break;
+             if (auto *index_const = dyn_cast<ConstantInt>(insert->getOperand(2))) {
+               if (i != index_const->getZExtValue()) break;
+
+               candidates[i] = insert;
+               if (i == 0) {
+                 // We're done!
+                 return new InsertionVector(candidates);
+               }
+
+               value = insert->getOperand(0);
+               --i;
+             } else {
+               break;
+             }
+           }
+         } else {
+           return nullptr;
+         }
+       }
+     }
+     return nullptr;
+   }
 
    // Return the name for the wrap function for the given type.
    string &WrapFunctionNameForType(Type *type) {
@@ -153,14 +207,14 @@ class RewriteInsertsPass : public ModulePass {
    }
 
    // Get or create the composite construct function definition.
-   Function *GetConstructFunction(Module &M, CompositeType *constructed_type,
-                                  unsigned num_elements) {
+   Function *GetConstructFunction(Module &M, CompositeType *constructed_type) {
      // Get or create the composite construct function definition.
      const string &fn_name = WrapFunctionNameForType(constructed_type);
      Function *fn = M.getFunction(fn_name);
      if (!fn) {
        // Make the function.
        SmallVector<Type*, 16> elements;
+       unsigned num_elements = GetNumElements(constructed_type);
        for (unsigned i = 0; i != num_elements; ++i)
          elements.push_back(constructed_type->getTypeAtIndex(i));
        FunctionType *fnTy = FunctionType::get(
@@ -170,18 +224,6 @@ class RewriteInsertsPass : public ModulePass {
        fn->addFnAttr(Attribute::ReadOnly);
      }
      return fn;
-   }
-
-   // Returns the number of elements in the struct or array.
-   unsigned GetNumElements(Type *type) {
-     // CompositeType doesn't implement getNumElements(), but its inheritors
-     // do.
-     if (auto *struct_ty = dyn_cast<StructType>(type)) {
-       return struct_ty->getNumElements();
-     } else if (auto *array_ty = dyn_cast<ArrayType>(type)) {
-       return array_ty->getNumElements();
-     }
-     return 0;
    }
 
    // Maps a loaded type to the name of the wrap function for that type.
@@ -221,6 +263,10 @@ bool RewriteInsertsPass::ReplaceCompleteInsertionChains(Module &M) {
           if (InsertionVector *insertions = CompleteInsertionChain(iv)) {
             WorkList.push_back(insertions);
           }
+        } else if (InsertElementInst *ie = dyn_cast<InsertElementInst>(&I)) {
+          if (InsertionVector *insertions = CompleteInsertionChain(ie)) {
+            WorkList.push_back(insertions);
+          }
         }
       }
     }
@@ -235,16 +281,18 @@ bool RewriteInsertsPass::ReplaceCompleteInsertionChains(Module &M) {
 
     // Gather the member values and types.
     SmallVector<Value*, 4> values;
-    SmallVector<Type*, 4> types;
-    for (InsertValueInst* insert : *insertions) {
-      Value* value = insert->getInsertedValueOperand();
-      values.push_back(value);
-      types.push_back(value->getType());
+    for (Instruction* inst : *insertions) {
+      if (auto *insert_value = dyn_cast<InsertValueInst>(inst)) {
+        values.push_back(insert_value->getInsertedValueOperand());
+      } else if (auto *insert_element = dyn_cast<InsertElementInst>(inst)) {
+        values.push_back(insert_element->getOperand(1));
+      } else {
+        llvm_unreachable("Unhandled insertion instruction");
+      }
     }
 
     CompositeType *resultTy = cast<CompositeType>(insertions->back()->getType());
-    unsigned numElems = GetNumElements(resultTy);
-    Function *fn = GetConstructFunction(M, resultTy, numElems);
+    Function *fn = GetConstructFunction(M, resultTy);
 
     // Replace the chain.
     auto call = CallInst::Create(fn, values);
@@ -255,7 +303,7 @@ bool RewriteInsertsPass::ReplaceCompleteInsertionChains(Module &M) {
     // the head, since the tail uses the previous insertion, etc.
     for (auto iter = insertions->rbegin(), end = insertions->rend();
          iter != end; ++iter) {
-      InsertValueInst *insertion = *iter;
+      Instruction *insertion = *iter;
       if (!insertion->hasNUsesOrMore(1)) {
         insertion->eraseFromParent();
       }
@@ -323,7 +371,9 @@ bool RewriteInsertsPass::ReplacePartialInsertions(Module &M) {
     // Record the list of tails for the next round.
     InsertionVector NextRoundWorkList;
 
-    for (InsertValueInst *insertion : WorkList) {
+    //for (InsertValueInst *insertion : WorkList) {
+    for (Instruction *inst : WorkList) {
+      InsertValueInst *insertion = cast<InsertValueInst>(inst);
       // Rewrite |insertion|.
 
       StructType *resultTy = cast<StructType>(insertion->getType());
@@ -355,8 +405,7 @@ bool RewriteInsertsPass::ReplacePartialInsertions(Module &M) {
 
       // Create the call.  It's dominated by any extractions we've just
       // created.
-      Function *construct_fn =
-          GetConstructFunction(M, resultTy, resultTy->getNumElements());
+      Function *construct_fn = GetConstructFunction(M, resultTy);
       auto *call = CallInst::Create(construct_fn, members, "", insertion);
 
       // Disconnect this insertion.  We'll remove it later.
@@ -366,7 +415,7 @@ bool RewriteInsertsPass::ReplacePartialInsertions(Module &M) {
       // we can.  Stop at the first element that has a remaining use.
       for (auto* chainElem : chain) {
         if (chainElem->hasNUsesOrMore(1)) {
-          unsigned &use_count = num_uses[insertions.idFor(chainElem)];
+          unsigned &use_count = num_uses[insertions.idFor(cast<InsertValueInst>(chainElem))];
           assert(use_count > 0);
           --use_count;
           if (use_count == 0) {

--- a/test/HalfStorage/clspv_vloada_half4_global.cl
+++ b/test/HalfStorage/clspv_vloada_half4_global.cl
@@ -18,7 +18,7 @@ kernel void foo(global float4* A, global float4* B, uint n) {
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 61
+// CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -61,7 +61,6 @@ kernel void foo(global float4* A, global float4* B, uint n) {
 // CHECK-DAG: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK: [[_22]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_23]] = OpSpecConstant [[_uint]] 1
@@ -82,11 +81,10 @@ kernel void foo(global float4* A, global float4* B, uint n) {
 // CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_uint]] [[_34]] [[_uint_1]]
 // CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_uint]] [[_38]] [[_uint_1]]
 // CHECK: [[_40:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_37]] [[_39]]
-// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_40]] [[_20]] 0
 // CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_39]] [[_uint_1]]
 // CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_37]] [[_42]]
-// CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_43]] [[_41]] 1
-// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[_44]]
+// CHECK: [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_40]] [[_43]]
+// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[construct]]
 // CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_45]] 0
 // CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_45]] 1
 // CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] [[_1]] UnpackHalf2x16 [[_46]]

--- a/test/HalfStorage/clspv_vloada_half4_local.cl
+++ b/test/HalfStorage/clspv_vloada_half4_local.cl
@@ -13,7 +13,7 @@ kernel void foo(global float4* A, local float4* B, uint n) {
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 65
+// CHECK: ; Bound: 63
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -59,7 +59,6 @@ kernel void foo(global float4* A, local float4* B, uint n) {
 // CHECK-DAG: [[__ptr_Workgroup__arr_v4float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_v4float_2]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK: [[_28]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_29]] = OpSpecConstant [[_uint]] 1
@@ -80,11 +79,10 @@ kernel void foo(global float4* A, local float4* B, uint n) {
 // CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_uint]] [[_39]] [[_uint_1]]
 // CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_uint]] [[_43]] [[_uint_1]]
 // CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_42]] [[_44]]
-// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_45]] [[_26]] 0
 // CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_44]] [[_uint_1]]
 // CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_42]] [[_47]]
-// CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_48]] [[_46]] 1
-// CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[_49]]
+// CHECK: [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_45]] [[_48]]
+// CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[construct]]
 // CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_50]] 0
 // CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_50]] 1
 // CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] [[_6]] UnpackHalf2x16 [[_51]]

--- a/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
+++ b/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
@@ -8,7 +8,7 @@
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 35
+// CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -39,7 +39,6 @@
 
 // CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 // CHECK: %[[FLOAT4_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
-// CHECK: %[[UINT2_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[UINT2_TYPE_ID]]
 // CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 
 // CHECK: %[[ARG0_ID]] = OpVariable %[[ARG_POINTER_TYPE_ID]] StorageBuffer
@@ -57,8 +56,7 @@
 // CHECK: %[[X_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_TYPE_ID]] %[[EXT_INST]] PackHalf2x16 %[[LO_ID]]
 // CHECK: %[[Y_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_TYPE_ID]] %[[EXT_INST]] PackHalf2x16 %[[HI_ID]]
 
-// CHECK: %[[TEMP_INSERT_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[UINT2_TYPE_ID]] %[[X_ID]] %[[UINT2_UNDEF_ID]] 0
-// CHECK: %[[INSERT_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[UINT2_TYPE_ID]] %[[Y_ID]] %[[TEMP_INSERT_ID]] 1
+// CHECK: %[[INSERT_ID:[a-zA-Z0-9_]*]] = OpCompositeConstruct %[[UINT2_TYPE_ID]] %[[X_ID]] %[[Y_ID]]
 
 // CHECK: %[[INSERT_BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT2_TYPE_ID]] %[[INSERT_ID]]
 

--- a/test/HalfStorage/vstorea_half4_global.cl
+++ b/test/HalfStorage/vstorea_half4_global.cl
@@ -15,7 +15,7 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 63
+// CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -63,7 +63,6 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK-DAG: [[__ptr_Private_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_v3uint]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_22:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
-// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpUndef [[_v2uint]]
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK-DAG: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK-DAG: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
@@ -85,26 +84,23 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: [[_42:%[0-9a-zA-Z_]+]] = OpVectorShuffle [[_v2float]] [[_38]] [[_22]] 2 3
 // CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_41]]
 // CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_42]]
-// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_43]] [[_23]] 0
-// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_44]] [[_45]] 1
+// CHECK: [[construct1:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_43]] [[_44]]
 // CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_1]] [[_40]]
 // CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_32]] [[_uint_0]] [[_47]]
-// CHECK: OpStore [[_48]] [[_46]]
+// CHECK: OpStore [[_48]] [[construct1]]
 // CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_40]] [[_uint_1]]
 // CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_41]]
 // CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_42]]
-// CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_50]] [[_23]] 0
-// CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_51]] [[_52]] 1
+// CHECK: [[construct2:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_50]] [[_51]]
 // CHECK: [[_54:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_2]] [[_49]]
 // CHECK: [[_55:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_32]] [[_uint_0]] [[_54]]
-// CHECK: OpStore [[_55]] [[_53]]
+// CHECK: OpStore [[_55]] [[construct2]]
 // CHECK: [[_56:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_40]] [[_uint_2]]
 // CHECK: [[_57:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_41]]
 // CHECK: [[_58:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_42]]
-// CHECK: [[_59:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_57]] [[_23]] 0
-// CHECK: [[_60:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_58]] [[_59]] 1
+// CHECK: [[construct3:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_57]] [[_58]]
 // CHECK: [[_61:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_3]] [[_56]]
 // CHECK: [[_62:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_v2uint]] [[_32]] [[_uint_0]] [[_61]]
-// CHECK: OpStore [[_62]] [[_60]]
+// CHECK: OpStore [[_62]] [[construct3]]
 // CHECK: OpReturn
 // CHECK: OpFunctionEnd

--- a/test/HalfStorage/vstorea_half4_local.cl
+++ b/test/HalfStorage/vstorea_half4_local.cl
@@ -14,7 +14,7 @@ kernel void foo(local uint2* A, float4 val, uint n) {
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 63
+// CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -58,7 +58,6 @@ kernel void foo(local uint2* A, float4 val, uint n) {
 // CHECK-DAG: [[__ptr_Workgroup__arr_v2uint_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_v2uint_2]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
-// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpUndef [[_v2uint]]
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK-DAG: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK-DAG: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
@@ -80,26 +79,23 @@ kernel void foo(local uint2* A, float4 val, uint n) {
 // CHECK: [[_43:%[0-9a-zA-Z_]+]] = OpVectorShuffle [[_v2float]] [[_39]] [[_24]] 2 3
 // CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_42]]
 // CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_43]]
-// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_44]] [[_25]] 0
-// CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_45]] [[_46]] 1
+// CHECK: [[construct1:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_44]] [[_45]]
 // CHECK: [[_48:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_1]] [[_41]]
 // CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_v2uint]] [[_1]] [[_48]]
-// CHECK: OpStore [[_49]] [[_47]]
+// CHECK: OpStore [[_49]] [[construct1]]
 // CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_41]] [[_uint_1]]
 // CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_42]]
 // CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_43]]
-// CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_51]] [[_25]] 0
-// CHECK: [[_54:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_52]] [[_53]] 1
+// CHECK: [[construct2:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_51]] [[_52]]
 // CHECK: [[_55:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_2]] [[_50]]
 // CHECK: [[_56:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_v2uint]] [[_1]] [[_55]]
-// CHECK: OpStore [[_56]] [[_54]]
+// CHECK: OpStore [[_56]] [[construct2]]
 // CHECK: [[_57:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_41]] [[_uint_2]]
 // CHECK: [[_58:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_42]]
 // CHECK: [[_59:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_6]] PackHalf2x16 [[_43]]
-// CHECK: [[_60:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_58]] [[_25]] 0
-// CHECK: [[_61:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_59]] [[_60]] 1
+// CHECK: [[construct3:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_58]] [[_59]]
 // CHECK: [[_62:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_3]] [[_57]]
 // CHECK: [[_63:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_v2uint]] [[_1]] [[_62]]
-// CHECK: OpStore [[_63]] [[_61]]
+// CHECK: OpStore [[_63]] [[construct3]]
 // CHECK: OpReturn
 // CHECK: OpFunctionEnd

--- a/test/HalfStorage/vstorea_half4_private.cl
+++ b/test/HalfStorage/vstorea_half4_private.cl
@@ -16,7 +16,7 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: ; SPIR-V
 // CHECK: ; Version: 1.0
 // CHECK: ; Generator: Codeplay; 0
-// CHECK: ; Bound: 72
+// CHECK: ; Bound: 68
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability VariablePointers
@@ -70,7 +70,6 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_27:%[0-9a-zA-Z_]+]] = OpConstantNull [[__arr_v2uint_uint_64]]
-// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpUndef [[_v2uint]]
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK-DAG: [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK-DAG: [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
@@ -96,27 +95,24 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: OpStore [[_42]] [[_27]]
 // CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_49]]
 // CHECK: [[_52:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_50]]
-// CHECK: [[_53:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_51]] [[_28]] 0
-// CHECK: [[_54:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_52]] [[_53]] 1
+// CHECK: [[construct1:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_51]] [[_52]]
 // CHECK: [[_55:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_1]] [[_47]]
 // CHECK: [[_56:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Function_v2uint]] [[_42]] [[_55]]
-// CHECK: OpStore [[_56]] [[_54]]
+// CHECK: OpStore [[_56]] [[construct1]]
 // CHECK: [[_57:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_47]] [[_uint_1]]
 // CHECK: [[_58:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_49]]
 // CHECK: [[_59:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_50]]
-// CHECK: [[_60:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_58]] [[_28]] 0
-// CHECK: [[_61:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_59]] [[_60]] 1
+// CHECK: [[construct2:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_58]] [[_59]]
 // CHECK: [[_62:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_2]] [[_57]]
 // CHECK: [[_63:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Function_v2uint]] [[_42]] [[_62]]
-// CHECK: OpStore [[_63]] [[_61]]
+// CHECK: OpStore [[_63]] [[construct2]]
 // CHECK: [[_64:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_47]] [[_uint_2]]
 // CHECK: [[_65:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_49]]
 // CHECK: [[_66:%[0-9a-zA-Z_]+]] = OpExtInst [[_uint]] [[_1]] PackHalf2x16 [[_50]]
-// CHECK: [[_67:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_65]] [[_28]] 0
-// CHECK: [[_68:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_66]] [[_67]] 1
+// CHECK: [[construct3:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_65]] [[_66]]
 // CHECK: [[_69:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_uint_3]] [[_64]]
 // CHECK: [[_70:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Function_v2uint]] [[_42]] [[_69]]
-// CHECK: OpStore [[_70]] [[_68]]
+// CHECK: OpStore [[_70]] [[construct3]]
 // CHECK: [[_71:%[0-9a-zA-Z_]+]] = OpLoad [[_v2uint]] [[_48]]
 // CHECK: OpStore [[_43]] [[_71]]
 // CHECK: OpReturn

--- a/test/PointerCasts/load_cast_float4_to_float2.cl
+++ b/test/PointerCasts/load_cast_float4_to_float2.cl
@@ -27,7 +27,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 39
+// CHECK:  ; Bound: 37
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -70,7 +70,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  [[__ptr_StorageBuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_v4float]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
@@ -85,10 +84,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_uint]] [[_28]] [[_uint_1]]
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_uint]] [[_32]] [[_uint_1]]
 // CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_31]] [[_33]]
-// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_34]] [[_20]] 0
 // CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_33]] [[_uint_1]]
 // CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_31]] [[_36]]
-// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_37]] [[_35]] 1
-// CHECK:  OpStore [[_26]] [[_38]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_34]] [[_37]]
+// CHECK:  OpStore [[_26]] [[construct]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_float4_to_int2.cl
+++ b/test/PointerCasts/load_cast_float4_to_int2.cl
@@ -27,7 +27,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 41
+// CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -71,7 +71,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  [[_v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 2
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
 // CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
@@ -86,11 +85,10 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_uint]] [[_29]] [[_uint_1]]
 // CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_uint]] [[_33]] [[_uint_1]]
 // CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_32]] [[_34]]
-// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_35]] [[_21]] 0
 // CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_34]] [[_uint_1]]
 // CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_float]] [[_32]] [[_37]]
-// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_38]] [[_36]] 1
-// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[_39]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_35]] [[_38]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[construct]]
 // CHECK:  OpStore [[_27]] [[_40]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_float_to_float2.cl
+++ b/test/PointerCasts/load_cast_float_to_float2.cl
@@ -27,7 +27,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 36
+// CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -69,7 +69,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK:  [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
@@ -84,8 +83,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_28]] [[_uint_1]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_31]]
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_32]]
-// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_30]] [[_19]] 0
-// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_33]] [[_34]] 1
-// CHECK:  OpStore [[_25]] [[_35]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_30]] [[_33]]
+// CHECK:  OpStore [[_25]] [[construct]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_float_to_float4.cl
+++ b/test/PointerCasts/load_cast_float_to_float4.cl
@@ -30,7 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 45
+// CHECK:  ; Bound: 41
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -73,7 +73,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
@@ -94,10 +93,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_35]] [[_uint_1]]
 // CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_21]] [[_uint_0]] [[_38]]
 // CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_39]]
-// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_31]] [[_20]] 0
-// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_34]] [[_41]] 1
-// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_37]] [[_42]] 2
-// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_40]] [[_43]] 3
-// CHECK:  OpStore [[_26]] [[_44]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4float]] [[_31]] [[_34]] [[_37]] [[_40]]
+// CHECK:  OpStore [[_26]] [[construct]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_float_to_int2.cl
+++ b/test/PointerCasts/load_cast_float_to_int2.cl
@@ -27,7 +27,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 38
+// CHECK:  ; Bound: 36
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -70,7 +70,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 2
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpUndef [[_v2float]]
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
@@ -85,9 +84,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_29]] [[_uint_1]]
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_21]] [[_uint_0]] [[_32]]
 // CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_33]]
-// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_31]] [[_20]] 0
-// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2float]] [[_34]] [[_35]] 1
-// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[_36]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2float]] [[_31]] [[_34]]
+// CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2uint]] [[construct]]
 // CHECK:  OpStore [[_26]] [[_37]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_float_to_int4.cl
+++ b/test/PointerCasts/load_cast_float_to_int4.cl
@@ -30,7 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 47
+// CHECK:  ; Bound: 43
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -74,7 +74,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
 // CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
@@ -95,11 +94,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_36]] [[_uint_1]]
 // CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_22]] [[_uint_0]] [[_39]]
 // CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_40]]
-// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_32]] [[_21]] 0
-// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_35]] [[_42]] 1
-// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_38]] [[_43]] 2
-// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_41]] [[_44]] 3
-// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_45]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4float]] [[_32]] [[_35]] [[_38]] [[_41]]
+// CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[construct]]
 // CHECK:  OpStore [[_27]] [[_46]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_int4_to_float2.cl
+++ b/test/PointerCasts/load_cast_int4_to_float2.cl
@@ -27,7 +27,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 41
+// CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -71,7 +71,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpUndef [[_v2uint]]
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
 // CHECK:  [[_24]] = OpVariable [[__ptr_StorageBuffer__struct_11]] StorageBuffer
@@ -86,11 +85,10 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_uint]] [[_29]] [[_uint_1]]
 // CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpShiftLeftLogical [[_uint]] [[_33]] [[_uint_1]]
 // CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_uint]] [[_32]] [[_34]]
-// CHECK:  [[_36:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_35]] [[_21]] 0
 // CHECK:  [[_37:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_34]] [[_uint_1]]
 // CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpVectorExtractDynamic [[_uint]] [[_32]] [[_37]]
-// CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v2uint]] [[_38]] [[_36]] 1
-// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2float]] [[_39]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v2uint]] [[_35]] [[_38]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpBitcast [[_v2float]] [[construct]]
 // CHECK:  OpStore [[_27]] [[_40]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/PointerCasts/load_cast_int_to_float4.cl
+++ b/test/PointerCasts/load_cast_int_to_float4.cl
@@ -32,7 +32,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, g
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 46
+// CHECK:  ; Bound: 42
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -75,7 +75,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, g
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_20:%[0-9a-zA-Z_]+]] = OpUndef [[_v4uint]]
 // CHECK:  [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[_22]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
 // CHECK:  [[_23]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
@@ -96,11 +95,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, g
 // CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_35]] [[_uint_1]]
 // CHECK:  [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_21]] [[_uint_0]] [[_38]]
 // CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_39]]
-// CHECK:  [[_41:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4uint]] [[_31]] [[_20]] 0
-// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4uint]] [[_34]] [[_41]] 1
-// CHECK:  [[_43:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4uint]] [[_37]] [[_42]] 2
-// CHECK:  [[_44:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4uint]] [[_40]] [[_43]] 3
-// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4float]] [[_44]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4uint]] [[_31]] [[_34]] [[_37]] [[_40]]
+// CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4float]] [[construct]]
 // CHECK:  OpStore [[_26]] [[_45]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/VectorLoadStore/vload_global_float4.cl
+++ b/test/VectorLoadStore/vload_global_float4.cl
@@ -12,7 +12,7 @@ kernel void foo(global float4* A, global float* B, uint n) {
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0
 // CHECK:  ; Generator: Codeplay; 0
-// CHECK:  ; Bound: 52
+// CHECK:  ; Bound: 48
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability VariablePointers
@@ -60,7 +60,6 @@ kernel void foo(global float4* A, global float* B, uint n) {
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_uint_2:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 2
 // CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_22:%[0-9a-zA-Z_]+]] = OpUndef [[_v4float]]
 // CHECK:  [[_23]] = OpSpecConstant [[_uint]] 1
 // CHECK:  [[_24]] = OpSpecConstant [[_uint]] 1
 // CHECK:  [[_25]] = OpSpecConstant [[_uint]] 1
@@ -86,10 +85,7 @@ kernel void foo(global float4* A, global float* B, uint n) {
 // CHECK:  [[_45:%[0-9a-zA-Z_]+]] = OpIAdd [[_uint]] [[_42]] [[_uint_1]]
 // CHECK:  [[_46:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_29]] [[_uint_0]] [[_45]]
 // CHECK:  [[_47:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_46]]
-// CHECK:  [[_48:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_38]] [[_22]] 0
-// CHECK:  [[_49:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_41]] [[_48]] 1
-// CHECK:  [[_50:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_44]] [[_49]] 2
-// CHECK:  [[_51:%[0-9a-zA-Z_]+]] = OpCompositeInsert [[_v4float]] [[_47]] [[_50]] 3
-// CHECK:  OpStore [[_33]] [[_51]]
+// CHECK:  [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4float]] [[_38]] [[_41]] [[_44]] [[_47]] 
+// CHECK:  OpStore [[_33]] [[construct]]
 // CHECK:  OpReturn
 // CHECK:  OpFunctionEnd

--- a/test/uchar4_extract_to_float.cl
+++ b/test/uchar4_extract_to_float.cl
@@ -28,7 +28,6 @@ kernel void foo(global uchar4* IN, global float4* OUT) {
 // CHECK-DAG: [[uint_8:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 8
 // CHECK-DAG: [[uint_16:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 16
 // CHECK-DAG: [[uint_24:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 24
-// CHECK-DAG: [[undef_float4:%[_a-zA-Z0-9]+]] = OpUndef [[float4]]
 
 
 // There is only one load
@@ -38,22 +37,20 @@ kernel void foo(global uchar4* IN, global float4* OUT) {
 // CHECK: [[c0:%[_a-zA-Z0-9]+]] = OpShiftRightLogical [[uint]] [[load]] [[uint_0]]
 // CHECK: [[and0:%[_a-zA-Z0-9]+]] = OpBitwiseAnd [[uint]] [[c0]] [[uint_255]]
 // CHECK: [[f0:%[_a-zA-Z0-9]+]] = OpConvertUToF [[float]] [[and0]]
-// CHECK: [[v0:%[_a-zA-Z0-9]+]] = OpCompositeInsert [[float4]] [[f0]] [[undef_float4]] 0
 
 // CHECK: [[c1:%[_a-zA-Z0-9]+]] = OpShiftRightLogical [[uint]] [[load]] [[uint_8]]
 // CHECK: [[and1:%[_a-zA-Z0-9]+]] = OpBitwiseAnd [[uint]] [[c1]] [[uint_255]]
 // CHECK: [[f1:%[_a-zA-Z0-9]+]] = OpConvertUToF [[float]] [[and1]]
-// CHECK: [[v1:%[_a-zA-Z0-9]+]] = OpCompositeInsert [[float4]] [[f1]] [[v0]] 1
 
 // CHECK: [[c2:%[_a-zA-Z0-9]+]] = OpShiftRightLogical [[uint]] [[load]] [[uint_16]]
 // CHECK: [[and2:%[_a-zA-Z0-9]+]] = OpBitwiseAnd [[uint]] [[c2]] [[uint_255]]
 // CHECK: [[f2:%[_a-zA-Z0-9]+]] = OpConvertUToF [[float]] [[and2]]
-// CHECK: [[v2:%[_a-zA-Z0-9]+]] = OpCompositeInsert [[float4]] [[f2]] [[v1]] 2
 
 // CHECK: [[c3:%[_a-zA-Z0-9]+]] = OpShiftRightLogical [[uint]] [[load]] [[uint_24]]
 // CHECK: [[and3:%[_a-zA-Z0-9]+]] = OpBitwiseAnd [[uint]] [[c3]] [[uint_255]]
 // CHECK: [[f3:%[_a-zA-Z0-9]+]] = OpConvertUToF [[float]] [[and3]]
-// CHECK: [[v3:%[_a-zA-Z0-9]+]] = OpCompositeInsert [[float4]] [[f3]] [[v2]] 3
 
-// CHECK: OpStore {{%[_0-9a-zA-Z]+}} [[v3]]
+// CHECK: [[construct:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[float4]] [[f0]] [[f1]] [[f2]] [[f3]]
+
+// CHECK: OpStore {{%[_0-9a-zA-Z]+}} [[construct]]
 // CHECK-NOT: OpStore


### PR DESCRIPTION
* Pass now handles complete chains of InsertElementInst
* updated tests

I didn't try to handle InsertElementInst in the same function as InsertValueInst since it seemed more trouble than it was worth to do the bookkeeping.

This fixes some customer issues I'm facing.