### PR TITLE
Emit pod argument size to descriptor map

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -162,9 +162,9 @@ Consider this example:
 It generates the following descriptor map:
 
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,buffer
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,4
 
 For kernel arguments of types pointer-to-global, pointer-to-constant, and
 plain-old-data types, the fields are:
@@ -189,6 +189,8 @@ plain-old-data types, the fields are:
   - `ro_image` - Read-only image
   - `wo_image` - Write-only image
   - `sampler` - Sampler
+- `argSize`
+- only present for plain-old-data kernel arguments.
 
 Consider this example, which uses pointer-to-local arguments:
 
@@ -239,9 +241,9 @@ Then `mydescriptormap` will contain:
     sampler,18,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_NEAREST|CLK_NORMALIZED_COORDS_FALSE",descriptorSet,0,binding,0
     sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,pod,argSize,4
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,buffer
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,pod
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,pod,argSize,4
 
 #### Sending in plain-old-data kernel arguments in uniform buffers
 
@@ -299,8 +301,8 @@ will produce the following in `myclusteredmap`:
 
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,2,offset,0,argKind,pod
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,2,offset,4,argKind,pod
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,2,offset,0,argKind,pod,argSize,4
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,2,offset,4,argKind,pod,argSize,4
 
 If `foo` were the second kernel in the translation unit, then its arguments
 would also use descriptor set 0.
@@ -318,8 +320,8 @@ produces the following descriptor map:
     sampler,35,samplerExpr,"CLK_ADDRESS_CLAMP_TO_EDGE|CLK_FILTER_LINEAR|CLK_NORMALIZED_COORDS_TRUE",descriptorSet,0,binding,1
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,buffer
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,1,binding,1,offset,0,argKind,buffer
-    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,2,offset,0,argKind,pod
-    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,2,offset,4,argKind,pod
+    kernel,foo,arg,f,argOrdinal,1,descriptorSet,1,binding,2,offset,0,argKind,pod,argSize,4
+    kernel,foo,arg,c,argOrdinal,3,descriptorSet,1,binding,2,offset,4,argKind,pod,argSize,4
 
 
 TODO(dneto): Give an example using images.

--- a/test/DirectResourceAccess/common_global_into_helper.cl
+++ b/test/DirectResourceAccess/common_global_into_helper.cl
@@ -7,9 +7,9 @@
 
 
 //      MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 // MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 // MAP-NONE: kernel
 
 

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -18,7 +18,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].a; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,61000000cdab34120000803f62000000ffffffff0000c03f000000000000000000000000
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 
 
 // CHECK:  ; SPIR-V

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -15,7 +15,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i][i]; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,010000000200000003000000050000000000000000000000
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -17,7 +17,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,0100000002000000030000000000000005000000050000000500000000000000
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 
 // CHECK:  ; SPIR-V
 // CHECK:  ; Version: 1.0

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
@@ -12,7 +12,7 @@ kernel void foo(global uint* A, uint i) { A[i] = 0; }
 // MAP-NOT: constant,descriptorSet
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NOT: constant,descriptorSet
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 // MAP-NOT: constant,descriptorSet
 
 // CHECK:  ; SPIR-V

--- a/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
+++ b/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -pod-ubo -descriptormap=%t.map
 // RUN: FileCheck %s < %t.spvasm
 // RUN: FileCheck %s < %t.map -check-prefix=MAP
-// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -pod-ubo -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck %s < %t2.map -check-prefix=MAP
@@ -15,8 +15,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,B,argOrdinal,2,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,3,descriptorSet,0,binding,1,offset,4,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod_ubo,argSize,4
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,3,descriptorSet,0,binding,1,offset,4,argKind,pod_ubo,argSize,4
 // MAP-NOT: kernel
 
 
@@ -36,10 +36,10 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: OpDecorate [[__runtimearr_float:%[0-9a-zA-Z_]+]] ArrayStride 4
 // CHECK: OpMemberDecorate [[__struct_9:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK: OpDecorate [[__struct_9]] Block
-// CHECK: OpMemberDecorate [[__struct_12:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[__struct_12]] 1 Offset 4
-// CHECK: OpMemberDecorate [[__struct_13:%[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK: OpDecorate [[__struct_13]] Block
+// CHECK: OpMemberDecorate [[__struct_10:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[__struct_10]] 1 Offset 4
+// CHECK: OpMemberDecorate [[__struct_11:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK: OpDecorate [[__struct_11]] Block
 // CHECK: OpDecorate [[_20:%[0-9a-zA-Z_]+]] DescriptorSet 0
 // CHECK: OpDecorate [[_20]] Binding 0
 // CHECK: OpDecorate [[_21:%[0-9a-zA-Z_]+]] DescriptorSet 0
@@ -51,30 +51,30 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK-DAG: [[__struct_9]] = OpTypeStruct [[__runtimearr_float]]
 // CHECK-DAG: [[__ptr_StorageBuffer__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
 // CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[__struct_12]] = OpTypeStruct [[_float]] [[_uint]]
-// CHECK-DAG: [[__struct_13]] = OpTypeStruct [[__struct_12]]
-// CHECK-DAG: [[__ptr_StorageBuffer__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
-// CHECK-DAG: [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
+// CHECK-DAG: [[__struct_10]] = OpTypeStruct [[_float]] [[_uint]]
+// CHECK-DAG: [[__struct_11]] = OpTypeStruct [[__struct_10]]
+// CHECK-DAG: [[__ptr_Uniform_struct_11:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_11]]
 // CHECK-DAG: [[_void:%[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK-DAG: [[_17:%[0-9a-zA-Z_]+]] = OpTypeFunction [[_void]]
+// CHECK-DAG: [[__ptr_Uniform_struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_10]]
 // CHECK-DAG: [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
 // CHECK: [[_2]] = OpSpecConstant [[_uint]] 1
 // CHECK-DAG: [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
 // CHECK-DAG: [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_20]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
-// CHECK: [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
-// CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
-// CHECK: [[_22]] = OpFunction [[_void]] None [[_17]]
-// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpLabel
-// CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_12]] [[_21]] [[_uint_0]]
-// CHECK: [[_25:%[0-9a-zA-Z_]+]] = OpLoad [[__struct_12]] [[_24]]
-// CHECK: [[_26:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_25]] 0
-// CHECK: [[_27:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_25]] 1
-// CHECK: [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_27]]
-// CHECK: [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_float]] [[_28]]
-// CHECK: [[_30:%[0-9a-zA-Z_]+]] = OpFAdd [[_float]] [[_26]] [[_29]]
-// CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_20]] [[_uint_0]] [[_27]]
-// CHECK: OpStore [[_31]] [[_30]]
-// CHECK: OpReturn
-// CHECK: OpFunctionEnd
+// CHECK: [[_19:%[0-9a-zA-Z]+]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK: [[_20:%[0-9a-zA-Z]+]] = OpVariable [[__ptr_Uniform_struct_11]] Uniform
+// CHECK: [[_1:%[0-9a-zA-Z]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
+// CHECK: [[_21:%[0-9a-zA-Z]+]] = OpFunction [[_void]] None [[_17]]
+// CHECK: [[_22:%[0-9a-zA-Z]+]] =	OpLabel
+// CHECK: [[_23:%[0-9a-zA-Z]+]] = OpAccessChain [[__ptr_Uniform_struct_10]] [[_20]] [[_uint_0]]
+// CHECK: [[_24:%[0-9a-zA-Z]+]] = OpLoad [[__struct_10]] [[_23]]
+// CHECK: [[_25:%[0-9a-zA-Z]+]] = OpCompositeExtract [[_float]] [[_24]] 0
+// CHECK: [[_26:%[0-9a-zA-Z]+]] = OpCompositeExtract [[_uint]] [[_24]] 1
+// CHECK: [[_27:%[0-9a-zA-Z]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_26]]
+// CHECK: [[_28:%[0-9a-zA-Z]+]] = OpLoad [[_float]] [[_27]]
+// CHECK: [[_29:%[0-9a-zA-Z]+]] = OpFAdd [[_float]] [[_25]] [[_28]]
+// CHECK: [[_30:%[0-9a-zA-Z]+]] = OpAccessChain [[__ptr_StorageBuffer_float]] [[_19]] [[_uint_0]] [[_26]]
+// CHECK: 	OpStore [[_30]] [[_29]]
+// CHECK: 	OpReturn
+// CHECK: 	OpFunctionEnd

--- a/test/descriptor_map_argtype.cl
+++ b/test/descriptor_map_argtype.cl
@@ -10,16 +10,16 @@
 // CHECK-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
 // CHECK-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
 // CHECK-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
-// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod
-// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argKind,pod
+// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod,argSize,4
+// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argKind,pod,argSize,4
 // CHECK-NOT: foo
 
 // CLUSTER: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // CLUSTER-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
 // CLUSTER-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
 // CLUSTER-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
-// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod
-// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,4,offset,4,argKind,pod
+// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod,argSize,4
+// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,4,offset,4,argKind,pod,argSize,4
 // CLUSTER-NOT: foo
 
 kernel void foo(global int *A, read_only image2d_t RO, write_only image2d_t WO,

--- a/test/pod_in_ubo.cl
+++ b/test/pod_in_ubo.cl
@@ -10,9 +10,9 @@ kernel void foo(int k, global int *A, int b) { *A = k + b; }
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 
-// MAP: kernel,foo,arg,k,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,pod_ubo
+// MAP: kernel,foo,arg,k,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,pod_ubo,argSize,4
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo
+// MAP-NEXT: kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo,argSize,4
 
 
 // CHECK:  ; SPIR-V

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -16,9 +16,9 @@ kernel void foo(local float *L, global float* A, float f, S local* LS, constant 
 }
 
 //      MAP: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 // MAP-NEXT: kernel,foo,arg,C,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,4
 // MAP-NEXT: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
 // MAP-NEXT: kernel,foo,arg,LS,argOrdinal,3,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NOT: kernel

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -19,8 +19,8 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,LS,argOrdinal,2,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NEXT: kernel,foo,arg,C,argOrdinal,3,descriptorSet,0,binding,1,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,pod
-// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,2,offset,4,argKind,pod
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,2,offset,4,argKind,pod,argSize,4
 // MAP-NOT: kernel
 
 // CHECK:      ; SPIR-V


### PR DESCRIPTION
Enable users to:

- know how much memory to allocate for their pod buffer when
  using -cluster-pod-kernel-args

- check the size of the data bound to pod bindings is correct

Fixes #185 

Signed-off-by: Kévin Petit <kpet@free.fr>