### PR TITLE
Remove 'local' kernel arguments from the list of restrictions

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -495,9 +495,6 @@ variant of SPIR-V are restricted.
 
 OpenCL C language kernels **must not** be called from other kernels.
 
-Pointer types in the `local` address space **must not** be used as kernel
-arguments.
-
 Pointers of type `half` **must not** be used as kernel arguments.
 
 ### Types


### PR DESCRIPTION
This is definitely supported now.

Signed-off-by: Kévin Petit <kpet@free.fr>