### PR TITLE
Make it possible to provide SPIRV-Tools and SPIRV-Headers externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,26 @@ endif()
 
 use_component(${CMAKE_CURRENT_SOURCE_DIR}/third_party/clang)
 use_component(${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm)
-use_component(${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Headers)
-use_component(${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Tools)
+
+if (NOT DEFINED SPIRV_HEADERS_SOURCE_DIR)
+  set(SPIRV_HEADERS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Headers)
+  use_component(${SPIRV_HEADERS_SOURCE_DIR})
+endif()
+
+if (NOT DEFINED SPIRV_TOOLS_SOURCE_DIR)
+
+  set(SPIRV_TOOLS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Tools)
+
+  use_component(${SPIRV_TOOLS_SOURCE_DIR})
+
+  # First tell SPIR-V Tools where to find SPIR-V Headers
+  set(SPIRV-Headers_SOURCE_DIR ${SPIRV_HEADERS_SOURCE_DIR})
+
+  # Bring in the SPIR-V Tools repository which we'll use for testing
+  add_subdirectory(${SPIRV_TOOLS_SOURCE_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+set(SPIRV_TOOLS_BINARY_DIR "$<TARGET_FILE_DIR:spirv-dis>")
 
 set(CLSPV_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -58,7 +76,6 @@ set(LLVM_EXTERNAL_CLANG_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/clang
 # Then pull in LLVM for building.
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm EXCLUDE_FROM_ALL)
 
-set(SPIRV_HEADERS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Headers)
 set(SPIRV_HEADERS_INCLUDE_DIRS
   ${SPIRV_HEADERS_SOURCE_DIR}/include/
 )
@@ -74,16 +91,6 @@ set(CLANG_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/clang)
 set(CLANG_INCLUDE_DIRS
   ${CLANG_SOURCE_DIR}/include
   ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm/tools/clang/include
-)
-
-# First tell SPIR-V Tools where to find SPIR-V Headers
-set(SPIRV-Headers_SOURCE_DIR ${SPIRV_HEADERS_SOURCE_DIR})
-
-# Bring in the SPIR-V Tools repository which we'll use for testing
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/SPIRV-Tools EXCLUDE_FROM_ALL)
-
-set(SPIRV_TOOLS_BINARY_DIR
-  ${CMAKE_CURRENT_BINARY_DIR}/third_party/SPIRV-Tools/tools
 )
 
 if(NOT WIN32)

--- a/utils/fetch_sources.py
+++ b/utils/fetch_sources.py
@@ -121,15 +121,22 @@ def GetGoodCommits():
 
 
 def main():
+
+    commits = GetGoodCommits()
+
+    all_deps = [c.name for c in commits]
+
     parser = argparse.ArgumentParser(description='Get sources for '
                                      ' dependencies at a specified commit')
     parser.add_argument('--dir', dest='dir', default='.',
                         help='Set target directory for dependencies source '
                         'root. Default is the current directory.')
 
-    args = parser.parse_args()
+    parser.add_argument('--deps', choices=all_deps, nargs='+', default=all_deps,
+                        help='A list of dependencies to fetch sources for. '
+                             'All is the default.')
 
-    commits = GetGoodCommits()
+    args = parser.parse_args()
 
     distutils.dir_util.mkpath(args.dir)
     print('Change directory to {d}'.format(d=args.dir))
@@ -138,6 +145,8 @@ def main():
     # Create the subdirectories in sorted order so that parent git repositories
     # are created first.
     for c in sorted(commits, key=lambda x: x.subdir):
+        if c.name not in args.deps:
+            continue
         print('Get {n}\n'.format(n=c.name))
         c.Checkout()
     sys.exit(0)


### PR DESCRIPTION
The default behaviour doesn't change but a project embedding clspv
can now:
- pass SPIRV_HEADERS_SOURCE_DIR to provide SPIRV-Headers
- pass SPIRV_TOOLS_SOURCE_DIR to provide SPIRV-Tools
- pass a list of dependencies to be managed by utils/fetch_sources.py

Signed-off-by: Kévin Petit <kpet@free.fr>