### PR TITLE
Add partial support for the smoothstep built-in

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5298,6 +5298,7 @@ glsl::ExtInst SPIRVProducerPass::getExtInstEnum(StringRef Name) {
       .StartsWith("_Z8distance", glsl::ExtInst::ExtInstDistance)
       .StartsWith("_Z13fast_distance", glsl::ExtInst::ExtInstDistance)
       .StartsWith("_Z4step", glsl::ExtInst::ExtInstStep)
+      .StartsWith("_Z10smoothstep", glsl::ExtInst::ExtInstSmoothStep)
       .Case("_Z5crossDv3_fS_", glsl::ExtInst::ExtInstCross)
       .StartsWith("_Z9normalize", glsl::ExtInst::ExtInstNormalize)
       .StartsWith("_Z14fast_normalize", glsl::ExtInst::ExtInstNormalize)

--- a/test/CommonBuiltins/float2_smoothstep.cl
+++ b/test/CommonBuiltins/float2_smoothstep.cl
@@ -1,0 +1,63 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 26
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
+// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
+// CHECK: OpDecorate %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 8
+// CHECK: OpMemberDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID]] Block
+// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
+// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
+// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
+// CHECK-DAG: %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_ARG_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_ARG_STRUCT_TYPE_ID]]
+// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
+// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[FLOAT_ARG_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG2_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG3_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+
+// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
+// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[B_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[O_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[B_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[LOADA_ID]] %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore %[[O_ACCESS_CHAIN_ID]] %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b, global float2* c, global float2*o)
+{
+  *o = smoothstep(*a, *b, *c);
+}

--- a/test/CommonBuiltins/float3_smoothstep.cl
+++ b/test/CommonBuiltins/float3_smoothstep.cl
@@ -1,0 +1,63 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 26
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
+// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
+// CHECK: OpDecorate %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
+// CHECK: OpMemberDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID]] Block
+// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
+// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
+// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_ARG_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_ARG_STRUCT_TYPE_ID]]
+// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
+// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[FLOAT_ARG_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG2_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG3_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+
+// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
+// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[B_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[O_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[B_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[LOADA_ID]] %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore %[[O_ACCESS_CHAIN_ID]] %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3* c, global float3*o)
+{
+  *o = smoothstep(*a, *b, *c);
+}

--- a/test/CommonBuiltins/float4_smoothstep.cl
+++ b/test/CommonBuiltins/float4_smoothstep.cl
@@ -1,0 +1,63 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 26
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
+// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
+// CHECK: OpDecorate %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 16
+// CHECK: OpMemberDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID]] Block
+// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
+// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
+// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_ARG_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_ARG_STRUCT_TYPE_ID]]
+// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
+// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[FLOAT_ARG_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG2_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG3_ID]] = OpVariable %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] StorageBuffer
+
+// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
+// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[B_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[O_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_ARG_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[B_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[LOADA_ID]] %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore %[[O_ACCESS_CHAIN_ID]] %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b, global float4* c, global float4*o)
+{
+  *o = smoothstep(*a, *b, *c);
+}

--- a/test/CommonBuiltins/float_smoothstep.cl
+++ b/test/CommonBuiltins/float_smoothstep.cl
@@ -1,0 +1,62 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: ; SPIR-V
+// CHECK: ; Version: 1.0
+// CHECK: ; Generator: Codeplay; 0
+// CHECK: ; Bound: 25
+// CHECK: ; Schema: 0
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK: OpMemoryModel Logical GLSL450
+// CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
+// CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1
+// CHECK: OpDecorate %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID:[a-zA-Z0-9_]*]] ArrayStride 4
+// CHECK: OpMemberDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] 0 Offset 0
+// CHECK: OpDecorate %[[FLOAT_ARG_STRUCT_TYPE_ID]] Block
+// CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG0_ID]] Binding 0
+// CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG1_ID]] Binding 1
+// CHECK: OpDecorate %[[ARG2_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG2_ID]] Binding 2
+// CHECK: OpDecorate %[[ARG3_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
+// CHECK: OpDecorate %[[ARG3_ID]] Binding 3
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_GLOBAL_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]] = OpTypeRuntimeArray %[[FLOAT_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_ARG_STRUCT_TYPE_ID]] = OpTypeStruct %[[FLOAT_DYNAMIC_ARRAY_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_ARG_POINTER_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypePointer StorageBuffer %[[FLOAT_ARG_STRUCT_TYPE_ID]]
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[VOID_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVoid
+// CHECK-DAG: %[[FOO_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFunction %[[VOID_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK: %[[ARG0_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG1_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG2_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
+// CHECK: %[[ARG3_ID]] = OpVariable %[[FLOAT_ARG_POINTER_TYPE_ID]] StorageBuffer
+
+// CHECK: %[[FOO_ID]] = OpFunction %[[VOID_TYPE_ID]] None %[[FOO_TYPE_ID]]
+// CHECK: %[[LABEL_ID:[a-zA-Z0-9_]*]] = OpLabel
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] %[[ARG0_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[B_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] %[[ARG1_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] %[[ARG2_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[O_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain %[[FLOAT_GLOBAL_POINTER_TYPE_ID]] %[[ARG3_ID]] %[[CONSTANT_0_ID]] %[[CONSTANT_0_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]] %[[A_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]] %[[B_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[LOADA_ID]] %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore %[[O_ACCESS_CHAIN_ID]] %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b, global float* c, global float *o)
+{
+  *o = smoothstep(*a, *b, *c);
+}


### PR DESCRIPTION
This suffers from the same issues as step (see #199).

The supported cases (all parameters having the same type)
pass the OpenCL conformance tests run via clvk on NVidia
hardware.

Signed-off-by: Kévin Petit <kpet@free.fr>