### PR TITLE
Pointer-to-constant kernel args in uniform buffers

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -70,6 +70,8 @@ following way:
   descriptor set type is `VK_DESCRIPTOR_TYPE_SAMPLER`.
 - If the argument to the kernel is a constant or global pointer type, the
   matching Vulkan descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`.
+  If option -constant-args-ubo' is used and the kernel has constant pointer
+  types, set `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
 - If the argument to the kernel is a plain-old-data type, the matching Vulkan
   descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER` by default.
   If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -186,6 +186,7 @@ plain-old-data types, the fields are:
 - `argKind`
 - a string describing the kind of argument, one of:
   - `buffer` - OpenCL buffer
+  - `buffer_ubo` - OpenCL constant buffer. Sent in a uniform buffer.
   - `pod` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a storage buffer.
   - `pod_ubo` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a uniform buffer.
   - `ro_image` - Read-only image

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -79,5 +79,8 @@ bool InlineSingleCallSite();
 // Returns true if entry points should be fully inlined.
 bool InlineEntryPoints();
 
+// Returns true if pointer-to-constant kernel args should be generated as UBOs.
+bool ConstantArgsInUniformBuffer();
+
 } // namespace Option
 } // namespace clspv

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -578,7 +578,8 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         // 3) Generate no SPIR-V code for the call itself.
 
         switch (arg_kind) {
-        case clspv::ArgKind::Buffer: {
+        case clspv::ArgKind::Buffer:
+        case clspv::ArgKind::BufferUBO: {
           // If original argument is:
           //   Elem addrspace(1)*
           // Then make a zero-length array to mimic a StorageBuffer struct
@@ -661,6 +662,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         Value *zero = Builder.getInt32(0);
         switch (arg_kind) {
         case clspv::ArgKind::Buffer:
+        case clspv::ArgKind::BufferUBO:
           // Return a GEP to the first element
           // in the runtime array we'll make.
           replacement = Builder.CreateGEP(call, {zero, zero, zero});

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/AddressSpace.h"
+#include "clspv/Option.h"
 
 
 using namespace llvm;
@@ -46,8 +47,10 @@ ArgKind GetArgKindForType(Type *type) {
     // Pointer to constant and pointer to global are both in
     // storage buffers.
     case clspv::AddressSpace::Global:
-    case clspv::AddressSpace::Constant:
       return ArgKind::Buffer;
+    case clspv::AddressSpace::Constant:
+      return Option::ConstantArgsInUniformBuffer() ? ArgKind::BufferUBO
+                                                   : ArgKind::Buffer;
     case clspv::AddressSpace::Local:
       return ArgKind::Local;
     default:
@@ -65,6 +68,8 @@ const char *GetArgKindName(ArgKind kind) {
   switch (kind) {
   case ArgKind::Buffer:
     return "buffer";
+  case ArgKind::BufferUBO:
+    return "buffer_ubo";
   case ArgKind::Local:
     return "local";
   case ArgKind::Pod:

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -24,6 +24,7 @@ namespace clspv {
 
 enum class ArgKind : int {
   Buffer,
+  BufferUBO,
   Local,
   Pod,
   ReadOnlyImage,
@@ -39,13 +40,14 @@ const char* GetArgKindName(ArgKind);
 
 // Maps an LLVM type for a kernel argument to an argument
 // kind suitable for a descriptor map.  The result is one of:
-//   buffer   - storage buffer
-//   local    - array in Workgroup storage, number of elements given by
-//              a specialization constant
-//   pod      - plain-old-data
-//   ro_image - read-only image
-//   wo_image - write-only image
-//   sampler  - sampler
+//   buffer     - storage buffer
+//   buffer_ubo - uniform buffer
+//   local      - array in Workgroup storage, number of elements given by
+//                a specialization constant
+//   pod        - plain-old-data
+//   ro_image   - read-only image
+//   wo_image   - write-only image
+//   sampler    - sampler
 inline const char *GetArgKindNameForType(llvm::Type *type) {
   return GetArgKindName(GetArgKindForType(type));
 }

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -190,6 +190,7 @@ bool DirectResourceAccessPass::RewriteResourceAccesses(Function *fn) {
   for (Argument &arg : fn->args()) {
     switch (clspv::GetArgKindForType(arg.getType())) {
     case clspv::ArgKind::Buffer:
+    case clspv::ArgKind::BufferUBO:
     case clspv::ArgKind::ReadOnlyImage:
     case clspv::ArgKind::WriteOnlyImage:
     case clspv::ArgKind::Sampler:

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -114,6 +114,10 @@ llvm::cl::opt<bool> module_constants_in_storage_buffer(
 llvm::cl::opt<bool> show_ids("show-ids", llvm::cl::init(false),
                              llvm::cl::desc("Show SPIR-V IDs for functions"));
 
+llvm::cl::opt<bool> constant_args_in_uniform_buffer(
+    "constant-args-ubo", llvm::cl::init(false),
+    llvm::cl::desc("Put pointer-to-constant kernel args in UBOs."));
+
 } // namespace
 
 namespace clspv {
@@ -138,6 +142,9 @@ bool ModuleConstantsInStorageBuffer() {
 }
 bool PodArgsInUniformBuffer() { return pod_ubo; }
 bool ShowIDs() { return show_ids; }
+bool ConstantArgsInUniformBuffer() {
+  return constant_args_in_uniform_buffer;
+}
 
 } // namespace Option
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -540,7 +540,6 @@ createSPIRVProducerPass(raw_pwrite_stream &out, raw_ostream &descriptor_map_out,
 } // namespace clspv
 
 bool SPIRVProducerPass::runOnModule(Module &module) {
-  //llvm::errs() << module << "\n";
   binaryOut = outputCInitList ? &binaryTempOut : &out;
 
   constant_i32_zero_id_ = 0; // Reset, for the benefit of validity checks.

--- a/test/UBO/bad_after_array.cl
+++ b/test/UBO/bad_after_array.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct dt {
+  int x[2];
+  int y;
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO element size must be a multiple of that element's alignment}}

--- a/test/UBO/bad_array.cl
+++ b/test/UBO/bad_array.cl
@@ -1,0 +1,9 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct dt {
+  int x;
+  int y[4];
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{in an UBO, arrays must be aligned to their element alignment, rounded up to a multiple of 16}}
+

--- a/test/UBO/bad_padding.cl
+++ b/test/UBO/bad_padding.cl
@@ -1,8 +1,7 @@
 // RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
 
 struct dt {
-  int x;
-  int4 y;
+  int x __attribute((aligned(16)));
 };
 
 __kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO structures may not have implicit padding}}

--- a/test/UBO/bad_padding.cl
+++ b/test/UBO/bad_padding.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct dt {
+  int x;
+  int4 y;
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO structures may not have implicit padding}}

--- a/test/UBO/bad_scalar.cl
+++ b/test/UBO/bad_scalar.cl
@@ -1,0 +1,8 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, scalar elements must be aligned to their size}}

--- a/test/UBO/bad_struct.cl
+++ b/test/UBO/bad_struct.cl
@@ -1,0 +1,12 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct inner {
+  int x;
+};
+
+struct outer {
+  int x;
+  struct inner y;
+};
+
+__kernel void foo(__constant struct outer* c) { } //expected-error{{in an UBO, structs must be aligned to their largest element alignment, rounded up to a multiple of 16 bytes}}

--- a/test/UBO/bad_vec2.cl
+++ b/test/UBO/bad_vec2.cl
@@ -1,0 +1,8 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int2 y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, two-component vectors must be aligned to 2 times their element size}}

--- a/test/UBO/bad_vec4.cl
+++ b/test/UBO/bad_vec4.cl
@@ -1,0 +1,9 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int4 y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, three- and four-component vectors must be aligned to 4 times their element size}}
+

--- a/test/UBO/copy.cl
+++ b/test/UBO/copy.cl
@@ -1,0 +1,23 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void foo(__global int* data, __constant int* c) {
+  *data = *c;
+}
+
+// CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
+// CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[var]] Binding 1
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[int]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[ptr_int:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[var]] = OpVariable [[ptr]] Uniform
+// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_int]] [[var]] [[zero]] [[zero]]
+// CHECK: OpLoad [[int]] [[gep]]

--- a/test/UBO/vec2_no_pad.cl
+++ b/test/UBO/vec2_no_pad.cl
@@ -1,0 +1,40 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Natural alignment don't lead to LLVM inserting packing so this is ok.
+typedef struct {
+  int x;
+  int2 y;
+} data_type;
+
+__kernel void foo(__global data_type* d, __constant data_type* c) {
+  d->y = c->y;
+}
+
+//      MAP: kernel,foo,arg,d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 8
+// CHECK-DAG: OpMemberDecorate [[struct:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
+// CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[var]] Binding 1
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[int2:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 2
+// CHECK: [[s]] = OpTypeStruct [[int]] [[int2]]
+// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[s]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[ptr_int2:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int2]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
+// CHECK: [[var]] = OpVariable [[ptr]] Uniform
+// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_int2]] [[var]] [[zero]] [[zero]] [[one]]
+// CHECK: OpLoad [[int2]] [[gep]]


### PR DESCRIPTION
Contributes to #208 

Initial implementation of support for pointer-to-constant kernel arguments in uniform buffers.

If the new option (`-constant-args-ubo`) is enabled, pointer-to-constant kernel arguments will be generated as variables in the Uniform storage class. A new ArgKind, `BufferUBO`, has been added to indicate this change. Standard uniform buffer layout rules from Vulkan specification section 14.5.4 are checked in the AST.

Limitations
 * Full inlining must be enabled
  * this will be somewhat relaxed in the future for cases that DRA can handle
 * Extra layout restrictions
  * All types must have a size that is a multiple of their alignment
  * structures may not have implicit padding
  * Both of these restrictions should be relaxed in the future, but require significant changes to support.

I added a new command line option, -verify, which enables diagnostic verification to support testing the new AST based error checks.