### PR TITLE
pointer-to-constant args in Uniform buffer

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -70,6 +70,8 @@ following way:
   descriptor set type is `VK_DESCRIPTOR_TYPE_SAMPLER`.
 - If the argument to the kernel is a constant or global pointer type, the
   matching Vulkan descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`.
+  If option -constant-args-ubo' is used and the kernel has constant pointer
+  types, set `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
 - If the argument to the kernel is a plain-old-data type, the matching Vulkan
   descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER` by default.
   If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -186,6 +186,7 @@ plain-old-data types, the fields are:
 - `argKind`
 - a string describing the kind of argument, one of:
   - `buffer` - OpenCL buffer
+  - `buffer_ubo` - OpenCL constant buffer. Sent in a uniform buffer.
   - `pod` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a storage buffer.
   - `pod_ubo` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a uniform buffer.
   - `ro_image` - Read-only image

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -79,5 +79,8 @@ bool InlineSingleCallSite();
 // Returns true if entry points should be fully inlined.
 bool InlineEntryPoints();
 
+// Returns true if pointer-to-constant kernel args should be generated as UBOs.
+bool ConstantArgsInUniformBuffer();
+
 } // namespace Option
 } // namespace clspv

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -349,4 +349,6 @@ llvm::ModulePass *createInlineEntryPointsPass();
 /// bugs. See HackPhis().
 llvm::ModulePass *createScalarizePass();
 
+llvm::ModulePass *createUBOTypeTransformPass();
+
 } // namespace clspv

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -349,6 +349,12 @@ llvm::ModulePass *createInlineEntryPointsPass();
 /// bugs. See HackPhis().
 llvm::ModulePass *createScalarizePass();
 
+/// Transform types for UBOs to conform to Vulkan 14.5.4 rules.
+/// @return An LLVM module pass
+///
+/// Performs type mutation on the module so that types destined for UBOs satisfy
+/// requirements in SPIR-V. It is assumed that the types are correct except for
+/// LLVM inserted padding added to represent the types as laid out in OpenCL C.
 llvm::ModulePass *createUBOTypeTransformPass();
 
 } // namespace clspv

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -578,7 +578,8 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         // 3) Generate no SPIR-V code for the call itself.
 
         switch (arg_kind) {
-        case clspv::ArgKind::Buffer: {
+        case clspv::ArgKind::Buffer:
+        case clspv::ArgKind::BufferUBO: {
           // If original argument is:
           //   Elem addrspace(1)*
           // Then make a zero-length array to mimic a StorageBuffer struct
@@ -661,6 +662,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         Value *zero = Builder.getInt32(0);
         switch (arg_kind) {
         case clspv::ArgKind::Buffer:
+        case clspv::ArgKind::BufferUBO:
           // Return a GEP to the first element
           // in the runtime array we'll make.
           replacement = Builder.CreateGEP(call, {zero, zero, zero});

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/AddressSpace.h"
+#include "clspv/Option.h"
 
 
 using namespace llvm;
@@ -46,8 +47,10 @@ ArgKind GetArgKindForType(Type *type) {
     // Pointer to constant and pointer to global are both in
     // storage buffers.
     case clspv::AddressSpace::Global:
-    case clspv::AddressSpace::Constant:
       return ArgKind::Buffer;
+    case clspv::AddressSpace::Constant:
+      return Option::ConstantArgsInUniformBuffer() ? ArgKind::BufferUBO
+                                                   : ArgKind::Buffer;
     case clspv::AddressSpace::Local:
       return ArgKind::Local;
     default:
@@ -65,6 +68,8 @@ const char *GetArgKindName(ArgKind kind) {
   switch (kind) {
   case ArgKind::Buffer:
     return "buffer";
+  case ArgKind::BufferUBO:
+    return "buffer_ubo";
   case ArgKind::Local:
     return "local";
   case ArgKind::Pod:

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -24,6 +24,7 @@ namespace clspv {
 
 enum class ArgKind : int {
   Buffer,
+  BufferUBO,
   Local,
   Pod,
   ReadOnlyImage,
@@ -39,13 +40,14 @@ const char* GetArgKindName(ArgKind);
 
 // Maps an LLVM type for a kernel argument to an argument
 // kind suitable for a descriptor map.  The result is one of:
-//   buffer   - storage buffer
-//   local    - array in Workgroup storage, number of elements given by
-//              a specialization constant
-//   pod      - plain-old-data
-//   ro_image - read-only image
-//   wo_image - write-only image
-//   sampler  - sampler
+//   buffer     - storage buffer
+//   buffer_ubo - uniform buffer
+//   local      - array in Workgroup storage, number of elements given by
+//                a specialization constant
+//   pod        - plain-old-data
+//   ro_image   - read-only image
+//   wo_image   - write-only image
+//   sampler    - sampler
 inline const char *GetArgKindNameForType(llvm::Type *type) {
   return GetArgKindName(GetArgKindForType(type));
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(clspv_core STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/SimplifyPointerBitcastPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatSelectCondition.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/UBOTypeTransformPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoBoolPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoByvalPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoGetElementPtrConstantExprPass.cpp

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -26,7 +26,11 @@ inline std::string WorkgroupAccessorFunction() { return "clspv.local.var."; }
 // Base name for resource variable accessor function.
 inline std::string ResourceAccessorFunction() { return "clspv.resource.var."; }
 
+// Name for module level metadata storing UBO remapped type offsets.
 inline std::string RemappedTypeOffsetMetadataName() { return "clspv.remapped.offsets"; }
+
+// Name for module level metadata storing UBO remapped type sizes.
+inline std::string RemappedTypeSizesMetadataName() { return "clspv.remapped.type.sizes"; }
 
 // The first useable SpecId for pointer-to-local arguments.
 // 0, 1 and 2 are reserved for workgroup size.

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -26,6 +26,8 @@ inline std::string WorkgroupAccessorFunction() { return "clspv.local.var."; }
 // Base name for resource variable accessor function.
 inline std::string ResourceAccessorFunction() { return "clspv.resource.var."; }
 
+inline std::string RemappedTypeOffsetMetadataName() { return "clspv.remapped.offsets"; }
+
 // The first useable SpecId for pointer-to-local arguments.
 // 0, 1 and 2 are reserved for workgroup size.
 inline int FirstLocalSpecId() { return 3; }

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -190,6 +190,7 @@ bool DirectResourceAccessPass::RewriteResourceAccesses(Function *fn) {
   for (Argument &arg : fn->args()) {
     switch (clspv::GetArgKindForType(arg.getType())) {
     case clspv::ArgKind::Buffer:
+    case clspv::ArgKind::BufferUBO:
     case clspv::ArgKind::ReadOnlyImage:
     case clspv::ArgKind::WriteOnlyImage:
     case clspv::ArgKind::Sampler:

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -114,6 +114,10 @@ llvm::cl::opt<bool> module_constants_in_storage_buffer(
 llvm::cl::opt<bool> show_ids("show-ids", llvm::cl::init(false),
                              llvm::cl::desc("Show SPIR-V IDs for functions"));
 
+llvm::cl::opt<bool> constant_args_in_uniform_buffer(
+    "constant-args-ubo", llvm::cl::init(false),
+    llvm::cl::desc("Put pointer-to-constant kernel args in UBOs."));
+
 } // namespace
 
 namespace clspv {
@@ -138,6 +142,9 @@ bool ModuleConstantsInStorageBuffer() {
 }
 bool PodArgsInUniformBuffer() { return pod_ubo; }
 bool ShowIDs() { return show_ids; }
+bool ConstantArgsInUniformBuffer() {
+  return constant_args_in_uniform_buffer;
+}
 
 } // namespace Option
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -540,7 +540,6 @@ createSPIRVProducerPass(raw_pwrite_stream &out, raw_ostream &descriptor_map_out,
 } // namespace clspv
 
 bool SPIRVProducerPass::runOnModule(Module &module) {
-  //llvm::errs() << module << "\n";
   binaryOut = outputCInitList ? &binaryTempOut : &out;
 
   constant_i32_zero_id_ = 0; // Reset, for the benefit of validity checks.

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3745,11 +3745,15 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       // an OpenCL program-scope constant, we'll swap out the LLVM base pointer
       // for something else in the SPIR-V.
       // E.g. see test/PointerAccessChain/pointer_index_is_constant_1.cl
-      if (GetStorageClass(ResultType->getAddressSpace()) ==
-          spv::StorageClassStorageBuffer) {
+      switch (GetStorageClass(ResultType->getAddressSpace())) {
+      case spv::StorageClassStorageBuffer:
+      case spv::StorageClassUniform:
         // Save the need to generate an ArrayStride decoration.  But defer
         // generation until later, so we only make one decoration.
         getTypesNeedingArrayStride().insert(ResultType);
+        break;
+      default:
+        break;
       }
     }
 

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -122,8 +122,6 @@ bool UBOTypeTransformPass::runOnModule(Module &M) {
   if (!clspv::Option::ConstantArgsInUniformBuffer())
     return false;
 
-  //llvm::errs() << "BEFORE\n" << M << "\nBEFORE\n";
-
   bool changed = false;
   for (auto &F : M) {
     if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL)
@@ -144,7 +142,6 @@ bool UBOTypeTransformPass::runOnModule(Module &M) {
     changed |= RemapTypes(M);
   }
 
-  //llvm::errs() << "\n\nAFTER\n" << M << "\nAFTER\n";
   return changed;
 }
 

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -1,0 +1,222 @@
+// Copyright 2018 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "ArgKind.h"
+#include "Constants.h"
+#include "clspv/AddressSpace.h"
+#include "clspv/Option.h"
+#include "clspv/Passes.h"
+
+using namespace llvm;
+
+namespace {
+
+class UBOTypeTransformPass final : public ModulePass {
+ public:
+  static char ID;
+  UBOTypeTransformPass() : ModulePass(ID) {}
+  bool runOnModule(Module &M) override;
+ private:
+  Type *MapType(Type* type, Module &M);
+  StructType *MapStructType(StructType *struct_ty, Module &M);
+  bool RemapTypes(Module &M);
+  bool RemapUser(User *user, Module &M);
+  bool RemapValue(Value *value, Module &M);
+
+  DenseMap<Type*,Type*> remapped_types_;
+  DenseSet<Type*> deferred_types_;
+  DenseSet<Type*> processing_types_;
+};
+
+char UBOTypeTransformPass::ID = 0;
+static RegisterPass<UBOTypeTransformPass>
+  X("UBOTypeTransformPass", "Transform UBO types");
+
+}
+
+namespace clspv {
+ModulePass *createUBOTypeTransformPass() {
+  return new UBOTypeTransformPass();
+}
+} // namespace clspv
+
+namespace {
+
+bool UBOTypeTransformPass::runOnModule(Module &M) {
+  //llvm::errs() << M << "\n";
+
+  if (!clspv::Option::ConstantArgsInUniformBuffer())
+    return false;
+
+  bool changed = false;
+  for (auto &F : M) {
+    if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL)
+      continue;
+
+    for (auto &Arg : F.args()) {
+      if (clspv::GetArgKindForType(Arg.getType()) == clspv::ArgKind::BufferUBO) {
+        // Pre-populate the type mapping for types that must change.
+        Type *remapped = MapType(Arg.getType(), M);
+        llvm::errs() << "Remapping " << *Arg.getType()->getPointerElementType() << " to:\n " << *remapped->getPointerElementType() << "\n";
+      }
+    }
+  }
+
+  if (!remapped_types_.empty()) {
+    changed |= RemapTypes(M);
+  }
+
+  llvm::errs() << M << "\n";
+  llvm_unreachable("intentional");
+  return changed;
+}
+
+Type *UBOTypeTransformPass::MapType(Type *type, Module &M) {
+  auto iter = remapped_types_.find(type);
+  if (iter != remapped_types_.end()) {
+    return iter->second;
+  }
+
+  // Fix circular references.
+  if (!processing_types_.insert(type).second) {
+    deferred_types_.insert(type);
+    return type;
+  }
+
+  Type *remapped = type;
+  switch (type->getTypeID()) {
+    case Type::PointerTyID: {
+      PointerType *pointer = cast<PointerType>(type);
+      Type *pointee = MapType(pointer->getElementType(), M);
+      remapped = PointerType::get(pointee, pointer->getAddressSpace());
+      break;
+    }
+    case Type::StructTyID:
+      remapped = MapStructType(cast<StructType>(type), M);
+      break;
+    case Type::ArrayTyID: {
+      ArrayType *array = cast<ArrayType>(type);
+      Type *element = MapType(array->getElementType(), M);
+      remapped = ArrayType::get(element, array->getNumElements());
+      break;
+    }
+    default:
+      break;
+  }
+
+  deferred_types_.erase(type);
+
+  return remapped_types_.insert(std::make_pair(type, remapped)).first->second;
+}
+
+StructType *UBOTypeTransformPass::MapStructType(StructType *struct_ty, Module &M) {
+  bool changed = false;
+  SmallVector<Type *, 8> elements;
+  SmallVector<uint64_t, 8> offsets;
+  const auto *layout = M.getDataLayout().getStructLayout(struct_ty);
+  for (unsigned i = 0; i != struct_ty->getNumElements(); ++i) {
+    Type *element = struct_ty->getElementType(i);
+    uint64_t offset = layout->getElementOffset(i);
+    const auto *array = dyn_cast<ArrayType>(element);
+    if (array && array->getElementType()->isIntegerTy(8) && offset % 16 != 0) {
+      // This is a padding element.
+      elements.push_back(Type::getInt32Ty(M.getContext()));
+      changed = true;
+    } else {
+      elements.push_back(MapType(element, M));
+    }
+    offsets.push_back(offset);
+  }
+
+  if (changed) {
+    StructType *replacement = StructType::create(elements);
+
+    // Record the correct offsets.
+    NamedMDNode *offsets_md =
+        M.getOrInsertNamedMetadata(clspv::RemappedTypeOffsetMetadataName());
+    SmallVector<Metadata*, 8> offset_values;
+    for (auto offset : offsets) {
+      offset_values.push_back(ConstantAsMetadata::get(
+          ConstantInt::get(Type::getInt32Ty(M.getContext()), offset)));
+    }
+    MDTuple *values_md = MDTuple::get(M.getContext(), offset_values);
+    MDTuple *entry = MDTuple::get(
+        M.getContext(),
+        {ConstantAsMetadata::get(Constant::getNullValue(replacement)),
+         values_md});
+    offsets_md->addOperand(entry);
+
+    return replacement;
+  } else {
+    return struct_ty;
+  }
+}
+
+bool UBOTypeTransformPass::RemapTypes(Module &M) {
+  bool changed = false;
+
+  // Fix globals.
+  // Functions are problematic. Need to recreate them.
+
+  for (auto &F : M) {
+    for (auto &Arg : F.args()) {
+      changed |= RemapValue(&Arg, M);
+    }
+
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        changed |= RemapUser(&I, M);
+      }
+    }
+  }
+
+  return changed;
+}
+
+bool UBOTypeTransformPass::RemapUser(User *user, Module &M) {
+  bool changed = RemapValue(user, M);
+
+  for (Use &use : user->operands()) {
+    User *operand_user = use.getUser();
+    if (!operand_user)
+      changed |= RemapValue(use.get(), M);
+    else if (!isa<Instruction>(operand_user) &&
+             !isa<GlobalValue>(operand_user) && !isa<Argument>(operand_user))
+      changed |= RemapUser(operand_user, M);
+  }
+
+  return changed;
+}
+
+bool UBOTypeTransformPass::RemapValue(Value *value, Module &M) {
+  Type *remapped = MapType(value->getType(), M);
+  if (remapped == value->getType())
+    return false;
+
+  value->mutateType(remapped);
+  return true;
+}
+
+}
+

--- a/test/UBO/array_stride_32.cl
+++ b/test/UBO/array_stride_32.cl
@@ -1,0 +1,40 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Checking for correct offsets and array strides.
+
+typedef struct {
+  int x;
+  int y __attribute((aligned(16)));
+} s;
+
+__kernel void foo(__global s* data, __constant s* c) {
+  data->x = c->x;
+}
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 4
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 16
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 20
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 32
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c]] DescriptorSet 0
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[s]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[s]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+// CHECK: [[c]] = OpVariable [[c_ptr]] Uniform

--- a/test/UBO/bad_after_array.cl
+++ b/test/UBO/bad_after_array.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct dt {
+  int x[2];
+  int y;
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO element size must be a multiple of that element's alignment}}

--- a/test/UBO/bad_array.cl
+++ b/test/UBO/bad_array.cl
@@ -1,0 +1,9 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct dt {
+  int x;
+  int y[4];
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{in an UBO, arrays must be aligned to their element alignment, rounded up to a multiple of 16}}
+

--- a/test/UBO/bad_padding.cl
+++ b/test/UBO/bad_padding.cl
@@ -1,7 +1,0 @@
-// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
-
-struct dt {
-  int x __attribute((aligned(16)));
-};
-
-__kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO structures may not have implicit padding}}

--- a/test/UBO/bad_padding.cl
+++ b/test/UBO/bad_padding.cl
@@ -1,8 +1,7 @@
 // RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
 
 struct dt {
-  int x;
-  int4 y;
+  int x __attribute((aligned(16)));
 };
 
 __kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO structures may not have implicit padding}}

--- a/test/UBO/bad_padding.cl
+++ b/test/UBO/bad_padding.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct dt {
+  int x;
+  int4 y;
+};
+
+__kernel void foo(__constant struct dt* c) { } //expected-error{{clspv restriction: UBO structures may not have implicit padding}}

--- a/test/UBO/bad_scalar.cl
+++ b/test/UBO/bad_scalar.cl
@@ -1,0 +1,8 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, scalar elements must be aligned to their size}}

--- a/test/UBO/bad_struct.cl
+++ b/test/UBO/bad_struct.cl
@@ -1,0 +1,12 @@
+// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+
+struct inner {
+  int x;
+};
+
+struct outer {
+  int x;
+  struct inner y;
+};
+
+__kernel void foo(__constant struct outer* c) { } //expected-error{{in an UBO, structs must be aligned to their largest element alignment, rounded up to a multiple of 16 bytes}}

--- a/test/UBO/bad_vec2.cl
+++ b/test/UBO/bad_vec2.cl
@@ -1,0 +1,8 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int2 y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, two-component vectors must be aligned to 2 times their element size}}

--- a/test/UBO/bad_vec4.cl
+++ b/test/UBO/bad_vec4.cl
@@ -1,0 +1,9 @@
+// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+
+struct s {
+  uchar x;
+  int4 y;
+} __attribute((packed));
+
+__kernel void foo(__constant struct s* arg) { } //expected-error{{in an UBO, three- and four-component vectors must be aligned to 4 times their element size}}
+

--- a/test/UBO/constant_wrapping.cl
+++ b/test/UBO/constant_wrapping.cl
@@ -1,0 +1,55 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x;
+  int y __attribute((aligned(16)));
+} inner;
+
+typedef struct {
+  inner i[2];
+} outer;
+
+__kernel void foo(__global inner* data, __constant outer* c) {
+  data->x = c->i[0].x;
+}
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[inner:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[inner]] 1 Offset 4
+// CHECK-DAG: OpMemberDecorate [[inner]] 2 Offset 16
+// CHECK-DAG: OpMemberDecorate [[inner]] 3 Offset 20
+// CHECK-DAG: OpDecorate [[inner_runtime:%[0-9a-zA-Z_]+]] ArrayStride 32
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 64
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c]] DescriptorSet 0
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[inner]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
+// CHECK: [[inner_runtime]] = OpTypeRuntimeArray [[inner]]
+// CHECK: [[data_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner_runtime]]
+// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[data_struct]]
+// CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2
+// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[inner]] [[two]]
+// CHECK: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[outer]]
+// CHECK: [[block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[block]]
+// CHECK: [[c_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+// CHECK: [[c]] = OpVariable [[c_ptr]] Uniform
+// CHECK: [[c_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_ele_ptr]] [[c]] [[zero]] [[zero]] [[zero]] [[zero]] [[zero]]
+// CHECK: [[c_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_gep]]
+// CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[zero]]
+// CHECK: OpStore [[data_gep]] [[c_load]]

--- a/test/UBO/copy.cl
+++ b/test/UBO/copy.cl
@@ -1,0 +1,23 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void foo(__global int* data, __constant int* c) {
+  *data = *c;
+}
+
+// CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
+// CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[var]] Binding 1
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[int]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[ptr_int:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[var]] = OpVariable [[ptr]] Uniform
+// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_int]] [[var]] [[zero]] [[zero]]
+// CHECK: OpLoad [[int]] [[gep]]

--- a/test/UBO/copy_nested.cl
+++ b/test/UBO/copy_nested.cl
@@ -22,6 +22,7 @@ __kernel void foo(__global outer* data, __constant outer* c) {
 //      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
 // CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[var]] Binding 1
@@ -29,7 +30,7 @@ __kernel void foo(__global outer* data, __constant outer* c) {
 // CHECK: [[float4:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
 // CHECK: [[inner:%[0-9a-zA-Z_]+]] = OpTypeStruct [[float4]]
 // CHECK: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner]]
-// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[outer]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[outer]]
 // CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 // CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
 // CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0

--- a/test/UBO/global_wrapping.cl
+++ b/test/UBO/global_wrapping.cl
@@ -1,0 +1,56 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x;
+  int y __attribute((aligned(16)));
+} inner;
+
+typedef struct {
+  inner i[2];
+} outer;
+
+__kernel void foo(__global outer* data, __constant inner* c) {
+  data->i[0].x = c->x;
+}
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[inner:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[inner]] 1 Offset 4
+// CHECK-DAG: OpMemberDecorate [[inner]] 2 Offset 16
+// CHECK-DAG: OpMemberDecorate [[inner]] 3 Offset 20
+// CHECK-DAG: OpDecorate [[inner_runtime:%[0-9a-zA-Z_]+]] ArrayStride 32
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 64
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c]] DescriptorSet 0
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[inner]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
+// CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2
+// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[inner]] [[two]]
+// CHECK: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[outer]]
+// CHECK: [[block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[block]]
+// CHECK: [[inner_runtime]] = OpTypeRuntimeArray [[inner]]
+// CHECK: [[c_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner_runtime]]
+// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[c_struct]]
+// CHECK: [[c_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+// CHECK: [[c]] = OpVariable [[c_ptr]] Uniform
+// CHECK: [[c_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_ele_ptr]] [[c]] [[zero]] [[zero]] [[zero]]
+// CHECK: [[c_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_gep]]
+// CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]] [[zero]]
+// CHECK: OpStore [[data_gep]] [[c_load]]
+

--- a/test/UBO/nested_padding.cl
+++ b/test/UBO/nested_padding.cl
@@ -1,0 +1,52 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x;
+  int y __attribute((aligned(16)));
+} inner;
+
+typedef struct {
+  inner i[2];
+} outer;
+
+__kernel void foo(__global outer* data, __constant outer* c) {
+  data->i[0].x = c->i[0].x;
+}
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[inner:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[inner]] 1 Offset 4
+// CHECK-DAG: OpMemberDecorate [[inner]] 2 Offset 16
+// CHECK-DAG: OpMemberDecorate [[inner]] 3 Offset 20
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 64
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c]] DescriptorSet 0
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[inner]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
+// CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2
+// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[inner]] [[two]]
+// CHECK: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[outer]]
+// CHECK: [[block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[block]]
+// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[block]]
+// CHECK: [[c_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+// CHECK: [[c]] = OpVariable [[c_ptr]] Uniform
+// CHECK: [[c_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_ele_ptr]] [[c]] [[zero]] [[zero]] [[zero]] [[zero]] [[zero]]
+// CHECK: [[c_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_gep]]
+// CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]] [[zero]]
+// CHECK: OpStore [[data_gep]] [[c_load]]

--- a/test/UBO/test_cluster_pod_args.cl
+++ b/test/UBO/test_cluster_pod_args.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x __attribute__((aligned(16)));
+} data_type;
+
+__constant data_type c_var[2] = {{0}, {1}};
+
+__kernel void foo(__global data_type *data, __constant data_type *c_arg,
+                  int n) {
+  data[n].x = c_arg[n].x + c_var[n].x;
+}
+
+// Just checking that the argument names are recorded correctly when clustering pod args.
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
+

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -22,6 +22,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 // MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 // MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
 
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
 // CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
@@ -33,7 +34,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 // CHECK-DAG: OpDecorate [[n]] DescriptorSet 0
 //     CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 //     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
-//     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
+//     CHECK: [[runtime]] = OpTypeRuntimeArray [[data_type]]
 //     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 //     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
 //     CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -1,9 +1,11 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
-// -descriptormap=%t.map RUN: FileCheck %s < %t.spvasm RUN: FileCheck
-// -check-prefix=MAP %s < %t.map RUN: clspv -constant-args-ubo
-// -inline-entry-points %s -o %t.spv -descriptormap=%t2.map RUN: spirv-dis -o
-// %t2.spvasm %t.spv RUN: FileCheck %s < %t2.spvasm RUN: FileCheck
-// -check-prefix=MAP %s < %t2.map RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 typedef struct {
   int x __attribute__((aligned(16)));
@@ -16,12 +18,9 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
   data[n].x = c_arg[n].x + c_var[n].x;
 }
 
-//      MAP:
-//      kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT:
-// kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
-// MAP-NEXT:
-// kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
 
 // CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
@@ -36,34 +35,32 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 //     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
 //     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
 //     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
-//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
-//     [[struct]] CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform
-//     [[struct]] CHECK: [[n_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[int]]
-//     CHECK: [[n_struct_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
-//     [[n_struct]] CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
-//     StorageBuffer [[int]] CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] =
-//     OpTypePointer Uniform [[int]] CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant
-//     [[int]] 2 CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]]
-//     [[two]] CHECK: [[c_var_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private
-//     [[array]] CHECK: [[c_var_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private
-//     [[int]] CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0 CHECK:
-//     [[undef:%[0-9a-zA-Z_]+]] = OpUndef [[int]] CHECK:
-//     [[zero_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]]
-//     [[zero]] [[undef]] CHECK: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
-//     CHECK: [[one_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]]
-//     [[one]] [[undef]] CHECK: [[array_const:%[0-9a-zA-Z_]+]] =
-//     OpConstantComposite [[array]] [[zero_undef]] [[one_undef]] CHECK:
-//     [[c_var:%[0-9a-zA-Z_]+]] = OpVariable [[c_var_ptr]] Private
-//     [[array_const]] CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+//     CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+//     CHECK: [[n_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[int]]
+//     CHECK: [[n_struct_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[n_struct]]
+//     CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+//     CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+//     CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2
+//     CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[two]]
+//     CHECK: [[c_var_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[array]]
+//     CHECK: [[c_var_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[int]]
+//     CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+//     CHECK: [[undef:%[0-9a-zA-Z_]+]] = OpUndef [[int]]
+//     CHECK: [[zero_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[zero]] [[undef]]
+//     CHECK: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
+//     CHECK: [[one_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[one]] [[undef]]
+//     CHECK: [[array_const:%[0-9a-zA-Z_]+]] = OpConstantComposite [[array]] [[zero_undef]] [[one_undef]]
+//     CHECK: [[c_var:%[0-9a-zA-Z_]+]] = OpVariable [[c_var_ptr]] Private [[array_const]]
+//     CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
 //     CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
 //     CHECK: [[n]] = OpVariable [[n_struct_ptr]] StorageBuffer
-//     CHECK: [[n_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[n]]
-//     [[zero]] CHECK: [[n_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[n_gep]]
-//     CHECK: [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]]
-//     [[c_arg]] [[zero]] [[n_load]] [[zero]] CHECK: [[c_load:%[0-9a-zA-Z_]+]] =
-//     OpLoad [[int]] [[c_arg_gep]] CHECK: [[priv_gep:%[0-9a-zA-Z_]+]] =
-//     OpAccessChain [[c_var_ele_ptr]] [[c_var]] [[n_load]] [[zero]] CHECK:
-//     [[priv_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[priv_gep]] CHECK:
-//     [[add:%[0-9a-zA-Z_]+]] = OpIAdd [[int]] [[priv_load]] [[c_load]] CHECK:
-//     [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]]
-//     [[zero]] [[n_load]] [[zero]] CHECK: OpStore [[data_gep]] [[add]]
+//     CHECK: [[n_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[n]] [[zero]]
+//     CHECK: [[n_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[n_gep]]
+//     CHECK: [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]] [[c_arg]] [[zero]] [[n_load]] [[zero]]
+//     CHECK: [[c_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_arg_gep]]
+//     CHECK: [[priv_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_var_ele_ptr]] [[c_var]] [[n_load]] [[zero]]
+//     CHECK: [[priv_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[priv_gep]]
+//     CHECK: [[add:%[0-9a-zA-Z_]+]] = OpIAdd [[int]] [[priv_load]] [[c_load]]
+//     CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[n_load]] [[zero]]
+//     CHECK: OpStore [[data_gep]] [[add]]

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -1,0 +1,69 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
+// -descriptormap=%t.map RUN: FileCheck %s < %t.spvasm RUN: FileCheck
+// -check-prefix=MAP %s < %t.map RUN: clspv -constant-args-ubo
+// -inline-entry-points %s -o %t.spv -descriptormap=%t2.map RUN: spirv-dis -o
+// %t2.spvasm %t.spv RUN: FileCheck %s < %t2.spvasm RUN: FileCheck
+// -check-prefix=MAP %s < %t2.map RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x __attribute__((aligned(16)));
+} data_type;
+
+__constant data_type c_var[2] = {{0}, {1}};
+
+__kernel void foo(__global data_type *data, __constant data_type *c_arg,
+                  int n) {
+  data[n].x = c_arg[n].x + c_var[n].x;
+}
+
+//      MAP:
+//      kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT:
+// kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+// MAP-NEXT:
+// kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
+
+// CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_arg:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c_arg]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_arg]] NonWritable
+// CHECK-DAG: OpDecorate [[n:%[0-9a-zA-Z_]+]] Binding 2
+// CHECK-DAG: OpDecorate [[n]] DescriptorSet 0
+//     CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+//     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
+//     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
+//     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
+//     [[struct]] CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform
+//     [[struct]] CHECK: [[n_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[int]]
+//     CHECK: [[n_struct_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
+//     [[n_struct]] CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
+//     StorageBuffer [[int]] CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] =
+//     OpTypePointer Uniform [[int]] CHECK: [[two:%[0-9a-zA-Z_]+]] = OpConstant
+//     [[int]] 2 CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]]
+//     [[two]] CHECK: [[c_var_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private
+//     [[array]] CHECK: [[c_var_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private
+//     [[int]] CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0 CHECK:
+//     [[undef:%[0-9a-zA-Z_]+]] = OpUndef [[int]] CHECK:
+//     [[zero_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]]
+//     [[zero]] [[undef]] CHECK: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
+//     CHECK: [[one_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]]
+//     [[one]] [[undef]] CHECK: [[array_const:%[0-9a-zA-Z_]+]] =
+//     OpConstantComposite [[array]] [[zero_undef]] [[one_undef]] CHECK:
+//     [[c_var:%[0-9a-zA-Z_]+]] = OpVariable [[c_var_ptr]] Private
+//     [[array_const]] CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+//     CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
+//     CHECK: [[n]] = OpVariable [[n_struct_ptr]] StorageBuffer
+//     CHECK: [[n_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[n]]
+//     [[zero]] CHECK: [[n_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[n_gep]]
+//     CHECK: [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]]
+//     [[c_arg]] [[zero]] [[n_load]] [[zero]] CHECK: [[c_load:%[0-9a-zA-Z_]+]] =
+//     OpLoad [[int]] [[c_arg_gep]] CHECK: [[priv_gep:%[0-9a-zA-Z_]+]] =
+//     OpAccessChain [[c_var_ele_ptr]] [[c_var]] [[n_load]] [[zero]] CHECK:
+//     [[priv_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[priv_gep]] CHECK:
+//     [[add:%[0-9a-zA-Z_]+]] = OpIAdd [[int]] [[priv_load]] [[c_load]] CHECK:
+//     [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]]
+//     [[zero]] [[n_load]] [[zero]] CHECK: OpStore [[data_gep]] [[add]]

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// rUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// rUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  int x __attribute__((aligned(16)));
+} data_type;
+
+__kernel void foo(__global data_type* data, __constant data_type* c_arg, __local data_type* l_arg) {
+  data->x = c_arg->x + l_arg->x;
+}
+
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+// MAP-NEXT: kernel,foo,arg,l_arg,argOrdinal,2,argKind,local,arrayElemSize,16,arrayNumElemSpecId,3

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -1,9 +1,9 @@
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// rUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
 // RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
-// rUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
@@ -15,6 +15,39 @@ __kernel void foo(__global data_type* data, __constant data_type* c_arg, __local
   data->x = c_arg->x + l_arg->x;
 }
 
+// Most important thing here is the arrayElemSize check for the pointer-to-local arg.
 //      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 // MAP-NEXT: kernel,foo,arg,l_arg,argOrdinal,2,argKind,local,arrayElemSize,16,arrayNumElemSpecId,3
+
+// CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_arg:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c_arg]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[spec_id:%[0-9a-zA-Z_]+]] SpecId 3
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[data_type]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+// CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK: [[l_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[int]]
+// CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
+// CHECK: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+// CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
+// CHECK: [[l_arg:%[0-9a-zA-Z_]+]] = OpVariable [[l_arg_ptr]] Workgroup
+// CHECK: [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]] [[c_arg]] [[zero]] [[zero]] [[zero]]
+// CHECK: [[c_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_arg_gep]]
+// CHECK: [[l_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[l_arg_ele_ptr]] [[l_arg]] [[zero]] [[zero]]
+// CHECK: [[l_load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[l_arg_gep]]
+// CHECK: [[add:%[0-9a-zA-Z_]+]] = OpIAdd [[int]] [[l_load]] [[c_load]]
+// CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]]
+// CHECK: OpStore [[data_gep]] [[add]]

--- a/test/UBO/transform_padding.cl
+++ b/test/UBO/transform_padding.cl
@@ -1,0 +1,45 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
+// -descriptormap=%t.map RUN: FileCheck %s < %t.spvasm RUN: FileCheck
+// -check-prefix=MAP %s < %t.map RUN: clspv -constant-args-ubo
+// -inline-entry-points %s -o %t.spv -descriptormap=%t2.map RUN: spirv-dis -o
+// %t2.spvasm %t.spv RUN: FileCheck %s < %t2.spvasm RUN: FileCheck
+// -check-prefix=MAP %s < %t2.map RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// The data_type struct translates as { i32, [12 x i8] } which is transformed
+// to { i32, i32 }
+typedef struct {
+  int x __attribute((aligned(16)));
+} data_type;
+
+__kernel void foo(__global data_type *data, __constant data_type *c_arg) {
+  data->x = c_arg->x;
+}
+
+//      MAP:
+//      kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT:
+// kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
+// CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[data]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_arg:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[c_arg]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_arg]] NonWritable
+//     CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+//     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
+//     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
+//     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
+//     [[struct]] CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform
+//     [[struct]] CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
+//     Uniform [[int]] CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
+//     StorageBuffer [[int]] CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]]
+//     0 CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer CHECK:
+//     [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform CHECK:
+//     [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]] [[c_arg]]
+//     [[zero]] [[zero]] [[zero]] CHECK: [[load:%[0-9a-zA-Z_]+]] = OpLoad
+//     [[int]] [[c_arg_gep]] CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain
+//     [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]] CHECK: OpStore
+//     [[data_gep]] [[load]]

--- a/test/UBO/transform_padding.cl
+++ b/test/UBO/transform_padding.cl
@@ -20,6 +20,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg) {
 //      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
 // CHECK-DAG: OpDecorate [[data:%[0-9a-zA-Z_]+]] Binding 0
@@ -29,7 +30,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg) {
 // CHECK-DAG: OpDecorate [[c_arg]] NonWritable
 //     CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 //     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
-//     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
+//     CHECK: [[runtime]] = OpTypeRuntimeArray [[data_type]]
 //     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 //     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
 //     CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]

--- a/test/UBO/transform_padding.cl
+++ b/test/UBO/transform_padding.cl
@@ -1,9 +1,11 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm
-// -descriptormap=%t.map RUN: FileCheck %s < %t.spvasm RUN: FileCheck
-// -check-prefix=MAP %s < %t.map RUN: clspv -constant-args-ubo
-// -inline-entry-points %s -o %t.spv -descriptormap=%t2.map RUN: spirv-dis -o
-// %t2.spvasm %t.spv RUN: FileCheck %s < %t2.spvasm RUN: FileCheck
-// -check-prefix=MAP %s < %t2.map RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // The data_type struct translates as { i32, [12 x i8] } which is transformed
 // to { i32, i32 }
@@ -15,10 +17,8 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg) {
   data->x = c_arg->x;
 }
 
-//      MAP:
-//      kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT:
-// kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+//      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 
 // CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK-DAG: OpMemberDecorate [[data_type]] 1 Offset 4
@@ -31,15 +31,14 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg) {
 //     CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
 //     CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[data_type]]
 //     CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
-//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer
-//     [[struct]] CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform
-//     [[struct]] CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
-//     Uniform [[int]] CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer
-//     StorageBuffer [[int]] CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]]
-//     0 CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer CHECK:
-//     [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform CHECK:
-//     [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]] [[c_arg]]
-//     [[zero]] [[zero]] [[zero]] CHECK: [[load:%[0-9a-zA-Z_]+]] = OpLoad
-//     [[int]] [[c_arg_gep]] CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain
-//     [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]] CHECK: OpStore
-//     [[data_gep]] [[load]]
+//     CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+//     CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+//     CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+//     CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+//     CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+//     CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
+//     CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
+//     CHECK: [[c_arg_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[c_arg_ele_ptr]] [[c_arg]] [[zero]] [[zero]] [[zero]]
+//     CHECK: [[load:%[0-9a-zA-Z_]+]] = OpLoad [[int]] [[c_arg_gep]]
+//     CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[data_ele_ptr]] [[data]] [[zero]] [[zero]] [[zero]]
+//     CHECK: OpStore [[data_gep]] [[load]]

--- a/test/UBO/vec2_no_pad.cl
+++ b/test/UBO/vec2_no_pad.cl
@@ -1,0 +1,40 @@
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Natural alignment don't lead to LLVM inserting packing so this is ok.
+typedef struct {
+  int x;
+  int2 y;
+} data_type;
+
+__kernel void foo(__global data_type* d, __constant data_type* c) {
+  d->y = c->y;
+}
+
+//      MAP: kernel,foo,arg,d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 8
+// CHECK-DAG: OpMemberDecorate [[struct:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
+// CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[var]] Binding 1
+// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: [[int2:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 2
+// CHECK: [[s]] = OpTypeStruct [[int]] [[int2]]
+// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[s]]
+// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK: [[ptr_int2:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int2]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
+// CHECK: [[var]] = OpVariable [[ptr]] Uniform
+// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_int2]] [[var]] [[zero]] [[zero]] [[one]]
+// CHECK: OpLoad [[int2]] [[gep]]

--- a/test/UBO/vec2_no_pad.cl
+++ b/test/UBO/vec2_no_pad.cl
@@ -20,6 +20,7 @@ __kernel void foo(__global data_type* d, __constant data_type* c) {
 //      MAP: kernel,foo,arg,d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
 
+// CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
 // CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 8
 // CHECK-DAG: OpMemberDecorate [[struct:%[0-9a-zA-Z_]+]] 0 Offset 0
@@ -29,7 +30,7 @@ __kernel void foo(__global data_type* d, __constant data_type* c) {
 // CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK: [[int2:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 2
 // CHECK: [[s]] = OpTypeStruct [[int]] [[int2]]
-// CHECK: [[runtime:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[s]]
+// CHECK: [[runtime]] = OpTypeRuntimeArray [[s]]
 // CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 // CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
 // CHECK: [[ptr_int2:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int2]]

--- a/tools/driver/main.cpp
+++ b/tools/driver/main.cpp
@@ -261,30 +261,30 @@ private:
         // TODO(alan-baker): Remove this restriction
         // Padding would need to be inserted if this field is not laid out at
         // the next available suitable alignment.
-        const auto nearest_offset = llvm::alignTo(next_available, field_alignment);
-        if (nearest_offset != field_offset) {
-          Instance.getDiagnostics().Report(
-              SR.getBegin(),
-              CustomDiagnosticsIDMap[CustomDiagnosticUBORestrictedStruct]);
-          return false;
-        }
+        //const auto nearest_offset = llvm::alignTo(next_available, field_alignment);
+        //if (nearest_offset != field_offset) {
+        //  Instance.getDiagnostics().Report(
+        //      SR.getBegin(),
+        //      CustomDiagnosticsIDMap[CustomDiagnosticUBORestrictedStruct]);
+        //  return false;
+        //}
       }
 
       // TODO(alan-baker): Remove this restriction
       // No padding allowed at the end of the struct.
-      if (field_no == layout.getFieldCount() - 1) {
-        const auto field_size =
-            context.getTypeSizeInChars(field_type).getQuantity();
-        const auto used_field_size = llvm::alignTo(field_size, field_alignment);
-        const auto type_size = context.getTypeSizeInChars(QT).getQuantity();
-        const auto used_type_size = llvm::alignTo(type_size, type_alignment);
-        if (field_offset + used_field_size != offset + used_type_size) {
-          Instance.getDiagnostics().Report(
-              SR.getBegin(),
-              CustomDiagnosticsIDMap[CustomDiagnosticUBORestrictedStruct]);
-          return false;
-        }
-      }
+      //if (field_no == layout.getFieldCount() - 1) {
+      //  const auto field_size =
+      //      context.getTypeSizeInChars(field_type).getQuantity();
+      //  const auto used_field_size = llvm::alignTo(field_size, field_alignment);
+      //  const auto type_size = context.getTypeSizeInChars(QT).getQuantity();
+      //  const auto used_type_size = llvm::alignTo(type_size, type_alignment);
+      //  if (field_offset + used_field_size != offset + used_type_size) {
+      //    Instance.getDiagnostics().Report(
+      //        SR.getBegin(),
+      //        CustomDiagnosticsIDMap[CustomDiagnosticUBORestrictedStruct]);
+      //    return false;
+      //  }
+      //}
 
       prev = field_decl;
     }
@@ -1074,6 +1074,7 @@ int main(const int argc, const char *const argv[]) {
   // This pass generates insertions that need to be rewritten.
   pm.add(clspv::createScalarizePass());
   pm.add(clspv::createRewriteInsertsPass());
+  pm.add(clspv::createUBOTypeTransformPass());
   pm.add(clspv::createSPIRVProducerPass(
       binaryStream, descriptor_map_out, SamplerMapEntries,
       OutputAssembly.getValue(), OutputFormat == "c"));


### PR DESCRIPTION
This adds support for pointer-to-constant args in Uniform buffers.

Contributes to #208 

New option: `-constant-args-ubo` tells clspv to put _all_ pointer-to-constant kernel args in an Uniform buffer. Compiler errors if the argument does not satisfy std140 layouts.

Major changes:
 * New frontend checks that the input conforms to standard Uniform buffer layout rules (Vulkan 14.5.4)
  * error if non-compliant
 * New ArgKind, `BufferUBO`, to represent difference
 * New transform `UBOTypeTransformPass` fixes up LLVM struct padding to work with uniform layout rules
  * Passes type transform information forward in the flow via module scope metadata maps
  * SPIRVProducerPass now uses wrapper methods around DataLayout accessors to ensure the right type information is used
 * Tested with module scope __constant variables, pointer-to-local args, etc.

Restrictions:
 * All or nothing: can't fallback on SSBO currently
 * Requires inlining currently
  * future improvement to relax this requirement
 * non-multiple of 16 byte arrays are not supported
  * 14.5.4 rules about where the next element goes requires significant changes in the llvm representation to make this work