### PR TITLE
Make the check-spirv target work for projects embedding clspv

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_custom_target(check-spirv
   COMMAND ${LLVM_SOURCE_DIR}/utils/lit/lit.py --verbose ${CMAKE_CURRENT_BINARY_DIR}
     --path ${LLVM_BINARY_DIR}/bin
     --path ${SPIRV_TOOLS_BINARY_DIR}/
-    --path ${CLSPV_BINARY_DIR}/bin
+    --path "$<TARGET_FILE_DIR:clspv>"
   DEPENDS clspv spirv-as spirv-dis spirv-val spirv-opt FileCheck not
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
Projects that embed clspv and relocate the clspv binary in the build
output couldn't use the check-spirv target as clspv wasn't where
lit.py expected to find it.

Use a generator expression so the path is correct in all cases.

Signed-off-by: Kévin Petit <kpet@free.fr>