### PR TITLE
Add an option for a stronger basic block ordering

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -61,6 +61,9 @@ bool HackUndef();
 // Returns true if code generation should avoid creating OpPhi of structs.
 bool HackPhis();
 
+// Returns true if basic blocks should be in "structured" order.
+bool HackBlockOrder();
+
 // Returns true if module-scope constants are to be collected into a single
 // storage buffer.  The binding for that buffer, and its intialization data
 // are given in the descriptor map file.

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -571,6 +571,7 @@ void PopulatePassManager(llvm::legacy::PassManager *pm,
   pm->add(clspv::createUndoBoolPass());
   pm->add(clspv::createUndoTruncatedSwitchConditionPass());
   pm->add(llvm::createStructurizeCFGPass(false));
+  // Must be run after structurize cfg.
   pm->add(clspv::createReorderBasicBlocksPass());
   pm->add(clspv::createUndoGetElementPtrConstantExprPass());
   pm->add(clspv::createSplatArgPass());

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -100,6 +100,10 @@ llvm::cl::opt<bool> hack_phis(
     llvm::cl::desc(
         "Scalarize phi instructions of struct type before code generation"));
 
+llvm::cl::opt<bool> hack_block_order(
+    "hack-block-order", llvm::cl::init(false),
+    llvm::cl::desc("Order basic blocks using structured order"));
+
 llvm::cl::opt<bool>
     pod_ubo("pod-ubo", llvm::cl::init(false),
             llvm::cl::desc("POD kernel arguments are in uniform buffers"));
@@ -137,14 +141,13 @@ bool HackInserts() { return hack_inserts; }
 bool HackSignedCompareFixup() { return hack_signed_compare_fixup; }
 bool HackUndef() { return hack_undef; }
 bool HackPhis() { return hack_phis; }
+bool HackBlockOrder() { return hack_block_order; }
 bool ModuleConstantsInStorageBuffer() {
   return module_constants_in_storage_buffer;
 }
 bool PodArgsInUniformBuffer() { return pod_ubo; }
 bool ShowIDs() { return show_ids; }
-bool ConstantArgsInUniformBuffer() {
-  return constant_args_in_uniform_buffer;
-}
+bool ConstantArgsInUniformBuffer() { return constant_args_in_uniform_buffer; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/ReorderBasicBlocksPass.cpp
+++ b/lib/ReorderBasicBlocksPass.cpp
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <deque>
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include "clspv/Option.h"
 
 using namespace llvm;
 
@@ -27,11 +33,18 @@ struct ReorderBasicBlocksPass : public FunctionPass {
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<DominatorTreeWrapperPass>();
+    AU.addRequired<LoopInfoWrapperPass>();
   }
 
   bool runOnFunction(Function &F) override;
+
+private:
+  // Produce structured sorting from |block| into |order|.
+  void StructuredOrder(BasicBlock *block, const LoopInfo &LI,
+                       std::deque<BasicBlock *> *order,
+                       DenseSet<BasicBlock *> *visited);
 };
-}
+} // namespace
 
 char ReorderBasicBlocksPass::ID = 0;
 static RegisterPass<ReorderBasicBlocksPass> X("ReorderBasicBlocks",
@@ -41,21 +54,94 @@ namespace clspv {
 FunctionPass *createReorderBasicBlocksPass() {
   return new ReorderBasicBlocksPass();
 }
+} // namespace clspv
+
+void ReorderBasicBlocksPass::StructuredOrder(BasicBlock *block,
+                                             const LoopInfo &LI,
+                                             std::deque<BasicBlock *> *order,
+                                             DenseSet<BasicBlock *> *visited) {
+  if (!visited->insert(block).second)
+    return;
+
+  // Identify the merge and continue blocks for special treatment.
+  const auto *terminator = dyn_cast<TerminatorInst>(block->getTerminator());
+  BasicBlock *continue_block = nullptr;
+  BasicBlock *merge_block = nullptr;
+  if (LI.isLoopHeader(block)) {
+    Loop *loop = LI.getLoopFor(block);
+    merge_block = loop->getExitBlock();
+
+    if (loop->isLoopLatch(block)) {
+      continue_block = block;
+    } else {
+      DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+      auto *header = loop->getHeader();
+      auto *latch = loop->getLoopLatch();
+      for (auto *bb : loop->blocks()) {
+        if (bb == header)
+          continue;
+
+        if (DT.dominates(bb, latch))
+          continue_block = bb;
+      }
+    }
+    assert(continue_block && merge_block && "Bad loop");
+  } else if (terminator->getNumSuccessors() > 1) {
+    bool has_back_edge = false;
+
+    for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
+      if (LI.isLoopHeader(terminator->getSuccessor(i)))
+        has_back_edge = true;
+    }
+
+    if (!has_back_edge) {
+      merge_block = terminator->getSuccessor(1);
+    }
+  }
+
+  // Traverse merge and continue first.
+  if (merge_block) {
+    StructuredOrder(merge_block, LI, order, visited);
+    if (continue_block)
+      StructuredOrder(continue_block, LI, order, visited);
+  }
+  for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
+    auto *successor = terminator->getSuccessor(i);
+    if (successor != merge_block && successor != continue_block)
+      StructuredOrder(successor, LI, order, visited);
+  }
+
+  order->push_front(block);
 }
 
 bool ReorderBasicBlocksPass::runOnFunction(Function &F) {
   bool Changed = false;
 
-  // spirv-val wants the order of basic blocks to follow dominance relation.
-  // Reorder basic blocks according to dominance relation.
-  DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+  if (clspv::Option::HackBlockOrder()) {
+    // Order basic blocks according to structured order. Structured subgraphs
+    // will be ordered contiguously within the binary.
+    //
+    // Assumes CFG has been structurized.
+    const LoopInfo &LI = getAnalysis<LoopInfoWrapperPass>(F).getLoopInfo();
+    std::deque<BasicBlock *> order;
+    DenseSet<BasicBlock *> visited;
+    StructuredOrder(&*F.begin(), LI, &order, &visited);
 
-  // Traverse dominator tree using depth first order. Reorder basic blocks
-  // according to dominance relation.
-  for (auto II = df_begin(DT.getRootNode()), IE = df_end(DT.getRootNode());
-       II != IE; ++II) {
-    BasicBlock *BB = (*II)->getBlock();
-    BB->moveAfter(&F.back());
+    for (unsigned i = 1; i != order.size(); ++i) {
+      order[i]->moveAfter(order[i - 1]);
+    }
+  } else {
+    // spirv-val wants the order of basic blocks to follow dominance relation.
+    // Reorder basic blocks according to dominance relation.
+    DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+
+    // Traverse dominator tree using depth first order. Reorder basic blocks
+    // according to dominance relation.
+    for (auto II = df_begin(DT.getRootNode()), IE = df_end(DT.getRootNode());
+         II != IE; ++II) {
+      BasicBlock *BB = (*II)->getBlock();
+      BB->moveAfter(&F.back());
+    }
   }
 
   return Changed;


### PR DESCRIPTION
* Adds -hack-block-order to produce blocks in structured order to
satisfy some drivers

Did not change the default ordering because this is slower, the default ordering should be accepted by drivers and there would be too many test updates.