### PR TITLE
Attempt to speed windows bots

### DIFF
--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -15,7 +15,7 @@
 @echo on
 
 set BUILD_ROOT=%cd%
-set SRC=%cd%\github\SPIRV-Tools
+set SRC=%cd%\github\clspv
 set BUILD_TYPE=%1
 set VS_VERSION=%2
 
@@ -30,12 +30,15 @@ python utils/fetch_sources.py
 :: #########################################
 if %VS_VERSION% == 2017 (
   call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+  set GENERATOR="Visual Studio 15 2017 Win64"
   echo "Using VS 2017..."
 ) else if %VS_VERSION% == 2015 (
   call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+  set GENERATOR="Visual Studio 14 2015 Win64"
   echo "Using VS 2015..."
 ) else if %VS_VERSION% == 2013 (
   call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
+  set GENERATOR="Visual Studio 12 2013 Win64"
   echo "Using VS 2013..."
 )
 
@@ -53,20 +56,14 @@ if "%KOKORO_GITHUB_COMMIT%." == "." (
   set BUILD_SHA=%KOKORO_GITHUB_COMMIT%
 )
 
-cmake -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe ..
+cmake -G%GENERATOR% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DLLVM_TARGETS_TO_BUILD="" ..
 
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 
 echo "Build everything... %DATE% %TIME%"
-ninja
+cmake --build .
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 echo "Build Completed %DATE% %TIME%"
-
-:: Run tests.
-echo "Running Tests... %DATE% %TIME%"
-ninja check-spirv
-if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
-echo "Tests Completed %DATE% %TIME%"
 
 :: Clean up some directories.
 rm -rf %SRC%\build

--- a/kokoro/windows-msvc-2015-release/build.bat
+++ b/kokoro/windows-msvc-2015-release/build.bat
@@ -18,4 +18,4 @@
 set SCRIPT_DIR=%~dp0
 
 :: Call with correct parameter
-call %SCRIPT_DIR%\..\scripts\windows\build.bat RelWithDebInfo 2015
+call %SCRIPT_DIR%\..\scripts\windows\build.bat Release 2015

--- a/kokoro/windows-msvc-2017-debug/build.bat
+++ b/kokoro/windows-msvc-2017-debug/build.bat
@@ -18,5 +18,5 @@
 set SCRIPT_DIR=%~dp0
 
 :: Call with correct parameter
-call %SCRIPT_DIR%\..\scripts\windows\build.bat Debug 2017
+call %SCRIPT_DIR%\..\scripts\windows\build.bat RelWithDebInfo 2017
 

--- a/kokoro/windows-msvc-2017-release/build.bat
+++ b/kokoro/windows-msvc-2017-release/build.bat
@@ -18,5 +18,5 @@
 set SCRIPT_DIR=%~dp0
 
 :: Call with correct parameter
-call %SCRIPT_DIR%\..\scripts\windows\build.bat RelWithDebInfo 2017
+call %SCRIPT_DIR%\..\scripts\windows\build.bat Release 2017
 


### PR DESCRIPTION
* Don't build any LLVM targets
* Run Release and RelWithDebInfo instead of RelWithDebInfo and Debug

Testing whether Windows bots will still timeout in this configuration.