### PR TITLE
Enable unit tests on windows bots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(clspv)
 endif()
 
+# Make sure CMAKE_BUILD_TYPE gets a value because we rely on it for
+# running unit tests correctly on Windows.
+if (NOT DEFINED ${CMAKE_BUILD_TYPE})
+  message(STATUS "CMAKE_BUILD_TYPE was not specified, defaulting to Debug")
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 # Check if required third-party dependencies exist.
 macro(use_component path)
 if(NOT IS_DIRECTORY ${path})

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -65,6 +65,11 @@ cmake --build .
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 echo "Build Completed %DATE% %TIME%"
 
+echo "Run tests... %DATE% %TIME%"
+cmake --build . --target check-spirv
+if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
+echo "Tests Completed %DATE% %TIME%"
+
 :: Clean up some directories.
 rm -rf %SRC%\build
 rm -rf %SRC%\third_party

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -367,7 +367,9 @@ bool ReplaceLLVMIntrinsicsPass::removeLifetimeDeclarations(Module &M) {
 
   for (auto *F : WorkList) {
     Changed = true;
-    for (auto U : F->users()) {
+    // Copy users to avoid modifying the list in place.
+    SmallVector<User *, 8> users(F->users());
+    for (auto U : users) {
       if (auto *CI = dyn_cast<CallInst>(U)) {
         CI->eraseFromParent();
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,9 +14,15 @@
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.in ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg @ONLY)
 
+# Visual Studio generates puts LLVM executables in different location.
+set (LLVM_BINARY_SUBDIR bin)
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+  set (LLVM_BINARY_SUBDIR ${CMAKE_BUILD_TYPE}/bin)
+endif()
+
 add_custom_target(check-spirv
-  COMMAND ${LLVM_SOURCE_DIR}/utils/lit/lit.py --verbose ${CMAKE_CURRENT_BINARY_DIR}
-    --path ${LLVM_BINARY_DIR}/bin
+  COMMAND python ${LLVM_SOURCE_DIR}/utils/lit/lit.py --verbose ${CMAKE_CURRENT_BINARY_DIR}
+    --path ${LLVM_BINARY_DIR}/${LLVM_BINARY_SUBDIR}
     --path ${SPIRV_TOOLS_BINARY_DIR}/
     --path "$<TARGET_FILE_DIR:clspv>"
   DEPENDS clspv spirv-as spirv-dis spirv-val spirv-opt FileCheck not


### PR DESCRIPTION
* Changes to cmake setup necessary to run with Visual Studio
* Fixed two crashes found through the unit tests

Contributes to #238. One of the crashes that was fixed is similar to a reported customer issue.