### PR TITLE
Downgrade variable pointers

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6559,18 +6559,16 @@ bool SPIRVProducerPass::selectFromSameObject(Instruction *inst) {
       // Null values satisfy the constraint of selecting of selecting from the
       // same object.
       if (!value) {
-        if (auto *cst = dyn_cast<Constant>(value)) {
-          if (!cst->isNullValue() && (!hack_undef || !isa<UndefValue>(value)))
+        if (auto *cst = dyn_cast<Constant>(base)) {
+          if (!cst->isNullValue() && !(hack_undef && isa<UndefValue>(base)))
             value = base;
         } else {
           value = base;
         }
       } else if (base != value) {
         if (auto *base_cst = dyn_cast<Constant>(base)) {
-          if (base_cst->isNullValue())
+          if (base_cst->isNullValue() || (hack_undef && isa<UndefValue>(base)))
             continue;
-        } else if (hack_undef && isa<UndefValue>(base)) {
-          continue;
         }
 
         if (sameResource(value, base))

--- a/test/AtomicBuiltins/atom_add_int.cl
+++ b/test/AtomicBuiltins/atom_add_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_add_uint.cl
+++ b/test/AtomicBuiltins/atom_add_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_and_int.cl
+++ b/test/AtomicBuiltins/atom_and_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_and_uint.cl
+++ b/test/AtomicBuiltins/atom_and_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_cmpxchg_int.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 20
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_cmpxchg_uint.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 20
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_dec_int.cl
+++ b/test/AtomicBuiltins/atom_dec_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 18
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_dec_uint.cl
+++ b/test/AtomicBuiltins/atom_dec_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 18
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_inc_int.cl
+++ b/test/AtomicBuiltins/atom_inc_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 18
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_inc_uint.cl
+++ b/test/AtomicBuiltins/atom_inc_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 18
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_max_int.cl
+++ b/test/AtomicBuiltins/atom_max_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_max_uint.cl
+++ b/test/AtomicBuiltins/atom_max_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_min_int.cl
+++ b/test/AtomicBuiltins/atom_min_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_min_uint.cl
+++ b/test/AtomicBuiltins/atom_min_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_or_int.cl
+++ b/test/AtomicBuiltins/atom_or_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_or_uint.cl
+++ b/test/AtomicBuiltins/atom_or_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_sub_int.cl
+++ b/test/AtomicBuiltins/atom_sub_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_sub_uint.cl
+++ b/test/AtomicBuiltins/atom_sub_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_xchg_int.cl
+++ b/test/AtomicBuiltins/atom_xchg_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_xchg_uint.cl
+++ b/test/AtomicBuiltins/atom_xchg_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_xor_int.cl
+++ b/test/AtomicBuiltins/atom_xor_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atom_xor_uint.cl
+++ b/test/AtomicBuiltins/atom_xor_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 19
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_add_int.cl
+++ b/test/AtomicBuiltins/atomic_add_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_add_uint.cl
+++ b/test/AtomicBuiltins/atomic_add_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_and_int.cl
+++ b/test/AtomicBuiltins/atomic_and_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_and_uint.cl
+++ b/test/AtomicBuiltins/atomic_and_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_cmpxchg_int.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_cmpxchg_uint.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_dec_int.cl
+++ b/test/AtomicBuiltins/atomic_dec_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_dec_uint.cl
+++ b/test/AtomicBuiltins/atomic_dec_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_inc_int.cl
+++ b/test/AtomicBuiltins/atomic_inc_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_inc_uint.cl
+++ b/test/AtomicBuiltins/atomic_inc_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_max_int.cl
+++ b/test/AtomicBuiltins/atomic_max_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_max_uint.cl
+++ b/test/AtomicBuiltins/atomic_max_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_min_int.cl
+++ b/test/AtomicBuiltins/atomic_min_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_min_uint.cl
+++ b/test/AtomicBuiltins/atomic_min_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_or_int.cl
+++ b/test/AtomicBuiltins/atomic_or_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_or_uint.cl
+++ b/test/AtomicBuiltins/atomic_or_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_sub_int.cl
+++ b/test/AtomicBuiltins/atomic_sub_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_sub_uint.cl
+++ b/test/AtomicBuiltins/atomic_sub_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_xchg_int.cl
+++ b/test/AtomicBuiltins/atomic_xchg_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_xchg_uint.cl
+++ b/test/AtomicBuiltins/atomic_xchg_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_xor_int.cl
+++ b/test/AtomicBuiltins/atomic_xor_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/AtomicBuiltins/atomic_xor_uint.cl
+++ b/test/AtomicBuiltins/atomic_xor_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/CommonBuiltins/float2_clamp.cl
+++ b/test/CommonBuiltins/float2_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_degrees.cl
+++ b/test/CommonBuiltins/float2_degrees.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_max.cl
+++ b/test/CommonBuiltins/float2_max.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_min.cl
+++ b/test/CommonBuiltins/float2_min.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_mix.cl
+++ b/test/CommonBuiltins/float2_mix.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_radians.cl
+++ b/test/CommonBuiltins/float2_radians.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float2_sign.cl
+++ b/test/CommonBuiltins/float2_sign.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_clamp.cl
+++ b/test/CommonBuiltins/float3_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_degrees.cl
+++ b/test/CommonBuiltins/float3_degrees.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_max.cl
+++ b/test/CommonBuiltins/float3_max.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_min.cl
+++ b/test/CommonBuiltins/float3_min.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_mix.cl
+++ b/test/CommonBuiltins/float3_mix.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_radians.cl
+++ b/test/CommonBuiltins/float3_radians.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float3_sign.cl
+++ b/test/CommonBuiltins/float3_sign.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_clamp.cl
+++ b/test/CommonBuiltins/float4_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_degrees.cl
+++ b/test/CommonBuiltins/float4_degrees.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_max.cl
+++ b/test/CommonBuiltins/float4_max.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_min.cl
+++ b/test/CommonBuiltins/float4_min.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_mix.cl
+++ b/test/CommonBuiltins/float4_mix.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_radians.cl
+++ b/test/CommonBuiltins/float4_radians.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float4_sign.cl
+++ b/test/CommonBuiltins/float4_sign.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_clamp.cl
+++ b/test/CommonBuiltins/float_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_degrees.cl
+++ b/test/CommonBuiltins/float_degrees.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_max.cl
+++ b/test/CommonBuiltins/float_max.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_min.cl
+++ b/test/CommonBuiltins/float_min.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_mix.cl
+++ b/test/CommonBuiltins/float_mix.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_radians.cl
+++ b/test/CommonBuiltins/float_radians.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/float_sign.cl
+++ b/test/CommonBuiltins/float_sign.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float2.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float4.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float2.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_20:[0-9]+]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_20:[0-9]+]] "foo"

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float4.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_20:[0-9]+]] "foo"

--- a/test/CommonBuiltins/step/step_float.cl
+++ b/test/CommonBuiltins/step/step_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/step/step_float2.cl
+++ b/test/CommonBuiltins/step/step_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/step/step_float3.cl
+++ b/test/CommonBuiltins/step/step_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/step/step_float4.cl
+++ b/test/CommonBuiltins/step/step_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/CommonBuiltins/step/step_float_float2.cl
+++ b/test/CommonBuiltins/step/step_float_float2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 28
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_19:[0-9]+]] "foo"

--- a/test/CommonBuiltins/step/step_float_float3.cl
+++ b/test/CommonBuiltins/step/step_float_float3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 28
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_19:[0-9]+]] "foo"

--- a/test/CommonBuiltins/step/step_float_float4.cl
+++ b/test/CommonBuiltins/step/step_float_float4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 28
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_19:[0-9]+]] "foo"

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/GeometricBuiltins/float2_distance.cl
+++ b/test/GeometricBuiltins/float2_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float2_dot.cl
+++ b/test/GeometricBuiltins/float2_dot.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/GeometricBuiltins/float2_fast_distance.cl
+++ b/test/GeometricBuiltins/float2_fast_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float2_fast_length.cl
+++ b/test/GeometricBuiltins/float2_fast_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float2_fast_normalize.cl
+++ b/test/GeometricBuiltins/float2_fast_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float2_length.cl
+++ b/test/GeometricBuiltins/float2_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float2_normalize.cl
+++ b/test/GeometricBuiltins/float2_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_cross.cl
+++ b/test/GeometricBuiltins/float3_cross.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_distance.cl
+++ b/test/GeometricBuiltins/float3_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_dot.cl
+++ b/test/GeometricBuiltins/float3_dot.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/GeometricBuiltins/float3_fast_distance.cl
+++ b/test/GeometricBuiltins/float3_fast_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_fast_length.cl
+++ b/test/GeometricBuiltins/float3_fast_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_fast_normalize.cl
+++ b/test/GeometricBuiltins/float3_fast_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_length.cl
+++ b/test/GeometricBuiltins/float3_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float3_normalize.cl
+++ b/test/GeometricBuiltins/float3_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_cross.cl
+++ b/test/GeometricBuiltins/float4_cross.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_distance.cl
+++ b/test/GeometricBuiltins/float4_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_dot.cl
+++ b/test/GeometricBuiltins/float4_dot.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/GeometricBuiltins/float4_fast_distance.cl
+++ b/test/GeometricBuiltins/float4_fast_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_fast_length.cl
+++ b/test/GeometricBuiltins/float4_fast_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_fast_normalize.cl
+++ b/test/GeometricBuiltins/float4_fast_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_length.cl
+++ b/test/GeometricBuiltins/float4_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float4_normalize.cl
+++ b/test/GeometricBuiltins/float4_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_distance.cl
+++ b/test/GeometricBuiltins/float_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_dot.cl
+++ b/test/GeometricBuiltins/float_dot.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/GeometricBuiltins/float_fast_distance.cl
+++ b/test/GeometricBuiltins/float_fast_distance.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_fast_length.cl
+++ b/test/GeometricBuiltins/float_fast_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_fast_normalize.cl
+++ b/test/GeometricBuiltins/float_fast_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_length.cl
+++ b/test/GeometricBuiltins/float_length.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/GeometricBuiltins/float_normalize.cl
+++ b/test/GeometricBuiltins/float_normalize.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/clspv_vloada_half2_global.cl
+++ b/test/HalfStorage/clspv_vloada_half2_global.cl
@@ -17,9 +17,7 @@ kernel void foo(global float2* A, global uint* B, uint n) {
 // CHECK: ; Bound: 41
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_29:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/clspv_vloada_half2_local.cl
+++ b/test/HalfStorage/clspv_vloada_half2_local.cl
@@ -17,9 +17,7 @@ kernel void foo(global float2* A, local uint* B, uint n) {
 // CHECK: ; Bound: 42
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/clspv_vloada_half2_private.cl
+++ b/test/HalfStorage/clspv_vloada_half2_private.cl
@@ -16,9 +16,7 @@ kernel void foo(global float2* A, uint v, uint w, uint n) {
 // CHECK: ; Bound: 48
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/clspv_vloada_half4_global.cl
+++ b/test/HalfStorage/clspv_vloada_half4_global.cl
@@ -21,9 +21,7 @@ kernel void foo(global float4* A, global float4* B, uint n) {
 // CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_30:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/clspv_vloada_half4_local.cl
+++ b/test/HalfStorage/clspv_vloada_half4_local.cl
@@ -16,9 +16,7 @@ kernel void foo(global float4* A, local float4* B, uint n) {
 // CHECK: ; Bound: 63
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/clspv_vloada_half4_private.cl
+++ b/test/HalfStorage/clspv_vloada_half4_private.cl
@@ -17,9 +17,7 @@ kernel void foo(global float4* A, uint2 v, uint2 w, uint n) {
 // CHECK: ; Bound: 61
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vload_half2_pointer_cast_from_float4.cl
+++ b/test/HalfStorage/vload_half2_pointer_cast_from_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
+++ b/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vload_half_pointer_cast_from_short.cl
+++ b/test/HalfStorage/vload_half_pointer_cast_from_short.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability Int16
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vloada_half2_global.cl
+++ b/test/HalfStorage/vloada_half2_global.cl
@@ -17,9 +17,7 @@ kernel void foo(global float2* A, global uint* B, uint n) {
 // CHECK: ; Bound: 41
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_29:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vloada_half4_global.cl
+++ b/test/HalfStorage/vloada_half4_global.cl
@@ -17,9 +17,7 @@ kernel void foo(global float4* A, global uint2* B, uint n) {
 // CHECK: ; Bound: 55
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstore_half2_pointer_cast_to_float4.cl
+++ b/test/HalfStorage/vstore_half2_pointer_cast_to_float4.cl
@@ -16,9 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK:  ; Bound: 26
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_19:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
+++ b/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
+++ b/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability Int16
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
+++ b/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
@@ -10,9 +10,7 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK-NOT: OpCapability Int16
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/HalfStorage/vstorea_half2_global.cl
+++ b/test/HalfStorage/vstorea_half2_global.cl
@@ -18,9 +18,7 @@ kernel void foo(global uint* A, float2 val, uint n) {
 // CHECK: ; Bound: 43
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_29:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstorea_half2_local.cl
+++ b/test/HalfStorage/vstorea_half2_local.cl
@@ -18,9 +18,7 @@ kernel void foo(local uint* A, float2 val, uint n) {
 // CHECK: ; Bound: 44
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstorea_half2_private.cl
+++ b/test/HalfStorage/vstorea_half2_private.cl
@@ -19,9 +19,7 @@ kernel void foo(global uint* A, float2 val, uint n) {
 // CHECK: ; Bound: 52
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstorea_half4_global.cl
+++ b/test/HalfStorage/vstorea_half4_global.cl
@@ -18,9 +18,7 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstorea_half4_local.cl
+++ b/test/HalfStorage/vstorea_half4_local.cl
@@ -17,9 +17,7 @@ kernel void foo(local uint2* A, float4 val, uint n) {
 // CHECK: ; Bound: 59
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_6:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"

--- a/test/HalfStorage/vstorea_half4_private.cl
+++ b/test/HalfStorage/vstorea_half4_private.cl
@@ -19,9 +19,7 @@ kernel void foo(global uint2* A, float4 val, uint n) {
 // CHECK: ; Bound: 68
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_40:%[0-9a-zA-Z_]+]] "foo"

--- a/test/ImageBuiltins/get_image_height_image2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_readonly.cl
@@ -18,9 +18,7 @@ foo(global int* out, read_only image2d_t im)
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability ImageQuery
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_15:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_15]] LocalSize 1 1 1

--- a/test/ImageBuiltins/get_image_height_image2d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_writeonly.cl
@@ -18,9 +18,7 @@ foo(global int* out, write_only image2d_t im)
 // CHECK: OpCapability Shader
 // CHECK: OpCapability StorageImageWriteWithoutFormat
 // CHECK: OpCapability ImageQuery
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_15:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_15]] LocalSize 1 1 1

--- a/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
@@ -18,9 +18,7 @@ foo(global int* out, read_only image2d_t im)
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability ImageQuery
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_15:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_15]] LocalSize 1 1 1

--- a/test/ImageBuiltins/get_image_width_imaged2d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_width_imaged2d_writeonly.cl
@@ -18,9 +18,7 @@ foo(global int* out, write_only image2d_t im)
 // CHECK: OpCapability Shader
 // CHECK: OpCapability StorageImageWriteWithoutFormat
 // CHECK: OpCapability ImageQuery
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_15:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_15]] LocalSize 1 1 1

--- a/test/ImageBuiltins/read_imagef_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float2.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1
@@ -91,9 +89,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CLUSTER: ; Bound: 36
 // CLUSTER: ; Schema: 0
 // CLUSTER: OpCapability Shader
-// CLUSTER: OpCapability VariablePointers
 // CLUSTER: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CLUSTER: OpExtension "SPV_KHR_variable_pointers"
 // CLUSTER: OpMemoryModel Logical GLSL450
 // CLUSTER: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"
 // CLUSTER: OpExecutionMode [[_26]] LocalSize 1 1 1

--- a/test/ImageBuiltins/read_imagef_sampler_float4.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float4.cl
@@ -11,9 +11,7 @@
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK-NOT: OpCapability StorageImageReadWithoutFormat
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
@@ -34,9 +34,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK:  ; Bound: 43
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_35]] LocalSize 1 1 1

--- a/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
@@ -34,9 +34,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK:  ; Bound: 41
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_33]] LocalSize 1 1 1

--- a/test/ImageBuiltins/write_imagef_sampler_int2.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ImageBuiltins/write_imagef_sampler_int4.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int4.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
@@ -33,9 +33,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability StorageImageWriteWithoutFormat
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_27]] LocalSize 1 1 1

--- a/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
@@ -35,9 +35,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image3
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability StorageImageWriteWithoutFormat
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_27]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_int.cl
+++ b/test/IntegerBuiltins/abs/abs_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/abs/abs_int2.cl
+++ b/test/IntegerBuiltins/abs/abs_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/abs/abs_int3.cl
+++ b/test/IntegerBuiltins/abs/abs_int3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/abs/abs_int4.cl
+++ b/test/IntegerBuiltins/abs/abs_int4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/abs/abs_long.cl
+++ b/test/IntegerBuiltins/abs/abs_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_long2.cl
+++ b/test/IntegerBuiltins/abs/abs_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_long3.cl
+++ b/test/IntegerBuiltins/abs/abs_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_long4.cl
+++ b/test/IntegerBuiltins/abs/abs_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_short.cl
+++ b/test/IntegerBuiltins/abs/abs_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_short2.cl
+++ b/test/IntegerBuiltins/abs/abs_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_short3.cl
+++ b/test/IntegerBuiltins/abs/abs_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_short4.cl
+++ b/test/IntegerBuiltins/abs/abs_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/abs/abs_uint.cl
+++ b/test/IntegerBuiltins/abs/abs_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 16
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_uint2.cl
+++ b/test/IntegerBuiltins/abs/abs_uint2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 17
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_uint3.cl
+++ b/test/IntegerBuiltins/abs/abs_uint3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 17
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_uint4.cl
+++ b/test/IntegerBuiltins/abs/abs_uint4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 17
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ulong.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_12:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_12]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ulong2.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ulong3.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ulong4.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ushort.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_12:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_12]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ushort2.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ushort3.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/abs/abs_ushort4.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int2_clamp.cl
+++ b/test/IntegerBuiltins/int2_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int2_clz.cl
+++ b/test/IntegerBuiltins/int2_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int2_mad24.cl
+++ b/test/IntegerBuiltins/int2_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int2_max_var.cl
+++ b/test/IntegerBuiltins/int2_max_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int2_min_var.cl
+++ b/test/IntegerBuiltins/int2_min_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int2_mul24.cl
+++ b/test/IntegerBuiltins/int2_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int2_popcount.cl
+++ b/test/IntegerBuiltins/int2_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int3_clamp.cl
+++ b/test/IntegerBuiltins/int3_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int3_clz.cl
+++ b/test/IntegerBuiltins/int3_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int3_mad24.cl
+++ b/test/IntegerBuiltins/int3_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int3_max_var.cl
+++ b/test/IntegerBuiltins/int3_max_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int3_min_var.cl
+++ b/test/IntegerBuiltins/int3_min_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int3_mul24.cl
+++ b/test/IntegerBuiltins/int3_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int3_popcount.cl
+++ b/test/IntegerBuiltins/int3_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int4_clamp.cl
+++ b/test/IntegerBuiltins/int4_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int4_clz.cl
+++ b/test/IntegerBuiltins/int4_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int4_mad24.cl
+++ b/test/IntegerBuiltins/int4_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int4_max_var.cl
+++ b/test/IntegerBuiltins/int4_max_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int4_min_var.cl
+++ b/test/IntegerBuiltins/int4_min_var.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int4_mul24.cl
+++ b/test/IntegerBuiltins/int4_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int4_popcount.cl
+++ b/test/IntegerBuiltins/int4_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int_clamp.cl
+++ b/test/IntegerBuiltins/int_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int_clz.cl
+++ b/test/IntegerBuiltins/int_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/int_mad24.cl
+++ b/test/IntegerBuiltins/int_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int_mul24.cl
+++ b/test/IntegerBuiltins/int_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/int_popcount.cl
+++ b/test/IntegerBuiltins/int_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 17
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/max/max_int.cl
+++ b/test/IntegerBuiltins/max/max_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_int2.cl
+++ b/test/IntegerBuiltins/max/max_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_int3.cl
+++ b/test/IntegerBuiltins/max/max_int3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_int4.cl
+++ b/test/IntegerBuiltins/max/max_int4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_long.cl
+++ b/test/IntegerBuiltins/max/max_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_long2.cl
+++ b/test/IntegerBuiltins/max/max_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_long3.cl
+++ b/test/IntegerBuiltins/max/max_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_long4.cl
+++ b/test/IntegerBuiltins/max/max_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_short.cl
+++ b/test/IntegerBuiltins/max/max_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_short2.cl
+++ b/test/IntegerBuiltins/max/max_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_short3.cl
+++ b/test/IntegerBuiltins/max/max_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_short4.cl
+++ b/test/IntegerBuiltins/max/max_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_uint.cl
+++ b/test/IntegerBuiltins/max/max_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_uint2.cl
+++ b/test/IntegerBuiltins/max/max_uint2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_uint3.cl
+++ b/test/IntegerBuiltins/max/max_uint3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_uint4.cl
+++ b/test/IntegerBuiltins/max/max_uint4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/max/max_ulong.cl
+++ b/test/IntegerBuiltins/max/max_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ulong2.cl
+++ b/test/IntegerBuiltins/max/max_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ulong3.cl
+++ b/test/IntegerBuiltins/max/max_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ulong4.cl
+++ b/test/IntegerBuiltins/max/max_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ushort.cl
+++ b/test/IntegerBuiltins/max/max_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ushort2.cl
+++ b/test/IntegerBuiltins/max/max_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ushort3.cl
+++ b/test/IntegerBuiltins/max/max_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/max/max_ushort4.cl
+++ b/test/IntegerBuiltins/max/max_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_int.cl
+++ b/test/IntegerBuiltins/min/min_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_int2.cl
+++ b/test/IntegerBuiltins/min/min_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21 
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_int3.cl
+++ b/test/IntegerBuiltins/min/min_int3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21 
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_int4.cl
+++ b/test/IntegerBuiltins/min/min_int4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21 
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_long.cl
+++ b/test/IntegerBuiltins/min/min_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_long2.cl
+++ b/test/IntegerBuiltins/min/min_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_long3.cl
+++ b/test/IntegerBuiltins/min/min_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_long4.cl
+++ b/test/IntegerBuiltins/min/min_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_short.cl
+++ b/test/IntegerBuiltins/min/min_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_short2.cl
+++ b/test/IntegerBuiltins/min/min_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_short3.cl
+++ b/test/IntegerBuiltins/min/min_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_short4.cl
+++ b/test/IntegerBuiltins/min/min_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_uint.cl
+++ b/test/IntegerBuiltins/min/min_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_uint2.cl
+++ b/test/IntegerBuiltins/min/min_uint2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_uint3.cl
+++ b/test/IntegerBuiltins/min/min_uint3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_uint4.cl
+++ b/test/IntegerBuiltins/min/min_uint4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/min/min_ulong.cl
+++ b/test/IntegerBuiltins/min/min_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ulong2.cl
+++ b/test/IntegerBuiltins/min/min_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ulong3.cl
+++ b/test/IntegerBuiltins/min/min_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ulong4.cl
+++ b/test/IntegerBuiltins/min/min_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ushort.cl
+++ b/test/IntegerBuiltins/min/min_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ushort2.cl
+++ b/test/IntegerBuiltins/min/min_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ushort3.cl
+++ b/test/IntegerBuiltins/min/min_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/min/min_ushort4.cl
+++ b/test/IntegerBuiltins/min/min_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"

--- a/test/IntegerBuiltins/uint2_clamp.cl
+++ b/test/IntegerBuiltins/uint2_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint2_clz.cl
+++ b/test/IntegerBuiltins/uint2_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint2_mad24.cl
+++ b/test/IntegerBuiltins/uint2_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint2_mul24.cl
+++ b/test/IntegerBuiltins/uint2_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint2_popcount.cl
+++ b/test/IntegerBuiltins/uint2_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint3_clamp.cl
+++ b/test/IntegerBuiltins/uint3_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint3_clz.cl
+++ b/test/IntegerBuiltins/uint3_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint3_mad24.cl
+++ b/test/IntegerBuiltins/uint3_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint3_mul24.cl
+++ b/test/IntegerBuiltins/uint3_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint3_popcount.cl
+++ b/test/IntegerBuiltins/uint3_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint4_clamp.cl
+++ b/test/IntegerBuiltins/uint4_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint4_clz.cl
+++ b/test/IntegerBuiltins/uint4_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint4_mad24.cl
+++ b/test/IntegerBuiltins/uint4_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint4_mul24.cl
+++ b/test/IntegerBuiltins/uint4_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint4_popcount.cl
+++ b/test/IntegerBuiltins/uint4_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint_clamp.cl
+++ b/test/IntegerBuiltins/uint_clamp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint_clz.cl
+++ b/test/IntegerBuiltins/uint_clz.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/IntegerBuiltins/uint_mad24.cl
+++ b/test/IntegerBuiltins/uint_mad24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint_mul24.cl
+++ b/test/IntegerBuiltins/uint_mul24.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/IntegerBuiltins/uint_popcount.cl
+++ b/test/IntegerBuiltins/uint_popcount.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 17
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/LLVMIntrinsics/memcpy_bitcast_used_twice.cl
+++ b/test/LLVMIntrinsics/memcpy_bitcast_used_twice.cl
@@ -10,8 +10,6 @@
 // CHECK: ; Generator: Codeplay; 0
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[entry_id:[a-zA-Z0-9_]*]] "bitcast_used_twice"
 

--- a/test/LLVMIntrinsics/memcpy_mismatched_dest_is_array.cl
+++ b/test/LLVMIntrinsics/memcpy_mismatched_dest_is_array.cl
@@ -21,9 +21,7 @@ dest_is_array(global float *A, int n, int k) {
 // CHECK:  ; Bound: 50
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_26:%[0-9a-zA-Z_]+]] "dest_is_array"
 // CHECK:  OpExecutionMode [[_26]] LocalSize 1 1 1

--- a/test/LLVMIntrinsics/memcpy_mismatched_src_is_array.cl
+++ b/test/LLVMIntrinsics/memcpy_mismatched_src_is_array.cl
@@ -22,9 +22,7 @@ src_is_array(global float *A, int n, int k) {
 // CHECK:  ; Bound: 68
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "src_is_array"
 // CHECK:  OpExecutionMode [[_33]] LocalSize 1 1 1

--- a/test/LLVMIntrinsics/memset_null_many_copies.cl
+++ b/test/LLVMIntrinsics/memset_null_many_copies.cl
@@ -23,9 +23,7 @@ __kernel void myTest(__global float* jasper)
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[a-zA-Z0-9_]+]] "myTest"
 // CHECK: OpSource OpenCL_C 120

--- a/test/MathBuiltins/float2_acos.cl
+++ b/test/MathBuiltins/float2_acos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_acosh.cl
+++ b/test/MathBuiltins/float2_acosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_acospi.cl
+++ b/test/MathBuiltins/float2_acospi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float2* A, float2 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_asin.cl
+++ b/test/MathBuiltins/float2_asin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_asinh.cl
+++ b/test/MathBuiltins/float2_asinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_asinpi.cl
+++ b/test/MathBuiltins/float2_asinpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float2* A, float2 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_atan.cl
+++ b/test/MathBuiltins/float2_atan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_atan2.cl
+++ b/test/MathBuiltins/float2_atan2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_atan2pi.cl
+++ b/test/MathBuiltins/float2_atan2pi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float2* A, float2 y, float2 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_atanh.cl
+++ b/test/MathBuiltins/float2_atanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_atanpi.cl
+++ b/test/MathBuiltins/float2_atanpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float2* A, float2 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_ceil.cl
+++ b/test/MathBuiltins/float2_ceil.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_cos.cl
+++ b/test/MathBuiltins/float2_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_cosh.cl
+++ b/test/MathBuiltins/float2_cosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_exp.cl
+++ b/test/MathBuiltins/float2_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_exp10.cl
+++ b/test/MathBuiltins/float2_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_exp2.cl
+++ b/test/MathBuiltins/float2_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_fabs.cl
+++ b/test/MathBuiltins/float2_fabs.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_floor.cl
+++ b/test/MathBuiltins/float2_floor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_fma.cl
+++ b/test/MathBuiltins/float2_fma.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_fmax.cl
+++ b/test/MathBuiltins/float2_fmax.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_fmin.cl
+++ b/test/MathBuiltins/float2_fmin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_fmod.cl
+++ b/test/MathBuiltins/float2_fmod.cl
@@ -14,9 +14,7 @@ kernel void foo(global float2 *A, float2 x, float2 y) {
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/MathBuiltins/float2_fract_private.cl
+++ b/test/MathBuiltins/float2_fract_private.cl
@@ -17,9 +17,7 @@ void kernel foo(global float2* A, global float2* B, float2 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_frexp_global.cl
+++ b/test/MathBuiltins/float2_frexp_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_frexp_local.cl
+++ b/test/MathBuiltins/float2_frexp_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_frexp_private.cl
+++ b/test/MathBuiltins/float2_frexp_private.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_cos.cl
+++ b/test/MathBuiltins/float2_half_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_divide.cl
+++ b/test/MathBuiltins/float2_half_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float2_half_exp.cl
+++ b/test/MathBuiltins/float2_half_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_exp10.cl
+++ b/test/MathBuiltins/float2_half_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_exp2.cl
+++ b/test/MathBuiltins/float2_half_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_log.cl
+++ b/test/MathBuiltins/float2_half_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_log10.cl
+++ b/test/MathBuiltins/float2_half_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_log2.cl
+++ b/test/MathBuiltins/float2_half_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_powr.cl
+++ b/test/MathBuiltins/float2_half_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_recip.cl
+++ b/test/MathBuiltins/float2_half_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float2_half_rsqrt.cl
+++ b/test/MathBuiltins/float2_half_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_sin.cl
+++ b/test/MathBuiltins/float2_half_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_sqrt.cl
+++ b/test/MathBuiltins/float2_half_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_half_tan.cl
+++ b/test/MathBuiltins/float2_half_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_ldexp.cl
+++ b/test/MathBuiltins/float2_ldexp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_log.cl
+++ b/test/MathBuiltins/float2_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_log10.cl
+++ b/test/MathBuiltins/float2_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_log2.cl
+++ b/test/MathBuiltins/float2_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_mad.cl
+++ b/test/MathBuiltins/float2_mad.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float2_native_cos.cl
+++ b/test/MathBuiltins/float2_native_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_divide.cl
+++ b/test/MathBuiltins/float2_native_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float2_native_exp.cl
+++ b/test/MathBuiltins/float2_native_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_exp10.cl
+++ b/test/MathBuiltins/float2_native_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_exp2.cl
+++ b/test/MathBuiltins/float2_native_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_log.cl
+++ b/test/MathBuiltins/float2_native_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_log10.cl
+++ b/test/MathBuiltins/float2_native_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_log2.cl
+++ b/test/MathBuiltins/float2_native_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_powr.cl
+++ b/test/MathBuiltins/float2_native_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_recip.cl
+++ b/test/MathBuiltins/float2_native_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float2_native_rsqrt.cl
+++ b/test/MathBuiltins/float2_native_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_sin.cl
+++ b/test/MathBuiltins/float2_native_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_sqrt.cl
+++ b/test/MathBuiltins/float2_native_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_native_tan.cl
+++ b/test/MathBuiltins/float2_native_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_pow.cl
+++ b/test/MathBuiltins/float2_pow.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_powr.cl
+++ b/test/MathBuiltins/float2_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_round.cl
+++ b/test/MathBuiltins/float2_round.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_rsqrt.cl
+++ b/test/MathBuiltins/float2_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_sin.cl
+++ b/test/MathBuiltins/float2_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_sinh.cl
+++ b/test/MathBuiltins/float2_sinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_sqrt.cl
+++ b/test/MathBuiltins/float2_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_step.cl
+++ b/test/MathBuiltins/float2_step.cl
@@ -14,9 +14,7 @@ kernel void foo(global float2 *A, float2 edge, float2 x) {
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_24:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float2_tan.cl
+++ b/test/MathBuiltins/float2_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_tanh.cl
+++ b/test/MathBuiltins/float2_tanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float2_trunc.cl
+++ b/test/MathBuiltins/float2_trunc.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_acos.cl
+++ b/test/MathBuiltins/float3_acos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_acosh.cl
+++ b/test/MathBuiltins/float3_acosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_acospi.cl
+++ b/test/MathBuiltins/float3_acospi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_asin.cl
+++ b/test/MathBuiltins/float3_asin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_asinh.cl
+++ b/test/MathBuiltins/float3_asinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_asinpi.cl
+++ b/test/MathBuiltins/float3_asinpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_atan.cl
+++ b/test/MathBuiltins/float3_atan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_atan2.cl
+++ b/test/MathBuiltins/float3_atan2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_atan2pi.cl
+++ b/test/MathBuiltins/float3_atan2pi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float3* A, float3 y, float3 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_atanh.cl
+++ b/test/MathBuiltins/float3_atanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_atanpi.cl
+++ b/test/MathBuiltins/float3_atanpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_ceil.cl
+++ b/test/MathBuiltins/float3_ceil.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_cos.cl
+++ b/test/MathBuiltins/float3_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_cosh.cl
+++ b/test/MathBuiltins/float3_cosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_exp.cl
+++ b/test/MathBuiltins/float3_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_exp10.cl
+++ b/test/MathBuiltins/float3_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_exp2.cl
+++ b/test/MathBuiltins/float3_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_fabs.cl
+++ b/test/MathBuiltins/float3_fabs.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_floor.cl
+++ b/test/MathBuiltins/float3_floor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_fma.cl
+++ b/test/MathBuiltins/float3_fma.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_fmax.cl
+++ b/test/MathBuiltins/float3_fmax.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_fmin.cl
+++ b/test/MathBuiltins/float3_fmin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_fmod.cl
+++ b/test/MathBuiltins/float3_fmod.cl
@@ -14,9 +14,7 @@ kernel void foo(global float3 *A, float3 x, float3 y) {
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/MathBuiltins/float3_fract_private.cl
+++ b/test/MathBuiltins/float3_fract_private.cl
@@ -17,9 +17,7 @@ void kernel foo(global float3* A, global float3* B, float3 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_frexp_global.cl
+++ b/test/MathBuiltins/float3_frexp_global.cl
@@ -17,9 +17,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a,
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"

--- a/test/MathBuiltins/float3_frexp_local.cl
+++ b/test/MathBuiltins/float3_frexp_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_frexp_private.cl
+++ b/test/MathBuiltins/float3_frexp_private.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a,
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"

--- a/test/MathBuiltins/float3_half_cos.cl
+++ b/test/MathBuiltins/float3_half_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_divide.cl
+++ b/test/MathBuiltins/float3_half_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float3_half_exp.cl
+++ b/test/MathBuiltins/float3_half_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_exp10.cl
+++ b/test/MathBuiltins/float3_half_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_exp2.cl
+++ b/test/MathBuiltins/float3_half_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_log.cl
+++ b/test/MathBuiltins/float3_half_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_log10.cl
+++ b/test/MathBuiltins/float3_half_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_log2.cl
+++ b/test/MathBuiltins/float3_half_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_powr.cl
+++ b/test/MathBuiltins/float3_half_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_recip.cl
+++ b/test/MathBuiltins/float3_half_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float3_half_rsqrt.cl
+++ b/test/MathBuiltins/float3_half_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_sin.cl
+++ b/test/MathBuiltins/float3_half_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_sqrt.cl
+++ b/test/MathBuiltins/float3_half_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_half_tan.cl
+++ b/test/MathBuiltins/float3_half_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_ldexp.cl
+++ b/test/MathBuiltins/float3_ldexp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_log.cl
+++ b/test/MathBuiltins/float3_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_log10.cl
+++ b/test/MathBuiltins/float3_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_log2.cl
+++ b/test/MathBuiltins/float3_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_mad.cl
+++ b/test/MathBuiltins/float3_mad.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float3_native_cos.cl
+++ b/test/MathBuiltins/float3_native_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_divide.cl
+++ b/test/MathBuiltins/float3_native_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float3_native_exp.cl
+++ b/test/MathBuiltins/float3_native_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_exp10.cl
+++ b/test/MathBuiltins/float3_native_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_exp2.cl
+++ b/test/MathBuiltins/float3_native_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_log.cl
+++ b/test/MathBuiltins/float3_native_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_log10.cl
+++ b/test/MathBuiltins/float3_native_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_log2.cl
+++ b/test/MathBuiltins/float3_native_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_powr.cl
+++ b/test/MathBuiltins/float3_native_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_recip.cl
+++ b/test/MathBuiltins/float3_native_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float3_native_rsqrt.cl
+++ b/test/MathBuiltins/float3_native_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_sin.cl
+++ b/test/MathBuiltins/float3_native_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_sqrt.cl
+++ b/test/MathBuiltins/float3_native_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_native_tan.cl
+++ b/test/MathBuiltins/float3_native_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_pow.cl
+++ b/test/MathBuiltins/float3_pow.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_powr.cl
+++ b/test/MathBuiltins/float3_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_round.cl
+++ b/test/MathBuiltins/float3_round.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_rsqrt.cl
+++ b/test/MathBuiltins/float3_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_sin.cl
+++ b/test/MathBuiltins/float3_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_sinh.cl
+++ b/test/MathBuiltins/float3_sinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_sqrt.cl
+++ b/test/MathBuiltins/float3_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_step.cl
+++ b/test/MathBuiltins/float3_step.cl
@@ -14,9 +14,7 @@ kernel void foo(global float3 *A, float3 edge, float3 x) {
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_24:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float3_tan.cl
+++ b/test/MathBuiltins/float3_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_tanh.cl
+++ b/test/MathBuiltins/float3_tanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float3_trunc.cl
+++ b/test/MathBuiltins/float3_trunc.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_acos.cl
+++ b/test/MathBuiltins/float4_acos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_acosh.cl
+++ b/test/MathBuiltins/float4_acosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_acospi.cl
+++ b/test/MathBuiltins/float4_acospi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float4* A, float4 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_asin.cl
+++ b/test/MathBuiltins/float4_asin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_asinh.cl
+++ b/test/MathBuiltins/float4_asinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_asinpi.cl
+++ b/test/MathBuiltins/float4_asinpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float4* A, float4 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_atan.cl
+++ b/test/MathBuiltins/float4_atan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_atan2.cl
+++ b/test/MathBuiltins/float4_atan2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_atan2pi.cl
+++ b/test/MathBuiltins/float4_atan2pi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float4* A, float4 y, float4 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_atanh.cl
+++ b/test/MathBuiltins/float4_atanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_atanpi.cl
+++ b/test/MathBuiltins/float4_atanpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float4* A, float4 x)
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_25:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_ceil.cl
+++ b/test/MathBuiltins/float4_ceil.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_cos.cl
+++ b/test/MathBuiltins/float4_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_cosh.cl
+++ b/test/MathBuiltins/float4_cosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_exp.cl
+++ b/test/MathBuiltins/float4_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_exp10.cl
+++ b/test/MathBuiltins/float4_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_exp2.cl
+++ b/test/MathBuiltins/float4_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_fabs.cl
+++ b/test/MathBuiltins/float4_fabs.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_floor.cl
+++ b/test/MathBuiltins/float4_floor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_fma.cl
+++ b/test/MathBuiltins/float4_fma.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_fmax.cl
+++ b/test/MathBuiltins/float4_fmax.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_fmin.cl
+++ b/test/MathBuiltins/float4_fmin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_fmod.cl
+++ b/test/MathBuiltins/float4_fmod.cl
@@ -14,9 +14,7 @@ kernel void foo(global float4 *A, float4 x, float4 y) {
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/MathBuiltins/float4_fract_private.cl
+++ b/test/MathBuiltins/float4_fract_private.cl
@@ -17,9 +17,7 @@ void kernel foo(global float4* A, global float4* B, float4 x)
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_26:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_frexp_global.cl
+++ b/test/MathBuiltins/float4_frexp_global.cl
@@ -16,9 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"

--- a/test/MathBuiltins/float4_frexp_local.cl
+++ b/test/MathBuiltins/float4_frexp_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_frexp_private.cl
+++ b/test/MathBuiltins/float4_frexp_private.cl
@@ -19,9 +19,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"

--- a/test/MathBuiltins/float4_half_cos.cl
+++ b/test/MathBuiltins/float4_half_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_divide.cl
+++ b/test/MathBuiltins/float4_half_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float4_half_exp.cl
+++ b/test/MathBuiltins/float4_half_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_exp10.cl
+++ b/test/MathBuiltins/float4_half_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_exp2.cl
+++ b/test/MathBuiltins/float4_half_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_log.cl
+++ b/test/MathBuiltins/float4_half_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_log10.cl
+++ b/test/MathBuiltins/float4_half_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_log2.cl
+++ b/test/MathBuiltins/float4_half_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_powr.cl
+++ b/test/MathBuiltins/float4_half_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_recip.cl
+++ b/test/MathBuiltins/float4_half_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float4_half_rsqrt.cl
+++ b/test/MathBuiltins/float4_half_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_sin.cl
+++ b/test/MathBuiltins/float4_half_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_sqrt.cl
+++ b/test/MathBuiltins/float4_half_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_half_tan.cl
+++ b/test/MathBuiltins/float4_half_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_ldexp.cl
+++ b/test/MathBuiltins/float4_ldexp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_log.cl
+++ b/test/MathBuiltins/float4_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_log10.cl
+++ b/test/MathBuiltins/float4_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_log2.cl
+++ b/test/MathBuiltins/float4_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_mad.cl
+++ b/test/MathBuiltins/float4_mad.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float4_native_cos.cl
+++ b/test/MathBuiltins/float4_native_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_divide.cl
+++ b/test/MathBuiltins/float4_native_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float4_native_exp.cl
+++ b/test/MathBuiltins/float4_native_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_exp10.cl
+++ b/test/MathBuiltins/float4_native_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_exp2.cl
+++ b/test/MathBuiltins/float4_native_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_log.cl
+++ b/test/MathBuiltins/float4_native_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_log10.cl
+++ b/test/MathBuiltins/float4_native_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 23
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_log2.cl
+++ b/test/MathBuiltins/float4_native_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_powr.cl
+++ b/test/MathBuiltins/float4_native_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_recip.cl
+++ b/test/MathBuiltins/float4_native_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float4_native_rsqrt.cl
+++ b/test/MathBuiltins/float4_native_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_sin.cl
+++ b/test/MathBuiltins/float4_native_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_sqrt.cl
+++ b/test/MathBuiltins/float4_native_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_native_tan.cl
+++ b/test/MathBuiltins/float4_native_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_pow.cl
+++ b/test/MathBuiltins/float4_pow.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_powr.cl
+++ b/test/MathBuiltins/float4_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_round.cl
+++ b/test/MathBuiltins/float4_round.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_rsqrt.cl
+++ b/test/MathBuiltins/float4_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_sin.cl
+++ b/test/MathBuiltins/float4_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_sinh.cl
+++ b/test/MathBuiltins/float4_sinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_sqrt.cl
+++ b/test/MathBuiltins/float4_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_step.cl
+++ b/test/MathBuiltins/float4_step.cl
@@ -14,9 +14,7 @@ kernel void foo(global float4 *A, float4 edge, float4 x) {
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_24:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float4_tan.cl
+++ b/test/MathBuiltins/float4_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_tanh.cl
+++ b/test/MathBuiltins/float4_tanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float4_trunc.cl
+++ b/test/MathBuiltins/float4_trunc.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_acos.cl
+++ b/test/MathBuiltins/float_acos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_acosh.cl
+++ b/test/MathBuiltins/float_acosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_acospi.cl
+++ b/test/MathBuiltins/float_acospi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float* A, float x)
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_asin.cl
+++ b/test/MathBuiltins/float_asin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_asinh.cl
+++ b/test/MathBuiltins/float_asinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_asinpi.cl
+++ b/test/MathBuiltins/float_asinpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float* A, float x)
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_atan.cl
+++ b/test/MathBuiltins/float_atan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_atan2.cl
+++ b/test/MathBuiltins/float_atan2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_atan2pi.cl
+++ b/test/MathBuiltins/float_atan2pi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float* A, float x, float y)
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_24:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_atanh.cl
+++ b/test/MathBuiltins/float_atanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_atanpi.cl
+++ b/test/MathBuiltins/float_atanpi.cl
@@ -15,9 +15,7 @@ void kernel foo(global float* A, float x)
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_ceil.cl
+++ b/test/MathBuiltins/float_ceil.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_cos.cl
+++ b/test/MathBuiltins/float_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_cosh.cl
+++ b/test/MathBuiltins/float_cosh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_exp.cl
+++ b/test/MathBuiltins/float_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_exp10.cl
+++ b/test/MathBuiltins/float_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_exp2.cl
+++ b/test/MathBuiltins/float_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_fabs.cl
+++ b/test/MathBuiltins/float_fabs.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_floor.cl
+++ b/test/MathBuiltins/float_floor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_fma.cl
+++ b/test/MathBuiltins/float_fma.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_fmax.cl
+++ b/test/MathBuiltins/float_fmax.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_fmin.cl
+++ b/test/MathBuiltins/float_fmin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_fmod.cl
+++ b/test/MathBuiltins/float_fmod.cl
@@ -14,9 +14,7 @@ kernel void foo(global float *A, float x, float y) {
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/MathBuiltins/float_fract_private.cl
+++ b/test/MathBuiltins/float_fract_private.cl
@@ -17,9 +17,7 @@ void kernel foo(global float* A, global float* B, float x)
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_24:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_frexp_global.cl
+++ b/test/MathBuiltins/float_frexp_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_frexp_local.cl
+++ b/test/MathBuiltins/float_frexp_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_frexp_private.cl
+++ b/test/MathBuiltins/float_frexp_private.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_cos.cl
+++ b/test/MathBuiltins/float_half_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_divide.cl
+++ b/test/MathBuiltins/float_half_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float_half_exp.cl
+++ b/test/MathBuiltins/float_half_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_exp10.cl
+++ b/test/MathBuiltins/float_half_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_exp2.cl
+++ b/test/MathBuiltins/float_half_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_log.cl
+++ b/test/MathBuiltins/float_half_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_log10.cl
+++ b/test/MathBuiltins/float_half_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_log2.cl
+++ b/test/MathBuiltins/float_half_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_powr.cl
+++ b/test/MathBuiltins/float_half_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_recip.cl
+++ b/test/MathBuiltins/float_half_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float_half_rsqrt.cl
+++ b/test/MathBuiltins/float_half_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_sin.cl
+++ b/test/MathBuiltins/float_half_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_sqrt.cl
+++ b/test/MathBuiltins/float_half_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_half_tan.cl
+++ b/test/MathBuiltins/float_half_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_ldexp.cl
+++ b/test/MathBuiltins/float_ldexp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 26
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_log.cl
+++ b/test/MathBuiltins/float_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_log10.cl
+++ b/test/MathBuiltins/float_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_log2.cl
+++ b/test/MathBuiltins/float_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_mad.cl
+++ b/test/MathBuiltins/float_mad.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float_native_cos.cl
+++ b/test/MathBuiltins/float_native_cos.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_divide.cl
+++ b/test/MathBuiltins/float_native_divide.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float_native_exp.cl
+++ b/test/MathBuiltins/float_native_exp.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_exp10.cl
+++ b/test/MathBuiltins/float_native_exp10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_exp2.cl
+++ b/test/MathBuiltins/float_native_exp2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_log.cl
+++ b/test/MathBuiltins/float_native_log.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_log10.cl
+++ b/test/MathBuiltins/float_native_log10.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_log2.cl
+++ b/test/MathBuiltins/float_native_log2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_powr.cl
+++ b/test/MathBuiltins/float_native_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_recip.cl
+++ b/test/MathBuiltins/float_native_recip.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/MathBuiltins/float_native_rsqrt.cl
+++ b/test/MathBuiltins/float_native_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_sin.cl
+++ b/test/MathBuiltins/float_native_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_sqrt.cl
+++ b/test/MathBuiltins/float_native_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_native_tan.cl
+++ b/test/MathBuiltins/float_native_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_pow.cl
+++ b/test/MathBuiltins/float_pow.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_powr.cl
+++ b/test/MathBuiltins/float_powr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_round.cl
+++ b/test/MathBuiltins/float_round.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_rsqrt.cl
+++ b/test/MathBuiltins/float_rsqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_sin.cl
+++ b/test/MathBuiltins/float_sin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_sinh.cl
+++ b/test/MathBuiltins/float_sinh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_sqrt.cl
+++ b/test/MathBuiltins/float_sqrt.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_step.cl
+++ b/test/MathBuiltins/float_step.cl
@@ -14,9 +14,7 @@ kernel void foo(global float *A, float edge, float x) {
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_23:%[a-zA-Z0-9_]+]] "foo"

--- a/test/MathBuiltins/float_tan.cl
+++ b/test/MathBuiltins/float_tan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_tanh.cl
+++ b/test/MathBuiltins/float_tanh.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/MathBuiltins/float_trunc.cl
+++ b/test/MathBuiltins/float_trunc.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/PointerCasts/deref_load_cast_float2_to_int4.cl
+++ b/test/PointerCasts/deref_load_cast_float2_to_int4.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; Bound: 29
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/deref_load_cast_float4_to_int2.cl
+++ b/test/PointerCasts/deref_load_cast_float4_to_int2.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/deref_store_cast_int2_to_float4.cl
+++ b/test/PointerCasts/deref_store_cast_int2_to_float4.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_21:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_21]] LocalSize 1 1 1

--- a/test/PointerCasts/deref_store_cast_int4_to_float2.cl
+++ b/test/PointerCasts/deref_store_cast_int4_to_float2.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; Bound: 29
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/inline_func_with_pointer_bitcast_as_argument.cl
+++ b/test/PointerCasts/inline_func_with_pointer_bitcast_as_argument.cl
@@ -24,9 +24,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(__global uint* ou
 // CHECK:  ; Bound: 14
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_11:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_11]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float2_to_float.cl
+++ b/test/PointerCasts/load_cast_float2_to_float.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float2_to_float4.cl
+++ b/test/PointerCasts/load_cast_float2_to_float4.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 35
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_23]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float2_to_int.cl
+++ b/test/PointerCasts/load_cast_float2_to_int.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK:  ; Bound: 32
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_21:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_21]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float2_to_int2.cl
+++ b/test/PointerCasts/load_cast_float2_to_int2.cl
@@ -29,9 +29,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float3_to_int3.cl
+++ b/test/PointerCasts/load_cast_float3_to_int3.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, g
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float3_to_uint3.cl
+++ b/test/PointerCasts/load_cast_float3_to_uint3.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, 
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float4_to_float.cl
+++ b/test/PointerCasts/load_cast_float4_to_float.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float4_to_float2.cl
+++ b/test/PointerCasts/load_cast_float4_to_float2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 37
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float4_to_int.cl
+++ b/test/PointerCasts/load_cast_float4_to_int.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK:  ; Bound: 33
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float4_to_int2.cl
+++ b/test/PointerCasts/load_cast_float4_to_int2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float4_to_int4.cl
+++ b/test/PointerCasts/load_cast_float4_to_int4.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float_to_float2.cl
+++ b/test/PointerCasts/load_cast_float_to_float2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_23]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float_to_float4.cl
+++ b/test/PointerCasts/load_cast_float_to_float4.cl
@@ -33,9 +33,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 41
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float_to_int.cl
+++ b/test/PointerCasts/load_cast_float_to_int.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_19:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_19]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float_to_int2.cl
+++ b/test/PointerCasts/load_cast_float_to_int2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 36
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_float_to_int4.cl
+++ b/test/PointerCasts/load_cast_float_to_int4.cl
@@ -33,9 +33,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 43
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_int2_to_float4.cl
+++ b/test/PointerCasts/load_cast_int2_to_float4.cl
@@ -32,9 +32,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 37
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_int2_to_int4.cl
+++ b/test/PointerCasts/load_cast_int2_to_int4.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, g
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_int4_to_float2.cl
+++ b/test/PointerCasts/load_cast_int4_to_float2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_int4_to_float4.cl
+++ b/test/PointerCasts/load_cast_int4_to_float4.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, g
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/load_cast_int_to_float4.cl
+++ b/test/PointerCasts/load_cast_int_to_float4.cl
@@ -35,9 +35,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, g
 // CHECK:  ; Bound: 42
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float2_to_float.cl
+++ b/test/PointerCasts/store_cast_float2_to_float.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float2_to_float4.cl
+++ b/test/PointerCasts/store_cast_float2_to_float4.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 36
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_24]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float2_to_int.cl
+++ b/test/PointerCasts/store_cast_float2_to_int.cl
@@ -29,9 +29,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 31
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_21:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_21]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float2_to_int2.cl
+++ b/test/PointerCasts/store_cast_float2_to_int2.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float2_to_int4.cl
+++ b/test/PointerCasts/store_cast_float2_to_int4.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a,
 // CHECK:  ; Bound: 38
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float4_to_float.cl
+++ b/test/PointerCasts/store_cast_float4_to_float.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float4_to_float2.cl
+++ b/test/PointerCasts/store_cast_float4_to_float2.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK:  ; Bound: 37
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_23]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float4_to_int.cl
+++ b/test/PointerCasts/store_cast_float4_to_int.cl
@@ -29,9 +29,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a,
 // CHECK:  ; Bound: 32
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float_to_float2.cl
+++ b/test/PointerCasts/store_cast_float_to_float2.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float_to_float4.cl
+++ b/test/PointerCasts/store_cast_float_to_float4.cl
@@ -33,9 +33,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 41
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_23]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_float_to_int.cl
+++ b/test/PointerCasts/store_cast_float_to_int.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, 
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_19:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_19]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_int_to_float.cl
+++ b/test/PointerCasts/store_cast_int_to_float.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK:  ; Bound: 27
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_19:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_19]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_int_to_float2.cl
+++ b/test/PointerCasts/store_cast_int_to_float2.cl
@@ -30,9 +30,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK:  ; Bound: 35
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/PointerCasts/store_cast_int_to_float4.cl
+++ b/test/PointerCasts/store_cast_int_to_float4.cl
@@ -34,9 +34,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK:  ; Bound: 42
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_23]] LocalSize 1 1 1

--- a/test/Preprocessor/LocalInclude.cl
+++ b/test/Preprocessor/LocalInclude.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 4 2 1

--- a/test/Preprocessor/SystemInclude.cl
+++ b/test/Preprocessor/SystemInclude.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 4 2 1

--- a/test/Preprocessor/TwoSystemIncludes.cl
+++ b/test/Preprocessor/TwoSystemIncludes.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 7
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpEntryPoint GLCompute %[[BAR_ID:[a-zA-Z0-9_]*]] "bar"

--- a/test/Preprocessor/UserDefine.cl
+++ b/test/Preprocessor/UserDefine.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 4 2 1

--- a/test/Preprocessor/UserDefineValue.cl
+++ b/test/Preprocessor/UserDefineValue.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 4 2 42

--- a/test/Preprocessor/VULKAN.cl
+++ b/test/Preprocessor/VULKAN.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 100 100 100

--- a/test/Preprocessor/__FAST_RELAXED_MATH__.cl
+++ b/test/Preprocessor/__FAST_RELAXED_MATH__.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 2 3 4

--- a/test/Preprocessor/__OPENCL_C_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_C_VERSION__.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 120 120 120

--- a/test/Preprocessor/__OPENCL_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_VERSION__.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 120 120 120

--- a/test/ProgramScopeConstants/constant.cl
+++ b/test/ProgramScopeConstants/constant.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 14
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ProgramScopeConstants/constant_array.cl
+++ b/test/ProgramScopeConstants/constant_array.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo" [[_gl_LocalInvocationID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_23]] LocalSize 4 1 1

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -27,9 +27,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].a; }
 // CHECK:  ; Bound: 35
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_28:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -23,9 +23,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i][i]; }
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_27:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -25,9 +25,7 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_26:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
@@ -21,9 +21,7 @@ kernel void foo(global uint* A, uint i) { A[i] = 0; }
 // CHECK:  ; Bound: 25
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ProgramScopeConstants/select_between_constant_load.cl
+++ b/test/ProgramScopeConstants/select_between_constant_load.cl
@@ -24,9 +24,7 @@ kernel void foo(global float *A, int c, int i) {
 // CHECK: ; Bound: 61
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_41:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/RelationalBuiltins/all/all_int.cl
+++ b/test/RelationalBuiltins/all/all_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_int2.cl
+++ b/test/RelationalBuiltins/all/all_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_int3.cl
+++ b/test/RelationalBuiltins/all/all_int3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_int4.cl
+++ b/test/RelationalBuiltins/all/all_int4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_long.cl
+++ b/test/RelationalBuiltins/all/all_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_long2.cl
+++ b/test/RelationalBuiltins/all/all_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_long3.cl
+++ b/test/RelationalBuiltins/all/all_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_long4.cl
+++ b/test/RelationalBuiltins/all/all_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_short.cl
+++ b/test/RelationalBuiltins/all/all_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_short2.cl
+++ b/test/RelationalBuiltins/all/all_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_short3.cl
+++ b/test/RelationalBuiltins/all/all_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/all/all_short4.cl
+++ b/test/RelationalBuiltins/all/all_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_int.cl
+++ b/test/RelationalBuiltins/any/any_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_int2.cl
+++ b/test/RelationalBuiltins/any/any_int2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_int3.cl
+++ b/test/RelationalBuiltins/any/any_int3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_int4.cl
+++ b/test/RelationalBuiltins/any/any_int4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 28
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_long.cl
+++ b/test/RelationalBuiltins/any/any_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_long2.cl
+++ b/test/RelationalBuiltins/any/any_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_long3.cl
+++ b/test/RelationalBuiltins/any/any_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_long4.cl
+++ b/test/RelationalBuiltins/any/any_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_short.cl
+++ b/test/RelationalBuiltins/any/any_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_short2.cl
+++ b/test/RelationalBuiltins/any/any_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_short3.cl
+++ b/test/RelationalBuiltins/any/any_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/any/any_short4.cl
+++ b/test/RelationalBuiltins/any/any_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_21:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_21]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_float.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 31
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_float2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_float3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_float4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 33
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_int.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 25
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_int2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_int3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_int4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_long.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_long2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_long3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_long4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_short.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_short2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_short3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_short4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_uint.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 25
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_uint2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_uint3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_uint4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 27
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_14:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_14]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isequal_float.cl
+++ b/test/RelationalBuiltins/isequal_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isequal_float2.cl
+++ b/test/RelationalBuiltins/isequal_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isequal_float3.cl
+++ b/test/RelationalBuiltins/isequal_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isequal_float4.cl
+++ b/test/RelationalBuiltins/isequal_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreater_float.cl
+++ b/test/RelationalBuiltins/isgreater_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreater_float2.cl
+++ b/test/RelationalBuiltins/isgreater_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreater_float3.cl
+++ b/test/RelationalBuiltins/isgreater_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreater_float4.cl
+++ b/test/RelationalBuiltins/isgreater_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreaterequal_float.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreaterequal_float2.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreaterequal_float3.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isgreaterequal_float4.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isinf_float.cl
+++ b/test/RelationalBuiltins/isinf_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isinf_float2.cl
+++ b/test/RelationalBuiltins/isinf_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isinf_float3.cl
+++ b/test/RelationalBuiltins/isinf_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isinf_float4.cl
+++ b/test/RelationalBuiltins/isinf_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isless_float.cl
+++ b/test/RelationalBuiltins/isless_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isless_float2.cl
+++ b/test/RelationalBuiltins/isless_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isless_float3.cl
+++ b/test/RelationalBuiltins/isless_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isless_float4.cl
+++ b/test/RelationalBuiltins/isless_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/islessequal_float.cl
+++ b/test/RelationalBuiltins/islessequal_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/islessequal_float2.cl
+++ b/test/RelationalBuiltins/islessequal_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/islessequal_float3.cl
+++ b/test/RelationalBuiltins/islessequal_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/islessequal_float4.cl
+++ b/test/RelationalBuiltins/islessequal_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnan_float.cl
+++ b/test/RelationalBuiltins/isnan_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnan_float2.cl
+++ b/test/RelationalBuiltins/isnan_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnan_float3.cl
+++ b/test/RelationalBuiltins/isnan_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnan_float4.cl
+++ b/test/RelationalBuiltins/isnan_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnotequal_float.cl
+++ b/test/RelationalBuiltins/isnotequal_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnotequal_float2.cl
+++ b/test/RelationalBuiltins/isnotequal_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnotequal_float3.cl
+++ b/test/RelationalBuiltins/isnotequal_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/isnotequal_float4.cl
+++ b/test/RelationalBuiltins/isnotequal_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float2_int2.cl
+++ b/test/RelationalBuiltins/select/select_float2_int2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_float2_uint2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float3_int3.cl
+++ b/test/RelationalBuiltins/select/select_float3_int3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_float3_uint3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float4_int4.cl
+++ b/test/RelationalBuiltins/select/select_float4_int4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_float4_uint4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 32
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_22:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_22]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float_int.cl
+++ b/test/RelationalBuiltins/select/select_float_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 28
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_18:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_18]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_float_uint.cl
+++ b/test/RelationalBuiltins/select/select_float_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 28
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_18:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_18]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int2_int2.cl
+++ b/test/RelationalBuiltins/select/select_int2_int2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_int2_uint2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int3_int3.cl
+++ b/test/RelationalBuiltins/select/select_int3_int3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_int3_uint3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int4_int4.cl
+++ b/test/RelationalBuiltins/select/select_int4_int4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_int4_uint4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int_int.cl
+++ b/test/RelationalBuiltins/select/select_int_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 23
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_int_uint.cl
+++ b/test/RelationalBuiltins/select/select_int_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 23
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long2_long2.cl
+++ b/test/RelationalBuiltins/select/select_long2_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long2_ulong2.cl
+++ b/test/RelationalBuiltins/select/select_long2_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long3_long3.cl
+++ b/test/RelationalBuiltins/select/select_long3_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long3_ulong3.cl
+++ b/test/RelationalBuiltins/select/select_long3_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long4_long4.cl
+++ b/test/RelationalBuiltins/select/select_long4_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long4_ulong4.cl
+++ b/test/RelationalBuiltins/select/select_long4_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long_long.cl
+++ b/test/RelationalBuiltins/select/select_long_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_long_ulong.cl
+++ b/test/RelationalBuiltins/select/select_long_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short2_short2.cl
+++ b/test/RelationalBuiltins/select/select_short2_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short2_ushort2.cl
+++ b/test/RelationalBuiltins/select/select_short2_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short3_short3.cl
+++ b/test/RelationalBuiltins/select/select_short3_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short3_ushort3.cl
+++ b/test/RelationalBuiltins/select/select_short3_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short4_short4.cl
+++ b/test/RelationalBuiltins/select/select_short4_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short4_ushort4.cl
+++ b/test/RelationalBuiltins/select/select_short4_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short_short.cl
+++ b/test/RelationalBuiltins/select/select_short_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_short_ushort.cl
+++ b/test/RelationalBuiltins/select/select_short_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint2_int2.cl
+++ b/test/RelationalBuiltins/select/select_uint2_int2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_uint2_uint2.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint3_int3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_int3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_uint3.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint4_int4.cl
+++ b/test/RelationalBuiltins/select/select_uint4_int4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_uint4_uint4.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 26
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_16]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint_int.cl
+++ b/test/RelationalBuiltins/select/select_uint_int.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 23
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_uint_uint.cl
+++ b/test/RelationalBuiltins/select/select_uint_uint.cl
@@ -11,9 +11,7 @@
 // CHECK:     ; Bound: 23
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_13:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_13]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong2_long2.cl
+++ b/test/RelationalBuiltins/select/select_ulong2_long2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong2_ulong2.cl
+++ b/test/RelationalBuiltins/select/select_ulong2_ulong2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong3_long3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_long3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong3_ulong3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_ulong3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong4_long4.cl
+++ b/test/RelationalBuiltins/select/select_ulong4_long4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong4_ulong4.cl
+++ b/test/RelationalBuiltins/select/select_ulong4_ulong4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong_long.cl
+++ b/test/RelationalBuiltins/select/select_ulong_long.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ulong_ulong.cl
+++ b/test/RelationalBuiltins/select/select_ulong_ulong.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int64
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort2_short2.cl
+++ b/test/RelationalBuiltins/select/select_ushort2_short2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort2_ushort2.cl
+++ b/test/RelationalBuiltins/select/select_ushort2_ushort2.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort3_short3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_short3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort3_ushort3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_ushort3.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort4_short4.cl
+++ b/test/RelationalBuiltins/select/select_ushort4_short4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort4_ushort4.cl
+++ b/test/RelationalBuiltins/select/select_ushort4_ushort4.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_17:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_17]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort_short.cl
+++ b/test/RelationalBuiltins/select/select_ushort_short.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/select/select_ushort_ushort.cl
+++ b/test/RelationalBuiltins/select/select_ushort_ushort.cl
@@ -12,9 +12,7 @@
 // CHECK:     ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-DAG: OpCapability Int16
-// CHECK-DAG: OpCapability VariablePointers
 // CHECK:     OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:     OpExtension "SPV_KHR_variable_pointers"
 // CHECK:     OpMemoryModel Logical GLSL450
 // CHECK:     OpEntryPoint GLCompute %[[__original_id_15:[0-9]+]] "foo"
 // CHECK:     OpExecutionMode %[[__original_id_15]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/signbit_float.cl
+++ b/test/RelationalBuiltins/signbit_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 24
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/signbit_float2.cl
+++ b/test/RelationalBuiltins/signbit_float2.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/signbit_float3.cl
+++ b/test/RelationalBuiltins/signbit_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/RelationalBuiltins/signbit_float4.cl
+++ b/test/RelationalBuiltins/signbit_float4.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SamplerMap/KernelScopeSampler.cl
+++ b/test/SamplerMap/KernelScopeSampler.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT: OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SamplerMap/ModuleScopeSampler.cl
+++ b/test/SamplerMap/ModuleScopeSampler.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SamplerMap/TwoModuleScopeSamplers.cl
+++ b/test/SamplerMap/TwoModuleScopeSamplers.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/Scalarize/constant_struct.cl
+++ b/test/Scalarize/constant_struct.cl
@@ -33,9 +33,7 @@ kernel void foo(global S2 *data, int n) {
 // CHECK: ; Bound: 64
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_28:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/Scalarize/nested_struct.cl
+++ b/test/Scalarize/nested_struct.cl
@@ -33,9 +33,7 @@ kernel void foo(global S2 *data, int n) {
 // CHECK: ; Bound: 107
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_88:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/Structs/byval.cl
+++ b/test/Structs/byval.cl
@@ -24,9 +24,7 @@ void kernel __attribute__((reqd_work_group_size(1, 2, 3))) foo(void) {
 // CHECK:  ; Bound: 5
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_4:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_4]] LocalSize 1 2 3

--- a/test/Structs/extract_value.cl
+++ b/test/Structs/extract_value.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 42 13 2

--- a/test/Structs/insert_value.cl
+++ b/test/Structs/insert_value.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 42 13 2

--- a/test/Structs/sret.cl
+++ b/test/Structs/sret.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SynchronizationBuiltins/barrier_both.cl
+++ b/test/SynchronizationBuiltins/barrier_both.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 9
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SynchronizationBuiltins/barrier_global.cl
+++ b/test/SynchronizationBuiltins/barrier_global.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 9
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/SynchronizationBuiltins/barrier_local.cl
+++ b/test/SynchronizationBuiltins/barrier_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/VariablePointers/function_call_ssbo.cl
+++ b/test/VariablePointers/function_call_ssbo.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Passing SSBO to function call requires VariablePointersStorageBuffer.
+int bar(global int* x) { return *x; }
+
+kernel void foo(global int* in, global int* out) {
+  *out = bar(in);
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpFunctionParameter [[ptr]]

--- a/test/VariablePointers/function_call_ssbo_subobject.cl
+++ b/test/VariablePointers/function_call_ssbo_subobject.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Passing SSBO to function call requires VariablePointersStorageBuffer.
+// SSBO args do not require memory object declarations.
+int bar(global int* x) { return *x; }
+
+kernel void foo(global int* in, global int* out) {
+  *out = bar(in + 1);
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] {{.*}} [[uint_0]] [[uint_1]]
+// CHECK-NEXT: OpFunctionCall [[uint]] {{.*}} [[gep]]
+

--- a/test/VariablePointers/function_call_wg.cl
+++ b/test/VariablePointers/function_call_wg.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Pass base workgroup object to a function shouldn't require variable
+// pointers, but the representation inserts an OpAccessChain so we require
+// VariablePointers because it is NOT a memory object declaration.
+int bar(local int* x) { return *x; }
+
+kernel void foo(local int* in, global int* out) {
+  *out = bar(in);
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]]
+// CHECK: OpFunctionCall [[uint]] {{.*}} [[gep]]
+

--- a/test/VariablePointers/null_pointer_ssbo.cl
+++ b/test/VariablePointers/null_pointer_ssbo.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Null pointer for SSBO requires VariablePointersStorageBuffer.
+kernel void foo(global int* out) {
+  global int* x = 0;
+  *out = *x;
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpConstantNull [[ptr]]

--- a/test/VariablePointers/null_pointer_wg.cl
+++ b/test/VariablePointers/null_pointer_wg.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Null pointer in workgroup requires VariablePointers.
+kernel void foo(global int* out) {
+  local int* x = 0;
+  *out = *x;
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK: OpConstantNull [[ptr]]

--- a/test/VariablePointers/phi_ssbo.cl
+++ b/test/VariablePointers/phi_ssbo.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Full VariablePointers required because phi is between different buffers.
+kernel void foo(global int* in1, global int* in2, global int* out, int a) {
+  if (a == 0) {
+    barrier(CLK_GLOBAL_MEM_FENCE);
+    *out = *in1;
+  } else {
+    *out = *in2;
+  }
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpPhi [[ptr]]
+

--- a/test/VariablePointers/phi_ssbo_null.cl
+++ b/test/VariablePointers/phi_ssbo_null.cl
@@ -1,0 +1,27 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// VariablePointersStorageBuffer required because phi has a single buffer.
+kernel void foo(global int* in, global int* out, int a) {
+  if (a == 0) {
+    barrier(CLK_GLOBAL_MEM_FENCE);
+    *out = *in;
+  } else {
+    global int* x = 0;
+    *out = *x;
+  }
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpPhi [[ptr]]
+
+

--- a/test/VariablePointers/phi_ssbo_same_buffer.cl
+++ b/test/VariablePointers/phi_ssbo_same_buffer.cl
@@ -1,0 +1,29 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// This should only require VariablePointersStorageBuffer, but the structurizer
+// does some funny things with the if statement and we end up with two
+// conditional branches.
+kernel void foo(global int* in, global int* out, int a) {
+  if (a == 0) {
+    barrier(CLK_GLOBAL_MEM_FENCE);
+    *out = *(in + 1);
+  } else {
+    *out = *(in + 2);
+  }
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpPhi [[ptr]]
+
+
+

--- a/test/VariablePointers/phi_wg.cl
+++ b/test/VariablePointers/phi_wg.cl
@@ -1,0 +1,27 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Despite choice against null, workgroup requires full VariablePointers.
+kernel void foo(local int* in, global int* out, int a) {
+  if (a == 0) {
+    barrier(CLK_GLOBAL_MEM_FENCE);
+    *out = *in;
+  } else {
+    local int* x = 0;
+    *out = *x;
+  }
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK: OpPhi [[ptr]]
+
+

--- a/test/VariablePointers/ptr_access_chain_ssbo.cl
+++ b/test/VariablePointers/ptr_access_chain_ssbo.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// The OpPtrAccessChain requires VariablePointersStorageBuffer. So does passing
+// the of the argument though...
+int bar(global int* x) { return x[1]; }
+kernel void foo(global int* in, global int* out) {
+  *out = bar(in);
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpPtrAccessChain [[ptr]]
+

--- a/test/VariablePointers/ptr_access_chain_wg.cl
+++ b/test/VariablePointers/ptr_access_chain_wg.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// The OpPtrAccessChain requires VariablePointers for Workgorup. So does passing
+// the of the argument though...
+int bar(local int* x) { return x[1]; }
+kernel void foo(local int* in, global int* out) {
+  *out = bar(in);
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK: OpPtrAccessChain [[ptr]]
+
+

--- a/test/VariablePointers/select_ssbo.cl
+++ b/test/VariablePointers/select_ssbo.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Requires full variable pointers because the selection is between different
+// objects.
+kernel void foo(global int* in1, global int* in2, global int* out, int a) {
+  global int* x = (a == 0) ? in1 : in2;
+  *out = *x;
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpSelect [[ptr]]

--- a/test/VariablePointers/select_ssbo_null.cl
+++ b/test/VariablePointers/select_ssbo_null.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Only requires VariablePointersStorageBuffer because of selection against null.
+kernel void foo(global int* in, global int* out, int a) {
+  global int* x = (a == 0) ? in : 0;
+  *out = *x;
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpSelect [[ptr]]

--- a/test/VariablePointers/select_ssbo_same_buffer.cl
+++ b/test/VariablePointers/select_ssbo_same_buffer.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Same object selection only requires VariablePointersStorageBuffer.
+kernel void foo(global int* in, global int* out, int a) {
+  global int* x = in + 1;
+  global int* y = in + 2;
+  global int* z = (a == 0) ? x : y;
+  *out = *z;
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpCapability VariablePointersStorageBuffer
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK: OpSelect [[ptr]]

--- a/test/VariablePointers/select_wg.cl
+++ b/test/VariablePointers/select_wg.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Despite same object selection, workgroup selection requires full
+// VariablePointers.
+kernel void foo(local int* in, global int* out, int a) {
+  local int* x = in + 1;
+  local int* y = in + 2;
+  local int* z = (a == 0) ? x : y;
+  *out = *z;
+}
+
+// CHECK-NOT: OpCapability VariablePointersStorageBuffer
+// CHECK: OpCapability VariablePointers
+// CHECK-NOT: StorageBuffer
+// CHECK: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK: OpSelect [[ptr]]

--- a/test/VaryingLocalSizes/one_kernel.cl
+++ b/test/VaryingLocalSizes/one_kernel.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 32
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpDecorate %[[BUILTIN_X_ID:[a-zA-Z0-9_]*]] SpecId 0

--- a/test/VaryingLocalSizes/reqd_work_group_size.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 42 13 5

--- a/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) foo(global uint* a)
 // CHECK:  ; Bound: 32
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 42 13 5

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -28,9 +28,7 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) bar(global uint* a)
 // CHECK:  ; Bound: 44
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpEntryPoint GLCompute [[_32:%[0-9a-zA-Z_]+]] "bar"

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -29,9 +29,7 @@ void kernel bar(global uint* a)
 // CHECK: ; Bound: 44
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_20:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpEntryPoint GLCompute [[_32:%[a-zA-Z0-9_]+]] "bar"

--- a/test/VectorLoadStore/vload_global_float4.cl
+++ b/test/VectorLoadStore/vload_global_float4.cl
@@ -15,9 +15,7 @@ kernel void foo(global float4* A, global float* B, uint n) {
 // CHECK:  ; Bound: 48
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/VectorLoadStore/vstore_global_float4.cl
+++ b/test/VectorLoadStore/vstore_global_float4.cl
@@ -16,9 +16,7 @@ kernel void foo(global float* A, float4 v, uint n) {
 // CHECK: ; Bound: 47
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_29:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/as_float.cl
+++ b/test/as_float.cl
@@ -19,9 +19,7 @@ kernel void foo(global float *A, uint a) {
 // CHECK:  ; Bound: 28
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/bool_and.cl
+++ b/test/bool_and.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *out, 
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_18:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_18]] LocalSize 1 1 1

--- a/test/bool_or.cl
+++ b/test/bool_or.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *out, 
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_18:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_18]] LocalSize 1 1 1

--- a/test/bool_vector_and.cl
+++ b/test/bool_vector_and.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 40
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/bool_vector_or.cl
+++ b/test/bool_vector_or.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 40
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/bool_xor.cl
+++ b/test/bool_xor.cl
@@ -25,9 +25,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *out, 
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_18:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_18]] LocalSize 1 1 1

--- a/test/char4_insert.cl
+++ b/test/char4_insert.cl
@@ -20,9 +20,7 @@ kernel void foo(global uchar4* A, int n) {
 // CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_28:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/char4_insert_from_float.cl
+++ b/test/char4_insert_from_float.cl
@@ -23,9 +23,7 @@ kernel void foo(global char4* A, float f) {
 // CHECK:  ; Bound: 40
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_29:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/cluster_pod_args_globals_scalars.cl
+++ b/test/cluster_pod_args_globals_scalars.cl
@@ -15,9 +15,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: ; Bound: 27
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_17:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpExecutionMode [[_17]] LocalSize 1 1 1

--- a/test/cluster_pod_args_locals_scalars.cl
+++ b/test/cluster_pod_args_locals_scalars.cl
@@ -26,9 +26,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
+++ b/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
@@ -26,9 +26,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: ; Bound: 31
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpExecutionMode [[_22]] LocalSize 1 1 1

--- a/test/composite_construct.cl
+++ b/test/composite_construct.cl
@@ -32,9 +32,7 @@ kernel void foo(global S* data, float f) {
 // CHECK: ; Bound: 49
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/composite_construct_varying.cl
+++ b/test/composite_construct_varying.cl
@@ -27,9 +27,7 @@ kernel void foo(global S* data, float f) {
 // CHECK:  ; Bound: 56
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/constant_buffer_arg_static_load_and_store.cl
+++ b/test/constant_buffer_arg_static_load_and_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 16
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/descriptor_set_default.cl
+++ b/test/descriptor_set_default.cl
@@ -32,9 +32,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(global float* B, 
 // CHECK:  ; Bound: 39
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_23:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpEntryPoint GLCompute [[_31:%[0-9a-zA-Z_]+]] "bar"

--- a/test/descriptor_set_distinct.cl
+++ b/test/descriptor_set_distinct.cl
@@ -31,9 +31,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(global float* B, 
 // CHECK:  ; Bound: 40
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_24:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpEntryPoint GLCompute [[_32:%[0-9a-zA-Z_]+]] "bar"

--- a/test/explicit_stdin.cl
+++ b/test/explicit_stdin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float2_add.cl
+++ b/test/float2_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float2_div.cl
+++ b/test/float2_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float2_mul.cl
+++ b/test/float2_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float2_sub.cl
+++ b/test/float2_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float3_add.cl
+++ b/test/float3_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float3_div.cl
+++ b/test/float3_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float3_frexp_local.cl
+++ b/test/float3_frexp_local.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"

--- a/test/float3_mul.cl
+++ b/test/float3_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float3_sub.cl
+++ b/test/float3_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float4_add.cl
+++ b/test/float4_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float4_div.cl
+++ b/test/float4_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float4_mul.cl
+++ b/test/float4_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float4_sub.cl
+++ b/test/float4_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_add.cl
+++ b/test/float_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_div.cl
+++ b/test/float_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_equal.cl
+++ b/test/float_equal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_greaterthan.cl
+++ b/test/float_greaterthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_greaterthanequal.cl
+++ b/test/float_greaterthanequal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_lessthan.cl
+++ b/test/float_lessthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_lessthanequal.cl
+++ b/test/float_lessthanequal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_mul.cl
+++ b/test/float_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_notequal.cl
+++ b/test/float_notequal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_sub.cl
+++ b/test/float_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_to_int.cl
+++ b/test/float_to_int.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/float_to_uint.cl
+++ b/test/float_to_uint.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/for.cl
+++ b/test/for.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 33
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/function_call.cl
+++ b/test/function_call.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/get_global_id.cl
+++ b/test/get_global_id.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo" [[_gl_GlobalInvocationID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/get_global_offset.cl
+++ b/test/get_global_offset.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/get_global_size.cl
+++ b/test/get_global_size.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 42
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo" [[_gl_NumWorkGroups:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/get_global_size_hack_initializers.cl
+++ b/test/get_global_size_hack_initializers.cl
@@ -19,9 +19,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 42
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo" [[_gl_NumWorkGroups:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_25]] LocalSize 1 1 1

--- a/test/get_group_id.cl
+++ b/test/get_group_id.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo" [[_gl_WorkGroupID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/get_local_id.cl
+++ b/test/get_local_id.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 34
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo" [[_gl_LocalInvocationID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_20]] LocalSize 1 1 1

--- a/test/get_local_size.cl
+++ b/test/get_local_size.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 35
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/get_num_groups.cl
+++ b/test/get_num_groups.cl
@@ -18,9 +18,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 // CHECK:  ; Bound: 35
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_21:%[0-9a-zA-Z_]+]] "foo" [[_gl_NumWorkGroups:%[0-9a-zA-Z_]+]]
 // CHECK:  OpExecutionMode [[_21]] LocalSize 1 1 1

--- a/test/get_work_dim.cl
+++ b/test/get_work_dim.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/global_buffer_arg_dynamic_store.cl
+++ b/test/global_buffer_arg_dynamic_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo" %[[GLOBAL_ID_VAR_ID:[a-zA-Z0-9_]*]]
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/global_buffer_arg_static_load_and_store.cl
+++ b/test/global_buffer_arg_static_load_and_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 16
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/global_buffer_arg_static_store.cl
+++ b/test/global_buffer_arg_static_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 14
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/hack_inserts_constant.cl
+++ b/test/hack_inserts_constant.cl
@@ -32,9 +32,7 @@ kernel void foo(global S* data, float f) {
 // CHECK: ; Bound: 49
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_36:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/hack_inserts_undef.cl
+++ b/test/hack_inserts_undef.cl
@@ -31,9 +31,7 @@ kernel void foo(global S* data, float f) {
 // CHECK: ; Bound: 48
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/hack_inserts_varying.cl
+++ b/test/hack_inserts_varying.cl
@@ -30,9 +30,7 @@ kernel void foo(global S* data, float f) {
 // CHECK:  ; Bound: 56
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/hack_inserts_zero.cl
+++ b/test/hack_inserts_zero.cl
@@ -31,9 +31,7 @@ kernel void foo(global S* data, float f) {
 // CHECK: ; Bound: 48
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_35:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/hack_scf_32bit.cl
+++ b/test/hack_scf_32bit.cl
@@ -228,9 +228,7 @@ kernel void greaterthan_const_vec4(__global int* outDest, int inWidth,
 // CHECK:  ; Bound: 681
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_78:%[0-9a-zA-Z_]+]] "greaterthan_m2" [[_gl_GlobalInvocationID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpEntryPoint GLCompute [[_111:%[0-9a-zA-Z_]+]] "greaterthan" [[_gl_GlobalInvocationID]]

--- a/test/hack_undef.cl
+++ b/test/hack_undef.cl
@@ -22,9 +22,7 @@ void kernel foo(global float4* A)
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/if.cl
+++ b/test/if.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ifelse.cl
+++ b/test/ifelse.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 29
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/ifelseif.cl
+++ b/test/ifelseif.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Bound: 30
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image2d.cl
+++ b/test/image2d.cl
@@ -13,8 +13,6 @@
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT: OpCapability StorageImageReadWithoutFormat
 // CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image2d_read.cl
+++ b/test/image2d_read.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image2d_write.cl
+++ b/test/image2d_write.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability StorageImageWriteWithoutFormat
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image3d.cl
+++ b/test/image3d.cl
@@ -13,8 +13,6 @@
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
 // CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image3d_read.cl
+++ b/test/image3d_read.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK-DAG: OpCapability Shader
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/image3d_write.cl
+++ b/test/image3d_write.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
 // CHECK: OpCapability StorageImageWriteWithoutFormat
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_add.cl
+++ b/test/int_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_and.cl
+++ b/test/int_and.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_div.cl
+++ b/test/int_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_equal.cl
+++ b/test/int_equal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_greaterthan.cl
+++ b/test/int_greaterthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_greaterthanequal.cl
+++ b/test/int_greaterthanequal.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_lessthan.cl
+++ b/test/int_lessthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_lessthanequal.cl
+++ b/test/int_lessthanequal.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_mod.cl
+++ b/test/int_mod.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_mul.cl
+++ b/test/int_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_not.cl
+++ b/test/int_not.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_notequal.cl
+++ b/test/int_notequal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_or.cl
+++ b/test/int_or.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_shl.cl
+++ b/test/int_shl.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_shr.cl
+++ b/test/int_shr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_sub.cl
+++ b/test/int_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_to_float.cl
+++ b/test/int_to_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/int_xor.cl
+++ b/test/int_xor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/local_array.cl
+++ b/test/local_array.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 17    
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1 

--- a/test/local_buffer_static_load_and_store.cl
+++ b/test/local_buffer_static_load_and_store.cl
@@ -12,8 +12,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/nop.cl
+++ b/test/nop.cl
@@ -11,9 +11,7 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/one_constant_buffer_arg.cl
+++ b/test/one_constant_buffer_arg.cl
@@ -17,9 +17,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(constant uint* a,
 // CHECK:  ; Bound: 16
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_11:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_11]] LocalSize 1 1 1

--- a/test/one_global_buffer_arg.cl
+++ b/test/one_global_buffer_arg.cl
@@ -14,9 +14,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a)
 // CHECK:  ; Bound: 13
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_10:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_10]] LocalSize 1 1 1

--- a/test/one_uint_arg.cl
+++ b/test/one_uint_arg.cl
@@ -14,9 +14,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(uint a)
 // CHECK:  ; Bound: 13
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_9:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_9]] LocalSize 1 1 1

--- a/test/opselect_float2.cl
+++ b/test/opselect_float2.cl
@@ -19,8 +19,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* A,
 // CHECK: ; Bound: 34
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/pod_in_ubo.cl
+++ b/test/pod_in_ubo.cl
@@ -21,9 +21,7 @@ kernel void foo(int k, global int *A, int b) { *A = k + b; }
 // CHECK:  ; Bound: 30
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_22:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ptr_function_as_return.cl
+++ b/test/ptr_function_as_return.cl
@@ -27,9 +27,7 @@ kernel void foo(global int* A, int n) {
 // CHECK:  ; Bound: 35
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_25:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/ptr_function_in_callee.cl
+++ b/test/ptr_function_in_callee.cl
@@ -25,9 +25,7 @@ kernel void foo(global int* A, int n) {
 // CHECK: ; Bound: 25
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
 // CHECK: OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK: OpSource OpenCL_C 120

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -29,9 +29,7 @@ kernel void foo(local float *L, global float* A, float f, S local* LS, constant 
 // CHECK:      ; Bound: 54
 // CHECK:      ; Schema: 0
 // CHECK:      OpCapability Shader
-// CHECK:      OpCapability VariablePointers
 // CHECK:      OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:      OpExtension "SPV_KHR_variable_pointers"
 // CHECK:      OpMemoryModel Logical GLSL450
 // CHECK:      OpEntryPoint GLCompute [[_38:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:      OpSource OpenCL_C 120

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -29,9 +29,7 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // CHECK:      ; Bound: 54
 // CHECK:      ; Schema: 0
 // CHECK:      OpCapability Shader
-// CHECK:      OpCapability VariablePointers
 // CHECK:      OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:      OpExtension "SPV_KHR_variable_pointers"
 // CHECK:      OpMemoryModel Logical GLSL450
 // CHECK:      OpEntryPoint GLCompute [[_38:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:      OpSource OpenCL_C 120

--- a/test/reuse_kernel_arg_var.cl
+++ b/test/reuse_kernel_arg_var.cl
@@ -52,9 +52,7 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 // CHECK:  ; Bound: 55
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_33:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpEntryPoint GLCompute [[_44:%[0-9a-zA-Z_]+]] "bar"
@@ -159,9 +157,7 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 // CLUSTER:  ; Bound: 56
 // CLUSTER:  ; Schema: 0
 // CLUSTER:  OpCapability Shader
-// CLUSTER:  OpCapability VariablePointers
 // CLUSTER:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CLUSTER:  OpExtension "SPV_KHR_variable_pointers"
 // CLUSTER:  OpMemoryModel Logical GLSL450
 // CLUSTER:  OpEntryPoint GLCompute [[_34:%[0-9a-zA-Z_]+]] "foo"
 // CLUSTER:  OpEntryPoint GLCompute [[_45:%[0-9a-zA-Z_]+]] "bar"

--- a/test/sampler.cl
+++ b/test/sampler.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 8
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/short_add.cl
+++ b/test/short_add.cl
@@ -16,9 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* a, 
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
 // CHECK:  OpCapability Int16
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_12:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_12]] LocalSize 1 1 1

--- a/test/stdin.cl
+++ b/test/stdin.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/stdout.cl
+++ b/test/stdout.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 5
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/two_global_buffer_args_static_store.cl
+++ b/test/two_global_buffer_args_static_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/two_nop_kernels.cl
+++ b/test/two_nop_kernels.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 7
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpEntryPoint GLCompute %[[BAR_ID:[a-zA-Z0-9_]*]] "bar"

--- a/test/uchar4_insert_from_float.cl
+++ b/test/uchar4_insert_from_float.cl
@@ -23,9 +23,7 @@ kernel void foo(global uchar4* A, float f) {
 // CHECK:  ; Bound: 40
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_29:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120

--- a/test/uint_add.cl
+++ b/test/uint_add.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_and.cl
+++ b/test/uint_and.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_arg_static_load_store.cl
+++ b/test/uint_arg_static_load_store.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_div.cl
+++ b/test/uint_div.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_equal.cl
+++ b/test/uint_equal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_greaterthan.cl
+++ b/test/uint_greaterthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_greaterthanequal.cl
+++ b/test/uint_greaterthanequal.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_lessthan.cl
+++ b/test/uint_lessthan.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_lessthanequal.cl
+++ b/test/uint_lessthanequal.cl
@@ -13,8 +13,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_mod.cl
+++ b/test/uint_mod.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_mul.cl
+++ b/test/uint_mul.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_not.cl
+++ b/test/uint_not.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_notequal.cl
+++ b/test/uint_notequal.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 19
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_or.cl
+++ b/test/uint_or.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_shl.cl
+++ b/test/uint_shl.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_shr.cl
+++ b/test/uint_shr.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 20
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_sub.cl
+++ b/test/uint_sub.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_to_float.cl
+++ b/test/uint_to_float.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/uint_xor.cl
+++ b/test/uint_xor.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 18
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/unreferenced_function.cl
+++ b/test/unreferenced_function.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 21
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1

--- a/test/vector_insert_dynamic.cl
+++ b/test/vector_insert_dynamic.cl
@@ -20,9 +20,7 @@ kernel void foo(global int4* in, global int4* out,
 // CHECK:  ; Bound: 38
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_28:%[0-9a-zA-Z_]+]] "foo" [[_gl_GlobalInvocationID:%[0-9a-zA-Z_]+]]
 // CHECK:  OpSource OpenCL_C 120

--- a/test/vector_shuffle.cl
+++ b/test/vector_shuffle.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22    
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute  %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1 

--- a/test/vector_shuffle_float3.cl
+++ b/test/vector_shuffle_float3.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 22    
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute  %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1 

--- a/test/vector_shuffle_hi_lo.cl
+++ b/test/vector_shuffle_hi_lo.cl
@@ -11,8 +11,6 @@
 // CHECK: ; Bound: 27    
 // CHECK: ; Schema: 0
 // CHECK: OpCapability Shader
-// CHECK: OpCapability VariablePointers
-// CHECK: OpExtension "SPV_KHR_variable_pointers"
 // CHECK: OpMemoryModel Logical GLSL450
 // CHECK: OpEntryPoint GLCompute  %[[FOO_ID:[a-zA-Z0-9_]*]] "foo"
 // CHECK: OpExecutionMode %[[FOO_ID]] LocalSize 1 1 1 

--- a/test/widen_switch_condition.cl
+++ b/test/widen_switch_condition.cl
@@ -56,9 +56,7 @@ kernel void foo(global float *out, float x, float y) {
 // CHECK:  ; Bound: 114
 // CHECK:  ; Schema: 0
 // CHECK:  OpCapability Shader
-// CHECK:  OpCapability VariablePointers
 // CHECK:  OpExtension "SPV_KHR_storage_buffer_storage_class"
-// CHECK:  OpExtension "SPV_KHR_variable_pointers"
 // CHECK:  OpMemoryModel Logical GLSL450
 // CHECK:  OpEntryPoint GLCompute [[_38:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpSource OpenCL_C 120


### PR DESCRIPTION
Only add the minimal variable pointers capabilities.

Most of the changes are test updates.

This only includes the detection of necessary capabilities in SPIRVProducer.  Removing unused arguments will be a separate PR.

