### PR TITLE
Add option to turn UBO layout checks off

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -97,6 +97,10 @@ uint64_t MaxUniformBufferSize();
 // that ArrayStride is a multiple of array alignment.
 bool RelaxedUniformBufferLayout();
 
+// Returns true if clspv should allow UBOs that conform to std430 (SSBO) layout
+// requirements.
+bool Std430UniformBufferLayout();
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -408,6 +408,7 @@ public:
 
             if (is_opencl_kernel &&
                 clspv::Option::ConstantArgsInUniformBuffer() &&
+                !clspv::Option::Std430UniformBufferLayout() &&
                 type->isPointerType() &&
                 type->getPointeeType().getAddressSpace() ==
                     LangAS::opencl_constant) {

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -134,6 +134,12 @@ llvm::cl::opt<bool> relaxed_ubo_layout(
                    "does not generate valid SPIR-V for the Vulkan environment; "
                    "however, some drivers may accept it."));
 
+llvm::cl::opt<bool> std430_ubo_layout(
+    "std430-ubo-layout",
+    llvm::cl::desc("Allow UBO layouts that conform to std430 (SSBO) layout "
+                   "requirements. This does not generate valid SPIR-V for the "
+                   "Vulkan environment; however, some drivers may accept it."));
+
 } // namespace
 
 namespace clspv {
@@ -162,6 +168,7 @@ bool ShowIDs() { return show_ids; }
 bool ConstantArgsInUniformBuffer() { return constant_args_in_uniform_buffer; }
 uint64_t MaxUniformBufferSize() { return maximum_ubo_size; }
 bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
+bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 
 } // namespace Option
 } // namespace clspv


### PR DESCRIPTION
* -std430-ubo-layout disables standard UBO layout checks

The frontend should verify the ssbo layouts, but currently does not. Leaving that for a different PR.