### PR TITLE
Generalise the production of constants for OpSelect

### DIFF
--- a/test/opselect_constants_int_scalar.cl
+++ b/test/opselect_constants_int_scalar.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK:     OpSelect %[[uint]] {{.*}} %[[uint_1]] %[[uint_0]]
+
+kernel void test(int A, int B, global int *dst)
+{
+    *dst = A >= B;
+}
+

--- a/test/opselect_constants_int_vector.cl
+++ b/test/opselect_constants_int_vector.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:     %[[v2uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 2
+// CHECK-DAG: %[[v2uint_0:[0-9]+]] = OpConstantNull %[[v2uint]]
+// CHECK-DAG: %[[uint_all_ones:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295
+// CHECK-DAG: %[[v2uint_all_ones:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_all_ones]] %[[uint_all_ones]]
+// CHECK:     OpSelect %[[v2uint]] {{.*}} %[[v2uint_all_ones]] %[[v2uint_0]]
+
+kernel void test(int2 A, int2 B, global int2 *dst)
+{
+    *dst = A >= B;
+}
+

--- a/test/opselect_constants_long_scalar.cl
+++ b/test/opselect_constants_long_scalar.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[ulong_0:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 0
+// CHECK-DAG: %[[ulong_1:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 1
+// CHECK:     OpSelect %[[ulong]] {{.*}} %[[ulong_1]] %[[ulong_0]]
+
+kernel void test(long A, long B, global long *dst)
+{
+    *dst = A >= B;
+}
+

--- a/test/opselect_constants_long_vector.cl
+++ b/test/opselect_constants_long_vector.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK:     %[[v2ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 2
+// CHECK-DAG: %[[v2ulong_0:[0-9]+]] = OpConstantNull %[[v2ulong]]
+// CHECK-DAG: %[[ulong_all_ones:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 18446744073709551615
+// CHECK-DAG: %[[v2ulong_all_ones:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_all_ones]] %[[ulong_all_ones]]
+// CHECK:     OpSelect %[[v2ulong]] {{.*}} %[[v2ulong_all_ones]] %[[v2ulong_0]]
+
+kernel void test(long2 A, long2 B, global long2 *dst)
+{
+    *dst = A >= B;
+}
+

--- a/test/opselect_constants_short_scalar.cl
+++ b/test/opselect_constants_short_scalar.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[ushort_0:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 0
+// CHECK-DAG: %[[ushort_1:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 1
+// CHECK:     OpSelect %[[ushort]] {{.*}} %[[ushort_1]] %[[ushort_0]]
+
+kernel void test(short A, short B, global short *dst)
+{
+    *dst = A >= B;
+}
+

--- a/test/opselect_constants_short_vector.cl
+++ b/test/opselect_constants_short_vector.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK:     %[[v2ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 2
+// CHECK-DAG: %[[v2ushort_0:[0-9]+]] = OpConstantNull %[[v2ushort]]
+// CHECK-DAG: %[[ushort_all_ones:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 65535
+// CHECK-DAG: %[[v2ushort_all_ones:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[ushort_all_ones]] %[[ushort_all_ones]]
+// CHECK:     OpSelect %[[v2ushort]] {{.*}} %[[v2ushort_all_ones]] %[[v2ushort_0]]
+
+kernel void test(short2 A, short2 B, global short2 *dst)
+{
+    *dst = A >= B;
+}
+


### PR DESCRIPTION
...so that non-32-bit integer types are correctly handled.

Also delete a bit of nearby dead code.

Fixes #235.

Signed-off-by: Kévin Petit <kpet@free.fr>