### PR TITLE
Add support for the upsample built-in function

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -602,8 +602,7 @@ functions **must not** be used.
 #### Integer Functions
 
 The `abs_diff()`, `add_sat()`, `hadd()`, `mad_hi()`, `mad_sat()`, `mul_hi()`,
-`rhadd()`, `rotate()`, `sub_sat()` and `upsample()` built-in functions
-**must not** be used.
+`rhadd()`, `rotate()` and `sub_sat()` built-in functions **must not** be used.
 
 #### Relational Functions
 

--- a/test/IntegerBuiltins/upsample/upsample_int.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int.cl
@@ -1,0 +1,20 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong_32:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 32
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[ulong]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[ulong]] %[[hicast]] %[[ulong_32]]
+// CHECK:     OpBitwiseOr %[[ulong]] %[[hishifted]] %[[ulong_42]]
+
+kernel void test_upsample(global long* out, int a)
+{
+    *out = upsample(a, (uint)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_int2.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int2.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v2ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 2
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v2uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 2
+// CHECK-DAG: %[[ulong_32:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 32
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_32]] %[[ulong_32]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v2ulong]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v2ulong]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v2ulong]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global long2* out, int2 a)
+{
+    *out = upsample(a, (uint2)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_int3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v3ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 3
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[ulong_32:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 32
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v3ulong]] %[[ulong_32]] %[[ulong_32]] %[[ulong_32]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v3ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v3ulong]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v3ulong]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v3ulong]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global long3* out, int3 a)
+{
+    *out = upsample(a, (uint3)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_int4.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int4.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong_32:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 32
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_32]] %[[ulong_32]] %[[ulong_32]] %[[ulong_32]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v4ulong]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v4ulong]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v4ulong]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global long4* out, int4 a)
+{
+    *out = upsample(a, (uint4)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_short.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short.cl
@@ -1,0 +1,20 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint_16:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 16
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[uint]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[uint]] %[[hicast]] %[[uint_16]]
+// CHECK:     OpBitwiseOr %[[uint]] %[[hishifted]] %[[uint_42]]
+
+kernel void test_upsample(global int* out, short a)
+{
+    *out = upsample(a, (ushort)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_short2.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short2.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v2uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 2
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v2ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 2
+// CHECK-DAG: %[[uint_16:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 16
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_16]] %[[uint_16]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v2uint]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v2uint]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v2uint]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global int2* out, short2 a)
+{
+    *out = upsample(a, (ushort2)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_short3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v3ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 3
+// CHECK-DAG: %[[uint_16:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 16
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v3uint]] %[[uint_16]] %[[uint_16]] %[[uint_16]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v3uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v3uint]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v3uint]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v3uint]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global int3* out, short3 a)
+{
+    *out = upsample(a, (ushort3)42);
+}
+

--- a/test/IntegerBuiltins/upsample/upsample_short4.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short4.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint_16:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 16
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_16]] %[[uint_16]] %[[uint_16]] %[[uint_16]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v4uint]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v4uint]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v4uint]] %[[hishifted]] %[[locst]]
+
+kernel void test_upsample(global int4* out, short4 a)
+{
+    *out = upsample(a, (ushort4)42);
+}
+


### PR DESCRIPTION
The tests added here are a compromise between succinctness,
ease of maintenance and coverage. The second argument to upsample
is a constant and its conversion to the result type is folded
into the constant. However, using two non-constant arguments
leads to a much longer and brittler test if one wants to ensure
that their relative ordering is correct.

Signed-off-by: Kévin Petit <kpet@free.fr>