### PR TITLE
Coherent decoration for global variables

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -926,13 +926,13 @@ bool AllocateDescriptorsPass::CallTreeContainsGlobalBarrier(Function *F) {
                 "__spirv_control_barrier")) {
           // barrier()
           if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(2))) {
-            uses_barrier = semantics->getZExtValue() & 0x40;
+            uses_barrier = semantics->getZExtValue() & kMemorySemanticsUniformMemory;
           }
         } else if (call->getCalledFunction()->getName().equals(
                        "__spirv_memory_barrier")) {
           // mem_fence()
           if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(1))) {
-            uses_barrier = semantics->getZExtValue() & 0x40;
+            uses_barrier = semantics->getZExtValue() & kMemorySemanticsUniformMemory;
           }
         } else if (!call->getCalledFunction()->isDeclaration()) {
           // Continue searching in the subfunction.

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -407,7 +407,6 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         std::tie(reads, writes) = HasReadsAndWrites(&Arg);
         coherent = (reads && writes) ? 1 : 0;
       }
-      outs() << " is coherent: " << coherent << "\n";
 
       KernelArgDiscriminant key(argTy, arg_index, separation_token, coherent);
 
@@ -948,7 +947,7 @@ std::pair<bool, bool> AllocateDescriptorsPass::HasReadsAndWrites(Value *V) {
     stack.push_back(std::make_pair(Use.getUser(), Use.getOperandNo()));
   }
 
-  while (!stack.empty() || !(read && write)) {
+  while (!stack.empty() && !(read && write)) {
     Value *value = stack.back().first;
     unsigned operand_no = stack.back().second;
     stack.pop_back();

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -91,6 +91,7 @@ private:
   // function calls until a non-pointer value is encountered.
   std::pair<bool, bool> HasReadsAndWrites(Value *V);
 
+  // Cache for which functions' call trees contain a global barrier.
   DenseMap<Function *, bool> barrier_map_;
 
   // The sampler map, which is an array ref of pairs, each of which is the
@@ -122,7 +123,8 @@ private:
     // variables that otherwise share the same type and argument index.
     // By default this will be zero, and so it won't force any separation.
     int separation_token;
-    // An extra bit that marks whether the variable is coherent.
+    // An extra bit that marks whether the variable is coherent. This means
+    // coherent and non-coherent variables will not share a binding.
     int coherent;
   };
   struct KADDenseMapInfo {
@@ -919,6 +921,7 @@ bool AllocateDescriptorsPass::CallTreeContainsGlobalBarrier(Function *F) {
             uses_barrier = semantics->getZExtValue() & 0x40;
           }
         } else if (!call->getCalledFunction()->isDeclaration()) {
+          // Continue searching in the subfunction.
           uses_barrier =
               CallTreeContainsGlobalBarrier(call->getCalledFunction());
         }

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -635,6 +635,7 @@ int PopulatePassManager(
   }
 
   pm->add(clspv::createShareModuleScopeVariablesPass());
+  // This should be run after LLVM and OpenCL intrinsics are replaced.
   pm->add(clspv::createAllocateDescriptorsPass(*SamplerMapEntries));
   pm->add(llvm::createVerifierPass());
   pm->add(clspv::createDirectResourceAccessPass());

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6641,7 +6641,8 @@ bool SPIRVProducerPass::selectFromSameObject(Instruction *inst) {
 }
 
 bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
-  if (clspv::GetArgKindForType(Arg.getType()) != clspv::ArgKind::Buffer) {
+  if (Arg.getType()->isPointerTy() &&
+      Arg.getType()->getPointerAddressSpace() == clspv::AddressSpace::Global) {
     // Only SSBOs need to be annotated as coherent.
     return false;
   }
@@ -6684,8 +6685,9 @@ bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
       // variables.
       for (unsigned i = 0; i != user->getNumOperands(); ++i) {
         Value *operand = user->getOperand(i);
-        if (clspv::GetArgKindForType(operand->getType()) ==
-            clspv::ArgKind::Buffer) {
+        if (operand->getType()->isPointerTy() &&
+            operand->getType()->getPointerAddressSpace() ==
+                clspv::AddressSpace::Global) {
           stack.push_back(operand);
         }
       }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -417,6 +417,9 @@ struct SPIRVProducerPass final : public ModulePass {
   // structure (or null).
   bool selectFromSameObject(Instruction *inst);
 
+  // Returns true if |Arg| is called with a coherent resource.
+  bool CalledWithCoherentResource(Argument &Arg);
+
 private:
   static char ID;
   ArrayRef<std::pair<unsigned, std::string>> samplerMap;
@@ -492,15 +495,16 @@ private:
   // Bookkeeping for mapping kernel arguments to resource variables.
   struct ResourceVarInfo {
     ResourceVarInfo(int index_arg, unsigned set_arg, unsigned binding_arg,
-                    Function *fn, clspv::ArgKind arg_kind_arg)
+                    Function *fn, clspv::ArgKind arg_kind_arg, int coherent_arg)
         : index(index_arg), descriptor_set(set_arg), binding(binding_arg),
-          var_fn(fn), arg_kind(arg_kind_arg),
+          var_fn(fn), arg_kind(arg_kind_arg), coherent(coherent_arg),
           addr_space(fn->getReturnType()->getPointerAddressSpace()) {}
     const int index; // Index into ResourceVarInfoList
     const unsigned descriptor_set;
     const unsigned binding;
     Function *const var_fn; // The @clspv.resource.var.* function.
     const clspv::ArgKind arg_kind;
+    const int coherent;
     const unsigned addr_space; // The LLVM address space
     // The SPIR-V ID of the OpVariable.  Not populated at construction time.
     uint32_t var_id = 0;
@@ -1060,6 +1064,8 @@ void SPIRVProducerPass::FindResourceVars(Module &M, const DataLayout &) {
               dyn_cast<ConstantInt>(call->getArgOperand(2))->getZExtValue());
           const auto arg_index = unsigned(
               dyn_cast<ConstantInt>(call->getArgOperand(3))->getZExtValue());
+          const auto coherent = unsigned(
+              dyn_cast<ConstantInt>(call->getArgOperand(5))->getZExtValue());
 
           // Find or make the resource var info for this combination.
           ResourceVarInfo *rv = nullptr;
@@ -1070,7 +1076,7 @@ void SPIRVProducerPass::FindResourceVars(Module &M, const DataLayout &) {
             auto where = set_and_binding_map.find(key);
             if (where == set_and_binding_map.end()) {
               rv = new ResourceVarInfo(int(ResourceVarInfoList.size()), set,
-                                       binding, &F, arg_kind);
+                                       binding, &F, arg_kind, coherent);
               ResourceVarInfoList.emplace_back(rv);
               set_and_binding_map[key] = rv;
             } else {
@@ -1082,7 +1088,7 @@ void SPIRVProducerPass::FindResourceVars(Module &M, const DataLayout &) {
             if (first_use) {
               first_use = false;
               rv = new ResourceVarInfo(int(ResourceVarInfoList.size()), set,
-                                       binding, &F, arg_kind);
+                                       binding, &F, arg_kind, coherent);
               ResourceVarInfoList.emplace_back(rv);
             } else {
               rv = ResourceVarInfoList.back().get();
@@ -2679,6 +2685,14 @@ void SPIRVProducerPass::GenerateResourceVars(Module &) {
     SPIRVInstList.insert(DecoInsertPoint,
                          new SPIRVInstruction(spv::OpDecorate, Ops));
 
+    if (info->coherent) {
+      // Decorate with Coherent if required for the variable.
+      Ops.clear();
+      Ops << MkId(info->var_id) << MkNum(spv::DecorationCoherent);
+      SPIRVInstList.insert(DecoInsertPoint,
+                           new SPIRVInstruction(spv::OpDecorate, Ops));
+    }
+
     // Generate NonWritable and NonReadable
     switch (info->arg_kind) {
     case clspv::ArgKind::Buffer:
@@ -3175,10 +3189,30 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
   //
 
   if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
+
+    // Find Insert Point for OpDecorate.
+    auto DecoInsertPoint =
+        std::find_if(SPIRVInstList.begin(), SPIRVInstList.end(),
+                     [](SPIRVInstruction *Inst) -> bool {
+                       return Inst->getOpcode() != spv::OpDecorate &&
+                              Inst->getOpcode() != spv::OpMemberDecorate &&
+                              Inst->getOpcode() != spv::OpExtInstImport;
+                     });
+
     // Iterate Argument for name instead of param type from function type.
     unsigned ArgIdx = 0;
     for (Argument &Arg : F.args()) {
-      VMap[&Arg] = nextID;
+      uint32_t param_id = nextID++;
+      VMap[&Arg] = param_id;
+
+      if (CalledWithCoherentResource(Arg)) {
+        // If the arg is passed a coherent resource ever, then decorate this
+        // parameter with Coherent too.
+        SPIRVOperandList decoration_ops;
+        decoration_ops << MkId(param_id) << MkNum(spv::DecorationCoherent);
+        SPIRVInstList.insert(DecoInsertPoint,
+                             new SPIRVInstruction(spv::OpDecorate, decoration_ops));
+      }
 
       // ParamOps[0] : Result Type ID
       SPIRVOperandList ParamOps;
@@ -3200,7 +3234,7 @@ void SPIRVProducerPass::GenerateFuncPrologue(Function &F) {
 
       // Generate SPIRV instruction for parameter.
       auto *ParamInst =
-          new SPIRVInstruction(spv::OpFunctionParameter, nextID++, ParamOps);
+          new SPIRVInstruction(spv::OpFunctionParameter, param_id, ParamOps);
       SPIRVInstList.push_back(ParamInst);
 
       ArgIdx++;
@@ -6603,5 +6637,61 @@ bool SPIRVProducerPass::selectFromSameObject(Instruction *inst) {
   }
 
   // Conservatively return false.
+  return false;
+}
+
+bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
+  if (clspv::GetArgKindForType(Arg.getType()) != clspv::ArgKind::Buffer) {
+    // Only SSBOs need to be annotated as coherent.
+    return false;
+  }
+
+  DenseSet<Value *> visited;
+  std::vector<Value *> stack;
+  for (auto *U : Arg.getParent()->users()) {
+    if (auto *call = dyn_cast<CallInst>(U)) {
+      stack.push_back(call->getOperand(Arg.getArgNo()));
+    }
+  }
+
+  while (!stack.empty()) {
+    Value *v = stack.back();
+    stack.pop_back();
+
+    if (!visited.insert(v).second)
+      continue;
+
+    auto *resource_call = dyn_cast<CallInst>(v);
+    if (resource_call &&
+        resource_call->getCalledFunction()->getName().startswith(
+            clspv::ResourceAccessorFunction())) {
+      // If this is a resource accessor function, check if the coherent operand
+      // is set.
+      const auto coherent =
+          unsigned(dyn_cast<ConstantInt>(resource_call->getArgOperand(5))
+                       ->getZExtValue());
+      if (coherent == 1)
+        return true;
+    } else if (auto *arg = dyn_cast<Argument>(v)) {
+      // If this is a function argument, trace through its callers.
+      for (auto U : arg->users()) {
+        if (auto *call = dyn_cast<CallInst>(U)) {
+          stack.push_back(call->getOperand(arg->getArgNo()));
+        }
+      }
+    } else if (auto *user = dyn_cast<User>(v)) {
+      // If this is a user, traverse all operands that could lead to resource
+      // variables.
+      for (unsigned i = 0; i != user->getNumOperands(); ++i) {
+        Value *operand = user->getOperand(i);
+        if (clspv::GetArgKindForType(operand->getType()) ==
+            clspv::ArgKind::Buffer) {
+          stack.push_back(operand);
+        }
+      }
+    }
+  }
+
+  // No coherent resource variables encountered.
   return false;
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6641,7 +6641,7 @@ bool SPIRVProducerPass::selectFromSameObject(Instruction *inst) {
 }
 
 bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
-  if (Arg.getType()->isPointerTy() &&
+  if (!Arg.getType()->isPointerTy() ||
       Arg.getType()->getPointerAddressSpace() != clspv::AddressSpace::Global) {
     // Only SSBOs need to be annotated as coherent.
     return false;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6642,7 +6642,7 @@ bool SPIRVProducerPass::selectFromSameObject(Instruction *inst) {
 
 bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
   if (Arg.getType()->isPointerTy() &&
-      Arg.getType()->getPointerAddressSpace() == clspv::AddressSpace::Global) {
+      Arg.getType()->getPointerAddressSpace() != clspv::AddressSpace::Global) {
     // Only SSBOs need to be annotated as coherent.
     return false;
   }

--- a/test/Coherent/coherent_barrier_subfunction.cl
+++ b/test/Coherent/coherent_barrier_subfunction.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void bar() { barrier(CLK_GLOBAL_MEM_FENCE); }
+
+kernel void foo(global int* data) {
+  int x = data[0];
+  bar();
+  data[1] = x;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent

--- a/test/Coherent/coherent_simple.cl
+++ b/test/Coherent/coherent_simple.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* data) {
+  int x = data[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent

--- a/test/Coherent/coherent_subfunction_parameter.cl
+++ b/test/Coherent/coherent_subfunction_parameter.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -no-inline-single -no-dra
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+int bar(global int* x) { return x[0]; }
+
+kernel void foo(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent
+// CHECK: OpDecorate [[param:%[a-zA-Z0-9_]+]] Coherent
+// CHECK: [[param]] = OpFunctionParameter
+

--- a/test/Coherent/frexp.cl
+++ b/test/Coherent/frexp.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global float *data, global float* x) {
+  float y = data[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  *x = frexp(y, data + 1);
+}
+
+// CHECK: OpDecorate [[data:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[data]] Binding 0
+// CHECK: OpDecorate [[data]] Coherent
+// CHECK: OpDecorate [[x:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[x]] Binding 1
+// CHECK-NOT: OpDecorate [[x]] Coherent

--- a/test/Coherent/frexp.cl
+++ b/test/Coherent/frexp.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-kernel void foo(global float *data, global float* x) {
+kernel void foo(global int *data, global float* x) {
   float y = data[0];
   barrier(CLK_GLOBAL_MEM_FENCE);
   *x = frexp(y, data + 1);

--- a/test/Coherent/missing_barrier.cl
+++ b/test/Coherent/missing_barrier.cl
@@ -1,0 +1,12 @@
+
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int *data) {
+  data[1] = data[0];
+}
+
+// Lack of barrier means |data| is not coherent.
+// CHECK-NOT: OpDecorate {{.*}} Coherent

--- a/test/Coherent/parameter_one_use_is_coherent.cl
+++ b/test/Coherent/parameter_one_use_is_coherent.cl
@@ -1,0 +1,28 @@
+// RUN: clspv %s -o %t.spv -no-inline-single -no-dra
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+int bar(global int* x) { return x[0]; }
+
+kernel void foo1(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+kernel void foo2(global int* x, global int* y) {
+  int z = bar(x);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  y[0] = z;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent
+// CHECK: OpDecorate [[var2:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var2]] Binding 1
+// CHECK-NOT: OpDecorate [[var2]] Coherent
+// CHECK: OpDecorate [[param:%[a-zA-Z0-9_]+]] Coherent
+// CHECK: [[param]] = OpFunctionParameter
+

--- a/test/Coherent/read_only.cl
+++ b/test/Coherent/read_only.cl
@@ -1,0 +1,16 @@
+
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int *data, local int* l) {
+  int x = data[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  l[0] = x;
+}
+
+// |data| is only read so is not marked as Coherent.
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+
+

--- a/test/Coherent/write_only.cl
+++ b/test/Coherent/write_only.cl
@@ -1,0 +1,15 @@
+
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int *data, local int* l) {
+  int x = l[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[0] = x;
+}
+
+// |data| is only written so it is not marked as Coherent.
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+


### PR DESCRIPTION
Global variables that are read and written in kernels that have barrier/fence synchronization are now decorated as coherent.

Descriptor allocation identifies whether variables are both read and written in synchronized kernels. Coherency is a new discriminant so coherent and non-coherent variables are not shared.

The spirv producer annotates function parameters by searching backwards to see which resource variables are used with it. Any coherent variable turns a function parameter coherent.