### PR TITLE
Allow -cluster-pod-kernel-args on kernels with only pod arguments

### DIFF
--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -265,8 +265,9 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
       CalleeArgs.back()->setName(Arg.getName());
     }
     assert(ptrIndex + podIndex == F->arg_size());
-    assert(ptrIndex = PtrArgTys.size());
-    assert(podIndex = PodArgTys.size());
+    assert(ptrIndex == PtrArgTys.size());
+    assert(podIndex != 0);
+    assert(podIndex == PodArgTys.size());
 
     auto Call = Builder.CreateCall(F, CalleeArgs);
     Call->setCallingConv(F->getCallingConv());

--- a/test/cluster_pod_args_pod_only.cl
+++ b/test/cluster_pod_args_pod_only.cl
@@ -1,0 +1,10 @@
+// RUN: clspv -cluster-pod-kernel-args -descriptormap=%t.map %s -o %t.spv
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// MAP: kernel,test,arg,pod,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,pod
+
+kernel void test(int pod)
+{
+}
+


### PR DESCRIPTION
There are programs out there with code like this.

Signed-off-by: Kévin Petit <kpet@free.fr>