### PR TITLE
Fix option parsing for repeated compiles online

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -815,6 +815,7 @@ int CompileFromSourceString(const std::string &program,
       "-simplifycfg-sink-common=false",
   };
 
+  llvm::cl::ResetAllOptionOccurrences();
   llvm::cl::ParseCommandLineOptions(llvmArgc, llvmArgv);
 
   llvm::SmallVector<const char *, 20> argv;


### PR DESCRIPTION
When used as an online compiler clspv must reset the command line between compiles.