### PR TITLE
Support for the mul_hi/mad_hi built-in functions

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -614,8 +614,8 @@ functions **must not** be used.
 
 #### Integer Functions
 
-The `abs_diff()`, `add_sat()`, `hadd()`, `mad_hi()`, `mad_sat()`, `mul_hi()`,
-`rhadd()` and `sub_sat()` built-in functions **must not** be used.
+The `abs_diff()`, `add_sat()`, `hadd()`, `mad_sat()`, `rhadd()` and
+`sub_sat()` built-in functions **must not** be used.
 
 #### Relational Functions
 

--- a/test/IntegerBuiltins/mad_hi/mad_hi_char.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_char.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uchar]] %[[uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[uchar_3:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[uchar_7]] %[[uchar_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[uchar]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[uchar]] %[[__original_id_19]] %[[uchar_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* a)
+{
+    *a = mad_hi((char)7, (char)42, (char)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_char4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_char4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uchar]] %[[v4uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK-DAG: %[[uchar_3:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_3]] %[[uchar_3]] %[[uchar_3]] %[[uchar_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4uchar]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4uchar]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* a)
+{
+    *a = mad_hi((char4)7, (char4)42, (char4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_int.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_int.cl
@@ -1,0 +1,23 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uint]] %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[uint_3:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 3
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpSMulExtended %[[_struct_8]] %[[uint_7]] %[[uint_42]]
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpCompositeExtract %[[uint]] %[[__original_id_17]] 1
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpIAdd %[[uint]] %[[__original_id_18]] %[[uint_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a)
+{
+    *a = mad_hi((int)7, (int)42, (int)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_int4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_int4.cl
@@ -1,0 +1,27 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uint]] %[[v4uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[__original_id_14:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK-DAG: %[[uint_3:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 3
+// CHECK-DAG: %[[__original_id_16:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_3]] %[[uint_3]] %[[uint_3]] %[[uint_3]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[__original_id_12]] %[[__original_id_14]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpCompositeExtract %[[v4uint]] %[[__original_id_21]] 1
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpIAdd %[[v4uint]] %[[__original_id_22]] %[[__original_id_16]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a)
+{
+    *a = mad_hi((int4)7, (int4)42, (int4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_long.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_long.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ulong]] %[[ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[ulong_3:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[ulong_7]] %[[ulong_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[ulong]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[ulong]] %[[__original_id_19]] %[[ulong_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* a)
+{
+    *a = mad_hi((long)7, (long)42, (long)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_long4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_long4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ulong]] %[[v4ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK-DAG: %[[ulong_3:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_3]] %[[ulong_3]] %[[ulong_3]] %[[ulong_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4ulong]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4ulong]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* a)
+{
+    *a = mad_hi((long4)7, (long4)42, (long4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_short.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_short.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ushort]] %[[ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[ushort_3:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[ushort_7]] %[[ushort_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[ushort]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[ushort]] %[[__original_id_19]] %[[ushort_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* a)
+{
+    *a = mad_hi((short)7, (short)42, (short)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_short4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_short4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ushort]] %[[v4ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK-DAG: %[[ushort_3:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_3]] %[[ushort_3]] %[[ushort_3]] %[[ushort_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4ushort]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4ushort]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* a)
+{
+    *a = mad_hi((short4)7, (short4)42, (short4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uchar.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uchar.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uchar]] %[[uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[uchar_3:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[uchar_7]] %[[uchar_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[uchar]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[uchar]] %[[__original_id_19]] %[[uchar_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* a)
+{
+    *a = mad_hi((uchar)7, (uchar)42, (uchar)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uchar4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uchar4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uchar]] %[[v4uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK-DAG: %[[uchar_3:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_3]] %[[uchar_3]] %[[uchar_3]] %[[uchar_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4uchar]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4uchar]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* a)
+{
+    *a = mad_hi((uchar4)7, (uchar4)42, (uchar4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uint.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uint.cl
@@ -1,0 +1,23 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uint]] %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[uint_3:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 3
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpUMulExtended %[[_struct_8]] %[[uint_7]] %[[uint_42]]
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpCompositeExtract %[[uint]] %[[__original_id_17]] 1
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpIAdd %[[uint]] %[[__original_id_18]] %[[uint_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a)
+{
+    *a = mad_hi((uint)7, (uint)42, (uint)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uint4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uint4.cl
@@ -1,0 +1,27 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uint]] %[[v4uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[__original_id_14:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK-DAG: %[[uint_3:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 3
+// CHECK-DAG: %[[__original_id_16:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_3]] %[[uint_3]] %[[uint_3]] %[[uint_3]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[__original_id_12]] %[[__original_id_14]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpCompositeExtract %[[v4uint]] %[[__original_id_21]] 1
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpIAdd %[[v4uint]] %[[__original_id_22]] %[[__original_id_16]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* a)
+{
+    *a = mad_hi((uint4)7, (uint4)42, (uint4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ulong.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ulong.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ulong]] %[[ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[ulong_3:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[ulong_7]] %[[ulong_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[ulong]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[ulong]] %[[__original_id_19]] %[[ulong_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* a)
+{
+    *a = mad_hi((ulong)7, (ulong)42, (ulong)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ulong4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ulong4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ulong]] %[[v4ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK-DAG: %[[ulong_3:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_3]] %[[ulong_3]] %[[ulong_3]] %[[ulong_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4ulong]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4ulong]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* a)
+{
+    *a = mad_hi((ulong4)7, (ulong4)42, (ulong4)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ushort.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ushort.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ushort]] %[[ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[ushort_3:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 3
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[ushort_7]] %[[ushort_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpCompositeExtract %[[ushort]] %[[__original_id_18]] 1
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpIAdd %[[ushort]] %[[__original_id_19]] %[[ushort_3]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* a)
+{
+    *a = mad_hi((ushort)7, (ushort)42, (ushort)3);
+}
+

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ushort4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ushort4.cl
@@ -1,0 +1,28 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ushort]] %[[v4ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK-DAG: %[[ushort_3:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 3
+// CHECK-DAG: %[[__original_id_17:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_3]] %[[ushort_3]] %[[ushort_3]] %[[ushort_3]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpCompositeExtract %[[v4ushort]] %[[__original_id_22]] 1
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpIAdd %[[v4ushort]] %[[__original_id_23]] %[[__original_id_17]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* a)
+{
+    *a = mad_hi((ushort4)7, (ushort4)42, (ushort4)3);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_char.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_char.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uchar]] %[[uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[uchar_7]] %[[uchar_42]]
+// CHECK:     OpCompositeExtract %[[uchar]] %[[__original_id_17]] 1
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* a)
+{
+    *a = mul_hi((char)7, (char)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_char4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_char4.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uchar]] %[[v4uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4uchar]] %[[__original_id_20]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* a)
+{
+    *a = mul_hi((char4)7, (char4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_int.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_int.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uint]] %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_16:[0-9]+]] = OpSMulExtended %[[_struct_8]] %[[uint_7]] %[[uint_42]]
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpCompositeExtract %[[uint]] %[[__original_id_16]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a)
+{
+    *a = mul_hi((int)7, (int)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_int4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_int4.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uint]] %[[v4uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[__original_id_14:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[__original_id_12]] %[[__original_id_14]]
+// CHECK:     OpCompositeExtract %[[v4uint]] %[[__original_id_19]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a)
+{
+    *a = mul_hi((int4)7, (int4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_long.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_long.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ulong]] %[[ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[ulong_7]] %[[ulong_42]]
+// CHECK:     OpCompositeExtract %[[ulong]] %[[__original_id_17]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* a)
+{
+    *a = mul_hi((long)7, (long)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_long4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_long4.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ulong]] %[[v4ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4ulong]] %[[__original_id_20]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* a)
+{
+    *a = mul_hi((long4)7, (long4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_short.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_short.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ushort]] %[[ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpSMulExtended %[[_struct_9]] %[[ushort_7]] %[[ushort_42]]
+// CHECK:     OpCompositeExtract %[[ushort]] %[[__original_id_17]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* a)
+{
+    *a = mul_hi((short)7, (short)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_short4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_short4.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ushort]] %[[v4ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpSMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4ushort]] %[[__original_id_20]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* a)
+{
+    *a = mul_hi((short4)7, (short4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uchar.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uchar.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uchar]] %[[uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[uchar_7]] %[[uchar_42]]
+// CHECK:     OpCompositeExtract %[[uchar]] %[[__original_id_17]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* a)
+{
+    *a = mul_hi((uchar)7, (uchar)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uchar4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uchar4.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uchar]] %[[v4uchar]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4uchar]] %[[__original_id_20]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* a)
+{
+    *a = mul_hi((uchar4)7, (uchar4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uint.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uint.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[uint]] %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_16:[0-9]+]] = OpUMulExtended %[[_struct_8]] %[[uint_7]] %[[uint_42]]
+// CHECK:     OpCompositeExtract %[[uint]] %[[__original_id_16]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a)
+{
+    *a = mul_hi((uint)7, (uint)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uint4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uint4.cl
@@ -1,0 +1,23 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4uint]] %[[v4uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[__original_id_14:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[__original_id_12]] %[[__original_id_14]]
+// CHECK:     OpCompositeExtract %[[v4uint]] %[[__original_id_19]] 1
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* a)
+{
+    *a = mul_hi((uint4)7, (uint4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ulong.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ulong.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ulong]] %[[ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[ulong_7]] %[[ulong_42]]
+// CHECK:     OpCompositeExtract %[[ulong]] %[[__original_id_17]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* a)
+{
+    *a = mul_hi((ulong)7, (ulong)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ulong4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ulong4.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ulong]] %[[v4ulong]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4ulong]] %[[__original_id_20]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* a)
+{
+    *a = mul_hi((ulong4)7, (ulong4)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ushort.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ushort.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_9:[0-9a-zA-Z_]+]] = OpTypeStruct %[[ushort]] %[[ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpUMulExtended %[[_struct_9]] %[[ushort_7]] %[[ushort_42]]
+// CHECK:     OpCompositeExtract %[[ushort]] %[[__original_id_17]] 1
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* a)
+{
+    *a = mul_hi((ushort)7, (ushort)42);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ushort4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ushort4.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v4ushort]] %[[v4ushort]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpUMulExtended %[[_struct_10]] %[[__original_id_13]] %[[__original_id_15]]
+// CHECK:     OpCompositeExtract %[[v4ushort]] %[[__original_id_20]] 1
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* a)
+{
+    *a = mul_hi((ushort4)7, (ushort4)42);
+}
+


### PR DESCRIPTION
Also introduce a utility function to get type infos from
mangled function names.

This change enables passing the corresponding OpenCL
conformance tests.

Signed-off-by: Kévin Petit <kpet@free.fr>