### PR TITLE
Add basic support for the convert_ built-in functions

### DIFF
--- a/test/ConvertBuiltins/convert_char4_float4.cl
+++ b/test/ConvertBuiltins/convert_char4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToS %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global float4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_int4.cl
+++ b/test/ConvertBuiltins/convert_char4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global int4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_long4.cl
+++ b/test/ConvertBuiltins/convert_char4_long4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global long4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_short4.cl
+++ b/test/ConvertBuiltins/convert_char4_short4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global short4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_char4_uchar4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global uchar4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_uint4.cl
+++ b/test/ConvertBuiltins/convert_char4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global uint4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_char4_ulong4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global ulong4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_char4_ushort4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char4* dst, global ushort4* src)
+{
+    *dst = convert_char4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_float.cl
+++ b/test/ConvertBuiltins/convert_char_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToS %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global float* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_int.cl
+++ b/test/ConvertBuiltins/convert_char_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global int* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_long.cl
+++ b/test/ConvertBuiltins/convert_char_long.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global long* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_short.cl
+++ b/test/ConvertBuiltins/convert_char_short.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global short* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_uchar.cl
+++ b/test/ConvertBuiltins/convert_char_uchar.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global uchar* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_uint.cl
+++ b/test/ConvertBuiltins/convert_char_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global uint* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_ulong.cl
+++ b/test/ConvertBuiltins/convert_char_ulong.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global ulong* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_char_ushort.cl
+++ b/test/ConvertBuiltins/convert_char_ushort.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char* dst, global ushort* src)
+{
+    *dst = convert_char(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_char4.cl
+++ b/test/ConvertBuiltins/convert_float4_char4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertSToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global char4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_int4.cl
+++ b/test/ConvertBuiltins/convert_float4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpConvertSToF %[[v4float]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global int4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_long4.cl
+++ b/test/ConvertBuiltins/convert_float4_long4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertSToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global long4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_short4.cl
+++ b/test/ConvertBuiltins/convert_float4_short4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertSToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global short4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_float4_uchar4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertUToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global uchar4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_uint4.cl
+++ b/test/ConvertBuiltins/convert_float4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpConvertUToF %[[v4float]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global uint4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_float4_ulong4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertUToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global ulong4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_float4_ushort4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertUToF %[[v4float]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* dst, global ushort4* src)
+{
+    *dst = convert_float4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_char.cl
+++ b/test/ConvertBuiltins/convert_float_char.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertSToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global char* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_int.cl
+++ b/test/ConvertBuiltins/convert_float_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpConvertSToF %[[float]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global int* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_long.cl
+++ b/test/ConvertBuiltins/convert_float_long.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertSToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global long* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_short.cl
+++ b/test/ConvertBuiltins/convert_float_short.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertSToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global short* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_uchar.cl
+++ b/test/ConvertBuiltins/convert_float_uchar.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertUToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global uchar* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_uint.cl
+++ b/test/ConvertBuiltins/convert_float_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpConvertUToF %[[float]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global uint* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_ulong.cl
+++ b/test/ConvertBuiltins/convert_float_ulong.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertUToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global ulong* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_float_ushort.cl
+++ b/test/ConvertBuiltins/convert_float_ushort.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertUToF %[[float]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* dst, global ushort* src)
+{
+    *dst = convert_float(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_char4.cl
+++ b/test/ConvertBuiltins/convert_int4_char4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global char4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_float4.cl
+++ b/test/ConvertBuiltins/convert_int4_float4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpConvertFToS %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global float4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_long4.cl
+++ b/test/ConvertBuiltins/convert_int4_long4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global long4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_short4.cl
+++ b/test/ConvertBuiltins/convert_int4_short4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global short4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_int4_uchar4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global uchar4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_uint4.cl
+++ b/test/ConvertBuiltins/convert_int4_uint4.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global uint4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_int4_ulong4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global ulong4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_int4_ushort4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* dst, global ushort4* src)
+{
+    *dst = convert_int4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_char.cl
+++ b/test/ConvertBuiltins/convert_int_char.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global char* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_float.cl
+++ b/test/ConvertBuiltins/convert_int_float.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpConvertFToS %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global float* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_long.cl
+++ b/test/ConvertBuiltins/convert_int_long.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global long* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_short.cl
+++ b/test/ConvertBuiltins/convert_int_short.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global short* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_uchar.cl
+++ b/test/ConvertBuiltins/convert_int_uchar.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global uchar* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_uint.cl
+++ b/test/ConvertBuiltins/convert_int_uint.cl
@@ -1,0 +1,16 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global uint* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_ulong.cl
+++ b/test/ConvertBuiltins/convert_int_ulong.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global ulong* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_int_ushort.cl
+++ b/test/ConvertBuiltins/convert_int_ushort.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* dst, global ushort* src)
+{
+    *dst = convert_int(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_char4.cl
+++ b/test/ConvertBuiltins/convert_long4_char4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global char4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_float4.cl
+++ b/test/ConvertBuiltins/convert_long4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToS %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global float4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_int4.cl
+++ b/test/ConvertBuiltins/convert_long4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global int4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_short4.cl
+++ b/test/ConvertBuiltins/convert_long4_short4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global short4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_long4_uchar4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global uchar4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_uint4.cl
+++ b/test/ConvertBuiltins/convert_long4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global uint4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_long4_ulong4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global ulong4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_long4_ushort4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long4* dst, global ushort4* src)
+{
+    *dst = convert_long4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_char.cl
+++ b/test/ConvertBuiltins/convert_long_char.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global char* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_float.cl
+++ b/test/ConvertBuiltins/convert_long_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToS %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global float* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_int.cl
+++ b/test/ConvertBuiltins/convert_long_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global int* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_short.cl
+++ b/test/ConvertBuiltins/convert_long_short.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global short* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_uchar.cl
+++ b/test/ConvertBuiltins/convert_long_uchar.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global uchar* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_uint.cl
+++ b/test/ConvertBuiltins/convert_long_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global uint* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_ulong.cl
+++ b/test/ConvertBuiltins/convert_long_ulong.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global ulong* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_long_ushort.cl
+++ b/test/ConvertBuiltins/convert_long_ushort.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long* dst, global ushort* src)
+{
+    *dst = convert_long(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_char4.cl
+++ b/test/ConvertBuiltins/convert_short4_char4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global char4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_float4.cl
+++ b/test/ConvertBuiltins/convert_short4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToS %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global float4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_int4.cl
+++ b/test/ConvertBuiltins/convert_short4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global int4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_long4.cl
+++ b/test/ConvertBuiltins/convert_short4_long4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global long4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_short4_uchar4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global uchar4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_uint4.cl
+++ b/test/ConvertBuiltins/convert_short4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global uint4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_short4_ulong4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global ulong4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_short4_ushort4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short4* dst, global ushort4* src)
+{
+    *dst = convert_short4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_char.cl
+++ b/test/ConvertBuiltins/convert_short_char.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global char* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_float.cl
+++ b/test/ConvertBuiltins/convert_short_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToS %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global float* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_int.cl
+++ b/test/ConvertBuiltins/convert_short_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global int* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_long.cl
+++ b/test/ConvertBuiltins/convert_short_long.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global long* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_uchar.cl
+++ b/test/ConvertBuiltins/convert_short_uchar.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global uchar* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_uint.cl
+++ b/test/ConvertBuiltins/convert_short_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global uint* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_ulong.cl
+++ b/test/ConvertBuiltins/convert_short_ulong.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global ulong* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_short_ushort.cl
+++ b/test/ConvertBuiltins/convert_short_ushort.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short* dst, global ushort* src)
+{
+    *dst = convert_short(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_char4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_char4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global char4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_float4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToU %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global float4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_int4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global int4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_long4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_long4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global long4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_short4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_short4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global short4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_uint4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global uint4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_ulong4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global ulong4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_ushort4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4uchar]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar4* dst, global ushort4* src)
+{
+    *dst = convert_uchar4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_char.cl
+++ b/test/ConvertBuiltins/convert_uchar_char.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global char* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_float.cl
+++ b/test/ConvertBuiltins/convert_uchar_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToU %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global float* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_int.cl
+++ b/test/ConvertBuiltins/convert_uchar_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global int* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_long.cl
+++ b/test/ConvertBuiltins/convert_uchar_long.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global long* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_short.cl
+++ b/test/ConvertBuiltins/convert_uchar_short.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global short* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_uint.cl
+++ b/test/ConvertBuiltins/convert_uchar_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global uint* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_ulong.cl
+++ b/test/ConvertBuiltins/convert_uchar_ulong.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global ulong* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uchar_ushort.cl
+++ b/test/ConvertBuiltins/convert_uchar_ushort.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[uchar]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar* dst, global ushort* src)
+{
+    *dst = convert_uchar(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_char4.cl
+++ b/test/ConvertBuiltins/convert_uint4_char4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global char4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_float4.cl
+++ b/test/ConvertBuiltins/convert_uint4_float4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpConvertFToU %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global float4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_int4.cl
+++ b/test/ConvertBuiltins/convert_uint4_int4.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global int4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_long4.cl
+++ b/test/ConvertBuiltins/convert_uint4_long4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global long4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_short4.cl
+++ b/test/ConvertBuiltins/convert_uint4_short4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global short4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_uint4_uchar4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global uchar4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_uint4_ulong4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global ulong4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_uint4_ushort4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4uint]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint4* dst, global ushort4* src)
+{
+    *dst = convert_uint4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_char.cl
+++ b/test/ConvertBuiltins/convert_uint_char.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global char* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_float.cl
+++ b/test/ConvertBuiltins/convert_uint_float.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpConvertFToU %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global float* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_int.cl
+++ b/test/ConvertBuiltins/convert_uint_int.cl
@@ -1,0 +1,16 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global int* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_long.cl
+++ b/test/ConvertBuiltins/convert_uint_long.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global long* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_short.cl
+++ b/test/ConvertBuiltins/convert_uint_short.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global short* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_uchar.cl
+++ b/test/ConvertBuiltins/convert_uint_uchar.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global uchar* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_ulong.cl
+++ b/test/ConvertBuiltins/convert_uint_ulong.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global ulong* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_uint_ushort.cl
+++ b/test/ConvertBuiltins/convert_uint_ushort.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[uint]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* dst, global ushort* src)
+{
+    *dst = convert_uint(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_char4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_char4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global char4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_float4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToU %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global float4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_int4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global int4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_long4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_long4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global long4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_short4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_short4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global short4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_uchar4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global uchar4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_uint4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global uint4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_ushort4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ulong]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong4* dst, global ushort4* src)
+{
+    *dst = convert_ulong4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_char.cl
+++ b/test/ConvertBuiltins/convert_ulong_char.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global char* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_float.cl
+++ b/test/ConvertBuiltins/convert_ulong_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToU %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global float* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_int.cl
+++ b/test/ConvertBuiltins/convert_ulong_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global int* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_long.cl
+++ b/test/ConvertBuiltins/convert_ulong_long.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global long* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_short.cl
+++ b/test/ConvertBuiltins/convert_ulong_short.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global short* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_uchar.cl
+++ b/test/ConvertBuiltins/convert_ulong_uchar.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global uchar* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_uint.cl
+++ b/test/ConvertBuiltins/convert_ulong_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global uint* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ulong_ushort.cl
+++ b/test/ConvertBuiltins/convert_ulong_ushort.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ulong]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong* dst, global ushort* src)
+{
+    *dst = convert_ulong(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_char4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_char4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global char4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_float4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_float4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpConvertFToU %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global float4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_int4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global int4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_long4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_long4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global long4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_short4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_short4.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global short4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_uchar4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global uchar4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_uint4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_uint4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_22:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global uint4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_ulong4.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUConvert %[[v4ushort]] %[[__original_id_23:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort4* dst, global ulong4* src)
+{
+    *dst = convert_ushort4(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_char.cl
+++ b/test/ConvertBuiltins/convert_ushort_char.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpSConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global char* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_float.cl
+++ b/test/ConvertBuiltins/convert_ushort_float.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpConvertFToU %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global float* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_int.cl
+++ b/test/ConvertBuiltins/convert_ushort_int.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global int* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_long.cl
+++ b/test/ConvertBuiltins/convert_ushort_long.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global long* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_short.cl
+++ b/test/ConvertBuiltins/convert_ushort_short.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global short* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_uchar.cl
+++ b/test/ConvertBuiltins/convert_ushort_uchar.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global uchar* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_uint.cl
+++ b/test/ConvertBuiltins/convert_ushort_uint.cl
@@ -1,0 +1,18 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_20:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global uint* src)
+{
+    *dst = convert_ushort(*src);
+}
+

--- a/test/ConvertBuiltins/convert_ushort_ulong.cl
+++ b/test/ConvertBuiltins/convert_ushort_ulong.cl
@@ -1,0 +1,19 @@
+// RUN: clspv -int8 %s -S -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv -int8 %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpUConvert %[[ushort]] %[[__original_id_21:[0-9]+]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort* dst, global ulong* src)
+{
+    *dst = convert_ushort(*src);
+}
+


### PR DESCRIPTION
All overloads that don't use saturation or an explicit
rounding mode are supported. This allows to pass 81 of
the 800 or so conformance tests and should cover most
of the uses in applications.

Fixes #291

Signed-off-by: Kévin Petit <kpet@free.fr>