### PR TITLE
Support chars in UBOs

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -730,14 +730,6 @@ int Compile(const int argc, const char *const argv[]) {
     return -1;
   }
 
-  // TODO: Remove when #279 is resolved.
-  if (clspv::Option::ConstantArgsInUniformBuffer() &&
-      clspv::Option::Int8Support()) {
-    llvm::errs() << "clspv restriction: -constant-args-ubo is currently "
-                    "incompatible with -int8\n";
-    return -1;
-  }
-
   llvm::PassRegistry &Registry = *llvm::PassRegistry::getPassRegistry();
   llvm::initializeCore(Registry);
   llvm::initializeScalarOpts(Registry);

--- a/test/UBO/char_ubo_struct.cl
+++ b/test/UBO/char_ubo_struct.cl
@@ -1,0 +1,48 @@
+// RUN: clspv -int8 -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  char a;
+  char2 b;
+  char3 c;
+  char4 d;
+  int pad; // necessary to get up to 16 byte size
+} S;
+
+kernel void foo(global S* out, constant S* in) {
+  out->d = in->d;
+}
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,in,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 2
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 4
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 8
+// CHECK-DAG: OpMemberDecorate [[s]] 4 Offset 12
+// CHECK: OpDecorate [[rta:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate [[out:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[out]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[in]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in]] NonWritable
+// CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[char2:%[0-9a-zA-Z_]+]] = OpTypeVector [[char]] 2
+// CHECK-DAG: [[char3:%[0-9a-zA-Z_]+]] = OpTypeVector [[char]] 3
+// CHECK-DAG: [[char4:%[0-9a-zA-Z_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[s]] = OpTypeStruct [[char]] [[char2]] [[char3]] [[char4]] [[int]]
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_4096]]
+// CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[ubo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_block]]
+// CHECK-DAG: [[rta]] = OpTypeRuntimeArray [[s]]
+// CHECK-DAG: [[ssbo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[rta]]
+// CHECK-DAG: [[ssbo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[ssbo_block]]
+// CHECK-DAG: [[out]] = OpVariable [[ssbo_ptr]] StorageBuffer
+// CHECK-DAG: [[in]] = OpVariable [[ubo_ptr]] Uniform

--- a/test/UBO/large_padding.cl
+++ b/test/UBO/large_padding.cl
@@ -1,0 +1,36 @@
+// RUN: clspv -int8 -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Prior to #279 this would produce a [16 x i8] padding array.
+typedef struct {
+  int4 a;
+  int4 b __attribute__((aligned(32)));
+  int4 c;
+} S;
+
+kernel void foo(global S* out, constant S* in) {
+  out->c = in->c;
+}
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,in,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 16
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 32
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 48
+// CHECK-DAG: OpDecorate [[in:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[in]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in]] NonWritable
+// CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 64
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int4:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 4
+// CHECK: [[s]] = OpTypeStruct [[int4]] [[int]] [[int4]] [[int4]]
+// CHECK-DAG: [[int_1024:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1024
+// CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_1024]]
+// CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[ubo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_block]]
+// CHECK-DAG: [[in]] = OpVariable [[ubo_ptr]] Uniform

--- a/test/UBO/large_padding.cl
+++ b/test/UBO/large_padding.cl
@@ -27,8 +27,9 @@ kernel void foo(global S* out, constant S* in) {
 // CHECK-DAG: OpDecorate [[in]] NonWritable
 // CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 64
 // CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK-DAG: [[int4:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 4
-// CHECK: [[s]] = OpTypeStruct [[int4]] [[int]] [[int4]] [[int4]]
+// CHECK: [[s]] = OpTypeStruct [[int4]] [[char]] [[int4]] [[int4]]
 // CHECK-DAG: [[int_1024:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1024
 // CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_1024]]
 // CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]

--- a/test/UBO/large_padding_std430.cl
+++ b/test/UBO/large_padding_std430.cl
@@ -1,0 +1,41 @@
+// RUN: clspv -int8 -constant-args-ubo -inline-entry-points -std430-ubo-layout %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+
+// With std430 layouts in UBO, the padding array ([16 x i8]) can be generated
+// with an ArrayStride of 1.
+typedef struct {
+  int4 a;
+  int4 b __attribute__((aligned(32)));
+  int4 c;
+} S;
+
+kernel void foo(global S* out, constant S* in) {
+  out->c = in->c;
+}
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,in,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 16
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 32
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 48
+// CHECK-DAG: OpDecorate [[in:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[in]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in]] NonWritable
+// CHECK: OpDecorate [[char_array:%[0-9a-zA-Z_]+]] ArrayStride 1
+// CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 64
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[int4:%[0-9a-zA-Z_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[int_16:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 16
+// CHECK-DAG: [[char_array]] = OpTypeArray [[char]] [[int_16]]
+// CHECK: [[s]] = OpTypeStruct [[int4]] [[char_array]] [[int4]] [[int4]]
+// CHECK-DAG: [[int_1024:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1024
+// CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_1024]]
+// CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[ubo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_block]]
+// CHECK-DAG: [[in]] = OpVariable [[ubo_ptr]] Uniform
+

--- a/test/UBO/odd_size_padding.cl
+++ b/test/UBO/odd_size_padding.cl
@@ -1,0 +1,30 @@
+// RUN: clspv -int8 -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  char a;
+  int b __attribute__((aligned(16)));
+} S;
+
+ kernel void foo(global S* out, constant S* in) {
+  out->b = in->b;
+}
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 1
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 16
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 20
+// CHECK-DAG: OpDecorate [[in:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[in]] DescriptorSet 0
+// CHECK: OpDecorate [[in]] NonWritable
+// CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 32
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK: [[s]] = OpTypeStruct [[char]] [[char]] [[int]] [[char]]
+// CHECK-DAG: [[int_2048:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2048
+// CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_2048]]
+// CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[ubo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_block]]
+// CHECK-DAG: [[in]] = OpVariable [[ubo_ptr]] Uniform


### PR DESCRIPTION
Fixes #279

* Type mutation now replaces any char array if char arrays are not
supported
  * char arrays are supported if -int8 and -std430-ubo-layout are
  specified
* New tests