### PR TITLE
Replace calls to abs() with unsigned values in a more consistent way

### DIFF
--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -248,6 +248,10 @@ bool ReplaceOpenCLBuiltinPass::replaceAbs(Module &M) {
   bool Changed = false;
 
   const char *Names[] = {
+    "_Z3absh",
+    "_Z3absDv2_h",
+    "_Z3absDv3_h",
+    "_Z3absDv4_h",
     "_Z3abst",
     "_Z3absDv2_t",
     "_Z3absDv3_t",

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4563,20 +4563,6 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       break;
     }
 
-    // Nothing to do for abs with uint. Map abs's operand ID to VMap for abs
-    // with unit.
-    if (Callee->getName().equals("_Z3absj") ||
-        Callee->getName().equals("_Z3absDv2_j") ||
-        Callee->getName().equals("_Z3absDv3_j") ||
-        Callee->getName().equals("_Z3absDv4_j") ||
-        Callee->getName().equals("_Z3absh") ||
-        Callee->getName().equals("_Z3absDv2_h") ||
-        Callee->getName().equals("_Z3absDv3_h") ||
-        Callee->getName().equals("_Z3absDv4_h")) {
-      VMap[&I] = VMap[Call->getOperand(0)];
-      break;
-    }
-
     // read_image is converted to OpSampledImage and OpImageSampleExplicitLod.
     // Additionally, OpTypeSampledImage is generated.
     if (Callee->getName().equals(


### PR DESCRIPTION
All replacements are now done in the ReplaceOpenCLBuiltinPass.

Signed-off-by: Kévin Petit <kpet@free.fr>