### PR TITLE
Add support for warnings

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -155,6 +155,14 @@ static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
 static llvm::cl::opt<bool> verify("verify", llvm::cl::init(false),
                                   llvm::cl::desc("Verify diagnostic outputs"));
 
+static llvm::cl::opt<bool>
+    IgnoreWarnings("w", llvm::cl::init(false),
+                   llvm::cl::desc("Disable all warnings"));
+
+static llvm::cl::opt<bool>
+    WarningsAsErrors("Werror", llvm::cl::init(false),
+                   llvm::cl::desc("Turn warnings into errors"));
+
 // Populates |SamplerMapEntries| with data from the input sampler map. Returns 0
 // if successful.
 int ParseSamplerMap(const std::string &sampler_map,
@@ -396,7 +404,7 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   instance.getCodeGenOpts().SimplifyLibCalls = false;
   instance.getCodeGenOpts().EmitOpenCLArgMetadata = false;
   instance.getCodeGenOpts().DisableO0ImplyOptNone = true;
-  instance.getDiagnosticOpts().IgnoreWarnings = false;
+  instance.getDiagnosticOpts().IgnoreWarnings = IgnoreWarnings;
 
   instance.getLangOpts().SinglePrecisionConstants =
       cl_single_precision_constants;
@@ -447,10 +455,14 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   // Override the C99 inline semantics to accommodate for more OpenCL C
   // programs in the wild.
   instance.getLangOpts().GNUInline = true;
+
+  // Set up diagnostics
   instance.createDiagnostics(
       new clang::TextDiagnosticPrinter(*diagnosticsStream,
                                        &instance.getDiagnosticOpts()),
       true);
+  instance.getDiagnostics().setWarningsAsErrors(WarningsAsErrors);
+  instance.getDiagnostics().setEnableAllWarnings(true);
 
   instance.getTargetOpts().Triple = triple.str();
 
@@ -717,9 +729,12 @@ int Compile(const int argc, const char *const argv[]) {
       instance.getDiagnostics().getClient();
   consumer->finish();
 
+  auto num_warnings = consumer->getNumWarnings();
   auto num_errors = consumer->getNumErrors();
+  if ((num_errors > 0) || (num_warnings > 0)) {
+    llvm::errs() << log;
+  }
   if (num_errors > 0) {
-    llvm::errs() << log << "\n";
     return -1;
   }
 
@@ -728,6 +743,12 @@ int Compile(const int argc, const char *const argv[]) {
     llvm::errs() << "clspv restriction: -constant-args-ubo requires "
                     "-inline-entry-points\n";
     return -1;
+  }
+
+  // Don't run the passes or produce any output in verify mode.
+  // Clang doesn't always produce a valid module.
+  if (verify) {
+    return 0;
   }
 
   llvm::PassRegistry &Registry = *llvm::PassRegistry::getPassRegistry();

--- a/test/UBO/bad_after_array.cl
+++ b/test/UBO/bad_after_array.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+// RUN: clspv -w -constant-args-ubo -verify -inline-entry-points %s
 
 struct dt {
   int x[2]; //expected-note{{here}}

--- a/test/UBO/bad_array.cl
+++ b/test/UBO/bad_array.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct dt {
   int x;

--- a/test/UBO/bad_int_array.cl
+++ b/test/UBO/bad_int_array.cl
@@ -1,3 +1,3 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 kernel void foo(__constant int* c) { } //expected-error{{clspv restriction: to satisfy UBO ArrayStride restrictions, element size must be a multiple of array alignment}}

--- a/test/UBO/bad_scalar.cl
+++ b/test/UBO/bad_scalar.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/bad_ssbo_scalar.cl
+++ b/test/UBO/bad_ssbo_scalar.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/bad_ssbo_vec2.cl
+++ b/test/UBO/bad_ssbo_vec2.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/bad_ssbo_vec4.cl
+++ b/test/UBO/bad_ssbo_vec4.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/bad_struct.cl
+++ b/test/UBO/bad_struct.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -constant-args-ubo -verify -inline-entry-points %s
+// RUN: clspv -w -constant-args-ubo -verify -inline-entry-points %s
 
 struct inner {
   int x;

--- a/test/UBO/bad_vec2.cl
+++ b/test/UBO/bad_vec2.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/bad_vec4.cl
+++ b/test/UBO/bad_vec4.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points
 
 struct s {
   uchar x;

--- a/test/UBO/relaxed_int_array.cl
+++ b/test/UBO/relaxed_int_array.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -constant-args-ubo -verify -inline-entry-points -relaxed-ubo-layout
+// RUN: clspv %s -w -constant-args-ubo -verify -inline-entry-points -relaxed-ubo-layout
 
 // With -relaxed-ubo-layout specified, the ArrayStride restriction is not checked.
 // expected-no-diagnostics

--- a/test/Warnings/error.cl
+++ b/test/Warnings/error.cl
@@ -1,0 +1,3 @@
+// RUN: clspv %s -Werror -verify
+
+kernel void foo(int arg) { } //expected-error{{unused parameter}}

--- a/test/Warnings/ignored.cl
+++ b/test/Warnings/ignored.cl
@@ -1,0 +1,3 @@
+// RUN: clspv %s -w -verify
+
+kernel void foo(int arg) { } //expected-no-diagnostics

--- a/test/Warnings/simple.cl
+++ b/test/Warnings/simple.cl
@@ -1,0 +1,3 @@
+// RUN: clspv %s -verify
+
+kernel void foo(int arg) { } //expected-warning{{unused parameter}}


### PR DESCRIPTION
Enable all warnings.

Support the two standard OpenCL options -w and -Werror.

CompileFromSourceString prints warnings only when there
are errors. It probably shouldn't print anything to stderr
but that's another story.

Signed-off-by: Kévin Petit <kpet@free.fr>