### PR TITLE
Remove the option to emit assembly

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -131,10 +131,6 @@ static llvm::cl::opt<char>
                       llvm::cl::desc("Optimization level to use"),
                       llvm::cl::value_desc("level"));
 
-static llvm::cl::opt<bool>
-    OutputAssembly("S", llvm::cl::init(false),
-                   llvm::cl::desc("This option controls output of assembly"));
-
 static llvm::cl::opt<std::string> OutputFormat(
     "mfmt", llvm::cl::init(""),
     llvm::cl::desc(
@@ -658,7 +654,7 @@ int PopulatePassManager(
   pm->add(clspv::createUBOTypeTransformPass());
   pm->add(clspv::createSPIRVProducerPass(
       *binaryStream, descriptor_map_entries, *SamplerMapEntries,
-      OutputAssembly.getValue(), OutputFormat == "c"));
+      false /* Output assembly */, OutputFormat == "c"));
 
   return 0;
 }
@@ -776,10 +772,7 @@ int Compile(const int argc, const char *const argv[]) {
   // Wait until now to try writing the file so that we only write it on
   // successful compilation.
   if (OutputFilename.empty()) {
-    // if we've to output assembly
-    if (OutputAssembly) {
-      OutputFilename = "a.spvasm";
-    } else if (OutputFormat == "c") {
+    if (OutputFormat == "c") {
       OutputFilename = "a.spvinc";
     } else {
       OutputFilename = "a.spv";

--- a/test/AtomicBuiltins/atom_add_int.cl
+++ b/test/AtomicBuiltins/atom_add_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_add_int_local.cl
+++ b/test/AtomicBuiltins/atom_add_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_add_uint.cl
+++ b/test/AtomicBuiltins/atom_add_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_add_uint_local.cl
+++ b/test/AtomicBuiltins/atom_add_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_and_int.cl
+++ b/test/AtomicBuiltins/atom_and_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_and_int_local.cl
+++ b/test/AtomicBuiltins/atom_and_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_and_uint.cl
+++ b/test/AtomicBuiltins/atom_and_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_and_uint_local.cl
+++ b/test/AtomicBuiltins/atom_and_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_cmpxchg_int.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_cmpxchg_int_local.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_cmpxchg_uint.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_cmpxchg_uint_local.cl
+++ b/test/AtomicBuiltins/atom_cmpxchg_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_dec_int.cl
+++ b/test/AtomicBuiltins/atom_dec_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_dec_int_local.cl
+++ b/test/AtomicBuiltins/atom_dec_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_dec_uint.cl
+++ b/test/AtomicBuiltins/atom_dec_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_dec_uint_local.cl
+++ b/test/AtomicBuiltins/atom_dec_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_inc_int.cl
+++ b/test/AtomicBuiltins/atom_inc_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_inc_int_local.cl
+++ b/test/AtomicBuiltins/atom_inc_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_inc_uint.cl
+++ b/test/AtomicBuiltins/atom_inc_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_inc_uint_local.cl
+++ b/test/AtomicBuiltins/atom_inc_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_max_int.cl
+++ b/test/AtomicBuiltins/atom_max_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_max_int_local.cl
+++ b/test/AtomicBuiltins/atom_max_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_max_uint.cl
+++ b/test/AtomicBuiltins/atom_max_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_max_uint_local.cl
+++ b/test/AtomicBuiltins/atom_max_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_min_int.cl
+++ b/test/AtomicBuiltins/atom_min_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_min_int_local.cl
+++ b/test/AtomicBuiltins/atom_min_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_min_uint.cl
+++ b/test/AtomicBuiltins/atom_min_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_min_uint_local.cl
+++ b/test/AtomicBuiltins/atom_min_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_or_int.cl
+++ b/test/AtomicBuiltins/atom_or_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_or_int_local.cl
+++ b/test/AtomicBuiltins/atom_or_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_or_uint.cl
+++ b/test/AtomicBuiltins/atom_or_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_or_uint_local.cl
+++ b/test/AtomicBuiltins/atom_or_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_sub_int.cl
+++ b/test/AtomicBuiltins/atom_sub_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_sub_int_local.cl
+++ b/test/AtomicBuiltins/atom_sub_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_sub_uint.cl
+++ b/test/AtomicBuiltins/atom_sub_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_sub_uint_local.cl
+++ b/test/AtomicBuiltins/atom_sub_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xchg_int.cl
+++ b/test/AtomicBuiltins/atom_xchg_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xchg_int_local.cl
+++ b/test/AtomicBuiltins/atom_xchg_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xchg_uint.cl
+++ b/test/AtomicBuiltins/atom_xchg_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xchg_uint_local.cl
+++ b/test/AtomicBuiltins/atom_xchg_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xor_int.cl
+++ b/test/AtomicBuiltins/atom_xor_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xor_int_local.cl
+++ b/test/AtomicBuiltins/atom_xor_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xor_uint.cl
+++ b/test/AtomicBuiltins/atom_xor_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atom_xor_uint_local.cl
+++ b/test/AtomicBuiltins/atom_xor_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_add_int.cl
+++ b/test/AtomicBuiltins/atomic_add_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_add_int_local.cl
+++ b/test/AtomicBuiltins/atomic_add_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_add_uint.cl
+++ b/test/AtomicBuiltins/atomic_add_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_add_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_add_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_and_int.cl
+++ b/test/AtomicBuiltins/atomic_and_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_and_int_local.cl
+++ b/test/AtomicBuiltins/atomic_and_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_and_uint.cl
+++ b/test/AtomicBuiltins/atomic_and_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_and_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_and_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_cmpxchg_int.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_cmpxchg_int_local.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_cmpxchg_uint.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_cmpxchg_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_cmpxchg_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_dec_int.cl
+++ b/test/AtomicBuiltins/atomic_dec_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_dec_int_local.cl
+++ b/test/AtomicBuiltins/atomic_dec_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_dec_uint.cl
+++ b/test/AtomicBuiltins/atomic_dec_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_dec_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_dec_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_inc_int.cl
+++ b/test/AtomicBuiltins/atomic_inc_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_inc_int_local.cl
+++ b/test/AtomicBuiltins/atomic_inc_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_inc_uint.cl
+++ b/test/AtomicBuiltins/atomic_inc_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_inc_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_inc_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_max_int.cl
+++ b/test/AtomicBuiltins/atomic_max_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_max_int_local.cl
+++ b/test/AtomicBuiltins/atomic_max_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_max_uint.cl
+++ b/test/AtomicBuiltins/atomic_max_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_max_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_max_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_min_int.cl
+++ b/test/AtomicBuiltins/atomic_min_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_min_int_local.cl
+++ b/test/AtomicBuiltins/atomic_min_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_min_uint.cl
+++ b/test/AtomicBuiltins/atomic_min_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_min_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_min_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_or_int.cl
+++ b/test/AtomicBuiltins/atomic_or_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_or_int_local.cl
+++ b/test/AtomicBuiltins/atomic_or_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_or_uint.cl
+++ b/test/AtomicBuiltins/atomic_or_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_or_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_or_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_sub_int.cl
+++ b/test/AtomicBuiltins/atomic_sub_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_sub_int_local.cl
+++ b/test/AtomicBuiltins/atomic_sub_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_sub_uint.cl
+++ b/test/AtomicBuiltins/atomic_sub_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_sub_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_sub_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xchg_int.cl
+++ b/test/AtomicBuiltins/atomic_xchg_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xchg_int_local.cl
+++ b/test/AtomicBuiltins/atomic_xchg_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xchg_uint.cl
+++ b/test/AtomicBuiltins/atomic_xchg_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xchg_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_xchg_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xor_int.cl
+++ b/test/AtomicBuiltins/atomic_xor_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xor_int_local.cl
+++ b/test/AtomicBuiltins/atomic_xor_int_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xor_uint.cl
+++ b/test/AtomicBuiltins/atomic_xor_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/AtomicBuiltins/atomic_xor_uint_local.cl
+++ b/test/AtomicBuiltins/atomic_xor_uint_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_clamp.cl
+++ b/test/CommonBuiltins/float2_clamp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_degrees.cl
+++ b/test/CommonBuiltins/float2_degrees.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_max.cl
+++ b/test/CommonBuiltins/float2_max.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_min.cl
+++ b/test/CommonBuiltins/float2_min.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_mix.cl
+++ b/test/CommonBuiltins/float2_mix.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_radians.cl
+++ b/test/CommonBuiltins/float2_radians.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float2_sign.cl
+++ b/test/CommonBuiltins/float2_sign.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_clamp.cl
+++ b/test/CommonBuiltins/float3_clamp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_degrees.cl
+++ b/test/CommonBuiltins/float3_degrees.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_max.cl
+++ b/test/CommonBuiltins/float3_max.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_min.cl
+++ b/test/CommonBuiltins/float3_min.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_mix.cl
+++ b/test/CommonBuiltins/float3_mix.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_radians.cl
+++ b/test/CommonBuiltins/float3_radians.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float3_sign.cl
+++ b/test/CommonBuiltins/float3_sign.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_clamp.cl
+++ b/test/CommonBuiltins/float4_clamp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_degrees.cl
+++ b/test/CommonBuiltins/float4_degrees.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_max.cl
+++ b/test/CommonBuiltins/float4_max.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_min.cl
+++ b/test/CommonBuiltins/float4_min.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_mix.cl
+++ b/test/CommonBuiltins/float4_mix.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_radians.cl
+++ b/test/CommonBuiltins/float4_radians.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float4_sign.cl
+++ b/test/CommonBuiltins/float4_sign.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_clamp.cl
+++ b/test/CommonBuiltins/float_clamp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_degrees.cl
+++ b/test/CommonBuiltins/float_degrees.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_max.cl
+++ b/test/CommonBuiltins/float_max.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_min.cl
+++ b/test/CommonBuiltins/float_min.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_mix.cl
+++ b/test/CommonBuiltins/float_mix.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_radians.cl
+++ b/test/CommonBuiltins/float_radians.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/float_sign.cl
+++ b/test/CommonBuiltins/float_sign.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float2.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float4.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float2.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float4.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float.cl
+++ b/test/CommonBuiltins/step/step_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float2.cl
+++ b/test/CommonBuiltins/step/step_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float3.cl
+++ b/test/CommonBuiltins/step/step_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float4.cl
+++ b/test/CommonBuiltins/step/step_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float_float2.cl
+++ b/test/CommonBuiltins/step/step_float_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float_float3.cl
+++ b/test/CommonBuiltins/step/step_float_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CommonBuiltins/step/step_float_float4.cl
+++ b/test/CommonBuiltins/step/step_float_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_float4.cl
+++ b/test/ConvertBuiltins/convert_char4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_int4.cl
+++ b/test/ConvertBuiltins/convert_char4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_long4.cl
+++ b/test/ConvertBuiltins/convert_char4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_short4.cl
+++ b/test/ConvertBuiltins/convert_char4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_char4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_uint4.cl
+++ b/test/ConvertBuiltins/convert_char4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_char4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_char4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_float.cl
+++ b/test/ConvertBuiltins/convert_char_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_int.cl
+++ b/test/ConvertBuiltins/convert_char_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_long.cl
+++ b/test/ConvertBuiltins/convert_char_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_short.cl
+++ b/test/ConvertBuiltins/convert_char_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_uchar.cl
+++ b/test/ConvertBuiltins/convert_char_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_uint.cl
+++ b/test/ConvertBuiltins/convert_char_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_ulong.cl
+++ b/test/ConvertBuiltins/convert_char_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_char_ushort.cl
+++ b/test/ConvertBuiltins/convert_char_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_char4.cl
+++ b/test/ConvertBuiltins/convert_float4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_int4.cl
+++ b/test/ConvertBuiltins/convert_float4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_long4.cl
+++ b/test/ConvertBuiltins/convert_float4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_short4.cl
+++ b/test/ConvertBuiltins/convert_float4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_float4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_uint4.cl
+++ b/test/ConvertBuiltins/convert_float4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_float4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_float4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_char.cl
+++ b/test/ConvertBuiltins/convert_float_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_int.cl
+++ b/test/ConvertBuiltins/convert_float_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_long.cl
+++ b/test/ConvertBuiltins/convert_float_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_short.cl
+++ b/test/ConvertBuiltins/convert_float_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_uchar.cl
+++ b/test/ConvertBuiltins/convert_float_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_uint.cl
+++ b/test/ConvertBuiltins/convert_float_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_ulong.cl
+++ b/test/ConvertBuiltins/convert_float_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_float_ushort.cl
+++ b/test/ConvertBuiltins/convert_float_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_char4.cl
+++ b/test/ConvertBuiltins/convert_int4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_float4.cl
+++ b/test/ConvertBuiltins/convert_int4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_long4.cl
+++ b/test/ConvertBuiltins/convert_int4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_short4.cl
+++ b/test/ConvertBuiltins/convert_int4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_int4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_uint4.cl
+++ b/test/ConvertBuiltins/convert_int4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_int4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_int4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_char.cl
+++ b/test/ConvertBuiltins/convert_int_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_float.cl
+++ b/test/ConvertBuiltins/convert_int_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_long.cl
+++ b/test/ConvertBuiltins/convert_int_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_short.cl
+++ b/test/ConvertBuiltins/convert_int_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_uchar.cl
+++ b/test/ConvertBuiltins/convert_int_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_uint.cl
+++ b/test/ConvertBuiltins/convert_int_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_ulong.cl
+++ b/test/ConvertBuiltins/convert_int_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_int_ushort.cl
+++ b/test/ConvertBuiltins/convert_int_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_char4.cl
+++ b/test/ConvertBuiltins/convert_long4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_float4.cl
+++ b/test/ConvertBuiltins/convert_long4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_int4.cl
+++ b/test/ConvertBuiltins/convert_long4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_short4.cl
+++ b/test/ConvertBuiltins/convert_long4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_long4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_uint4.cl
+++ b/test/ConvertBuiltins/convert_long4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_long4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_long4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_char.cl
+++ b/test/ConvertBuiltins/convert_long_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_float.cl
+++ b/test/ConvertBuiltins/convert_long_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_int.cl
+++ b/test/ConvertBuiltins/convert_long_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_short.cl
+++ b/test/ConvertBuiltins/convert_long_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_uchar.cl
+++ b/test/ConvertBuiltins/convert_long_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_uint.cl
+++ b/test/ConvertBuiltins/convert_long_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_ulong.cl
+++ b/test/ConvertBuiltins/convert_long_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_long_ushort.cl
+++ b/test/ConvertBuiltins/convert_long_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_char4.cl
+++ b/test/ConvertBuiltins/convert_short4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_float4.cl
+++ b/test/ConvertBuiltins/convert_short4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_int4.cl
+++ b/test/ConvertBuiltins/convert_short4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_long4.cl
+++ b/test/ConvertBuiltins/convert_short4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_short4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_uint4.cl
+++ b/test/ConvertBuiltins/convert_short4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_short4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_short4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_char.cl
+++ b/test/ConvertBuiltins/convert_short_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_float.cl
+++ b/test/ConvertBuiltins/convert_short_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_int.cl
+++ b/test/ConvertBuiltins/convert_short_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_long.cl
+++ b/test/ConvertBuiltins/convert_short_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_uchar.cl
+++ b/test/ConvertBuiltins/convert_short_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_uint.cl
+++ b/test/ConvertBuiltins/convert_short_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_ulong.cl
+++ b/test/ConvertBuiltins/convert_short_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_short_ushort.cl
+++ b/test/ConvertBuiltins/convert_short_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_char4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_float4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_int4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_long4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_short4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_uint4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_uchar4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_char.cl
+++ b/test/ConvertBuiltins/convert_uchar_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_float.cl
+++ b/test/ConvertBuiltins/convert_uchar_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_int.cl
+++ b/test/ConvertBuiltins/convert_uchar_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_long.cl
+++ b/test/ConvertBuiltins/convert_uchar_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_short.cl
+++ b/test/ConvertBuiltins/convert_uchar_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_uint.cl
+++ b/test/ConvertBuiltins/convert_uchar_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_ulong.cl
+++ b/test/ConvertBuiltins/convert_uchar_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uchar_ushort.cl
+++ b/test/ConvertBuiltins/convert_uchar_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_char4.cl
+++ b/test/ConvertBuiltins/convert_uint4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_float4.cl
+++ b/test/ConvertBuiltins/convert_uint4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_int4.cl
+++ b/test/ConvertBuiltins/convert_uint4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_long4.cl
+++ b/test/ConvertBuiltins/convert_uint4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_short4.cl
+++ b/test/ConvertBuiltins/convert_uint4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_uint4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_uint4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_uint4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_char.cl
+++ b/test/ConvertBuiltins/convert_uint_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_float.cl
+++ b/test/ConvertBuiltins/convert_uint_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_int.cl
+++ b/test/ConvertBuiltins/convert_uint_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_long.cl
+++ b/test/ConvertBuiltins/convert_uint_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_short.cl
+++ b/test/ConvertBuiltins/convert_uint_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_uchar.cl
+++ b/test/ConvertBuiltins/convert_uint_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_ulong.cl
+++ b/test/ConvertBuiltins/convert_uint_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_uint_ushort.cl
+++ b/test/ConvertBuiltins/convert_uint_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_char4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_float4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_int4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_long4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_short4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_uint4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong4_ushort4.cl
+++ b/test/ConvertBuiltins/convert_ulong4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_char.cl
+++ b/test/ConvertBuiltins/convert_ulong_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_float.cl
+++ b/test/ConvertBuiltins/convert_ulong_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_int.cl
+++ b/test/ConvertBuiltins/convert_ulong_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_long.cl
+++ b/test/ConvertBuiltins/convert_ulong_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_short.cl
+++ b/test/ConvertBuiltins/convert_ulong_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_uchar.cl
+++ b/test/ConvertBuiltins/convert_ulong_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_uint.cl
+++ b/test/ConvertBuiltins/convert_ulong_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ulong_ushort.cl
+++ b/test/ConvertBuiltins/convert_ulong_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_char4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_float4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_int4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_long4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_short4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_uchar4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_uint4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort4_ulong4.cl
+++ b/test/ConvertBuiltins/convert_ushort4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_char.cl
+++ b/test/ConvertBuiltins/convert_ushort_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_float.cl
+++ b/test/ConvertBuiltins/convert_ushort_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_int.cl
+++ b/test/ConvertBuiltins/convert_ushort_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_long.cl
+++ b/test/ConvertBuiltins/convert_ushort_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_short.cl
+++ b/test/ConvertBuiltins/convert_ushort_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_uchar.cl
+++ b/test/ConvertBuiltins/convert_ushort_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_uint.cl
+++ b/test/ConvertBuiltins/convert_ushort_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ConvertBuiltins/convert_ushort_ulong.cl
+++ b/test/ConvertBuiltins/convert_ushort_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/constant_arg.cl
+++ b/test/DirectResourceAccess/constant_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/global_arg.cl
+++ b/test/DirectResourceAccess/global_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/global_subobject_base.cl
+++ b/test/DirectResourceAccess/global_subobject_base.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/inconsistent_kernel_args_global.cl
+++ b/test/DirectResourceAccess/inconsistent_kernel_args_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/local_arg.cl
+++ b/test/DirectResourceAccess/local_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/local_arg_one_entry_point.cl
+++ b/test/DirectResourceAccess/local_arg_one_entry_point.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/local_variable.cl
+++ b/test/DirectResourceAccess/local_variable.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/partial_access_chain_global.cl
+++ b/test/DirectResourceAccess/partial_access_chain_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/ro_image2_sampler_args.cl
+++ b/test/DirectResourceAccess/ro_image2_sampler_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/ro_image3_sampler_args.cl
+++ b/test/DirectResourceAccess/ro_image3_sampler_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/wo_image2_args.cl
+++ b/test/DirectResourceAccess/wo_image2_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/DirectResourceAccess/wo_image3_args.cl
+++ b/test/DirectResourceAccess/wo_image3_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_distance.cl
+++ b/test/GeometricBuiltins/float2_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_dot.cl
+++ b/test/GeometricBuiltins/float2_dot.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_fast_distance.cl
+++ b/test/GeometricBuiltins/float2_fast_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_fast_length.cl
+++ b/test/GeometricBuiltins/float2_fast_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_fast_normalize.cl
+++ b/test/GeometricBuiltins/float2_fast_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_length.cl
+++ b/test/GeometricBuiltins/float2_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float2_normalize.cl
+++ b/test/GeometricBuiltins/float2_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_cross.cl
+++ b/test/GeometricBuiltins/float3_cross.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_distance.cl
+++ b/test/GeometricBuiltins/float3_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_dot.cl
+++ b/test/GeometricBuiltins/float3_dot.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_fast_distance.cl
+++ b/test/GeometricBuiltins/float3_fast_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_fast_length.cl
+++ b/test/GeometricBuiltins/float3_fast_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_fast_normalize.cl
+++ b/test/GeometricBuiltins/float3_fast_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_length.cl
+++ b/test/GeometricBuiltins/float3_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float3_normalize.cl
+++ b/test/GeometricBuiltins/float3_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_cross.cl
+++ b/test/GeometricBuiltins/float4_cross.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_distance.cl
+++ b/test/GeometricBuiltins/float4_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_dot.cl
+++ b/test/GeometricBuiltins/float4_dot.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_fast_distance.cl
+++ b/test/GeometricBuiltins/float4_fast_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_fast_length.cl
+++ b/test/GeometricBuiltins/float4_fast_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_fast_normalize.cl
+++ b/test/GeometricBuiltins/float4_fast_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_length.cl
+++ b/test/GeometricBuiltins/float4_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float4_normalize.cl
+++ b/test/GeometricBuiltins/float4_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_distance.cl
+++ b/test/GeometricBuiltins/float_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_dot.cl
+++ b/test/GeometricBuiltins/float_dot.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_fast_distance.cl
+++ b/test/GeometricBuiltins/float_fast_distance.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_fast_length.cl
+++ b/test/GeometricBuiltins/float_fast_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_fast_normalize.cl
+++ b/test/GeometricBuiltins/float_fast_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_length.cl
+++ b/test/GeometricBuiltins/float_length.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/GeometricBuiltins/float_normalize.cl
+++ b/test/GeometricBuiltins/float_normalize.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half2_global.cl
+++ b/test/HalfStorage/clspv_vloada_half2_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half2_local.cl
+++ b/test/HalfStorage/clspv_vloada_half2_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half2_private.cl
+++ b/test/HalfStorage/clspv_vloada_half2_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half4_global.cl
+++ b/test/HalfStorage/clspv_vloada_half4_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half4_local.cl
+++ b/test/HalfStorage/clspv_vloada_half4_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/clspv_vloada_half4_private.cl
+++ b/test/HalfStorage/clspv_vloada_half4_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vload_half2_pointer_cast_from_float4.cl
+++ b/test/HalfStorage/vload_half2_pointer_cast_from_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
+++ b/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vload_half_pointer_cast_from_short.cl
+++ b/test/HalfStorage/vload_half_pointer_cast_from_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -f16bit_storage
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -f16bit_storage
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vloada_half2_global.cl
+++ b/test/HalfStorage/vloada_half2_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vloada_half4_global.cl
+++ b/test/HalfStorage/vloada_half4_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstore_half2_pointer_cast_to_float4.cl
+++ b/test/HalfStorage/vstore_half2_pointer_cast_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
+++ b/test/HalfStorage/vstore_half4_pointer_cast_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
+++ b/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -f16bit_storage
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -f16bit_storage
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
+++ b/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half2_global.cl
+++ b/test/HalfStorage/vstorea_half2_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half2_local.cl
+++ b/test/HalfStorage/vstorea_half2_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half2_private.cl
+++ b/test/HalfStorage/vstorea_half2_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half4_global.cl
+++ b/test/HalfStorage/vstorea_half4_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half4_local.cl
+++ b/test/HalfStorage/vstorea_half4_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/HalfStorage/vstorea_half4_private.cl
+++ b/test/HalfStorage/vstorea_half4_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/get_image_height_image2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_readonly.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/get_image_height_image2d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_writeonly.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/get_image_width_imaged2d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_width_imaged2d_writeonly.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/read_imagef_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float2.cl
@@ -1,12 +1,8 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %s -S -o %t3.spvasm -cluster-pod-kernel-args
-// RUN: FileCheck %s < %t3.spvasm -check-prefix=CLUSTER
 // RUN: clspv %s -o %t4.spv -cluster-pod-kernel-args
 // RUN: spirv-dis -o %t4.spvasm %t4.spv
 // RUN: FileCheck %s < %t4.spvasm -check-prefix=CLUSTER

--- a/test/ImageBuiltins/read_imagef_sampler_float4.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/write_imagef_sampler_int2.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/write_imagef_sampler_int4.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/InlineEntryPoints/inline_everything.cl
+++ b/test/InlineEntryPoints/inline_everything.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -inline-entry-points
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -inline-entry-points
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/InlineFuncWithSingleCallSite/function_chain.cl
+++ b/test/InlineFuncWithSingleCallSite/function_chain.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/InlineFuncWithSingleCallSite/non_local_parameter.cl
+++ b/test/InlineFuncWithSingleCallSite/non_local_parameter.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/InlineFuncWithSingleCallSite/two_kernels_partial_chain_inline.cl
+++ b/test/InlineFuncWithSingleCallSite/two_kernels_partial_chain_inline.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_char.cl
+++ b/test/IntegerBuiltins/abs/abs_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_char2.cl
+++ b/test/IntegerBuiltins/abs/abs_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_char3.cl
+++ b/test/IntegerBuiltins/abs/abs_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_char4.cl
+++ b/test/IntegerBuiltins/abs/abs_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_int.cl
+++ b/test/IntegerBuiltins/abs/abs_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_int2.cl
+++ b/test/IntegerBuiltins/abs/abs_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_int3.cl
+++ b/test/IntegerBuiltins/abs/abs_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_int4.cl
+++ b/test/IntegerBuiltins/abs/abs_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_long.cl
+++ b/test/IntegerBuiltins/abs/abs_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_long2.cl
+++ b/test/IntegerBuiltins/abs/abs_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_long3.cl
+++ b/test/IntegerBuiltins/abs/abs_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_long4.cl
+++ b/test/IntegerBuiltins/abs/abs_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_short.cl
+++ b/test/IntegerBuiltins/abs/abs_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_short2.cl
+++ b/test/IntegerBuiltins/abs/abs_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_short3.cl
+++ b/test/IntegerBuiltins/abs/abs_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_short4.cl
+++ b/test/IntegerBuiltins/abs/abs_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uchar.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uchar2.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uchar3.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uchar4.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uint.cl
+++ b/test/IntegerBuiltins/abs/abs_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uint2.cl
+++ b/test/IntegerBuiltins/abs/abs_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uint3.cl
+++ b/test/IntegerBuiltins/abs/abs_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_uint4.cl
+++ b/test/IntegerBuiltins/abs/abs_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ulong.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ulong2.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ulong3.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ulong4.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ushort.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ushort2.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ushort3.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/abs/abs_ushort4.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_char.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_char2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_char3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_char4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_int.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_int2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_int3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_int4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_long.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_long2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_long3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_long4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_short.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_short2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_short3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_short4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uchar.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uchar2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uchar3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uchar4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uint.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uint2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uint3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_uint4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ulong.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ulong2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ulong3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ulong4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ushort.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ushort2.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ushort3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/clamp/clamp_ushort4.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int2_clz.cl
+++ b/test/IntegerBuiltins/int2_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int2_mad24.cl
+++ b/test/IntegerBuiltins/int2_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int2_max_var.cl
+++ b/test/IntegerBuiltins/int2_max_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int2_min_var.cl
+++ b/test/IntegerBuiltins/int2_min_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int2_mul24.cl
+++ b/test/IntegerBuiltins/int2_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int3_clz.cl
+++ b/test/IntegerBuiltins/int3_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int3_mad24.cl
+++ b/test/IntegerBuiltins/int3_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int3_max_var.cl
+++ b/test/IntegerBuiltins/int3_max_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int3_min_var.cl
+++ b/test/IntegerBuiltins/int3_min_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int3_mul24.cl
+++ b/test/IntegerBuiltins/int3_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int4_clz.cl
+++ b/test/IntegerBuiltins/int4_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int4_mad24.cl
+++ b/test/IntegerBuiltins/int4_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int4_max_var.cl
+++ b/test/IntegerBuiltins/int4_max_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int4_min_var.cl
+++ b/test/IntegerBuiltins/int4_min_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int4_mul24.cl
+++ b/test/IntegerBuiltins/int4_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int_clz.cl
+++ b/test/IntegerBuiltins/int_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int_mad24.cl
+++ b/test/IntegerBuiltins/int_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/int_mul24.cl
+++ b/test/IntegerBuiltins/int_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_char.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_char4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_int.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_int4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_long.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_long4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_short.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_short4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uchar.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uchar4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uint.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_uint4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ulong.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ulong4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ushort.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mad_hi/mad_hi_ushort4.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_char.cl
+++ b/test/IntegerBuiltins/max/max_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_char2.cl
+++ b/test/IntegerBuiltins/max/max_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_char3.cl
+++ b/test/IntegerBuiltins/max/max_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_char4.cl
+++ b/test/IntegerBuiltins/max/max_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_int.cl
+++ b/test/IntegerBuiltins/max/max_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_int2.cl
+++ b/test/IntegerBuiltins/max/max_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_int3.cl
+++ b/test/IntegerBuiltins/max/max_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_int4.cl
+++ b/test/IntegerBuiltins/max/max_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_long.cl
+++ b/test/IntegerBuiltins/max/max_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_long2.cl
+++ b/test/IntegerBuiltins/max/max_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_long3.cl
+++ b/test/IntegerBuiltins/max/max_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_long4.cl
+++ b/test/IntegerBuiltins/max/max_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_short.cl
+++ b/test/IntegerBuiltins/max/max_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_short2.cl
+++ b/test/IntegerBuiltins/max/max_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_short3.cl
+++ b/test/IntegerBuiltins/max/max_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_short4.cl
+++ b/test/IntegerBuiltins/max/max_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uchar.cl
+++ b/test/IntegerBuiltins/max/max_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uchar2.cl
+++ b/test/IntegerBuiltins/max/max_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uchar3.cl
+++ b/test/IntegerBuiltins/max/max_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uchar4.cl
+++ b/test/IntegerBuiltins/max/max_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uint.cl
+++ b/test/IntegerBuiltins/max/max_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uint2.cl
+++ b/test/IntegerBuiltins/max/max_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uint3.cl
+++ b/test/IntegerBuiltins/max/max_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_uint4.cl
+++ b/test/IntegerBuiltins/max/max_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ulong.cl
+++ b/test/IntegerBuiltins/max/max_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ulong2.cl
+++ b/test/IntegerBuiltins/max/max_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ulong3.cl
+++ b/test/IntegerBuiltins/max/max_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ulong4.cl
+++ b/test/IntegerBuiltins/max/max_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ushort.cl
+++ b/test/IntegerBuiltins/max/max_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ushort2.cl
+++ b/test/IntegerBuiltins/max/max_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ushort3.cl
+++ b/test/IntegerBuiltins/max/max_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/max/max_ushort4.cl
+++ b/test/IntegerBuiltins/max/max_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_char.cl
+++ b/test/IntegerBuiltins/min/min_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_char2.cl
+++ b/test/IntegerBuiltins/min/min_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_char3.cl
+++ b/test/IntegerBuiltins/min/min_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_char4.cl
+++ b/test/IntegerBuiltins/min/min_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_int.cl
+++ b/test/IntegerBuiltins/min/min_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_int2.cl
+++ b/test/IntegerBuiltins/min/min_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_int3.cl
+++ b/test/IntegerBuiltins/min/min_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_int4.cl
+++ b/test/IntegerBuiltins/min/min_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_long.cl
+++ b/test/IntegerBuiltins/min/min_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_long2.cl
+++ b/test/IntegerBuiltins/min/min_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_long3.cl
+++ b/test/IntegerBuiltins/min/min_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_long4.cl
+++ b/test/IntegerBuiltins/min/min_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_short.cl
+++ b/test/IntegerBuiltins/min/min_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_short2.cl
+++ b/test/IntegerBuiltins/min/min_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_short3.cl
+++ b/test/IntegerBuiltins/min/min_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_short4.cl
+++ b/test/IntegerBuiltins/min/min_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uchar.cl
+++ b/test/IntegerBuiltins/min/min_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uchar2.cl
+++ b/test/IntegerBuiltins/min/min_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uchar3.cl
+++ b/test/IntegerBuiltins/min/min_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uchar4.cl
+++ b/test/IntegerBuiltins/min/min_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uint.cl
+++ b/test/IntegerBuiltins/min/min_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uint2.cl
+++ b/test/IntegerBuiltins/min/min_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uint3.cl
+++ b/test/IntegerBuiltins/min/min_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_uint4.cl
+++ b/test/IntegerBuiltins/min/min_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ulong.cl
+++ b/test/IntegerBuiltins/min/min_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ulong2.cl
+++ b/test/IntegerBuiltins/min/min_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ulong3.cl
+++ b/test/IntegerBuiltins/min/min_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ulong4.cl
+++ b/test/IntegerBuiltins/min/min_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ushort.cl
+++ b/test/IntegerBuiltins/min/min_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ushort2.cl
+++ b/test/IntegerBuiltins/min/min_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ushort3.cl
+++ b/test/IntegerBuiltins/min/min_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/min/min_ushort4.cl
+++ b/test/IntegerBuiltins/min/min_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_char.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_char4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_int.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_int4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_long.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_long4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_short.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_short4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uchar.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uchar4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uint.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_uint4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ulong.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ulong4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ushort.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/mul_hi/mul_hi_ushort4.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -int8 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -int8 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/int2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/int2_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/int3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/int3_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/int4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/int4_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/int_popcount.cl
+++ b/test/IntegerBuiltins/popcount/int_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/uint2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uint2_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/uint3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uint3_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/uint4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uint4_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/popcount/uint_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uint_popcount.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uchar.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uchar2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uchar3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uchar4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uint.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uint2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uint3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_uint4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ulong.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ulong2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ulong3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ulong4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ushort.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ushort2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ushort3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/rotate/rotate_ushort4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint2_clz.cl
+++ b/test/IntegerBuiltins/uint2_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint2_mad24.cl
+++ b/test/IntegerBuiltins/uint2_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint2_mul24.cl
+++ b/test/IntegerBuiltins/uint2_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint3_clz.cl
+++ b/test/IntegerBuiltins/uint3_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint3_mad24.cl
+++ b/test/IntegerBuiltins/uint3_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint3_mul24.cl
+++ b/test/IntegerBuiltins/uint3_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint4_clz.cl
+++ b/test/IntegerBuiltins/uint4_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint4_mad24.cl
+++ b/test/IntegerBuiltins/uint4_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint4_mul24.cl
+++ b/test/IntegerBuiltins/uint4_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint_clz.cl
+++ b/test/IntegerBuiltins/uint_clz.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint_mad24.cl
+++ b/test/IntegerBuiltins/uint_mad24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/uint_mul24.cl
+++ b/test/IntegerBuiltins/uint_mul24.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_char.cl
+++ b/test/IntegerBuiltins/upsample/upsample_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_char2.cl
+++ b/test/IntegerBuiltins/upsample/upsample_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_char3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_char4.cl
+++ b/test/IntegerBuiltins/upsample/upsample_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_int.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_int2.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_int3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_int4.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_short.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_short2.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_short3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/IntegerBuiltins/upsample/upsample_short4.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/descend_into_array.cl
+++ b/test/LLVMIntrinsics/descend_into_array.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/lifetime_start.cl
+++ b/test/LLVMIntrinsics/lifetime_start.cl
@@ -2,8 +2,6 @@
 // Fixes https://github.com/google/clspv/issues/142
 
 
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/memcpy_bitcast_used_twice.cl
+++ b/test/LLVMIntrinsics/memcpy_bitcast_used_twice.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/memcpy_from_constant.cl
+++ b/test/LLVMIntrinsics/memcpy_from_constant.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/memcpy_mismatched_dest_is_array.cl
+++ b/test/LLVMIntrinsics/memcpy_mismatched_dest_is_array.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/memcpy_mismatched_src_is_array.cl
+++ b/test/LLVMIntrinsics/memcpy_mismatched_src_is_array.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/LLVMIntrinsics/memset_null_many_copies.cl
+++ b/test/LLVMIntrinsics/memset_null_many_copies.cl
@@ -2,8 +2,6 @@
 // A memset of 0 bytes that spans many pointee values should
 // result in replicated stores.
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/copysign/copysign_float.cl
+++ b/test/MathBuiltins/copysign/copysign_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/copysign/copysign_float2.cl
+++ b/test/MathBuiltins/copysign/copysign_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/copysign/copysign_float3.cl
+++ b/test/MathBuiltins/copysign/copysign_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/copysign/copysign_float4.cl
+++ b/test/MathBuiltins/copysign/copysign_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_acos.cl
+++ b/test/MathBuiltins/float2_acos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_acosh.cl
+++ b/test/MathBuiltins/float2_acosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_acospi.cl
+++ b/test/MathBuiltins/float2_acospi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_asin.cl
+++ b/test/MathBuiltins/float2_asin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_asinh.cl
+++ b/test/MathBuiltins/float2_asinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_asinpi.cl
+++ b/test/MathBuiltins/float2_asinpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_atan.cl
+++ b/test/MathBuiltins/float2_atan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_atan2.cl
+++ b/test/MathBuiltins/float2_atan2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_atan2pi.cl
+++ b/test/MathBuiltins/float2_atan2pi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_atanh.cl
+++ b/test/MathBuiltins/float2_atanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_atanpi.cl
+++ b/test/MathBuiltins/float2_atanpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_ceil.cl
+++ b/test/MathBuiltins/float2_ceil.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_cos.cl
+++ b/test/MathBuiltins/float2_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_cosh.cl
+++ b/test/MathBuiltins/float2_cosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_exp.cl
+++ b/test/MathBuiltins/float2_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_exp10.cl
+++ b/test/MathBuiltins/float2_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_exp2.cl
+++ b/test/MathBuiltins/float2_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fabs.cl
+++ b/test/MathBuiltins/float2_fabs.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_floor.cl
+++ b/test/MathBuiltins/float2_floor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fma.cl
+++ b/test/MathBuiltins/float2_fma.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fmax.cl
+++ b/test/MathBuiltins/float2_fmax.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fmin.cl
+++ b/test/MathBuiltins/float2_fmin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fmod.cl
+++ b/test/MathBuiltins/float2_fmod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_fract_private.cl
+++ b/test/MathBuiltins/float2_fract_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_frexp_global.cl
+++ b/test/MathBuiltins/float2_frexp_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_frexp_local.cl
+++ b/test/MathBuiltins/float2_frexp_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_frexp_private.cl
+++ b/test/MathBuiltins/float2_frexp_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_cos.cl
+++ b/test/MathBuiltins/float2_half_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_divide.cl
+++ b/test/MathBuiltins/float2_half_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_exp.cl
+++ b/test/MathBuiltins/float2_half_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_exp10.cl
+++ b/test/MathBuiltins/float2_half_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_exp2.cl
+++ b/test/MathBuiltins/float2_half_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_log.cl
+++ b/test/MathBuiltins/float2_half_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_log10.cl
+++ b/test/MathBuiltins/float2_half_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_log2.cl
+++ b/test/MathBuiltins/float2_half_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_powr.cl
+++ b/test/MathBuiltins/float2_half_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_recip.cl
+++ b/test/MathBuiltins/float2_half_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_rsqrt.cl
+++ b/test/MathBuiltins/float2_half_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_sin.cl
+++ b/test/MathBuiltins/float2_half_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_sqrt.cl
+++ b/test/MathBuiltins/float2_half_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_half_tan.cl
+++ b/test/MathBuiltins/float2_half_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_ldexp.cl
+++ b/test/MathBuiltins/float2_ldexp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_log.cl
+++ b/test/MathBuiltins/float2_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_log10.cl
+++ b/test/MathBuiltins/float2_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_log2.cl
+++ b/test/MathBuiltins/float2_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_mad.cl
+++ b/test/MathBuiltins/float2_mad.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_cos.cl
+++ b/test/MathBuiltins/float2_native_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_divide.cl
+++ b/test/MathBuiltins/float2_native_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_exp.cl
+++ b/test/MathBuiltins/float2_native_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_exp10.cl
+++ b/test/MathBuiltins/float2_native_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_exp2.cl
+++ b/test/MathBuiltins/float2_native_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_log.cl
+++ b/test/MathBuiltins/float2_native_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_log10.cl
+++ b/test/MathBuiltins/float2_native_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_log2.cl
+++ b/test/MathBuiltins/float2_native_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_powr.cl
+++ b/test/MathBuiltins/float2_native_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_recip.cl
+++ b/test/MathBuiltins/float2_native_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_rsqrt.cl
+++ b/test/MathBuiltins/float2_native_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_sin.cl
+++ b/test/MathBuiltins/float2_native_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_sqrt.cl
+++ b/test/MathBuiltins/float2_native_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_native_tan.cl
+++ b/test/MathBuiltins/float2_native_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_pow.cl
+++ b/test/MathBuiltins/float2_pow.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_powr.cl
+++ b/test/MathBuiltins/float2_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_round.cl
+++ b/test/MathBuiltins/float2_round.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_rsqrt.cl
+++ b/test/MathBuiltins/float2_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_sin.cl
+++ b/test/MathBuiltins/float2_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_sinh.cl
+++ b/test/MathBuiltins/float2_sinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_sqrt.cl
+++ b/test/MathBuiltins/float2_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_step.cl
+++ b/test/MathBuiltins/float2_step.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_tan.cl
+++ b/test/MathBuiltins/float2_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_tanh.cl
+++ b/test/MathBuiltins/float2_tanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float2_trunc.cl
+++ b/test/MathBuiltins/float2_trunc.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_acos.cl
+++ b/test/MathBuiltins/float3_acos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_acosh.cl
+++ b/test/MathBuiltins/float3_acosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_acospi.cl
+++ b/test/MathBuiltins/float3_acospi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_asin.cl
+++ b/test/MathBuiltins/float3_asin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_asinh.cl
+++ b/test/MathBuiltins/float3_asinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_asinpi.cl
+++ b/test/MathBuiltins/float3_asinpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_atan.cl
+++ b/test/MathBuiltins/float3_atan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_atan2.cl
+++ b/test/MathBuiltins/float3_atan2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_atan2pi.cl
+++ b/test/MathBuiltins/float3_atan2pi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_atanh.cl
+++ b/test/MathBuiltins/float3_atanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_atanpi.cl
+++ b/test/MathBuiltins/float3_atanpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_ceil.cl
+++ b/test/MathBuiltins/float3_ceil.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_cos.cl
+++ b/test/MathBuiltins/float3_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_cosh.cl
+++ b/test/MathBuiltins/float3_cosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_exp.cl
+++ b/test/MathBuiltins/float3_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_exp10.cl
+++ b/test/MathBuiltins/float3_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_exp2.cl
+++ b/test/MathBuiltins/float3_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fabs.cl
+++ b/test/MathBuiltins/float3_fabs.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_floor.cl
+++ b/test/MathBuiltins/float3_floor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fma.cl
+++ b/test/MathBuiltins/float3_fma.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fmax.cl
+++ b/test/MathBuiltins/float3_fmax.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fmin.cl
+++ b/test/MathBuiltins/float3_fmin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fmod.cl
+++ b/test/MathBuiltins/float3_fmod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_fract_private.cl
+++ b/test/MathBuiltins/float3_fract_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_frexp_global.cl
+++ b/test/MathBuiltins/float3_frexp_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_frexp_local.cl
+++ b/test/MathBuiltins/float3_frexp_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_frexp_private.cl
+++ b/test/MathBuiltins/float3_frexp_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_cos.cl
+++ b/test/MathBuiltins/float3_half_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_divide.cl
+++ b/test/MathBuiltins/float3_half_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_exp.cl
+++ b/test/MathBuiltins/float3_half_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_exp10.cl
+++ b/test/MathBuiltins/float3_half_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_exp2.cl
+++ b/test/MathBuiltins/float3_half_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_log.cl
+++ b/test/MathBuiltins/float3_half_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_log10.cl
+++ b/test/MathBuiltins/float3_half_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_log2.cl
+++ b/test/MathBuiltins/float3_half_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_powr.cl
+++ b/test/MathBuiltins/float3_half_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_recip.cl
+++ b/test/MathBuiltins/float3_half_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_rsqrt.cl
+++ b/test/MathBuiltins/float3_half_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_sin.cl
+++ b/test/MathBuiltins/float3_half_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_sqrt.cl
+++ b/test/MathBuiltins/float3_half_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_half_tan.cl
+++ b/test/MathBuiltins/float3_half_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_ldexp.cl
+++ b/test/MathBuiltins/float3_ldexp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_log.cl
+++ b/test/MathBuiltins/float3_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_log10.cl
+++ b/test/MathBuiltins/float3_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_log2.cl
+++ b/test/MathBuiltins/float3_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_mad.cl
+++ b/test/MathBuiltins/float3_mad.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_cos.cl
+++ b/test/MathBuiltins/float3_native_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_divide.cl
+++ b/test/MathBuiltins/float3_native_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_exp.cl
+++ b/test/MathBuiltins/float3_native_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_exp10.cl
+++ b/test/MathBuiltins/float3_native_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_exp2.cl
+++ b/test/MathBuiltins/float3_native_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_log.cl
+++ b/test/MathBuiltins/float3_native_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_log10.cl
+++ b/test/MathBuiltins/float3_native_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_log2.cl
+++ b/test/MathBuiltins/float3_native_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_powr.cl
+++ b/test/MathBuiltins/float3_native_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_recip.cl
+++ b/test/MathBuiltins/float3_native_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_rsqrt.cl
+++ b/test/MathBuiltins/float3_native_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_sin.cl
+++ b/test/MathBuiltins/float3_native_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_sqrt.cl
+++ b/test/MathBuiltins/float3_native_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_native_tan.cl
+++ b/test/MathBuiltins/float3_native_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_pow.cl
+++ b/test/MathBuiltins/float3_pow.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_powr.cl
+++ b/test/MathBuiltins/float3_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_round.cl
+++ b/test/MathBuiltins/float3_round.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_rsqrt.cl
+++ b/test/MathBuiltins/float3_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_sin.cl
+++ b/test/MathBuiltins/float3_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_sinh.cl
+++ b/test/MathBuiltins/float3_sinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_sqrt.cl
+++ b/test/MathBuiltins/float3_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_step.cl
+++ b/test/MathBuiltins/float3_step.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_tan.cl
+++ b/test/MathBuiltins/float3_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_tanh.cl
+++ b/test/MathBuiltins/float3_tanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float3_trunc.cl
+++ b/test/MathBuiltins/float3_trunc.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_acos.cl
+++ b/test/MathBuiltins/float4_acos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_acosh.cl
+++ b/test/MathBuiltins/float4_acosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_acospi.cl
+++ b/test/MathBuiltins/float4_acospi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_asin.cl
+++ b/test/MathBuiltins/float4_asin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_asinh.cl
+++ b/test/MathBuiltins/float4_asinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_asinpi.cl
+++ b/test/MathBuiltins/float4_asinpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_atan.cl
+++ b/test/MathBuiltins/float4_atan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_atan2.cl
+++ b/test/MathBuiltins/float4_atan2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_atan2pi.cl
+++ b/test/MathBuiltins/float4_atan2pi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_atanh.cl
+++ b/test/MathBuiltins/float4_atanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_atanpi.cl
+++ b/test/MathBuiltins/float4_atanpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_ceil.cl
+++ b/test/MathBuiltins/float4_ceil.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_cos.cl
+++ b/test/MathBuiltins/float4_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_cosh.cl
+++ b/test/MathBuiltins/float4_cosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_exp.cl
+++ b/test/MathBuiltins/float4_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_exp10.cl
+++ b/test/MathBuiltins/float4_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_exp2.cl
+++ b/test/MathBuiltins/float4_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fabs.cl
+++ b/test/MathBuiltins/float4_fabs.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_floor.cl
+++ b/test/MathBuiltins/float4_floor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fma.cl
+++ b/test/MathBuiltins/float4_fma.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fmax.cl
+++ b/test/MathBuiltins/float4_fmax.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fmin.cl
+++ b/test/MathBuiltins/float4_fmin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fmod.cl
+++ b/test/MathBuiltins/float4_fmod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_fract_private.cl
+++ b/test/MathBuiltins/float4_fract_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_frexp_global.cl
+++ b/test/MathBuiltins/float4_frexp_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_frexp_local.cl
+++ b/test/MathBuiltins/float4_frexp_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_frexp_private.cl
+++ b/test/MathBuiltins/float4_frexp_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_cos.cl
+++ b/test/MathBuiltins/float4_half_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_divide.cl
+++ b/test/MathBuiltins/float4_half_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_exp.cl
+++ b/test/MathBuiltins/float4_half_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_exp10.cl
+++ b/test/MathBuiltins/float4_half_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_exp2.cl
+++ b/test/MathBuiltins/float4_half_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_log.cl
+++ b/test/MathBuiltins/float4_half_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_log10.cl
+++ b/test/MathBuiltins/float4_half_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_log2.cl
+++ b/test/MathBuiltins/float4_half_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_powr.cl
+++ b/test/MathBuiltins/float4_half_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_recip.cl
+++ b/test/MathBuiltins/float4_half_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_rsqrt.cl
+++ b/test/MathBuiltins/float4_half_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_sin.cl
+++ b/test/MathBuiltins/float4_half_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_sqrt.cl
+++ b/test/MathBuiltins/float4_half_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_half_tan.cl
+++ b/test/MathBuiltins/float4_half_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_ldexp.cl
+++ b/test/MathBuiltins/float4_ldexp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_log.cl
+++ b/test/MathBuiltins/float4_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_log10.cl
+++ b/test/MathBuiltins/float4_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_log2.cl
+++ b/test/MathBuiltins/float4_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_mad.cl
+++ b/test/MathBuiltins/float4_mad.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_cos.cl
+++ b/test/MathBuiltins/float4_native_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_divide.cl
+++ b/test/MathBuiltins/float4_native_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_exp.cl
+++ b/test/MathBuiltins/float4_native_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_exp10.cl
+++ b/test/MathBuiltins/float4_native_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_exp2.cl
+++ b/test/MathBuiltins/float4_native_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_log.cl
+++ b/test/MathBuiltins/float4_native_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_log10.cl
+++ b/test/MathBuiltins/float4_native_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_log2.cl
+++ b/test/MathBuiltins/float4_native_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_powr.cl
+++ b/test/MathBuiltins/float4_native_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_recip.cl
+++ b/test/MathBuiltins/float4_native_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_rsqrt.cl
+++ b/test/MathBuiltins/float4_native_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_sin.cl
+++ b/test/MathBuiltins/float4_native_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_sqrt.cl
+++ b/test/MathBuiltins/float4_native_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_native_tan.cl
+++ b/test/MathBuiltins/float4_native_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_pow.cl
+++ b/test/MathBuiltins/float4_pow.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_powr.cl
+++ b/test/MathBuiltins/float4_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_round.cl
+++ b/test/MathBuiltins/float4_round.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_rsqrt.cl
+++ b/test/MathBuiltins/float4_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_sin.cl
+++ b/test/MathBuiltins/float4_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_sinh.cl
+++ b/test/MathBuiltins/float4_sinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_sqrt.cl
+++ b/test/MathBuiltins/float4_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_step.cl
+++ b/test/MathBuiltins/float4_step.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_tan.cl
+++ b/test/MathBuiltins/float4_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_tanh.cl
+++ b/test/MathBuiltins/float4_tanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float4_trunc.cl
+++ b/test/MathBuiltins/float4_trunc.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_acos.cl
+++ b/test/MathBuiltins/float_acos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_acosh.cl
+++ b/test/MathBuiltins/float_acosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_acospi.cl
+++ b/test/MathBuiltins/float_acospi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_asin.cl
+++ b/test/MathBuiltins/float_asin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_asinh.cl
+++ b/test/MathBuiltins/float_asinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_asinpi.cl
+++ b/test/MathBuiltins/float_asinpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_atan.cl
+++ b/test/MathBuiltins/float_atan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_atan2.cl
+++ b/test/MathBuiltins/float_atan2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_atan2pi.cl
+++ b/test/MathBuiltins/float_atan2pi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_atanh.cl
+++ b/test/MathBuiltins/float_atanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_atanpi.cl
+++ b/test/MathBuiltins/float_atanpi.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_ceil.cl
+++ b/test/MathBuiltins/float_ceil.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_cos.cl
+++ b/test/MathBuiltins/float_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_cosh.cl
+++ b/test/MathBuiltins/float_cosh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_exp.cl
+++ b/test/MathBuiltins/float_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_exp10.cl
+++ b/test/MathBuiltins/float_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_exp2.cl
+++ b/test/MathBuiltins/float_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fabs.cl
+++ b/test/MathBuiltins/float_fabs.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_floor.cl
+++ b/test/MathBuiltins/float_floor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fma.cl
+++ b/test/MathBuiltins/float_fma.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fmax.cl
+++ b/test/MathBuiltins/float_fmax.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fmin.cl
+++ b/test/MathBuiltins/float_fmin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fmod.cl
+++ b/test/MathBuiltins/float_fmod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_fract_private.cl
+++ b/test/MathBuiltins/float_fract_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_frexp_global.cl
+++ b/test/MathBuiltins/float_frexp_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_frexp_local.cl
+++ b/test/MathBuiltins/float_frexp_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_frexp_private.cl
+++ b/test/MathBuiltins/float_frexp_private.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_cos.cl
+++ b/test/MathBuiltins/float_half_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_divide.cl
+++ b/test/MathBuiltins/float_half_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_exp.cl
+++ b/test/MathBuiltins/float_half_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_exp10.cl
+++ b/test/MathBuiltins/float_half_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_exp2.cl
+++ b/test/MathBuiltins/float_half_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_log.cl
+++ b/test/MathBuiltins/float_half_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_log10.cl
+++ b/test/MathBuiltins/float_half_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_log2.cl
+++ b/test/MathBuiltins/float_half_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_powr.cl
+++ b/test/MathBuiltins/float_half_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_recip.cl
+++ b/test/MathBuiltins/float_half_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_rsqrt.cl
+++ b/test/MathBuiltins/float_half_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_sin.cl
+++ b/test/MathBuiltins/float_half_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_sqrt.cl
+++ b/test/MathBuiltins/float_half_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_half_tan.cl
+++ b/test/MathBuiltins/float_half_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_ldexp.cl
+++ b/test/MathBuiltins/float_ldexp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_log.cl
+++ b/test/MathBuiltins/float_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_log10.cl
+++ b/test/MathBuiltins/float_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_log2.cl
+++ b/test/MathBuiltins/float_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_mad.cl
+++ b/test/MathBuiltins/float_mad.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_cos.cl
+++ b/test/MathBuiltins/float_native_cos.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_divide.cl
+++ b/test/MathBuiltins/float_native_divide.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_exp.cl
+++ b/test/MathBuiltins/float_native_exp.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_exp10.cl
+++ b/test/MathBuiltins/float_native_exp10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_exp2.cl
+++ b/test/MathBuiltins/float_native_exp2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_log.cl
+++ b/test/MathBuiltins/float_native_log.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_log10.cl
+++ b/test/MathBuiltins/float_native_log10.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_log2.cl
+++ b/test/MathBuiltins/float_native_log2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_powr.cl
+++ b/test/MathBuiltins/float_native_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_recip.cl
+++ b/test/MathBuiltins/float_native_recip.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_rsqrt.cl
+++ b/test/MathBuiltins/float_native_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_sin.cl
+++ b/test/MathBuiltins/float_native_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_sqrt.cl
+++ b/test/MathBuiltins/float_native_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_native_tan.cl
+++ b/test/MathBuiltins/float_native_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_pow.cl
+++ b/test/MathBuiltins/float_pow.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_powr.cl
+++ b/test/MathBuiltins/float_powr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_round.cl
+++ b/test/MathBuiltins/float_round.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_rsqrt.cl
+++ b/test/MathBuiltins/float_rsqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_sin.cl
+++ b/test/MathBuiltins/float_sin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_sinh.cl
+++ b/test/MathBuiltins/float_sinh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_sqrt.cl
+++ b/test/MathBuiltins/float_sqrt.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_step.cl
+++ b/test/MathBuiltins/float_step.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_tan.cl
+++ b/test/MathBuiltins/float_tan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_tanh.cl
+++ b/test/MathBuiltins/float_tanh.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/MathBuiltins/float_trunc.cl
+++ b/test/MathBuiltins/float_trunc.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerAccessChains/pointer_deref.cl
+++ b/test/PointerAccessChains/pointer_deref.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerAccessChains/pointer_index_in_called_function.cl
+++ b/test/PointerAccessChains/pointer_index_in_called_function.cl
@@ -1,12 +1,8 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm -check-prefix=NODRA
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA

--- a/test/PointerAccessChains/pointer_index_is_constant_0.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_0.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerAccessChains/pointer_index_is_constant_1.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_1.cl
@@ -1,12 +1,8 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm -check-prefix=NODRA
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA

--- a/test/PointerCasts/deref_load_cast_float2_to_int4.cl
+++ b/test/PointerCasts/deref_load_cast_float2_to_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/deref_load_cast_float4_to_int2.cl
+++ b/test/PointerCasts/deref_load_cast_float4_to_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/deref_store_cast_int2_to_float4.cl
+++ b/test/PointerCasts/deref_store_cast_int2_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/deref_store_cast_int4_to_float2.cl
+++ b/test/PointerCasts/deref_store_cast_int4_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/inline_func_with_pointer_bitcast_as_argument.cl
+++ b/test/PointerCasts/inline_func_with_pointer_bitcast_as_argument.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float2_to_float.cl
+++ b/test/PointerCasts/load_cast_float2_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float2_to_float4.cl
+++ b/test/PointerCasts/load_cast_float2_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float2_to_int.cl
+++ b/test/PointerCasts/load_cast_float2_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float2_to_int2.cl
+++ b/test/PointerCasts/load_cast_float2_to_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float3_to_int3.cl
+++ b/test/PointerCasts/load_cast_float3_to_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float3_to_uint3.cl
+++ b/test/PointerCasts/load_cast_float3_to_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float4_to_float.cl
+++ b/test/PointerCasts/load_cast_float4_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float4_to_float2.cl
+++ b/test/PointerCasts/load_cast_float4_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float4_to_int.cl
+++ b/test/PointerCasts/load_cast_float4_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float4_to_int2.cl
+++ b/test/PointerCasts/load_cast_float4_to_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float4_to_int4.cl
+++ b/test/PointerCasts/load_cast_float4_to_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float_to_float2.cl
+++ b/test/PointerCasts/load_cast_float_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float_to_float4.cl
+++ b/test/PointerCasts/load_cast_float_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float_to_int.cl
+++ b/test/PointerCasts/load_cast_float_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float_to_int2.cl
+++ b/test/PointerCasts/load_cast_float_to_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_float_to_int4.cl
+++ b/test/PointerCasts/load_cast_float_to_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_int2_to_float4.cl
+++ b/test/PointerCasts/load_cast_int2_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_int2_to_int4.cl
+++ b/test/PointerCasts/load_cast_int2_to_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_int4_to_float2.cl
+++ b/test/PointerCasts/load_cast_int4_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_int4_to_float4.cl
+++ b/test/PointerCasts/load_cast_int4_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/load_cast_int_to_float4.cl
+++ b/test/PointerCasts/load_cast_int_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float2_to_float.cl
+++ b/test/PointerCasts/store_cast_float2_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float2_to_float4.cl
+++ b/test/PointerCasts/store_cast_float2_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float2_to_int.cl
+++ b/test/PointerCasts/store_cast_float2_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float2_to_int2.cl
+++ b/test/PointerCasts/store_cast_float2_to_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float2_to_int4.cl
+++ b/test/PointerCasts/store_cast_float2_to_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float4_to_float.cl
+++ b/test/PointerCasts/store_cast_float4_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float4_to_float2.cl
+++ b/test/PointerCasts/store_cast_float4_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float4_to_int.cl
+++ b/test/PointerCasts/store_cast_float4_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float_to_float2.cl
+++ b/test/PointerCasts/store_cast_float_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float_to_float4.cl
+++ b/test/PointerCasts/store_cast_float_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_float_to_int.cl
+++ b/test/PointerCasts/store_cast_float_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_int_to_float.cl
+++ b/test/PointerCasts/store_cast_int_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_int_to_float2.cl
+++ b/test/PointerCasts/store_cast_int_to_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/PointerCasts/store_cast_int_to_float4.cl
+++ b/test/PointerCasts/store_cast_int_to_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/LocalInclude.cl
+++ b/test/Preprocessor/LocalInclude.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/SystemInclude.cl
+++ b/test/Preprocessor/SystemInclude.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -I %S/SomeIncludeDirectory %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -I %S/SomeIncludeDirectory %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/TwoSystemIncludes.cl
+++ b/test/Preprocessor/TwoSystemIncludes.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -I %S/SomeIncludeDirectory -I %S/AnotherIncludeDirectory %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -I %S/SomeIncludeDirectory -I %S/AnotherIncludeDirectory %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/UserDefine.cl
+++ b/test/Preprocessor/UserDefine.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -DUSER_SPECIFIED %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -DUSER_SPECIFIED %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/UserDefineValue.cl
+++ b/test/Preprocessor/UserDefineValue.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -DUSER_SPECIFIED=42 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -DUSER_SPECIFIED=42 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/VULKAN.cl
+++ b/test/Preprocessor/VULKAN.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/__FAST_RELAXED_MATH__.cl
+++ b/test/Preprocessor/__FAST_RELAXED_MATH__.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -cl-fast-relaxed-math %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -cl-fast-relaxed-math %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/__OPENCL_C_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_C_VERSION__.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Preprocessor/__OPENCL_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_VERSION__.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/constant.cl
+++ b/test/ProgramScopeConstants/constant.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/constant_array.cl
+++ b/test/ProgramScopeConstants/constant_array.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/constant_array_with_function_call.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -module-constants-in-storage-buffer
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -module-constants-in-storage-buffer
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ProgramScopeConstants/select_between_constant_load.cl
+++ b/test/ProgramScopeConstants/select_between_constant_load.cl
@@ -3,8 +3,6 @@
 // from that pointer.
 // https://github.com/google/clspv/issues/71
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_char.cl
+++ b/test/RelationalBuiltins/all/all_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_char2.cl
+++ b/test/RelationalBuiltins/all/all_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_char3.cl
+++ b/test/RelationalBuiltins/all/all_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_char4.cl
+++ b/test/RelationalBuiltins/all/all_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_int.cl
+++ b/test/RelationalBuiltins/all/all_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_int2.cl
+++ b/test/RelationalBuiltins/all/all_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_int3.cl
+++ b/test/RelationalBuiltins/all/all_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_int4.cl
+++ b/test/RelationalBuiltins/all/all_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_long.cl
+++ b/test/RelationalBuiltins/all/all_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_long2.cl
+++ b/test/RelationalBuiltins/all/all_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_long3.cl
+++ b/test/RelationalBuiltins/all/all_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_long4.cl
+++ b/test/RelationalBuiltins/all/all_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_short.cl
+++ b/test/RelationalBuiltins/all/all_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_short2.cl
+++ b/test/RelationalBuiltins/all/all_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_short3.cl
+++ b/test/RelationalBuiltins/all/all_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/all/all_short4.cl
+++ b/test/RelationalBuiltins/all/all_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_char.cl
+++ b/test/RelationalBuiltins/any/any_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_char2.cl
+++ b/test/RelationalBuiltins/any/any_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_char3.cl
+++ b/test/RelationalBuiltins/any/any_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_char4.cl
+++ b/test/RelationalBuiltins/any/any_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_int.cl
+++ b/test/RelationalBuiltins/any/any_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_int2.cl
+++ b/test/RelationalBuiltins/any/any_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_int3.cl
+++ b/test/RelationalBuiltins/any/any_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_int4.cl
+++ b/test/RelationalBuiltins/any/any_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_long.cl
+++ b/test/RelationalBuiltins/any/any_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_long2.cl
+++ b/test/RelationalBuiltins/any/any_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_long3.cl
+++ b/test/RelationalBuiltins/any/any_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_long4.cl
+++ b/test/RelationalBuiltins/any/any_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_short.cl
+++ b/test/RelationalBuiltins/any/any_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_short2.cl
+++ b/test/RelationalBuiltins/any/any_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_short3.cl
+++ b/test/RelationalBuiltins/any/any_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/any/any_short4.cl
+++ b/test/RelationalBuiltins/any/any_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_char.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_char2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_char3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_char4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_float.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_float2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_float3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_float4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_int.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_int2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_int3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_int4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_long.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_long2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_long3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_long4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_short.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_short2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_short3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_short4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uint.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uint2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uint3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_uint4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort2.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort4.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isequal_float.cl
+++ b/test/RelationalBuiltins/isequal_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isequal_float2.cl
+++ b/test/RelationalBuiltins/isequal_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isequal_float3.cl
+++ b/test/RelationalBuiltins/isequal_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isequal_float4.cl
+++ b/test/RelationalBuiltins/isequal_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreater_float.cl
+++ b/test/RelationalBuiltins/isgreater_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreater_float2.cl
+++ b/test/RelationalBuiltins/isgreater_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreater_float3.cl
+++ b/test/RelationalBuiltins/isgreater_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreater_float4.cl
+++ b/test/RelationalBuiltins/isgreater_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreaterequal_float.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreaterequal_float2.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreaterequal_float3.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isgreaterequal_float4.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isinf_float.cl
+++ b/test/RelationalBuiltins/isinf_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isinf_float2.cl
+++ b/test/RelationalBuiltins/isinf_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isinf_float3.cl
+++ b/test/RelationalBuiltins/isinf_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isinf_float4.cl
+++ b/test/RelationalBuiltins/isinf_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isless_float.cl
+++ b/test/RelationalBuiltins/isless_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isless_float2.cl
+++ b/test/RelationalBuiltins/isless_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isless_float3.cl
+++ b/test/RelationalBuiltins/isless_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isless_float4.cl
+++ b/test/RelationalBuiltins/isless_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/islessequal_float.cl
+++ b/test/RelationalBuiltins/islessequal_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/islessequal_float2.cl
+++ b/test/RelationalBuiltins/islessequal_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/islessequal_float3.cl
+++ b/test/RelationalBuiltins/islessequal_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/islessequal_float4.cl
+++ b/test/RelationalBuiltins/islessequal_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnan_float.cl
+++ b/test/RelationalBuiltins/isnan_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnan_float2.cl
+++ b/test/RelationalBuiltins/isnan_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnan_float3.cl
+++ b/test/RelationalBuiltins/isnan_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnan_float4.cl
+++ b/test/RelationalBuiltins/isnan_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnotequal_float.cl
+++ b/test/RelationalBuiltins/isnotequal_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnotequal_float2.cl
+++ b/test/RelationalBuiltins/isnotequal_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnotequal_float3.cl
+++ b/test/RelationalBuiltins/isnotequal_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/isnotequal_float4.cl
+++ b/test/RelationalBuiltins/isnotequal_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_char2.cl
+++ b/test/RelationalBuiltins/select/select_char2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_char3.cl
+++ b/test/RelationalBuiltins/select/select_char3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_char4.cl
+++ b/test/RelationalBuiltins/select/select_char4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm -int8
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float2_int2.cl
+++ b/test/RelationalBuiltins/select/select_float2_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_float2_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float3_int3.cl
+++ b/test/RelationalBuiltins/select/select_float3_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_float3_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float4_int4.cl
+++ b/test/RelationalBuiltins/select/select_float4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_float4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float_int.cl
+++ b/test/RelationalBuiltins/select/select_float_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_float_uint.cl
+++ b/test/RelationalBuiltins/select/select_float_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int2_int2.cl
+++ b/test/RelationalBuiltins/select/select_int2_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_int2_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int3_int3.cl
+++ b/test/RelationalBuiltins/select/select_int3_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_int3_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int4_int4.cl
+++ b/test/RelationalBuiltins/select/select_int4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_int4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int_int.cl
+++ b/test/RelationalBuiltins/select/select_int_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_int_uint.cl
+++ b/test/RelationalBuiltins/select/select_int_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long2_long2.cl
+++ b/test/RelationalBuiltins/select/select_long2_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long2_ulong2.cl
+++ b/test/RelationalBuiltins/select/select_long2_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long3_long3.cl
+++ b/test/RelationalBuiltins/select/select_long3_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long3_ulong3.cl
+++ b/test/RelationalBuiltins/select/select_long3_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long4_long4.cl
+++ b/test/RelationalBuiltins/select/select_long4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long4_ulong4.cl
+++ b/test/RelationalBuiltins/select/select_long4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long_long.cl
+++ b/test/RelationalBuiltins/select/select_long_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_long_ulong.cl
+++ b/test/RelationalBuiltins/select/select_long_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short2_short2.cl
+++ b/test/RelationalBuiltins/select/select_short2_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short2_ushort2.cl
+++ b/test/RelationalBuiltins/select/select_short2_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short3_short3.cl
+++ b/test/RelationalBuiltins/select/select_short3_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short3_ushort3.cl
+++ b/test/RelationalBuiltins/select/select_short3_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short4_short4.cl
+++ b/test/RelationalBuiltins/select/select_short4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short4_ushort4.cl
+++ b/test/RelationalBuiltins/select/select_short4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short_short.cl
+++ b/test/RelationalBuiltins/select/select_short_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_short_ushort.cl
+++ b/test/RelationalBuiltins/select/select_short_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint2_int2.cl
+++ b/test/RelationalBuiltins/select/select_uint2_int2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint2_uint2.cl
+++ b/test/RelationalBuiltins/select/select_uint2_uint2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint3_int3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_int3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint3_uint3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_uint3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint4_int4.cl
+++ b/test/RelationalBuiltins/select/select_uint4_int4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint4_uint4.cl
+++ b/test/RelationalBuiltins/select/select_uint4_uint4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint_int.cl
+++ b/test/RelationalBuiltins/select/select_uint_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_uint_uint.cl
+++ b/test/RelationalBuiltins/select/select_uint_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong2_long2.cl
+++ b/test/RelationalBuiltins/select/select_ulong2_long2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong2_ulong2.cl
+++ b/test/RelationalBuiltins/select/select_ulong2_ulong2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong3_long3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_long3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong3_ulong3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_ulong3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong4_long4.cl
+++ b/test/RelationalBuiltins/select/select_ulong4_long4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong4_ulong4.cl
+++ b/test/RelationalBuiltins/select/select_ulong4_ulong4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong_long.cl
+++ b/test/RelationalBuiltins/select/select_ulong_long.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ulong_ulong.cl
+++ b/test/RelationalBuiltins/select/select_ulong_ulong.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort2_short2.cl
+++ b/test/RelationalBuiltins/select/select_ushort2_short2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort2_ushort2.cl
+++ b/test/RelationalBuiltins/select/select_ushort2_ushort2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort3_short3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_short3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort3_ushort3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_ushort3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort4_short4.cl
+++ b/test/RelationalBuiltins/select/select_ushort4_short4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort4_ushort4.cl
+++ b/test/RelationalBuiltins/select/select_ushort4_ushort4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort_short.cl
+++ b/test/RelationalBuiltins/select/select_ushort_short.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/select/select_ushort_ushort.cl
+++ b/test/RelationalBuiltins/select/select_ushort_ushort.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/signbit_float.cl
+++ b/test/RelationalBuiltins/signbit_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/signbit_float2.cl
+++ b/test/RelationalBuiltins/signbit_float2.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/signbit_float3.cl
+++ b/test/RelationalBuiltins/signbit_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RelationalBuiltins/signbit_float4.cl
+++ b/test/RelationalBuiltins/signbit_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RemoveUnusedArguments/leverage_dra.cl
+++ b/test/RemoveUnusedArguments/leverage_dra.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RemoveUnusedArguments/multiple_remaining_args.cl
+++ b/test/RemoveUnusedArguments/multiple_remaining_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RemoveUnusedArguments/remove_multiple_args.cl
+++ b/test/RemoveUnusedArguments/remove_multiple_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RemoveUnusedArguments/remove_unused_arg.cl
+++ b/test/RemoveUnusedArguments/remove_unused_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/RemoveUnusedArguments/type_conversion_use.cl
+++ b/test/RemoveUnusedArguments/type_conversion_use.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SamplerMap/KernelScopeSampler.cl
+++ b/test/SamplerMap/KernelScopeSampler.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -samplermap %S/foo.samplermap %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -samplermap %S/foo.samplermap %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SamplerMap/ModuleScopeSampler.cl
+++ b/test/SamplerMap/ModuleScopeSampler.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -samplermap %S/foo.samplermap %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -samplermap %S/foo.samplermap %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SamplerMap/TwoModuleScopeSamplers.cl
+++ b/test/SamplerMap/TwoModuleScopeSamplers.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -samplermap %S/foo.samplermap %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -samplermap %S/foo.samplermap %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Scalarize/constant_struct.cl
+++ b/test/Scalarize/constant_struct.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -hack-phis -inline-entry-points
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-phis -inline-entry-points
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Scalarize/nested_struct.cl
+++ b/test/Scalarize/nested_struct.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -hack-phis
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-phis
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ShareModuleScopeVariables/helps_dra.cl
+++ b/test/ShareModuleScopeVariables/helps_dra.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ShareModuleScopeVariables/no_sharing.cl
+++ b/test/ShareModuleScopeVariables/no_sharing.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ShareModuleScopeVariables/share_local_var.cl
+++ b/test/ShareModuleScopeVariables/share_local_var.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Structs/byval.cl
+++ b/test/Structs/byval.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Structs/extract_value.cl
+++ b/test/Structs/extract_value.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Structs/insert_value.cl
+++ b/test/Structs/insert_value.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Structs/insert_value_issue_14.cl
+++ b/test/Structs/insert_value_issue_14.cl
@@ -21,8 +21,6 @@ kernel void foo(global S* A, global uchar4* B, int n) {
  *A = convert(10);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/Structs/sret.cl
+++ b/test/Structs/sret.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SynchronizationBuiltins/barrier_both.cl
+++ b/test/SynchronizationBuiltins/barrier_both.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SynchronizationBuiltins/barrier_global.cl
+++ b/test/SynchronizationBuiltins/barrier_global.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/SynchronizationBuiltins/barrier_local.cl
+++ b/test/SynchronizationBuiltins/barrier_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/array_stride_32.cl
+++ b/test/UBO/array_stride_32.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/constant_and_image.cl
+++ b/test/UBO/constant_and_image.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/constant_wrapping.cl
+++ b/test/UBO/constant_wrapping.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/copy.cl
+++ b/test/UBO/copy.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/copy_nested.cl
+++ b/test/UBO/copy_nested.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/global_wrapping.cl
+++ b/test/UBO/global_wrapping.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/max_ubo_size.cl
+++ b/test/UBO/max_ubo_size.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map -max-ubo-size=64
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map -max-ubo-size=64
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/nested_padding.cl
+++ b/test/UBO/nested_padding.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/test_cluster_pod_args.cl
+++ b/test/UBO/test_cluster_pod_args.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/transform_padding.cl
+++ b/test/UBO/transform_padding.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/UBO/vec2_no_pad.cl
+++ b/test/UBO/vec2_no_pad.cl
@@ -1,6 +1,3 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/function_call_ssbo.cl
+++ b/test/VariablePointers/function_call_ssbo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/function_call_ssbo_subobject.cl
+++ b/test/VariablePointers/function_call_ssbo_subobject.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/function_call_wg.cl
+++ b/test/VariablePointers/function_call_wg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/null_pointer_ssbo.cl
+++ b/test/VariablePointers/null_pointer_ssbo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/null_pointer_wg.cl
+++ b/test/VariablePointers/null_pointer_wg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/phi_ssbo.cl
+++ b/test/VariablePointers/phi_ssbo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/phi_ssbo_null.cl
+++ b/test/VariablePointers/phi_ssbo_null.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/phi_ssbo_same_buffer.cl
+++ b/test/VariablePointers/phi_ssbo_same_buffer.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/phi_wg.cl
+++ b/test/VariablePointers/phi_wg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/ptr_access_chain_ssbo.cl
+++ b/test/VariablePointers/ptr_access_chain_ssbo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/ptr_access_chain_wg.cl
+++ b/test/VariablePointers/ptr_access_chain_wg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-dra -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-dra -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/select_ssbo.cl
+++ b/test/VariablePointers/select_ssbo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/select_ssbo_null.cl
+++ b/test/VariablePointers/select_ssbo_null.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/select_ssbo_same_buffer.cl
+++ b/test/VariablePointers/select_ssbo_same_buffer.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VariablePointers/select_wg.cl
+++ b/test/VariablePointers/select_wg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VaryingLocalSizes/one_kernel.cl
+++ b/test/VaryingLocalSizes/one_kernel.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VaryingLocalSizes/reqd_work_group_size.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VectorLoadStore/vload_global_float4.cl
+++ b/test/VectorLoadStore/vload_global_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/VectorLoadStore/vstore_global_float4.cl
+++ b/test/VectorLoadStore/vstore_global_float4.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/as_float.cl
+++ b/test/as_float.cl
@@ -1,8 +1,6 @@
 // Test for https://github.com/google/clspv/issues/166
 // Function declarations were missing from builtin header.
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/bool_and.cl
+++ b/test/bool_and.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/bool_or.cl
+++ b/test/bool_or.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/bool_vector_and.cl
+++ b/test/bool_vector_and.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/bool_vector_or.cl
+++ b/test/bool_vector_or.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/bool_xor.cl
+++ b/test/bool_xor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_constant.cl
+++ b/test/char4_constant.cl
@@ -6,8 +6,6 @@ kernel void dup(global uchar4 *B) {
    *B = (uchar4)(1,128,3,4);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_constant_zero.cl
+++ b/test/char4_constant_zero.cl
@@ -6,8 +6,6 @@ kernel void dup(global uchar4 *B) {
    *B = (uchar4)(0,0,0,0);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_insert.cl
+++ b/test/char4_insert.cl
@@ -4,8 +4,6 @@ kernel void foo(global uchar4* A, int n) {
  *A = (uchar4)(1,2,(uchar)n,4);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_insert_from_float.cl
+++ b/test/char4_insert_from_float.cl
@@ -4,8 +4,6 @@ kernel void foo(global char4* A, float f) {
  *A = (char4)(1,2,(char)f,4);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_issue15_a.cl
+++ b/test/char4_issue15_a.cl
@@ -4,8 +4,6 @@
 // In this example, the uint is mentioned before the char4.
 kernel void dup(global uint* A, global char4 *B) {}
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/char4_issue15_b.cl
+++ b/test/char4_issue15_b.cl
@@ -4,8 +4,6 @@
 // In this example, the char4 is mentioned before the uint.
 kernel void dup(global char4* A, global uint *B) {}
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/cluster_pod_args_globals_scalars.cl
+++ b/test/cluster_pod_args_globals_scalars.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/cluster_pod_args_larger_alignment.cl
+++ b/test/cluster_pod_args_larger_alignment.cl
@@ -1,7 +1,5 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/cluster_pod_args_locals_scalars.cl
+++ b/test/cluster_pod_args_locals_scalars.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
+++ b/test/cluster_pod_args_locals_scalars_pod_in_ubo.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -pod-ubo -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -pod-ubo -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/cluster_pod_args_reuse_pod_type.cl
+++ b/test/cluster_pod_args_reuse_pod_type.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/composite_construct.cl
+++ b/test/composite_construct.cl
@@ -1,8 +1,6 @@
 // Test rewriting complete sets of insertions into a struct.
 // The rewrite is done by default.
 
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/composite_construct_array.cl
+++ b/test/composite_construct_array.cl
@@ -1,8 +1,6 @@
 // Test rewriting complete sets of insertions into an array.
 // The rewrite is done by default.
 
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/composite_construct_varying.cl
+++ b/test/composite_construct_varying.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -hack-inserts -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-inserts -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/constant_buffer_arg_static_load_and_store.cl
+++ b/test/constant_buffer_arg_static_load_and_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/explicit_stdin.cl
+++ b/test/explicit_stdin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv - -S -o %t.spvasm < %s
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv - -o %t.spv < %s
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float2_add.cl
+++ b/test/float2_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float2_div.cl
+++ b/test/float2_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float2_mul.cl
+++ b/test/float2_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float2_sub.cl
+++ b/test/float2_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float3_add.cl
+++ b/test/float3_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float3_div.cl
+++ b/test/float3_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float3_frexp_local.cl
+++ b/test/float3_frexp_local.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float3_mul.cl
+++ b/test/float3_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float3_sub.cl
+++ b/test/float3_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float4_add.cl
+++ b/test/float4_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float4_div.cl
+++ b/test/float4_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float4_mul.cl
+++ b/test/float4_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float4_sub.cl
+++ b/test/float4_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_add.cl
+++ b/test/float_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_div.cl
+++ b/test/float_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_equal.cl
+++ b/test/float_equal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_greaterthan.cl
+++ b/test/float_greaterthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_greaterthanequal.cl
+++ b/test/float_greaterthanequal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_lessthan.cl
+++ b/test/float_lessthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_lessthanequal.cl
+++ b/test/float_lessthanequal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_mul.cl
+++ b/test/float_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_notequal.cl
+++ b/test/float_notequal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_sub.cl
+++ b/test/float_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_to_int.cl
+++ b/test/float_to_int.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/float_to_uint.cl
+++ b/test/float_to_uint.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/for.cl
+++ b/test/for.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/function_call.cl
+++ b/test/function_call.cl
@@ -1,7 +1,5 @@
 // We use -O0 here because the compiler is smart enough to realise calling
 // a function that does nothing can be removed.
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_global_id.cl
+++ b/test/get_global_id.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_global_offset.cl
+++ b/test/get_global_offset.cl
@@ -1,7 +1,5 @@
 // We use -O0 here because get_global_offset() always returns 0, and otherwise
 // the compiler is smart enough to optimize everything away!
-// RUN: clspv -O0 %s -S -o %t.spvasm -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_global_size.cl
+++ b/test/get_global_size.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_global_size_hack_initializers.cl
+++ b/test/get_global_size_hack_initializers.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -hack-initializers -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-initializers -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_group_id.cl
+++ b/test/get_group_id.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_local_id.cl
+++ b/test/get_local_id.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_local_size.cl
+++ b/test/get_local_size.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_num_groups.cl
+++ b/test/get_num_groups.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/get_work_dim.cl
+++ b/test/get_work_dim.cl
@@ -1,7 +1,5 @@
 // We use -O0 here because get_work_dim() always returns 3, and otherwise
 // the compiler is smart enough to optimize everything away!
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/global_buffer_arg_dynamic_store.cl
+++ b/test/global_buffer_arg_dynamic_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/global_buffer_arg_static_load_and_store.cl
+++ b/test/global_buffer_arg_static_load_and_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/global_buffer_arg_static_store.cl
+++ b/test/global_buffer_arg_static_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_inserts_constant.cl
+++ b/test/hack_inserts_constant.cl
@@ -2,8 +2,6 @@
 // Check that we can remove partial chains of insertvalue
 // to avoid OpCompositeInsert entirely.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-inserts -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-inserts -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_inserts_undef.cl
+++ b/test/hack_inserts_undef.cl
@@ -2,8 +2,6 @@
 // Check that we can remove partial chains of insertvalue
 // to avoid OpCompositeInsert entirely.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-inserts -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-inserts -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_inserts_varying.cl
+++ b/test/hack_inserts_varying.cl
@@ -2,8 +2,6 @@
 // Check that we can remove partial chains of insertvalue
 // to avoid OpCompositeInsert entirely.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-inserts -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-inserts -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_inserts_zero.cl
+++ b/test/hack_inserts_zero.cl
@@ -2,8 +2,6 @@
 // Check that we can remove partial chains of insertvalue
 // to avoid OpCompositeInsert entirely.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-inserts -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-inserts -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_scf_32bit.cl
+++ b/test/hack_scf_32bit.cl
@@ -1,7 +1,5 @@
 // Test the -hack-scf option.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-scf
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-scf
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_undef.cl
+++ b/test/hack_undef.cl
@@ -2,8 +2,6 @@
 // It's a workaround for https://github.com/google/clspv/issues/95
 // This test no longer is powerful due to zero-initizalization of allocas.
 
-// RUN: clspv %s -S -o %t.spvasm -hack-undef
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-undef
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_undef_composite.cl
+++ b/test/hack_undef_composite.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -hack-undef
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-undef
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/hack_undef_image.cl
+++ b/test/hack_undef_image.cl
@@ -2,8 +2,6 @@
 // We must keep the undef image value.
 // See https://github.com/google/clspv/issues/95
 
-// RUN: clspv %s -S -o %t.spvasm -hack-undef -no-inline-single -keep-unused-arguments
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -hack-undef -no-inline-single -keep-unused-arguments
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/if.cl
+++ b/test/if.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ifelse.cl
+++ b/test/ifelse.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ifelseif.cl
+++ b/test/ifelseif.cl
@@ -1,6 +1,4 @@
 // We use -O0 here to ensure we thoroughly test that our CFG is structured.
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image2d.cl
+++ b/test/image2d.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image2d_read.cl
+++ b/test/image2d_read.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image2d_write.cl
+++ b/test/image2d_write.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image3d.cl
+++ b/test/image3d.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image3d_read.cl
+++ b/test/image3d_read.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/image3d_write.cl
+++ b/test/image3d_write.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_add.cl
+++ b/test/int_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_and.cl
+++ b/test/int_and.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_div.cl
+++ b/test/int_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_equal.cl
+++ b/test/int_equal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_greaterthan.cl
+++ b/test/int_greaterthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_greaterthanequal.cl
+++ b/test/int_greaterthanequal.cl
@@ -1,7 +1,5 @@
 // We use -O0 here otherwise the compiler will optimize greater than equal
 // to a greater than operation!
-// RUN: clspv %s -O0 -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -O0 -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_lessthan.cl
+++ b/test/int_lessthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_lessthanequal.cl
+++ b/test/int_lessthanequal.cl
@@ -1,7 +1,5 @@
 // We use -O0 here otherwise the compiler will optimize less than equal
 // to a less than operation!
-// RUN: clspv %s -O0 -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -O0 -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_mod.cl
+++ b/test/int_mod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_mul.cl
+++ b/test/int_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_not.cl
+++ b/test/int_not.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_notequal.cl
+++ b/test/int_notequal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_or.cl
+++ b/test/int_or.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_shl.cl
+++ b/test/int_shl.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_shr.cl
+++ b/test/int_shr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_sub.cl
+++ b/test/int_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_to_float.cl
+++ b/test/int_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/int_xor.cl
+++ b/test/int_xor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/local_array.cl
+++ b/test/local_array.cl
@@ -1,7 +1,5 @@
 // We have -O0 here because the compiler will optimize away the unused
 // local uint b[5] otherwise.
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/local_buffer_static_load_and_store.cl
+++ b/test/local_buffer_static_load_and_store.cl
@@ -1,6 +1,4 @@
 // We have -O0 here to ensure local uint c is used.
-// RUN: clspv -O0 %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -O0 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/nop.cl
+++ b/test/nop.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/one_constant_buffer_arg.cl
+++ b/test/one_constant_buffer_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/one_global_buffer_arg.cl
+++ b/test/one_global_buffer_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/one_uint_arg.cl
+++ b/test/one_uint_arg.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_int_scalar.cl
+++ b/test/opselect_constants_int_scalar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_int_vector.cl
+++ b/test/opselect_constants_int_vector.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_long_scalar.cl
+++ b/test/opselect_constants_long_scalar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_long_vector.cl
+++ b/test/opselect_constants_long_vector.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_short_scalar.cl
+++ b/test/opselect_constants_short_scalar.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_constants_short_vector.cl
+++ b/test/opselect_constants_short_vector.cl
@@ -1,5 +1,3 @@
-// RUN: clspv  %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opselect_float2.cl
+++ b/test/opselect_float2.cl
@@ -6,8 +6,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* A,
   *A = c ? (float2)(1.0,2.0) : (float2)(3.0,4.0);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/pod_in_ubo.cl
+++ b/test/pod_in_ubo.cl
@@ -1,8 +1,5 @@
 kernel void foo(int k, global int *A, int b) { *A = k + b; }
 
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map -pod-ubo
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: clspv %s -o %t.spv -descriptormap=%t.map -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ptr_function_as_return.cl
+++ b/test/ptr_function_as_return.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ptr_function_in_callee.cl
+++ b/test/ptr_function_in_callee.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: clspv %s -o %t.spv -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -1,6 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args -descriptormap=%t.map
-// RUN: FileCheck %s < %t.spvasm
-// RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/reuse_kernel_arg_var.cl
+++ b/test/reuse_kernel_arg_var.cl
@@ -14,15 +14,11 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
   *T = x;
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %s -S -o %t.spvasm -cluster-pod-kernel-args
-// RUN: FileCheck -check-prefix=CLUSTER %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -cluster-pod-kernel-args
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck -check-prefix=CLUSTER %s < %t2.spvasm

--- a/test/sampler.cl
+++ b/test/sampler.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/short_add.cl
+++ b/test/short_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/stdin.cl
+++ b/test/stdin.cl
@@ -1,5 +1,3 @@
-// RUN: clspv -S -o %t.spvasm < %s
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv -o %t.spv < %s
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/stdout.cl
+++ b/test/stdout.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o - > %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o - > %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/two_global_buffer_args_static_store.cl
+++ b/test/two_global_buffer_args_static_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/two_nop_kernels.cl
+++ b/test/two_nop_kernels.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uchar4_extract_to_float.cl
+++ b/test/uchar4_extract_to_float.cl
@@ -1,8 +1,6 @@
 // Test for https://github.com/google/clspv/issues/55
 // Extraction of char values from a uchar4.
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uchar4_insert_from_float.cl
+++ b/test/uchar4_insert_from_float.cl
@@ -4,8 +4,6 @@ kernel void foo(global uchar4* A, float f) {
  *A = (uchar4)(1,2,(uchar)f,4);
 }
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_add.cl
+++ b/test/uint_add.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_and.cl
+++ b/test/uint_and.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_arg_static_load_store.cl
+++ b/test/uint_arg_static_load_store.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_div.cl
+++ b/test/uint_div.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_equal.cl
+++ b/test/uint_equal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_greaterthan.cl
+++ b/test/uint_greaterthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_greaterthanequal.cl
+++ b/test/uint_greaterthanequal.cl
@@ -1,7 +1,5 @@
 // We use -O0 here otherwise the compiler will optimize greater than equal
 // to a greater than operation!
-// RUN: clspv %s -O0 -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -O0 -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_lessthan.cl
+++ b/test/uint_lessthan.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_lessthanequal.cl
+++ b/test/uint_lessthanequal.cl
@@ -1,7 +1,5 @@
 // We use -O0 here otherwise the compiler will optimize less than equal
 // to a less than operation!
-// RUN: clspv %s -O0 -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -O0 -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_mod.cl
+++ b/test/uint_mod.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_mul.cl
+++ b/test/uint_mul.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_not.cl
+++ b/test/uint_not.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_notequal.cl
+++ b/test/uint_notequal.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_or.cl
+++ b/test/uint_or.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_shl.cl
+++ b/test/uint_shl.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_shr.cl
+++ b/test/uint_shr.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_sub.cl
+++ b/test/uint_sub.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_to_float.cl
+++ b/test/uint_to_float.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/uint_xor.cl
+++ b/test/uint_xor.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/unreferenced_function.cl
+++ b/test/unreferenced_function.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm -no-inline-single
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_extract_element.cl
+++ b/test/vector_extract_element.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_insert_dynamic.cl
+++ b/test/vector_insert_dynamic.cl
@@ -1,8 +1,6 @@
 // Test for https://github.com/google/clspv/issues/143
 // Order of OpVectorInsertDynamic operands was incorrect.
 
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_insert_element.cl
+++ b/test/vector_insert_element.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_shuffle.cl
+++ b/test/vector_shuffle.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_shuffle_float3.cl
+++ b/test/vector_shuffle_float3.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/vector_shuffle_hi_lo.cl
+++ b/test/vector_shuffle_hi_lo.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/widen_switch_condition.cl
+++ b/test/widen_switch_condition.cl
@@ -1,5 +1,3 @@
-// RUN: clspv %s -S -o %t.spvasm
-// RUN: FileCheck %s < %t.spvasm
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/utils/make_test.py
+++ b/utils/make_test.py
@@ -136,8 +136,6 @@ def generate_run_section(args):
     clspv_options = ' '.join(args.clspv_options)
 
     runsec = ''
-    runsec += '// RUN: clspv {} %s -S -o %t.spvasm\n'.format(clspv_options)
-    runsec += '// RUN: FileCheck %s < %t.spvasm\n'
     runsec += '// RUN: clspv {} %s -o %t.spv\n'.format(clspv_options)
     runsec += '// RUN: spirv-dis -o %t2.spvasm %t.spv\n'
     runsec += '// RUN: FileCheck %s < %t2.spvasm\n'


### PR DESCRIPTION
Leave most of the code in place for now but remove the plumbing.

Remove uses in tests and test scripts.

Contributes to #265.

Signed-off-by: Kévin Petit <kpet@free.fr>