### PR TITLE
Always report local arguments in descriptor map

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -843,7 +843,7 @@ bool AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
     for (Argument &Arg : F.args()) {
       Type *argTy = Arg.getType();
       const auto arg_kind = clspv::GetArgKindForType(argTy);
-      if (arg_kind == clspv::ArgKind::Local && !Arg.use_empty()) {
+      if (arg_kind == clspv::ArgKind::Local) {
         // Assign a SpecId to this argument.
         int spec_id = GetSpecId(Arg.getType());
 

--- a/test/unused-local-arg-dmap.cl
+++ b/test/unused-local-arg-dmap.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -descriptormap=%t.map %s -o %t.spv
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// MAP: kernel,test,arg,arg,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+
+kernel void test(local int* arg) {}
+


### PR DESCRIPTION
Applications or runtimes like clvk that rely on the
descriptor map to know about valid kernel argument indices
need all arguments in the descriptor map, even if they're
unused.

Signed-off-by: Kévin Petit <kpet@free.fr>