### PR TITLE
[RFC] Experimental C++ support

### DIFF
--- a/include/clspv/AddressSpace.h
+++ b/include/clspv/AddressSpace.h
@@ -22,6 +22,7 @@ enum Type {
   Global,            // OpenCL global memory.
   Constant,          // OpenCL constant memory.
   Local,             // OpenCL local memory.
+  Generic,           // OpenCL generic.
   Input,             // Vulkan input memory.
   Uniform,           // Vulkan uniform memory.
   UniformConstant,   // Vulkan uniform constant memory.

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -110,6 +110,9 @@ bool KeepUnusedArguments();
 // Returns true if clspv should allow 8-bit integers.
 bool Int8Support();
 
+// Returns true when compiling C++.
+bool CPlusPlus();
+
 } // namespace Option
 } // namespace clspv
 

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -365,4 +365,7 @@ llvm::ModulePass *createUBOTypeTransformPass();
 /// @return An LLVM module pass
 llvm::ModulePass *createRemoveUnusedArgumentsPass();
 
+/// Demangles the name of all kernel functions.
+llvm::ModulePass *createDemangleKernelNamesPass();
+
 } // namespace clspv

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(clspv_passes ${shared_attribute}
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterConstants.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DemangleKernelNames.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DirectResourceAccessPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -383,7 +383,12 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
     instance.getDiagnosticOpts().VerifyPrefixes.push_back("expected");
   }
 
-  clang::LangStandard::Kind standard = clang::LangStandard::lang_opencl12;
+  clang::LangStandard::Kind standard;
+  if (clspv::Option::CPlusPlus()) {
+    standard = clang::LangStandard::lang_openclcpp;
+  } else {
+    standard = clang::LangStandard::lang_opencl12;
+  }
 
   // We are targeting OpenCL 1.2 only
   instance.getLangOpts().OpenCLVersion = 120;
@@ -602,6 +607,10 @@ int PopulatePassManager(
     pm->add(clspv::createInlineFuncWithSingleCallSitePass());
   }
 
+  if (clspv::Option::CPlusPlus()) {
+    pm->add(clspv::createDemangleKernelNamesPass());
+  }
+
   if (0 == pmBuilder.OptLevel) {
     // Mem2Reg pass should be run early because O0 level optimization leaves
     // redundant alloca, load and store instructions from function arguments.
@@ -688,6 +697,12 @@ int ParseOptions(const int argc, const char *const argv[]) {
       !clspv::Option::InlineEntryPoints()) {
     llvm::errs() << "clspv restriction: -constant-args-ubo requires "
                     "-inline-entry-points\n";
+    return -1;
+  }
+
+  if (clspv::Option::CPlusPlus() &&
+      !clspv::Option::InlineEntryPoints()) {
+    llvm::errs() << "cannot use -c++ without -inline-entry-points\n";
     return -1;
   }
 

--- a/lib/DemangleKernelNames.cpp
+++ b/lib/DemangleKernelNames.cpp
@@ -1,0 +1,65 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+#include "clspv/Passes.h"
+
+using namespace llvm;
+
+namespace {
+
+class DemangleKernelNames final : public ModulePass {
+public:
+  static char ID;
+  DemangleKernelNames() : ModulePass(ID) {}
+  bool runOnModule(Module &M) override;
+};
+
+char DemangleKernelNames::ID = 0;
+static RegisterPass<DemangleKernelNames> X("DemangleKernelNames",
+                                             "Demangle the name of kernel functions");
+}
+
+namespace clspv {
+ModulePass *createDemangleKernelNamesPass() { return new DemangleKernelNames(); }
+}
+
+namespace {
+
+bool DemangleKernelNames::runOnModule(Module &M) {
+  bool Changed = false;
+  for (auto &F : M) {
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
+      auto MangledName = F.getName();
+      if (!MangledName.consume_front("_Z")) {
+        continue;
+      }
+      size_t nameLen;
+      if (MangledName.consumeInteger(10, nameLen)) {
+        continue;
+      }
+      auto DemangledName = MangledName.take_front(nameLen);
+      F.setName(DemangledName);
+      Changed = true;
+    }
+  }
+  return Changed;
+}
+
+}

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -147,6 +147,9 @@ llvm::cl::opt<bool> keep_unused_arguments(
 llvm::cl::opt<bool> int8_support("int8", llvm::cl::init(false),
                                  llvm::cl::desc("Allow 8-bit integers"));
 
+static llvm::cl::opt<bool>
+    cplusplus("c++", llvm::cl::init(false),
+                   llvm::cl::desc("Enable experimental C++ support"));
 } // namespace
 
 namespace clspv {
@@ -178,6 +181,7 @@ bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
 bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 bool KeepUnusedArguments() { return keep_unused_arguments; }
 bool Int8Support() { return int8_support; }
+bool CPlusPlus() { return cplusplus; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3411,7 +3411,11 @@ void SPIRVProducerPass::GenerateModuleInfo(Module &module) {
   // Ops[1] = Version (LiteralNum)
   //
   Ops.clear();
-  Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(120);
+  if (clspv::Option::CPlusPlus()) {
+    Ops << MkNum(spv::SourceLanguageOpenCL_CPP) << MkNum(100);
+  } else {
+    Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(120);
+  }
 
   auto *OpenSourceInst = new SPIRVInstruction(spv::OpSource, Ops);
   SPIRVInstList.insert(InsertPoint, OpenSourceInst);

--- a/test/CPlusPlus/kernel-overload.cl
+++ b/test/CPlusPlus/kernel-overload.cl
@@ -1,0 +1,4 @@
+// RUN: clspv -w -c++ -inline-entry-points -verify %s
+
+void kernel test(global int* ptr) {}
+void kernel test(local int* ptr) {} //expected-error{{kernel functions can't be overloaded}}

--- a/test/CPlusPlus/object-and-overload.cl
+++ b/test/CPlusPlus/object-and-overload.cl
@@ -1,0 +1,73 @@
+// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: FileCheck %s < %t.dmap -check-prefix=MAP
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// MAP: kernel,test_objects,arg,gout,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,test_objects,arg,lout,argOrdinal,1,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_runtimearr_uint:[0-9a-zA-Z_]+]] = OpTypeRuntimeArray %[[uint]]
+// CHECK-DAG: %[[_struct_7:[0-9a-zA-Z_]+]] = OpTypeStruct %[[_runtimearr_uint]]
+// CHECK-DAG: %[[_ptr_StorageBuffer__struct_7:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[_struct_7]]
+// CHECK-DAG: %[[_ptr_Workgroup_uint:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[uint]]
+// CHECK-DAG: %[[_ptr_StorageBuffer_uint:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[uint]]
+// CHECK-DAG: %[[__original_id_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[_arr_uint_2:[0-9a-zA-Z_]+]] = OpTypeArray %[[uint]] %[[__original_id_2]]
+// CHECK-DAG: %[[_ptr_Workgroup__arr_uint_2:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[_arr_uint_2]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[uint_46:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 46
+// CHECK-DAG: %[[uint_2:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 2
+// CHECK-DAG: %[[uint_92:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 92
+// CHECK-DAG: %[[uint_25:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 25
+// CHECK-DAG: %[[uint_50:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 50
+// CHECK-DAG: %[[__original_id_27:[0-9]+]] = OpVariable %[[_ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK-DAG: %[[__original_id_1:[0-9]+]] = OpVariable %[[_ptr_Workgroup__arr_uint_2]] Workgroup
+// CHECK:     %[[__original_id_30:[0-9]+]] = OpAccessChain %[[_ptr_Workgroup_uint]] %[[__original_id_1]] %[[uint_0]]
+// CHECK:     %[[__original_id_31:[0-9]+]] = OpAccessChain %[[_ptr_StorageBuffer_uint]] %[[__original_id_27]] %[[uint_0]] %[[uint_0]]
+// CHECK:     OpStore %[[__original_id_31]] %[[uint_0]]
+// CHECK:     %[[__original_id_32:[0-9]+]] = OpAccessChain %[[_ptr_StorageBuffer_uint]] %[[__original_id_27]] %[[uint_0]] %[[uint_1]]
+// CHECK:     OpStore %[[__original_id_32]] %[[uint_46]]
+// CHECK:     %[[__original_id_33:[0-9]+]] = OpAccessChain %[[_ptr_StorageBuffer_uint]] %[[__original_id_27]] %[[uint_0]] %[[uint_2]]
+// CHECK:     OpStore %[[__original_id_33]] %[[uint_92]]
+// CHECK:     OpStore %[[__original_id_30]] %[[uint_25]]
+// CHECK:     %[[__original_id_34:[0-9]+]] = OpAccessChain %[[_ptr_Workgroup_uint]] %[[__original_id_1]] %[[uint_1]]
+// CHECK:     OpStore %[[__original_id_34]] %[[uint_50]]
+
+
+struct s {
+    s() : m_val(0) {}
+    s(int val) : m_val(val) {}
+    int val() const {
+        return m_val;
+    }
+    void dbl() {
+        m_val *= 2;
+    }
+private:
+    int m_val;
+};
+
+void fill(global int* out) {
+    s odef;
+    out[0] = odef.val();
+    s o(46);
+    out[1] = o.val();
+    o.dbl();
+    out[2] = o.val();
+}
+
+void fill(local int* out) {
+    s o(25);
+    out[0] = o.val();
+    o.dbl();
+    out[1] = o.val();
+}
+
+void kernel test_objects(global int* gout, local int* lout) {
+    fill(gout);
+    fill(lout);
+}
+

--- a/test/CPlusPlus/template.cl
+++ b/test/CPlusPlus/template.cl
@@ -1,0 +1,41 @@
+// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: FileCheck %s < %t.dmap -check-prefix=MAP
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// MAP: kernel,test_template,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+
+// CHECK: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK: %[[uint_233:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 233
+// CHECK: OpStore {{.*}} %[[uint_233]]
+
+
+template <int T>
+struct Fibonacci
+{
+    enum { value = (Fibonacci<T - 1>::value + Fibonacci<T - 2>::value) };
+};
+
+template <>
+struct Fibonacci<0>
+{
+    enum { value = 1 };
+};
+
+template <>
+struct Fibonacci<1>
+{
+    enum { value = 1 };
+};
+
+template <>
+struct Fibonacci<2>
+{
+    enum { value = 1 };
+};
+
+void kernel test_template(global int* out) {
+    *out = Fibonacci<13>::value;
+}
+


### PR DESCRIPTION
This change adds experimental support for C++ via Clang's
OpenCL C++ mode.

In that mode Clang uses OpenCL's generic address space for
a number of things so I've added it to
clspv::AddressSpace to align clspv's internal convention
with what Clang does a bit better.

This currently has to be used with -inline-entry-points to
maximise the chances that all traces of generic address
space will have been removed before passes that don't
support it. I have another change that plugs LLVM's address
space inference pass and enables quite a bit more code to be
compiled (and the use of the generic address space generally)
but it requires a couple of minor changes to LLVM.

Kernel function overloads are forbidden in the FrontendPlugin
with a custom diagnostic message. Kernel function names
are demangled before the descriptor map creation and the
absence of overload guarantees name unicity.

Signed-off-by: Kévin Petit <kpet@free.fr>