### PR TITLE
Fix coherent parameter tracing

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6505,7 +6505,7 @@ bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
         return true;
     } else if (auto *arg = dyn_cast<Argument>(v)) {
       // If this is a function argument, trace through its callers.
-      for (auto U : arg->users()) {
+      for (auto U : arg->getParent()->users()) {
         if (auto *call = dyn_cast<CallInst>(U)) {
           stack.push_back(call->getOperand(arg->getArgNo()));
         }

--- a/test/Coherent/coherent_multiple_subfunctions.cl
+++ b/test/Coherent/coherent_multiple_subfunctions.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %s -o %t.spv -no-inline-single -no-dra
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+int baz(global int* x) { return x[0]; }
+
+int bar(global int* x) { return baz(x); }
+
+kernel void foo(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent
+// CHECK: OpDecorate [[param1:%[a-zA-Z0-9_]+]] Coherent
+// CHECK: OpDecorate [[param2:%[a-zA-Z0-9_]+]] Coherent
+// CHECK: [[baz:%[a-zA-Z0-9_]+]] = OpFunction
+// CHECK: [[param1]] = OpFunctionParameter
+// CHECK: = OpFunction
+// CHECK: [[param2]] = OpFunctionParameter
+// CHECK: OpFunctionCall {{.*}} [[baz]] [[param2]]
+


### PR DESCRIPTION
Fixes #332

* Other function args encountered after the initial arg would not
correctly traverse to the caller
  * Added a test