### PR TITLE
Don't require inlining to use UBOs

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -368,4 +368,8 @@ llvm::ModulePass *createRemoveUnusedArgumentsPass();
 /// Demangles the name of all kernel functions.
 llvm::ModulePass *createDemangleKernelNamesPass();
 
+/// Specializes or inlines functions with UBO arguments to satisfy SPIR-V
+/// requirements.
+llvm::ModulePass *createMultiVersionUBOFunctionsPass();
+
 } // namespace clspv

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 add_library(clspv_passes ${shared_attribute}
   ${CMAKE_CURRENT_SOURCE_DIR}/AllocateDescriptorsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphOrderedFunctions.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterConstants.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
@@ -46,6 +47,7 @@ add_library(clspv_passes ${shared_attribute}
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerToFunctionArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/OpenCLInlinerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Option.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SPIRVOp.cpp

--- a/lib/CallGraphOrderedFunctions.cpp
+++ b/lib/CallGraphOrderedFunctions.cpp
@@ -1,0 +1,107 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <set>
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Instructions.h"
+
+#include "CallGraphOrderedFunctions.h"
+
+using namespace llvm;
+
+namespace clspv {
+
+UniqueVector<Function *> CallGraphOrderedFunctions(Module &M) {
+  // Use a topological sort.
+
+  // Make an ordered list of all functions having bodies, with kernel entry
+  // points listed first.
+  UniqueVector<Function *> functions;
+  SmallVector<Function *, 10> entry_points;
+  for (Function &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
+      functions.insert(&F);
+      entry_points.push_back(&F);
+    }
+  }
+  // Add the remaining functions.
+  for (Function &F : M) {
+    if (F.isDeclaration()) {
+      continue;
+    }
+    if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
+      functions.insert(&F);
+    }
+  }
+
+  // This will be a complete set of reveresed edges, i.e. with all pairs
+  // of (callee, caller).
+  using Edge = std::pair<unsigned, unsigned>;
+  auto make_edge = [&functions](Function *callee, Function *caller) {
+    return std::pair<unsigned, unsigned>{functions.idFor(callee),
+                                         functions.idFor(caller)};
+  };
+  std::set<Edge> reverse_edges;
+  // Map each function to the functions it calls, and populate |reverse_edges|.
+  std::map<Function *, SmallVector<Function *, 3>> calls_functions;
+  for (Function *callee : functions) {
+    for (auto &use : callee->uses()) {
+      if (auto *call = dyn_cast<CallInst>(use.getUser())) {
+        Function *caller = call->getParent()->getParent();
+        calls_functions[caller].push_back(callee);
+        reverse_edges.insert(make_edge(callee, caller));
+      }
+    }
+  }
+  // Sort the callees in module-order.  This helps us produce a deterministic
+  // result.
+  for (auto &pair : calls_functions) {
+    auto &callees = pair.second;
+    std::sort(callees.begin(), callees.end(),
+              [&functions](Function *lhs, Function *rhs) {
+                return functions.idFor(lhs) < functions.idFor(rhs);
+              });
+  }
+
+  // Use Kahn's algorithm for topoological sort.
+  UniqueVector<Function *> result;
+  SmallVector<Function *, 10> work_list(entry_points.begin(),
+                                        entry_points.end());
+  while (!work_list.empty()) {
+    Function *caller = work_list.back();
+    work_list.pop_back();
+    result.insert(caller);
+    auto &callees = calls_functions[caller];
+    for (auto *callee : callees) {
+      reverse_edges.erase(make_edge(callee, caller));
+      auto lower_bound = reverse_edges.lower_bound(make_edge(callee, nullptr));
+      if (lower_bound == reverse_edges.end() ||
+          lower_bound->first != functions.idFor(callee)) {
+        // Callee has no other unvisited callers.
+        work_list.push_back(callee);
+      }
+    }
+  }
+  // If reverse_edges is not empty then there was a cycle.  But we don't care
+  // about that erroneous case.
+
+  return result;
+}
+
+} // namespace clspv

--- a/lib/CallGraphOrderedFunctions.h
+++ b/lib/CallGraphOrderedFunctions.h
@@ -1,0 +1,27 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/ADT/UniqueVector.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+
+namespace clspv {
+
+// Return the functions reachable from entry point functions, where
+// callers appear before callees.  OpenCL C does not permit recursion
+// or function or pointers, so this is always well defined.  The ordering
+// should be reproducible from one run to the next.
+llvm::UniqueVector<llvm::Function *> CallGraphOrderedFunctions(llvm::Module &M);
+
+} // namespace clspv

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -1,0 +1,320 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <climits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/UniqueVector.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+#include "clspv/Passes.h"
+
+#include "ArgKind.h"
+#include "CallGraphOrderedFunctions.h"
+#include "Constants.h"
+
+using namespace llvm;
+
+namespace {
+
+class MultiVersionUBOFunctionsPass final : public ModulePass {
+public:
+  static char ID;
+  MultiVersionUBOFunctionsPass() : ModulePass(ID) {}
+  bool runOnModule(Module &M) override;
+
+private:
+  // Struct for tracking specialization information.
+  struct ResourceInfo {
+    // The specific argument.
+    Argument *arg;
+    // The resource var base call.
+    CallInst *base;
+    // Series of GEPs that operate on |base|.
+    std::vector<GetElementPtrInst *> indices;
+  };
+
+  // Analyzes the call, |user|, to |fn| in terms of its UBO arguments. Returns
+  // true if |user| can be transformed into a specialized function.
+  //
+  // Currently, this function is only successful in analyzing GEP chains to a
+  // resource variable.
+  bool AnalyzeCall(Function *fn, CallInst *user,
+                   std::vector<ResourceInfo> *resources);
+
+  // Inlines |call|.
+  void InlineCallSite(CallInst *call);
+
+  // Transforms the call to |fn| into a specialized call based on |resources|.
+  // Replaces |call| with a call to the specialized version.
+  void SpecializeCall(Function *fn, CallInst *call,
+                      const std::vector<ResourceInfo> &resources, size_t id);
+
+  // Adds extra arguments to |fn| by rebuilding the entire function.
+  Function *AddExtraArguments(Function *fn,
+                              const std::vector<Value *> &extra_args);
+};
+
+} // namespace
+
+char MultiVersionUBOFunctionsPass::ID = 0;
+static RegisterPass<MultiVersionUBOFunctionsPass>
+    X("MultiVersionUBOFunctionsPass",
+      "Multi-version functions with UBO params");
+
+namespace clspv {
+ModulePass *createMultiVersionUBOFunctionsPass() {
+  return new MultiVersionUBOFunctionsPass();
+}
+} // namespace clspv
+
+bool MultiVersionUBOFunctionsPass::runOnModule(Module &M) {
+  bool changed = false;
+  UniqueVector<Function *> ordered_functions =
+      clspv::CallGraphOrderedFunctions(M);
+
+  for (auto fn : ordered_functions) {
+    // Kernels don't need modified.
+    if (fn->isDeclaration() || fn->getCallingConv() == CallingConv::SPIR_KERNEL)
+      continue;
+
+    bool local_changed = false;
+    size_t count = 0;
+    for (auto user : fn->users()) {
+      if (auto call = dyn_cast<CallInst>(user)) {
+        std::vector<ResourceInfo> resources;
+        if (AnalyzeCall(fn, call, &resources)) {
+          if (!resources.empty()) {
+            local_changed = true;
+            SpecializeCall(fn, call, resources, count++);
+          }
+        } else {
+          local_changed = true;
+          InlineCallSite(call);
+        }
+      }
+    }
+
+    fn->removeDeadConstantUsers();
+    if (local_changed) {
+      // All calls to this function were either specialized or inlined.
+      fn->eraseFromParent();
+    }
+    changed |= local_changed;
+  }
+
+  return changed;
+}
+
+bool MultiVersionUBOFunctionsPass::AnalyzeCall(
+    Function *fn, CallInst *user, std::vector<ResourceInfo> *resources) {
+  for (auto &arg : fn->args()) {
+    if (clspv::GetArgKindForType(arg.getType()) != clspv::ArgKind::BufferUBO)
+      continue;
+
+    Value *arg_operand = user->getOperand(arg.getArgNo());
+    ResourceInfo info;
+    info.arg = &arg;
+
+    DenseSet<Value *> visited;
+    std::vector<Value *> stack;
+    stack.push_back(arg_operand);
+
+    while (!stack.empty()) {
+      Value *value = stack.back();
+      stack.pop_back();
+
+      if (!visited.insert(value).second)
+        continue;
+
+      if (CallInst *call = dyn_cast<CallInst>(value)) {
+        if (call->getCalledFunction()->getName().startswith(
+                clspv::ResourceAccessorFunction())) {
+          info.base = call;
+        } else {
+          // Unknown function call returning a constant pointer requires
+          // inlining.
+          return false;
+        }
+      } else if (auto gep = dyn_cast<GetElementPtrInst>(value)) {
+        info.indices.push_back(gep);
+        stack.push_back(gep->getOperand(0));
+      } else {
+        // Unhandled instruction requires inlining.
+        return false;
+      }
+    }
+
+    resources->push_back(std::move(info));
+  }
+
+  return true;
+}
+
+void MultiVersionUBOFunctionsPass::InlineCallSite(CallInst *call) {
+  InlineFunctionInfo IFI;
+  CallSite CS(call);
+  InlineFunction(CS, IFI, nullptr, false);
+}
+
+void MultiVersionUBOFunctionsPass::SpecializeCall(
+    Function *fn, CallInst *call, const std::vector<ResourceInfo> &resources,
+    size_t id) {
+
+  // The basis of the specialization is a clone of |fn|, however, the clone may
+  // need rebuilt in order to receive extra arguments.
+  ValueToValueMapTy remapped;
+  auto *clone = CloneFunction(fn, remapped);
+  std::string name;
+  raw_string_ostream str(name);
+  str << fn->getName() << "_clspv_" << id;
+  clone->setName(str.str());
+
+  std::vector<Value *> extra_args;
+  for (auto info : resources) {
+    // Must traverse the GEPs in reverse order to match how the code will be
+    // generated below so that the iterator for the extra arguments is
+    // consistent.
+    for (auto iter = info.indices.rbegin(); iter != info.indices.rend();
+         ++iter) {
+      // Skip pointer operand.
+      auto *idx = *iter;
+      for (size_t i = 1; i < idx->getNumOperands(); ++i) {
+        Value *operand = idx->getOperand(i);
+        if (!isa<Constant>(operand)) {
+          extra_args.push_back(operand);
+        }
+      }
+    }
+  }
+
+  if (!extra_args.empty()) {
+    // Need to add extra arguments to this function.
+    clone = AddExtraArguments(clone, extra_args);
+  }
+
+  auto where = clone->begin()->begin();
+  while (isa<AllocaInst>(where)) {
+    ++where;
+  }
+
+  IRBuilder<> builder(&*where);
+  auto new_arg_iter = clone->arg_begin();
+  for (auto &arg : fn->args()) {
+    ++new_arg_iter;
+  }
+  for (auto info : resources) {
+    // Create the resource var function.
+    SmallVector<Value *, 8> operands;
+    for (size_t i = 0; i < info.base->getNumOperands() - 1; ++i)
+      operands.push_back(info.base->getOperand(i));
+    CallInst *resource_fn =
+        builder.CreateCall(info.base->getCalledFunction(), operands);
+
+    // Create the chain of GEPs. Traversed in reverse order because we added
+    // them from use to def.
+    Value *ptr = resource_fn;
+    for (auto iter = info.indices.rbegin(); iter != info.indices.rend();
+         ++iter) {
+      SmallVector<Value *, 8> indices;
+      for (size_t i = 1; i != (*iter)->getNumOperands(); ++i) {
+        Value *operand = (*iter)->getOperand(i);
+        if (isa<Constant>(operand)) {
+          indices.push_back(operand);
+        } else {
+          // Each extra argument is unique so the iterator is "consumed".
+          indices.push_back(&*new_arg_iter);
+          ++new_arg_iter;
+        }
+      }
+      ptr = builder.CreateGEP(ptr, indices);
+    }
+
+    // Now replace the use of the argument with the result GEP.
+    Value *remapped_arg = remapped.lookup(info.arg);
+    remapped_arg->replaceAllUsesWith(ptr);
+  }
+
+  // Replace the call with a call to the newly specialized function.
+  SmallVector<Value *, 16> new_args;
+  for (size_t i = 0; i < call->getNumOperands() - 1; ++i) {
+    new_args.push_back(call->getOperand(i));
+  }
+  for (auto extra : extra_args) {
+    new_args.push_back(extra);
+  }
+  auto *replacement = CallInst::Create(clone, new_args, "", call);
+  call->replaceAllUsesWith(replacement);
+  call->eraseFromParent();
+}
+
+Function *MultiVersionUBOFunctionsPass::AddExtraArguments(
+    Function *fn, const std::vector<Value *> &extra_args) {
+  // Generate the new function type.
+  SmallVector<Type *, 8> arg_types;
+  for (auto &arg : fn->args()) {
+    arg_types.push_back(arg.getType());
+  }
+  for (auto v : extra_args) {
+    arg_types.push_back(v->getType());
+  }
+  FunctionType *new_type =
+      FunctionType::get(fn->getReturnType(), arg_types, fn->isVarArg());
+
+  // Insert the new function and copy calling conv, attributes and metadata.
+  auto *module = fn->getParent();
+  fn->removeFromParent();
+  auto pair =
+      module->getOrInsertFunction(fn->getName(), new_type, fn->getAttributes());
+  Function *new_function = cast<Function>(pair.getCallee());
+  new_function->setCallingConv(fn->getCallingConv());
+  new_function->copyMetadata(fn, 0);
+
+  // Move the basic blocks into the new function
+  if (!fn->isDeclaration()) {
+    std::vector<BasicBlock *> blocks;
+    for (auto &BB : *fn) {
+      blocks.push_back(&BB);
+    }
+    for (auto *BB : blocks) {
+      BB->removeFromParent();
+      BB->insertInto(new_function);
+    }
+  }
+
+  // Replace arg uses.
+  for (auto old_arg_iter = fn->arg_begin(),
+            new_arg_iter = new_function->arg_begin();
+       old_arg_iter != fn->arg_end(); ++old_arg_iter, ++new_arg_iter) {
+    old_arg_iter->replaceAllUsesWith(&*new_arg_iter);
+  }
+
+  // There are no calls to |fn| yet so we don't need to worry about updating
+  // calls.
+
+  delete fn;
+  return new_function;
+}

--- a/test/UBO/can_dra_but_disabled.cl
+++ b/test/UBO/can_dra_but_disabled.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo -no-dra
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* data) { return data[0]; }
+
+kernel void foo(global int4* out, constant int4* in) {
+  *out = bar(in);
+}
+
+// CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]]
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[foo]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar:%[a-zA-Z0-9_]+]]
+// CHECK: [[bar]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int0]]
+// CHECK: OpLoad {{.*}} [[gep]]

--- a/test/UBO/can_dra_but_disabled_two_kernels.cl
+++ b/test/UBO/can_dra_but_disabled_two_kernels.cl
@@ -1,0 +1,33 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo -no-dra
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* data) { return data[0]; }
+
+kernel void k1(global int4* out, constant int4* in) {
+  *out = bar(in);
+}
+
+kernel void k2(global int4* out, constant int4* in) {
+  *out = bar(in);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: OpEntryPoint GLCompute [[k2:%[a-zA-Z0-9_]+]]
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[k1]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar1:%[a-zA-Z0-9_]+]]
+// CHECK: [[k2]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar2:%[a-zA-Z0-9_]+]]
+// CHECK: [[bar2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int0]]
+// CHECK: OpLoad {{.*}} [[gep]]
+// CHECK: [[bar1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int0]]
+// CHECK: OpLoad {{.*}} [[gep]]
+

--- a/test/UBO/cannot_dra.cl
+++ b/test/UBO/cannot_dra.cl
@@ -1,0 +1,33 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* data) { return data[0]; }
+
+kernel void k1(global int4* out, constant int4* in) {
+  *out = bar(in);
+}
+
+kernel void k2(global int4* out, constant int4* in) {
+  *out = bar(in + 1);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: OpEntryPoint GLCompute [[k2:%[a-zA-Z0-9_]+]]
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK: [[k1]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar1:%[a-zA-Z0-9_]+]]
+// CHECK: [[k2]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar2:%[a-zA-Z0-9_]+]]
+// CHECK: [[bar2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int1]]
+// CHECK: OpLoad {{.*}} [[gep]]
+// CHECK: [[bar1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int0]]
+// CHECK: OpLoad {{.*}} [[gep]]

--- a/test/UBO/extra_arg.cl
+++ b/test/UBO/extra_arg.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* in) { return in[0]; }
+
+kernel void k1(global int4* out, constant int4* in) {
+  constant int4* x = in + in[0].x;
+  *out = bar(x);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK: [[k1]] = OpFunction
+// CHECK: [[ex:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] {{.*}} 0
+// CHECK: OpFunctionCall {{.*}} [[bar:%[a-zA-Z0-9_]+]] [[ex]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[bar]] = OpFunction
+// CHECK-NEXT: [[param:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[int]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[param]]
+// CHECK: OpLoad {{.*}} [[gep]]
+// CHECK: OpFunctionEnd
+// CHECK-NOT: OpFunction

--- a/test/UBO/extra_args.cl
+++ b/test/UBO/extra_args.cl
@@ -1,0 +1,33 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* in1, constant int4* in2) {
+  return in1[0] + in2[0];
+}
+
+kernel void k1(global int4* out, constant int4* in) {
+  constant int4* x = in + in[0].x;
+  constant int4* y = in + in[1].y;
+  *out = bar(x, y);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK: [[k1]] = OpFunction
+// CHECK: [[ex0:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] {{.*}} 0
+// CHECK: [[ex1:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] {{.*}} 1
+// CHECK: OpFunctionCall {{.*}} [[bar:%[a-zA-Z0-9_]+]] [[ex0]] [[ex1]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[bar]] = OpFunction
+// CHECK-NEXT: [[param0:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[int]]
+// CHECK-NEXT: [[param1:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[int]]
+// CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[param0]]
+// CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[param1]]
+// CHECK: OpLoad {{.*}} [[gep0]]
+// CHECK: OpLoad {{.*}} [[gep1]]
+// CHECK: OpFunctionEnd
+// CHECK-NOT: OpFunction

--- a/test/UBO/long_specialization_chain.cl
+++ b/test/UBO/long_specialization_chain.cl
@@ -1,0 +1,68 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 c(constant int4* data) { return data[0]; }
+
+int4 b(constant int4* data) { return c(data); }
+
+int4 a(constant int4* data) { return b(data); }
+
+kernel void k1(global int4* out, constant int4* in) {
+  *out = a(in);
+}
+
+kernel void k2(global int4* out, constant int4* in) {
+  *out = a(in + 1);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: OpEntryPoint GLCompute [[k2:%[a-zA-Z0-9_]+]]
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK: [[k1]] = OpFunction
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[a1:%[a-zA-Z0-9_]+]]
+// CHECK-NEXT: OpStore {{.*}} [[call]]
+// CHECK-NEXT: OpReturn
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[k2]] = OpFunction
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[a2:%[a-zA-Z0-9_]+]]
+// CHECK-NEXT: OpStore {{.*}} [[call]]
+// CHECK-NEXT: OpReturn
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[a2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[b2:%[a-zA-Z0-9_]+]]
+// CHECK: ReturnValue [[call]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[a1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[b1:%[a-zA-Z0-9_]+]]
+// CHECK: ReturnValue [[call]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[b1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[c1:%[a-zA-Z0-9_]+]]
+// CHECK: ReturnValue [[call]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[b2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[call:%[a-zA-Z0-9_]+]] = OpFunctionCall {{.*}} [[c2:%[a-zA-Z0-9_]+]]
+// CHECK: ReturnValue [[call]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[c2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int1]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep]]
+// CHECK: ReturnValue [[ld]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NEXT: [[c1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]] [[int0]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep]]
+// CHECK: ReturnValue [[ld]]
+// CHECK-NEXT: OpFunctionEnd
+// CHECK-NOT: OpFunction

--- a/test/UBO/mixed_inlining.cl
+++ b/test/UBO/mixed_inlining.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+
+// This test is not validated because it uses a selection between Uniform
+// pointers, which is disallowed by SPIR-V.
+int4 bar(constant int4* data) { return data[0]; }
+
+kernel void k1(global int4* out, constant int4* in1, constant int4* in2, int a) {
+  constant int4* x = (a == 0) ? in1 : in2;
+  // This call requires inlining.
+  *out = bar(x);
+}
+
+kernel void k2(global int4* out, constant int4* in) {
+  // This call is specialized.
+  *out = bar(in);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: OpEntryPoint GLCompute [[k2:%[a-zA-Z0-9_]+]]
+// CHECK: [[k1]] = OpFunction
+// CHECK-NOT: OpFunctionCall
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[k2]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar:%[a-zA-Z0-9_]+]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[bar]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain
+// CHECK: OpLoad {{.*}} [[gep]]
+// CHECK: OpFunctionEnd
+// CHECK-NOT: OpFunction
+

--- a/test/UBO/multiple_ubo_args.cl
+++ b/test/UBO/multiple_ubo_args.cl
@@ -1,0 +1,46 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+int4 bar(constant int4* in1, constant int4* in2) {
+  return in1[0] + in2[0];
+}
+
+kernel void k1(global int4* out, constant int4* in1, constant int4* in2) {
+  *out = bar(in1, in2);
+}
+
+kernel void k2(global int4* out, constant int4* in1, constant int4* in2) {
+  *out = bar(in2, in1);
+}
+
+// CHECK: OpEntryPoint GLCompute [[k1:%[a-zA-Z0-9_]+]]
+// CHECK: OpEntryPoint GLCompute [[k2:%[a-zA-Z0-9_]+]]
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[var1:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK: [[var2:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
+// CHECK: [[k1]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar1:%[a-zA-Z0-9_]+]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[k2]] = OpFunction
+// CHECK: OpFunctionCall {{.*}} [[bar2:%[a-zA-Z0-9_]+]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[bar2]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var2]] [[int0]] [[int0]]
+// CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var1]] [[int0]] [[int0]]
+// CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep1]]
+// CHECK: [[ld2:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep2]]
+// CHECK: OpIAdd {{.*}} [[ld2]] [[ld1]]
+// CHECK: OpFunctionEnd
+// CHECK-NEXT: [[bar1]] = OpFunction
+// CHECK-NOT: OpFunctionParameter
+// CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var1]] [[int0]] [[int0]]
+// CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var2]] [[int0]] [[int0]]
+// CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep1]]
+// CHECK: [[ld2:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[gep2]]
+// CHECK: OpIAdd {{.*}} [[ld2]] [[ld1]]
+// CHECK: OpFunctionEnd
+// CHECK-NOT: OpFunction

--- a/test/UBO/needs_inlined.cl
+++ b/test/UBO/needs_inlined.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -constant-args-ubo
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+
+// This test is not validated because it uses a selection between Uniform
+// pointers, which is disallowed by SPIR-V.
+int4 bar(constant int4* data) { return data[0]; }
+
+kernel void k1(global int4* out, constant int4* in1, constant int4* in2, int a) {
+  constant int4* x = (a == 0) ? in1 : in2;
+  *out = bar(x);
+}
+
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect
+// CHECK-NEXT: OpLoad {{.*}} [[sel]]
+// CHECK-NOT: OpFunctionCall
+// CHECK: OpFunctionEnd
+// CHECK-NOT: OpFunction


### PR DESCRIPTION
Fixes #330 

* changes to the type mutation to touch fewer types
* RebuildType just calls MapType with rewrite == false to be clear

Pass to specialize/inline functions with UBOs

SPIR-V does not support passing UBOs by reference. If DRA cannot
determine a singular source of a UBO, the new pass will either
specialize it or inline it. The decision is made on a per call basis.
* Refactored CallGraphOrderedFunctions to de-duplicate it
* added cleanup passes to run after specialization
* Added tests

This removes the requirement to exhaustively inline entry points. It has many opportunities for future improvement by handling more cases that it currently resorts to inlining to solve. Currently it handles chains of GEPs from a resource variable.

Future improvements:
* This pass hits similar targets as DRA. Due to the selective inlining it would be possible to further DRA a module before specializing a call
* Handle more cases than just GEPs
  * e.g. iterator increment in a loop could be transformed into an induction variable passed to the function call and used as a GEP index instead of the GEP being passed
* Each call is specialized individually, it is possible in some scenarios to reduce the number of specializations by sharing them between calls

Worth noting that this doesn't solve the underlying issue of kernels using fundamental variable pointers functionality (e.g. selection between pointers) in UBOs, but it does currently solve the reference passing aspect.