### PR TITLE
Fix shifts in scalar store pointer casts

### DIFF
--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -845,6 +845,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
               Mask = Builder.getInt32(0xFF);
             } else if (NumElement == 2) {
               Mask = Builder.getInt32(0xFFFF);
+            } else if (NumElement == 4) {
+              Mask = Builder.getInt32(0xFFFFFFFF);
             } else {
               llvm_unreachable("strange type on bitcast");
             }
@@ -855,7 +857,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
             for (unsigned i = 0; i < NumElement; i++) {
               Type *TmpTy = Type::getIntNTy(M.getContext(), DstTyBitWidth);
               Value *TmpVal = Builder.CreateBitCast(STVal, TmpTy);
-              TmpVal = Builder.CreateLShr(TmpVal, Builder.getInt32(i));
+              TmpVal = Builder.CreateLShr(TmpVal,
+                                          Builder.getInt32(i * SrcTyBitWidth));
               TmpVal = Builder.CreateAnd(TmpVal, Mask);
               TmpVal = Builder.CreateTrunc(TmpVal, SrcTy);
               STValues.push_back(TmpVal);

--- a/test/PointerCasts/store_cast_char_to_float.cl
+++ b/test/PointerCasts/store_cast_char_to_float.cl
@@ -1,0 +1,39 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void writeToSoaBuffer(__global uchar* soa)
+{
+  const uint index = get_global_id(0);
+  const size_t offset = (sizeof(float) / sizeof(uchar)) * index;
+  __global float* data = (__global float*)(soa + offset);
+  *data = (float)index;
+}
+
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[int8:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 8
+// CHECK: [[int16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
+// CHECK: [[int24:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 24
+// CHECK: [[int1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int0]]
+// CHECK: [[conv0:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[shr]]
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int8]]
+// CHECK: [[conv8:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[shr]]
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int16]]
+// CHECK: [[conv16:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[shr]]
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int24]]
+// CHECK: [[conv24:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[shr]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[idx:%[a-zA-Z0-9_]+]]
+// CHECK: OpStore [[gep]] [[conv0]]
+// CHECK: [[next:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[idx]] [[int1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[next]]
+// CHECK: OpStore [[gep]] [[conv8]]
+// CHECK: [[idx:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[next]] [[int1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[idx]]
+// CHECK: OpStore [[gep]] [[conv16]]
+// CHECK: [[next:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[idx]] [[int1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[next]]
+// CHECK: OpStore [[gep]] [[conv24]]

--- a/test/PointerCasts/store_cast_short_to_float.cl
+++ b/test/PointerCasts/store_cast_short_to_float.cl
@@ -1,0 +1,31 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void writeToSoaBuffer(__global ushort* soa)
+{
+  const uint index = get_global_id(0);
+  const size_t offset = (sizeof(float) / sizeof(ushort)) * index;
+  __global float* data = (__global float*)(soa + offset);
+  *data = (float)index;
+}
+
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
+// CHECK: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[int1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK: [[int65535:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 65535
+// CHECK: [[int16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int0]]
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[shr]] [[int65535]]
+// CHECK: [[conv0:%[a-zA-Z0-9_]+]] = OpUConvert [[short]] [[and]]
+// CHECK: [[shr:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[int]] {{.*}} [[int16]]
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[shr]] [[int65535]]
+// CHECK: [[conv16:%[a-zA-Z0-9_]+]] = OpUConvert [[short]] [[and]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[idx:%[a-zA-Z0-9_]+]]
+// CHECK: OpStore [[gep]] [[conv0]]
+// CHECK: [[next:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[idx]] [[int1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[int0]] [[next]]
+// CHECK: OpStore [[gep]] [[conv16]]
+


### PR DESCRIPTION
Fixes #334

* Shift should be sized by the source bitwidth
* Added tests for char -> float and short -> float