### PR TITLE
Make the Format CI bot do something

### DIFF
--- a/kokoro/check-format/build_continuous.sh
+++ b/kokoro/check-format/build_continuous.sh
@@ -18,18 +18,4 @@ set -e
 # Display commands being run.
 set -x
 
-BUILD_ROOT=$PWD
-SRC=$PWD/github/clspv
-
-# Get clang-format-5.0.0.
-# Once kokoro upgrades the Ubuntu VMs, we can use 'apt-get install clang-format'
-curl -L http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
-tar xf clang-llvm.tar.xz
-export PATH=$PWD/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
-
-cd $SRC
-curl -L http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py -o utils/clang-format-diff.py;
-
-echo $(date): Check formatting...
-./utils/check_code_format.sh $1
-echo $(date): check completed.
+./build.sh FULL

--- a/kokoro/check-format/continuous.cfg
+++ b/kokoro/check-format/continuous.cfg
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # Continuous integration build configuration.
-build_file: "clspv/kokoro/check-format/build.sh"
+build_file: "clspv/kokoro/check-format/build_continuous.sh"
 
 

--- a/utils/check_code_format.sh
+++ b/utils/check_code_format.sh
@@ -18,14 +18,22 @@
 #
 # This script assumes to be invoked at the project root directory.
 
-FILES_TO_CHECK=$(git diff --name-only master | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+if [ "$1" = "FULL" ]; then
+  FILES_TO_CHECK=$(find . | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+else
+  FILES_TO_CHECK=$(git diff --name-only master | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+fi
 
 if [ -z "${FILES_TO_CHECK}" ]; then
   echo "No source code to check for formatting."
   exit 0
 fi
 
-FORMAT_DIFF=$(git diff -U0 master -- ${FILES_TO_CHECK} | python ./utils/clang-format-diff.py -p1 -style=file)
+if [ "$1" = "FULL" ]; then
+  FORMAT_DIFF=$(python ./utils/clang-format-diff.py -p1 -style=file ${FILES_TO_CHECK})
+else
+  FORMAT_DIFF=$(git diff -U0 master -- ${FILES_TO_CHECK} | python ./utils/clang-format-diff.py -p1 -style=file)
+fi
 
 if [ -z "${FORMAT_DIFF}" ]; then
   echo "All source code in PR properly formatted."


### PR DESCRIPTION
* Provide an option to the code formatter to check the whole repo
* Change the CI version to use the new option