### PR TITLE
Add flag to emit LLVM IR after parsing.

### DIFF
--- a/test/emit_ir.cl
+++ b/test/emit_ir.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s --emit-ir=%t.ll
+// RUN: FileCheck %s < %t.ll
+
+void kernel foo(global double *out, int in)
+{
+  *out = in / 2.304;
+}
+
+// CHECK: define spir_kernel void @foo(double addrspace(1)* %out, i32 %in) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+// CHECK: entry:
+// CHECK:   %out.addr = alloca double addrspace(1)*, align 4
+// CHECK:   %in.addr = alloca i32, align 4
+// CHECK:   %1 = load double addrspace(1)*, double addrspace(1)** %out.addr, align 4
+// CHECK:  store double %div, double addrspace(1)* %1, align 8


### PR DESCRIPTION
This adds the flag `--emit-ir` which can be used in conjunction with
`clspv-opt` to develop and debug clspv passes.

The flag emits LLVM IR right after the module has been parsed.  It
seemed the most natural place to dump the IR, because it gives the most
flexibility.  Once the initial IR has been generated, all the passes up
to the problematic one can be applied via `clspv-opt`.