### PR TITLE
Add an option to undefine __IMAGE_SUPPORT__

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -113,6 +113,9 @@ bool Int8Support();
 // Returns true when compiling C++.
 bool CPlusPlus();
 
+// Returns true when images are supported.
+bool ImageSupport();
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -429,7 +429,9 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   instance.getLangOpts().FastRelaxedMath = cl_fast_relaxed_math;
 
   // Preprocessor options
-  instance.getPreprocessorOpts().addMacroDef("__IMAGE_SUPPORT__");
+  if (!clspv::Option::ImageSupport()) {
+    instance.getPreprocessorOpts().addMacroUndef("__IMAGE_SUPPORT__");
+  }
   if (cl_fast_relaxed_math) {
     instance.getPreprocessorOpts().addMacroDef("__FAST_RELAXED_MATH__");
   }

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -153,6 +153,10 @@ llvm::cl::opt<bool> int8_support("int8", llvm::cl::init(true),
 static llvm::cl::opt<bool>
     cplusplus("c++", llvm::cl::init(false),
               llvm::cl::desc("Enable experimental C++ support"));
+
+static llvm::cl::opt<bool>
+    images("images", llvm::cl::init(true),
+           llvm::cl::desc("Enable support for images"));
 } // namespace
 
 namespace clspv {
@@ -185,6 +189,7 @@ bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 bool KeepUnusedArguments() { return keep_unused_arguments; }
 bool Int8Support() { return int8_support; }
 bool CPlusPlus() { return cplusplus; }
+bool ImageSupport() { return images; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -154,9 +154,8 @@ static llvm::cl::opt<bool>
     cplusplus("c++", llvm::cl::init(false),
               llvm::cl::desc("Enable experimental C++ support"));
 
-static llvm::cl::opt<bool>
-    images("images", llvm::cl::init(true),
-           llvm::cl::desc("Enable support for images"));
+static llvm::cl::opt<bool> images("images", llvm::cl::init(true),
+                                  llvm::cl::desc("Enable support for images"));
 } // namespace
 
 namespace clspv {


### PR DESCRIPTION
Clang now defines it by default (was picked up in the update)
and the conformance tests check that this is defined if and only
if the runtime advertises support.

Signed-off-by: Kévin Petit <kpet@free.fr>