### PR TITLE
Normalize constant global variables

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerToFunctionArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NormalizeGlobalVariable.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/OpenCLInlinerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Option.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Passes.cpp

--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -33,6 +33,7 @@
 #include "clspv/Option.h"
 
 #include "ArgKind.h"
+#include "NormalizeGlobalVariable.h"
 #include "Passes.h"
 
 using namespace llvm;
@@ -63,6 +64,8 @@ llvm::ModulePass *createClusterModuleScopeConstantVars() {
 bool ClusterModuleScopeConstantVars::runOnModule(Module &M) {
   bool Changed = false;
   LLVMContext &Context = M.getContext();
+
+  clspv::NormalizeGlobalVariables(M);
 
   SmallVector<GlobalVariable *, 8> global_constants;
   UniqueVector<Constant *> initializers;

--- a/lib/NormalizeGlobalVariable.cpp
+++ b/lib/NormalizeGlobalVariable.cpp
@@ -1,0 +1,220 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "clspv/AddressSpace.h"
+
+#include "NormalizeGlobalVariable.h"
+
+using namespace llvm;
+
+namespace {
+
+// Returns the sole non-array, non-struct type contained in |type|. Returns
+// nullptr if there is no such type.
+Type *SoleContainedType(Type *type) {
+  if (auto *array_ty = dyn_cast<ArrayType>(type)) {
+    return SoleContainedType(array_ty->getSequentialElementType());
+  } else if (auto *struct_ty = dyn_cast<StructType>(type)) {
+    Type *unique_ty = nullptr;
+    for (auto ele_ty : struct_ty->elements()) {
+      if (unique_ty == nullptr) {
+        unique_ty = SoleContainedType(ele_ty);
+        if (!unique_ty)
+          return nullptr;
+      } else if (unique_ty != SoleContainedType(ele_ty)) {
+        return nullptr;
+      }
+    }
+    return unique_ty;
+  }
+
+  return type;
+}
+
+// Returns the number of subtypes in |type|.
+uint64_t GetNumElements(Type *type) {
+  if (type->isStructTy()) {
+    return type->getStructNumElements();
+  } else if (type->isArrayTy()) {
+    return type->getArrayNumElements();
+  } else {
+    return 0;
+  }
+}
+
+// Flattens |constant| into |flattened|. |flattened| is populated with all
+// arrays and structs broken down into constituent constants.
+void FlattenConstant(Constant *constant, std::vector<Constant *> *flattened) {
+  uint64_t num_elements = GetNumElements(constant->getType());
+  for (uint64_t i = 0; i != num_elements; ++i) {
+    auto *const_element = constant->getAggregateElement(i);
+    auto *element_ty = const_element->getType();
+    // Special cases for constant aggregate zero and constant data sequential
+    // to populate the right number of constant elements into |flattened|.
+    if (auto caz = dyn_cast<ConstantAggregateZero>(const_element)) {
+      for (auto i = 0; i != GetNumElements(element_ty); ++i) {
+        if (element_ty->isStructTy()) {
+          flattened->push_back(caz->getStructElement(i));
+        } else {
+          flattened->push_back(caz->getSequentialElement());
+        }
+      }
+    } else if (auto cds = dyn_cast<ConstantDataSequential>(const_element)) {
+      for (uint64_t i = 0; i != GetNumElements(element_ty); ++i) {
+        auto *element = cds->getElementAsConstant(i);
+        flattened->push_back(element);
+      }
+    } else if (element_ty->isArrayTy() || element_ty->isStructTy()) {
+      FlattenConstant(const_element, flattened);
+    } else {
+      flattened->push_back(const_element);
+    }
+  }
+}
+
+// Returns a constant for |new_type| out |elements|. |ele_index| is used to
+// index correctly into the full array of elements.
+Constant *BuildConstant(Type *new_type, const std::vector<Constant *> elements,
+                        uint64_t *ele_index) {
+  auto GetSubType = [](Type *type, uint64_t element) {
+    if (type->isStructTy()) {
+      return type->getContainedType(element);
+    } else if (type->isArrayTy()) {
+      return type->getSequentialElementType();
+    }
+    return type;
+  };
+
+  std::vector<Constant *> constants;
+  uint64_t num_eles = GetNumElements(new_type);
+  for (uint64_t i = 0; i != num_eles; ++i) {
+    auto *subtype = GetSubType(new_type, i);
+    if (subtype->isArrayTy() || subtype->isStructTy()) {
+      constants.push_back(BuildConstant(subtype, elements, ele_index));
+    } else {
+      constants.push_back(elements[*ele_index]);
+      ++(*ele_index);
+    }
+  }
+
+  // Generate the new constant.
+  if (auto struct_ty = dyn_cast<StructType>(new_type)) {
+    return ConstantStruct::get(struct_ty, constants);
+  } else {
+    return ConstantArray::get(cast<ArrayType>(new_type), constants);
+  }
+}
+
+// Returns |init| represented as |new_type|.
+Constant *TranslateConstant(Constant *init, Type *new_type) {
+  assert(init->getType()->isStructTy() || init->getType()->isArrayTy());
+
+  std::vector<Constant *> flattened;
+  FlattenConstant(init, &flattened);
+  uint64_t ele_index = 0;
+  auto *new_constant = BuildConstant(new_type, flattened, &ele_index);
+  return new_constant;
+}
+
+// Returns true if |GV| can be normalized to |to_type|. |gv_contained_ty| is
+// the sole contained type in |GV|.
+bool VariableNeedsNormalized(GlobalVariable *GV, Type *gv_contained_ty,
+                             Type *to_type) {
+  auto gv_pointee = GV->getType()->getPointerElementType();
+  if (!gv_pointee->isStructTy() && !gv_pointee->isArrayTy())
+    return false;
+
+  auto ce_pointee = to_type->getPointerElementType();
+  if (!ce_pointee->isStructTy() && !ce_pointee->isArrayTy())
+    return false;
+
+  const auto &DL = GV->getParent()->getDataLayout();
+  if (DL.getTypeStoreSize(gv_pointee) != DL.getTypeStoreSize(ce_pointee))
+    return false;
+
+  auto *ce_contained_ty = SoleContainedType(ce_pointee);
+  if (gv_contained_ty == ce_contained_ty)
+    return true;
+
+  return false;
+}
+
+// Normalize the user |user| of |GV|. Generates a global variable with
+// appropriate initializer and replaces uses of |user| with the new variable.
+GlobalVariable *NormalizeVariable(GlobalVariable *GV, Value *user) {
+  auto *new_type = user->getType()->getPointerElementType();
+  Constant *new_initializer = nullptr;
+  if (GV->hasInitializer()) {
+    auto *initializer = GV->getInitializer();
+    new_initializer = TranslateConstant(initializer, new_type);
+  }
+
+  GlobalVariable *new_gv = new GlobalVariable(
+      *GV->getParent(), new_type, GV->isConstant(), GV->getLinkage(),
+      new_initializer, "", nullptr, GV->getThreadLocalMode(),
+      GV->getType()->getPointerAddressSpace(), GV->isExternallyInitialized());
+  new_gv->takeName(GV);
+  user->replaceAllUsesWith(new_gv);
+
+  return new_gv;
+}
+
+// Normalize the users of |GV|.
+void NormalizeVariableUsers(GlobalVariable *GV) {
+  for (auto *user : GV->users()) {
+    auto *bitcast = dyn_cast<ConstantExpr>(user);
+    if (!bitcast || bitcast->getOpcode() != Instruction::BitCast)
+      continue;
+
+    Type *gv_contained_ty =
+        SoleContainedType(GV->getType()->getPointerElementType());
+    if (!gv_contained_ty)
+      continue;
+
+    if (!VariableNeedsNormalized(GV, gv_contained_ty, bitcast->getType()))
+      continue;
+
+    NormalizeVariable(GV, bitcast);
+  }
+
+  GV->removeDeadConstantUsers();
+  if (GV->use_empty()) {
+    GV->eraseFromParent();
+  }
+}
+
+} // namespace
+
+namespace clspv {
+
+void NormalizeGlobalVariables(Module &M) {
+  SmallVector<GlobalVariable *, 8> globals;
+  for (auto &GV : M.globals()) {
+    if (GV.hasInitializer() && GV.getType()->getPointerAddressSpace() ==
+                                   clspv::AddressSpace::Constant) {
+      globals.push_back(&GV);
+    }
+  }
+
+  for (auto *GV : globals) {
+    NormalizeVariableUsers(GV);
+  }
+}
+} // namespace clspv

--- a/lib/NormalizeGlobalVariable.h
+++ b/lib/NormalizeGlobalVariable.h
@@ -22,4 +22,4 @@ namespace clspv {
 // Rewrites variable intializers.
 void NormalizeGlobalVariables(llvm::Module &M);
 
-}
+} // namespace clspv

--- a/lib/NormalizeGlobalVariable.h
+++ b/lib/NormalizeGlobalVariable.h
@@ -1,0 +1,25 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/GlobalVariable.h"
+
+namespace clspv {
+
+// Normalize global variables to remove constant expression bitcasts of the
+// entire variable. Only considers constant address space variables. Introduces
+// a new global variable for each case of type casting to remove the cast.
+// Rewrites variable intializers.
+void NormalizeGlobalVariables(llvm::Module &M);
+
+}

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -53,6 +53,7 @@
 #include "ConstantEmitter.h"
 #include "Constants.h"
 #include "DescriptorCounter.h"
+#include "NormalizeGlobalVariable.h"
 #include "Passes.h"
 
 #if defined(_MSC_VER)
@@ -877,6 +878,8 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M, const DataLayout &DL) {
 }
 
 void SPIRVProducerPass::FindGlobalConstVars(Module &M, const DataLayout &DL) {
+  clspv::NormalizeGlobalVariables(M);
+
   SmallVector<GlobalVariable *, 8> GVList;
   SmallVector<GlobalVariable *, 8> DeadGVList;
   for (GlobalVariable &GV : M.globals()) {

--- a/test/NormalizeGlobalVariables/cluster_constants.ll
+++ b/test/NormalizeGlobalVariables/cluster_constants.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt %s -o %t -ClusterModuleScopeConstantVars
+; RUN: FileCheck %s < %t
+
+; Checks are split up due to problems with parsing regexs in FileCheck.
+; CHECK: [[global:@[a-zA-Z0-9_.]+]] = internal addrspace(2) constant { [4 x [17 x i32]] }
+; CHECK-SAME: [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+; CHECK-SAME: [17 x i32] [i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [17 x i32] zeroinitializer
+; CHECK-SAME: [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1]
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = getelementptr inbounds { [4 x [17 x i32]] }, { [4 x [17 x i32]] } addrspace(2)* [[global]], i32 0, i32 0
+; CHECK: getelementptr inbounds [4 x [17 x i32]], [4 x [17 x i32]] addrspace(2)* [[gep]], i32 0, i32 0, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@data = addrspace(2) constant <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> <{ <{ [9 x i32], [8 x i32] }> <{ [9 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [8 x i32] zeroinitializer }>, [17 x i32] [i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [17 x i32] zeroinitializer, [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1] }>, align 4
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @foo(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %gep = getelementptr inbounds [4 x [17 x i32]], [4 x [17 x i32]] addrspace(2)* bitcast (<{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> addrspace(2)* @data to [4 x [17 x i32]] addrspace(2)*), i32 0, i32 0, i32 0
+  ret void
+}
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.0 (https://github.com/llvm-mirror/clang 7c21fe2c07d1df4480ddf35a03d218e0f5b4af3d) (https://github.com/llvm-mirror/llvm 26882c9d258b62748a7266207513a06990c8decc)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"int*", !"int*"}
+!6 = !{!"", !""}
+

--- a/test/NormalizeGlobalVariables/constant_bitcast.cl
+++ b/test/NormalizeGlobalVariables/constant_bitcast.cl
@@ -1,0 +1,32 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+#define X 4 //33
+#define Y 17 //33
+
+__constant int data[X][Y] = {
+    {1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,},
+    {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,},
+    };
+
+kernel void foo(global int* in, global int* out, int x, int y) {
+  *out = *in + data[x][y];
+}
+
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 4
+// CHECK-DAG: [[int17:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 17
+// CHECK-DAG: [[int1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[array17:%[a-zA-Z0-9_]+]] = OpTypeArray [[int]] [[int17]]
+// CHECK-DAG: [[array4:%[a-zA-Z0-9_]+]] = OpTypeArray [[array17]] [[int4]]
+// CHECK: [[c0:%[a-zA-Z0-9_]+]] = OpConstantComposite [[array17]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]]
+// CHECK: [[c1:%[a-zA-Z0-9_]+]] = OpConstantComposite [[array17]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int0]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]]
+// CHECK: [[c2:%[a-zA-Z0-9_]+]] = OpConstantNull [[array17]]
+// CHECK: [[c3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[array17]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]] [[int1]]
+// CHECK: [[c:%[a-zA-Z0-9_]+]] = OpConstantComposite [[array4]]
+// CHECK: OpVariable {{.*}} Private [[c]]

--- a/test/NormalizeGlobalVariables/different_geometry.ll
+++ b/test/NormalizeGlobalVariables/different_geometry.ll
@@ -1,0 +1,54 @@
+; RUN: clspv-opt %s -o %t -ClusterModuleScopeConstantVars
+; RUN: FileCheck %s < %t
+
+; Checks are split up due to problems with parsing regexs in FileCheck.
+; CHECK: [[global:@[a-zA-Z0-9_.]+]] = internal addrspace(2) constant { [17 x [4 x i32]] }
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 0, i32 0, i32 0]
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] [i32 0, i32 0, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 0, i32 0]
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] zeroinitializer
+; CHECK-SAME: [4 x i32] [i32 0, i32 0, i32 0, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK-SAME: [4 x i32] [i32 1, i32 1, i32 1, i32 1]
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = getelementptr inbounds { [17 x [4 x i32]] }, { [17 x [4 x i32]] } addrspace(2)* [[global]], i32 0, i32 0
+; CHECK: getelementptr inbounds [17 x [4 x i32]], [17 x [4 x i32]] addrspace(2)* [[gep]], i32 0, i32 0, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@data = addrspace(2) constant <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> <{ <{ [9 x i32], [8 x i32] }> <{ [9 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [8 x i32] zeroinitializer }>, [17 x i32] [i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [17 x i32] zeroinitializer, [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1] }>, align 4
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @foo(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %gep = getelementptr inbounds [17 x [4 x i32]], [17 x [4 x i32]] addrspace(2)* bitcast (<{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> addrspace(2)* @data to [17 x [4 x i32]] addrspace(2)*), i32 0, i32 0, i32 0
+  ret void
+}
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.0 (https://github.com/llvm-mirror/clang 7c21fe2c07d1df4480ddf35a03d218e0f5b4af3d) (https://github.com/llvm-mirror/llvm 26882c9d258b62748a7266207513a06990c8decc)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"int*", !"int*"}
+!6 = !{!"", !""}
+
+

--- a/test/NormalizeGlobalVariables/mismatched_depths.ll
+++ b/test/NormalizeGlobalVariables/mismatched_depths.ll
@@ -1,0 +1,38 @@
+; RUN: clspv-opt %s -o %t -ClusterModuleScopeConstantVars
+; RUN: FileCheck %s < %t
+
+; Checks are split up due to problems with parsing regexs in FileCheck.
+; CHECK: [[global:@[a-zA-Z0-9_.]+]] = internal addrspace(2) constant { [1 x [1 x [17 x i32]]] }
+; CHECK-SAME: [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = getelementptr inbounds { [1 x [1 x [17 x i32]]] }, { [1 x [1 x [17 x i32]]] } addrspace(2)* [[global]], i32 0, i32 0
+; CHECK: getelementptr inbounds [1 x [1 x [17 x i32]]], [1 x [1 x [17 x i32]]] addrspace(2)* [[gep]], i32 0, i32 0, i32 0, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@data = addrspace(2) constant <{ <{ [9 x i32], [8 x i32] }> }> <{ <{ [9 x i32], [8 x i32] }> <{ [9 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [8 x i32] zeroinitializer }> }>, align 4
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @foo(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %gep = getelementptr inbounds [1 x [1 x [17 x i32]]], [1 x [1 x [17 x i32]]] addrspace(2)* bitcast (<{ <{ [9 x i32], [8 x i32] }> }> addrspace(2)* @data to [1 x [1 x [17 x i32]]] addrspace(2)*), i32 0, i32 0, i32 0, i32 0
+  ret void
+}
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.0 (https://github.com/llvm-mirror/clang 7c21fe2c07d1df4480ddf35a03d218e0f5b4af3d) (https://github.com/llvm-mirror/llvm 26882c9d258b62748a7266207513a06990c8decc)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"int*", !"int*"}
+!6 = !{!"", !""}
+
+

--- a/test/NormalizeGlobalVariables/multiple_uses.ll
+++ b/test/NormalizeGlobalVariables/multiple_uses.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt %s -o %t -ClusterModuleScopeConstantVars
+; RUN: FileCheck %s < %t
+
+; Cluster the original variable and the rewritten version.
+; CHECK: [[global:@[a-zA-Z0-9_.]+]] = internal addrspace(2) constant { <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, [4 x [17 x i32]] }
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = getelementptr inbounds { <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, [4 x [17 x i32]] }, { <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, [4 x [17 x i32]] } addrspace(2)* [[global]], i32 0, i32 1
+; CHECK: getelementptr inbounds [4 x [17 x i32]], [4 x [17 x i32]] addrspace(2)* [[gep]], i32 0, i32 0, i32 0
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = getelementptr inbounds { <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, [4 x [17 x i32]] }, { <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, [4 x [17 x i32]] } addrspace(2)* [[global]], i32 0, i32 0
+; CHECK: getelementptr inbounds <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> addrspace(2)* [[gep]], i32 0, i32 0, i32 0, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@data = addrspace(2) constant <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> <{ <{ [9 x i32], [8 x i32] }> <{ [9 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [8 x i32] zeroinitializer }>, [17 x i32] [i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], [17 x i32] zeroinitializer, [17 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1] }>, align 4
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @foo(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %gep1 = getelementptr inbounds [4 x [17 x i32]], [4 x [17 x i32]] addrspace(2)* bitcast (<{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> addrspace(2)* @data to [4 x [17 x i32]] addrspace(2)*), i32 0, i32 0, i32 0
+  %gep2 = getelementptr inbounds <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }>, <{ <{ [9 x i32], [8 x i32] }>, [17 x i32], [17 x i32], [17 x i32] }> addrspace(2)* @data, i32 0, i32 0, i32 0, i32 0
+  ret void
+}
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 9.0.0 (https://github.com/llvm-mirror/clang 7c21fe2c07d1df4480ddf35a03d218e0f5b4af3d) (https://github.com/llvm-mirror/llvm 26882c9d258b62748a7266207513a06990c8decc)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"int*", !"int*"}
+!6 = !{!"", !""}
+
+


### PR DESCRIPTION
Addresses some failures in customer kernels due to the way clang
codegen's constant aggregates.

* New utility to normalize constant global variables
  * called in cluster constants and spirv producer
  * rewrites global constants with constant bitcast users that are just
  simple reinterpret casts
  * added several tests