### PR TITLE
[C++] Replace generic address space before SPIR-V production

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm-mirror/llvm",
       "branch" : "master",
       "subdir" : "third_party/llvm",
-      "commit" : "26882c9d258b62748a7266207513a06990c8decc"
+      "commit" : "86b49e2b741eec98bc7afc6e075ace823e616f50"
     },
     {
       "name" : "clang",
@@ -14,7 +14,7 @@
       "subrepo" : "llvm-mirror/clang",
       "branch" : "master",
       "subdir" : "third_party/clang",
-      "commit" : "7c21fe2c07d1df4480ddf35a03d218e0f5b4af3d"
+      "commit" : "151e674ab9981c986990e45c8a0a97815cac2021"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
+#include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
 #include "clspv/Option.h"
 #include "clspv/Passes.h"
@@ -617,6 +618,7 @@ int PopulatePassManager(
 
   if (clspv::Option::CPlusPlus()) {
     pm->add(clspv::createDemangleKernelNamesPass());
+    pm->add(llvm::createInferAddressSpacesPass(clspv::AddressSpace::Generic));
   }
 
   if (0 == pmBuilder.OptLevel) {

--- a/test/CPlusPlus/generic-addrspace.cl
+++ b/test/CPlusPlus/generic-addrspace.cl
@@ -1,0 +1,39 @@
+// RUN: clspv -c++ -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[_runtimearr_uint:[0-9a-zA-Z_]+]] = OpTypeRuntimeArray %[[uint]]
+// CHECK-DAG: %[[_struct_7:[0-9a-zA-Z_]+]] = OpTypeStruct %[[_runtimearr_uint]]
+// CHECK-DAG: %[[_ptr_StorageBuffer__struct_7:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[_struct_7]]
+// CHECK-DAG: %[[_ptr_Workgroup_uint:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[uint]]
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[__original_id_11:[0-9]+]] = OpTypeFunction %[[void]]
+// CHECK-DAG: %[[_ptr_StorageBuffer_uint:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[uint]]
+// CHECK-DAG: %[[__original_id_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[_arr_uint_2:[0-9a-zA-Z_]+]] = OpTypeArray %[[uint]] %[[__original_id_2]]
+// CHECK-DAG: %[[_ptr_Workgroup__arr_uint_2:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[_arr_uint_2]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[__original_id_22:[0-9]+]] = OpVariable %[[_ptr_StorageBuffer__struct_7]] StorageBuffer
+// CHECK-DAG: %[[__original_id_1:[0-9]+]] = OpVariable %[[_ptr_Workgroup__arr_uint_2]] Workgroup
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpFunction %[[void]] None %[[__original_id_11]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLabel
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpAccessChain %[[_ptr_Workgroup_uint]] %[[__original_id_1]] %[[uint_0]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpAccessChain %[[_ptr_StorageBuffer_uint]] %[[__original_id_22]] %[[uint_0]] %[[uint_0]]
+// CHECK:     OpStore %[[__original_id_26]] %[[uint_42]]
+// CHECK:     OpStore %[[__original_id_25]] %[[uint_42]]
+// CHECK:     OpReturn
+// CHECK:     OpFunctionEnd
+
+
+void fill(int* out) {
+    *out = 42;
+}
+
+void kernel test(global int* gout, local int* lout) {
+    fill(gout);
+    fill(lout);
+}
+

--- a/test/CPlusPlus/issue-357.cl
+++ b/test/CPlusPlus/issue-357.cl
@@ -1,0 +1,152 @@
+// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.map %s -o %t.spv
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: FileCheck %s -check-prefix=MAP < %t.map
+
+// MAP: kernel,testCopyInstance1,arg,src,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testCopyInstance2,arg,dst,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod1,arg,instances,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod2,arg,instances,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod3,arg,instances,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod3,arg,dst,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod4,arg,instances,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testGlobalInstanceMethod4,arg,dst,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer
+// MAP: kernel,testLocalInstanceMethod1,arg,dst,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testLocalInstanceMethod2,arg,dst,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testLocalInstance3,arg,dst,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,testLocalInstance4,arg,dst,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+
+class InstanceTest
+{
+ public:
+  void init()
+  {
+    data1_ = 0;
+    data2_ = 0;
+    data3_ = 0;
+  }
+
+  uint getValue() const
+  {
+    return data2_;
+  }
+
+  void setValue(const uint value)
+  {
+    data2_ = value;
+  }
+
+  uint data1_;
+  uint data2_;
+  uint data3_;
+};
+
+// Copy a global instance to local
+__kernel void testCopyInstance1(const __global InstanceTest* src)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    instances[index] = src[index];
+  }
+}
+
+// Copy a local instance to global
+__kernel void testCopyInstance2(__global InstanceTest* dst)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    dst[index] = instances[index];
+  }
+}
+
+// Call a member function of global instance
+__kernel void testGlobalInstanceMethod1(__global InstanceTest* instances)
+{
+  const size_t index = get_global_id(0);
+
+  __global InstanceTest* instance = instances + index;
+  instance->init();
+  instance->setValue(10u);
+}
+
+// Call a member function of global instance
+__kernel void testGlobalInstanceMethod2(__global InstanceTest* instances)
+{
+  const size_t index = get_global_id(0);
+
+  instances[index].init();
+  instances[index].setValue(10u);
+}
+
+// Get a value from global instance
+__kernel void testGlobalInstanceMethod3(const __global InstanceTest* instances,
+    __global uint* dst)
+{
+  const size_t index = get_global_id(0);
+
+  const __global InstanceTest* instance = instances + index;
+  dst[index] = instance->getValue();
+}
+
+// Get a value from global instance
+__kernel void testGlobalInstanceMethod4(const __global InstanceTest* instances,
+    __global uint* dst)
+{
+  const size_t index = get_global_id(0);
+
+  dst[index] = instances[index].getValue();
+}
+
+// Call a member function of local instance
+__kernel void testLocalInstanceMethod1(__global InstanceTest* dst)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    __local InstanceTest* instance = instances + index;
+    instance->init();
+    instance->setValue(10u);
+    dst[index] = *instance;
+  }
+}
+
+// Call a member function of local instance
+__kernel void testLocalInstanceMethod2(__global InstanceTest* dst)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    instances[index].init();
+    instances[index].setValue(10u);
+    dst[index] = instances[index];
+  }
+}
+
+// Get a value from local instance
+__kernel void testLocalInstance3(__global uint* dst)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    const __local InstanceTest* instance = instances + index;
+    dst[index] = instance->getValue();
+  }
+}
+
+// Get a value from local instance
+__kernel void testLocalInstance4(__global uint* dst)
+{
+  __local InstanceTest instances[16];
+
+  const size_t index = get_global_id(0);
+  if (index < 16) {
+    dst[index] = instances[index].getValue();
+  }
+}
+


### PR DESCRIPTION
This enables support for the generic address space in all
cases where the final address space can be inferred before
the SPIR-V production.

This should provide a step change in the amount of C++ code
that can be compiled.

Nota: both the Clang and LLVM updates are required to make
this work.

Fixes #357.

Signed-off-by: Kévin Petit <kpet@free.fr>