### PR TITLE
Fix #361 - Initialize clspv passes into the registry.

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -935,6 +935,7 @@ int CompileFromSourceString(
   llvm::PassRegistry &Registry = *llvm::PassRegistry::getPassRegistry();
   llvm::initializeCore(Registry);
   llvm::initializeScalarOpts(Registry);
+  llvm::initializeClspvPasses(Registry);
 
   std::unique_ptr<llvm::Module> module(action.takeModule());
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -809,6 +809,7 @@ int Compile(const int argc, const char *const argv[]) {
   llvm::PassRegistry &Registry = *llvm::PassRegistry::getPassRegistry();
   llvm::initializeCore(Registry);
   llvm::initializeScalarOpts(Registry);
+  llvm::initializeClspvPasses(Registry);
 
   std::unique_ptr<llvm::Module> module(action.takeModule());
 

--- a/test/print-all.cl
+++ b/test/print-all.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -cluster-pod-kernel-args -o %t-before.spv -print-before-all 2> %t-before.txt
+// RUN: FileCheck -check-prefix=BEFORE %s < %t-before.txt
+// RUN: clspv %s -cluster-pod-kernel-args -o %t-after.spv -print-after-all 2> %t-after.txt
+// RUN: FileCheck -check-prefix=AFTER %s < %t-after.txt
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, uint b)
+{
+  for (uint i = 0; i < b; i++)
+  {
+    a[i]++;
+  }
+}
+
+// BEFORE: *** IR Dump Before Cluster POD Kernel Arguments Pass ***
+
+// AFTER: *** IR Dump After Cluster POD Kernel Arguments Pass ***

--- a/tools/clspv-opt/main.cpp
+++ b/tools/clspv-opt/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   llvm::initializeCore(registry);
   llvm::initializeScalarOpts(registry);
 
-  // clspv passes
+  // Initialize clspv passes.
   llvm::initializeClspvPasses(registry);
 
   llvm::cl::ParseCommandLineOptions(argc, argv,


### PR DESCRIPTION
Passes were not registering their print-after/print-before flags.  This calls the pass initializer and adds a test for a clspv pass.