### PR TITLE
Use InsertSPIRVOp to create calls to barrier SPIR-V intrinsics

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -924,14 +924,14 @@ bool AllocateDescriptorsPass::CallTreeContainsGlobalBarrier(Function *F) {
         // and StorageBuffer storage classes) semantics are checked because
         // Workgroup variables are inherently coherent (and do not require the
         // decoration).
-        if (call->getCalledFunction()->getName().startswith("spirv.op.224")) {
+        if (call->getCalledFunction()->getName().startswith("spirv.op.224.")) {
           // barrier()
           if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(3))) {
             uses_barrier =
                 semantics->getZExtValue() & kMemorySemanticsUniformMemory;
           }
         } else if (call->getCalledFunction()->getName().startswith(
-                       "spirv.op.225")) {
+                       "spirv.op.225.")) {
           // mem_fence()
           if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(2))) {
             uses_barrier =

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -924,17 +924,16 @@ bool AllocateDescriptorsPass::CallTreeContainsGlobalBarrier(Function *F) {
         // and StorageBuffer storage classes) semantics are checked because
         // Workgroup variables are inherently coherent (and do not require the
         // decoration).
-        if (call->getCalledFunction()->getName().equals(
-                "__spirv_control_barrier")) {
+        if (call->getCalledFunction()->getName().startswith("spirv.op.224")) {
           // barrier()
-          if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(2))) {
+          if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(3))) {
             uses_barrier =
                 semantics->getZExtValue() & kMemorySemanticsUniformMemory;
           }
-        } else if (call->getCalledFunction()->getName().equals(
-                       "__spirv_memory_barrier")) {
+        } else if (call->getCalledFunction()->getName().startswith(
+                       "spirv.op.225")) {
           // mem_fence()
-          if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(1))) {
+          if (auto *semantics = dyn_cast<ConstantInt>(call->getOperand(2))) {
             uses_barrier =
                 semantics->getZExtValue() & kMemorySemanticsUniformMemory;
           }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -545,107 +545,69 @@ bool ReplaceOpenCLBuiltinPass::replaceLog10(Module &M) {
 }
 
 bool ReplaceOpenCLBuiltinPass::replaceBarrier(Module &M) {
-  bool Changed = false;
 
   enum { CLK_LOCAL_MEM_FENCE = 0x01, CLK_GLOBAL_MEM_FENCE = 0x02 };
 
-  const std::map<const char *, const char *> Map = {
-      {"_Z7barrierj", "__spirv_control_barrier"}};
+  const std::vector<const char *> Names = {
+      {"_Z7barrierj"},
+  };
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+    auto Arg = CI->getOperand(0);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto FType = F->getFunctionType();
-          SmallVector<Type *, 3> Params;
-          for (unsigned i = 0; i < 3; i++) {
-            Params.push_back(FType->getParamType(0));
-          }
-          auto NewFType =
-              FunctionType::get(FType->getReturnType(), Params, false);
-          auto NewF = M.getOrInsertFunction(Pair.second, NewFType);
-          cast<Function>(NewF.getCallee())->setCannotDuplicate();
+    // We need to map the OpenCL constants to the SPIR-V equivalents.
+    const auto LocalMemFence =
+        ConstantInt::get(Arg->getType(), CLK_LOCAL_MEM_FENCE);
+    const auto GlobalMemFence =
+        ConstantInt::get(Arg->getType(), CLK_GLOBAL_MEM_FENCE);
+    const auto ConstantSequentiallyConsistent = ConstantInt::get(
+        Arg->getType(), spv::MemorySemanticsSequentiallyConsistentMask);
+    const auto ConstantScopeDevice =
+        ConstantInt::get(Arg->getType(), spv::ScopeDevice);
+    const auto ConstantScopeWorkgroup =
+        ConstantInt::get(Arg->getType(), spv::ScopeWorkgroup);
 
-          auto Arg = CI->getOperand(0);
+    // Map CLK_LOCAL_MEM_FENCE to MemorySemanticsWorkgroupMemoryMask.
+    const auto LocalMemFenceMask =
+        BinaryOperator::Create(Instruction::And, LocalMemFence, Arg, "", CI);
+    const auto WorkgroupShiftAmount =
+        clz(spv::MemorySemanticsWorkgroupMemoryMask) - clz(CLK_LOCAL_MEM_FENCE);
+    const auto MemorySemanticsWorkgroup = BinaryOperator::Create(
+        Instruction::Shl, LocalMemFenceMask,
+        ConstantInt::get(Arg->getType(), WorkgroupShiftAmount), "", CI);
 
-          // We need to map the OpenCL constants to the SPIR-V equivalents.
-          const auto LocalMemFence =
-              ConstantInt::get(Arg->getType(), CLK_LOCAL_MEM_FENCE);
-          const auto GlobalMemFence =
-              ConstantInt::get(Arg->getType(), CLK_GLOBAL_MEM_FENCE);
-          const auto ConstantSequentiallyConsistent = ConstantInt::get(
-              Arg->getType(), spv::MemorySemanticsSequentiallyConsistentMask);
-          const auto ConstantScopeDevice =
-              ConstantInt::get(Arg->getType(), spv::ScopeDevice);
-          const auto ConstantScopeWorkgroup =
-              ConstantInt::get(Arg->getType(), spv::ScopeWorkgroup);
+    // Map CLK_GLOBAL_MEM_FENCE to MemorySemanticsUniformMemoryMask.
+    const auto GlobalMemFenceMask =
+        BinaryOperator::Create(Instruction::And, GlobalMemFence, Arg, "", CI);
+    const auto UniformShiftAmount =
+        clz(spv::MemorySemanticsUniformMemoryMask) - clz(CLK_GLOBAL_MEM_FENCE);
+    const auto MemorySemanticsUniform = BinaryOperator::Create(
+        Instruction::Shl, GlobalMemFenceMask,
+        ConstantInt::get(Arg->getType(), UniformShiftAmount), "", CI);
 
-          // Map CLK_LOCAL_MEM_FENCE to MemorySemanticsWorkgroupMemoryMask.
-          const auto LocalMemFenceMask = BinaryOperator::Create(
-              Instruction::And, LocalMemFence, Arg, "", CI);
-          const auto WorkgroupShiftAmount =
-              clz(spv::MemorySemanticsWorkgroupMemoryMask) -
-              clz(CLK_LOCAL_MEM_FENCE);
-          const auto MemorySemanticsWorkgroup = BinaryOperator::Create(
-              Instruction::Shl, LocalMemFenceMask,
-              ConstantInt::get(Arg->getType(), WorkgroupShiftAmount), "", CI);
+    // And combine the above together, also adding in
+    // MemorySemanticsSequentiallyConsistentMask.
+    auto MemorySemantics =
+        BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
+                               ConstantSequentiallyConsistent, "", CI);
+    MemorySemantics = BinaryOperator::Create(Instruction::Or, MemorySemantics,
+                                             MemorySemanticsUniform, "", CI);
 
-          // Map CLK_GLOBAL_MEM_FENCE to MemorySemanticsUniformMemoryMask.
-          const auto GlobalMemFenceMask = BinaryOperator::Create(
-              Instruction::And, GlobalMemFence, Arg, "", CI);
-          const auto UniformShiftAmount =
-              clz(spv::MemorySemanticsUniformMemoryMask) -
-              clz(CLK_GLOBAL_MEM_FENCE);
-          const auto MemorySemanticsUniform = BinaryOperator::Create(
-              Instruction::Shl, GlobalMemFenceMask,
-              ConstantInt::get(Arg->getType(), UniformShiftAmount), "", CI);
+    // For Memory Scope if we used CLK_GLOBAL_MEM_FENCE, we need to use
+    // Device Scope, otherwise Workgroup Scope.
+    const auto Cmp =
+        CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ, GlobalMemFenceMask,
+                        GlobalMemFence, "", CI);
+    const auto MemoryScope = SelectInst::Create(Cmp, ConstantScopeDevice,
+                                                ConstantScopeWorkgroup, "", CI);
 
-          // And combine the above together, also adding in
-          // MemorySemanticsSequentiallyConsistentMask.
-          auto MemorySemantics =
-              BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
-                                     ConstantSequentiallyConsistent, "", CI);
-          MemorySemantics = BinaryOperator::Create(
-              Instruction::Or, MemorySemantics, MemorySemanticsUniform, "", CI);
+    // Lastly, the Execution Scope is always Workgroup Scope.
+    const auto ExecutionScope = ConstantScopeWorkgroup;
 
-          // For Memory Scope if we used CLK_GLOBAL_MEM_FENCE, we need to use
-          // Device Scope, otherwise Workgroup Scope.
-          const auto Cmp =
-              CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_EQ,
-                              GlobalMemFenceMask, GlobalMemFence, "", CI);
-          const auto MemoryScope = SelectInst::Create(
-              Cmp, ConstantScopeDevice, ConstantScopeWorkgroup, "", CI);
-
-          // Lastly, the Execution Scope is always Workgroup Scope.
-          const auto ExecutionScope = ConstantScopeWorkgroup;
-
-          auto NewCI = CallInst::Create(
-              NewF, {ExecutionScope, MemoryScope, MemorySemantics}, "", CI);
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return clspv::InsertSPIRVOp(CI, spv::OpControlBarrier,
+                                {Attribute::NoDuplicate}, CI->getType(),
+                                {ExecutionScope, MemoryScope, MemorySemantics});
+  });
 }
 
 bool ReplaceOpenCLBuiltinPass::replaceMemFence(Module &M) {
@@ -653,14 +615,14 @@ bool ReplaceOpenCLBuiltinPass::replaceMemFence(Module &M) {
 
   enum { CLK_LOCAL_MEM_FENCE = 0x01, CLK_GLOBAL_MEM_FENCE = 0x02 };
 
-  using Tuple = std::tuple<const char *, unsigned>;
+  using Tuple = std::tuple<spv::Op, unsigned>;
   const std::map<const char *, Tuple> Map = {
-      {"_Z9mem_fencej", Tuple("__spirv_memory_barrier",
+      {"_Z9mem_fencej", Tuple(spv::OpMemoryBarrier,
                               spv::MemorySemanticsSequentiallyConsistentMask)},
       {"_Z14read_mem_fencej",
-       Tuple("__spirv_memory_barrier", spv::MemorySemanticsAcquireMask)},
+       Tuple(spv::OpMemoryBarrier, spv::MemorySemanticsAcquireMask)},
       {"_Z15write_mem_fencej",
-       Tuple("__spirv_memory_barrier", spv::MemorySemanticsReleaseMask)}};
+       Tuple(spv::OpMemoryBarrier, spv::MemorySemanticsReleaseMask)}};
 
   for (auto Pair : Map) {
     // If we find a function with the matching name.
@@ -670,14 +632,6 @@ bool ReplaceOpenCLBuiltinPass::replaceMemFence(Module &M) {
       // Walk the users of the function.
       for (auto &U : F->uses()) {
         if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto FType = F->getFunctionType();
-          SmallVector<Type *, 2> Params;
-          for (unsigned i = 0; i < 2; i++) {
-            Params.push_back(FType->getParamType(0));
-          }
-          auto NewFType =
-              FunctionType::get(FType->getReturnType(), Params, false);
-          auto NewF = M.getOrInsertFunction(std::get<0>(Pair.second), NewFType);
 
           auto Arg = CI->getOperand(0);
 
@@ -722,8 +676,9 @@ bool ReplaceOpenCLBuiltinPass::replaceMemFence(Module &M) {
           // Memory Scope is always device.
           const auto MemoryScope = ConstantScopeDevice;
 
-          auto NewCI =
-              CallInst::Create(NewF, {MemoryScope, MemorySemantics}, "", CI);
+          const auto SPIRVOp = std::get<0>(Pair.second);
+          auto NewCI = clspv::InsertSPIRVOp(CI, SPIRVOp, {}, CI->getType(),
+                                            {MemoryScope, MemorySemantics});
 
           CI->replaceAllUsesWith(NewCI);
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4383,8 +4383,6 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
             .Case("spirv.atomic_dec", spv::OpAtomicIDecrement)
             .Case("spirv.atomic_compare_exchange", spv::OpAtomicCompareExchange)
             .Case("spirv.atomic_xor", spv::OpAtomicXor)
-            .Case("__spirv_control_barrier", spv::OpControlBarrier)
-            .Case("__spirv_memory_barrier", spv::OpMemoryBarrier)
             .StartsWith("spirv.store_null", spv::OpStore)
             .Default(spv::OpNop);
 

--- a/test/Coherent/coherent_fence_simple.cl
+++ b/test/Coherent/coherent_fence_simple.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* data) {
+  int x = data[0];
+  mem_fence(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[var]] Binding 0
+// CHECK: OpDecorate [[var]] Coherent

--- a/test/CommonBuiltins/no_duplicate_barrier.ll
+++ b/test/CommonBuiltins/no_duplicate_barrier.ll
@@ -2,7 +2,7 @@
 ; RUN: FileCheck %s < %t
 
 ; CHECK: noduplicate
-; CHECK-NEXT: spirv.op.224
+; CHECK-NEXT: spirv.op.224.
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/CommonBuiltins/no_duplicate_barrier.ll
+++ b/test/CommonBuiltins/no_duplicate_barrier.ll
@@ -2,7 +2,7 @@
 ; RUN: FileCheck %s < %t
 
 ; CHECK: noduplicate
-; CHECK-NEXT: __spirv_control_barrier
+; CHECK-NEXT: spirv.op.224
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"


### PR DESCRIPTION
Add missing test for coherent decorations.

Contributes to #308.

Signed-off-by: Kévin Petit <kpet@free.fr>