### PR TITLE
Use unified1 version of spirv.h

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "Passes.h"
 

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -27,7 +27,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/Option.h"
 

--- a/lib/SPIRVOp.h
+++ b/lib/SPIRVOp.h
@@ -18,7 +18,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 namespace clspv {
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -41,7 +41,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
@@ -667,8 +667,9 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
 void SPIRVProducerPass::outputHeader() {
   binaryOut->write(reinterpret_cast<const char *>(&spv::MagicNumber),
                    sizeof(spv::MagicNumber));
-  binaryOut->write(reinterpret_cast<const char *>(&spv::Version),
-                   sizeof(spv::Version));
+  const uint32_t spv_version = 0x10000; // SPIR-V 1.0
+  binaryOut->write(reinterpret_cast<const char *>(&spv_version),
+                   sizeof(spv_version));
 
   // use Google's vendor ID
   const uint32_t vendor = 21 << 16;


### PR DESCRIPTION
Output targets SPIR-V 1.0 always.