### PR TITLE
Add support for taking LLVM IR as input

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -120,12 +120,11 @@ static llvm::cl::opt<std::string>
     InputFilename(llvm::cl::Positional, llvm::cl::desc("<input .cl file>"),
                   llvm::cl::init("-"));
 
-static llvm::cl::opt<clang::Language>
-    InputLanguage("x", llvm::cl::desc("Select input type"),
-                  llvm::cl::init(clang::Language::OpenCL),
-                  llvm::cl::values(
-                    clEnumValN(clang::Language::OpenCL, "cl", "OpenCL source"),
-                    clEnumValN(clang::Language::LLVM_IR, "ir", "LLVM IR")));
+static llvm::cl::opt<clang::Language> InputLanguage(
+    "x", llvm::cl::desc("Select input type"),
+    llvm::cl::init(clang::Language::OpenCL),
+    llvm::cl::values(clEnumValN(clang::Language::OpenCL, "cl", "OpenCL source"),
+                     clEnumValN(clang::Language::LLVM_IR, "ir", "LLVM IR")));
 
 static llvm::cl::opt<std::string>
     OutputFilename("o", llvm::cl::desc("Override output filename"),
@@ -789,7 +788,7 @@ int Compile(const int argc, const char *const argv[]) {
   // If we are reading our input file from stdin.
   if ("-" == InputFilename) {
     // We need to overwrite the file name we use.
-    switch(InputLanguage) {
+    switch (InputLanguage) {
     case clang::Language::OpenCL:
       overiddenInputFilename = "stdin.cl";
       break;
@@ -800,8 +799,8 @@ int Compile(const int argc, const char *const argv[]) {
   }
 
   clang::CompilerInstance instance;
-  clang::FrontendInputFile kernelFile(
-      overiddenInputFilename, clang::InputKind(InputLanguage));
+  clang::FrontendInputFile kernelFile(overiddenInputFilename,
+                                      clang::InputKind(InputLanguage));
   std::string log;
   llvm::raw_string_ostream diagnosticsStream(log);
   if (auto error = SetCompilerInstanceOptions(

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -120,6 +120,13 @@ static llvm::cl::opt<std::string>
     InputFilename(llvm::cl::Positional, llvm::cl::desc("<input .cl file>"),
                   llvm::cl::init("-"));
 
+static llvm::cl::opt<clang::Language>
+    InputLanguage("x", llvm::cl::desc("Select input type"),
+                  llvm::cl::init(clang::Language::OpenCL),
+                  llvm::cl::values(
+                    clEnumValN(clang::Language::OpenCL, "cl", "OpenCL source"),
+                    clEnumValN(clang::Language::LLVM_IR, "ir", "LLVM IR")));
+
 static llvm::cl::opt<std::string>
     OutputFilename("o", llvm::cl::desc("Override output filename"),
                    llvm::cl::value_desc("filename"));
@@ -782,12 +789,19 @@ int Compile(const int argc, const char *const argv[]) {
   // If we are reading our input file from stdin.
   if ("-" == InputFilename) {
     // We need to overwrite the file name we use.
-    overiddenInputFilename = "stdin.cl";
+    switch(InputLanguage) {
+    case clang::Language::OpenCL:
+      overiddenInputFilename = "stdin.cl";
+      break;
+    case clang::Language::LLVM_IR:
+      overiddenInputFilename = "stdin.ll";
+      break;
+    }
   }
 
   clang::CompilerInstance instance;
   clang::FrontendInputFile kernelFile(
-      overiddenInputFilename, clang::InputKind(clang::Language::OpenCL));
+      overiddenInputFilename, clang::InputKind(InputLanguage));
   std::string log;
   llvm::raw_string_ostream diagnosticsStream(log);
   if (auto error = SetCompilerInstanceOptions(

--- a/test/ir-input.ll
+++ b/test/ir-input.ll
@@ -1,0 +1,21 @@
+; RUN: clspv -x ir %s -o %t
+; RUN: spirv-val %t
+; RUN: spirv-dis -o %t2 %t
+; RUN: FileCheck %s < %t2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(i32 addrspace(1)* %out) {
+entry:
+  %out.addr = alloca i32 addrspace(1)*, align 4
+  store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 4
+  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %out.addr, align 4
+  store i32 42, i32 addrspace(1)* %0, align 4
+  ret void
+}
+
+; CHECK: %uint = OpTypeInt 32 0
+; CHECK: %uint_42 = OpConstant %uint 42
+; CHECK: OpStore {{.*}} %uint_42
+


### PR DESCRIPTION
Add a -x option to select the input type, defaulting to OpenCL C.

Signed-off-by: Kévin Petit <kpet@free.fr>