### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "master",
       "subdir" : "third_party/llvm",
-      "commit" : "e73177ea5fd611026abcbaecc6232eee8d8d2ed8"
+      "commit" : "c0f6ad7d1f3ccb9d0b9ce9ef8dfa06409ccf1b3e"
     },
     {
       "name" : "SPIRV-Headers",

--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "master",
       "subdir" : "third_party/llvm",
-      "commit" : "367df1ebbc9e2a9d7922cf81630552dcd0323734"
+      "commit" : "e73177ea5fd611026abcbaecc6232eee8d8d2ed8"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -18,6 +18,7 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Lex/PreprocessorOptions.h"
+#include "llvm/InitializePasses.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -28,6 +28,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/Option.h"

--- a/lib/ShareModuleScopeVariables.cpp
+++ b/lib/ShareModuleScopeVariables.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/AddressSpace.h"

--- a/lib/SignedCompareFixupPass.cpp
+++ b/lib/SignedCompareFixupPass.cpp
@@ -22,6 +22,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/Option.h"


### PR DESCRIPTION
...to pick up a fix that makes it possible to use add_llvm_tool
when LLVM_TARGETS_TO_BUILD is set to an empty list like clspv does.

This allows to fix the clvk issue mentioned on #435.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>