### PR TITLE
Add simple functional image tests

### DIFF
--- a/amber/README.md
+++ b/amber/README.md
@@ -1,0 +1,5 @@
+# Amber Tests
+
+This directory (and subdirectories) contain
+[Amber](https://github.com/google/amber) script
+tests to check the functional correctness of clspv.

--- a/amber/images/read_image2d_r32f.amber
+++ b/amber/images/read_image2d_r32f.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, r32f) uniform image2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  vec4 data = vec4(gl_GlobalInvocationID.x,
+                   3.0,
+                   gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                   gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global float4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagef(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE float WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER out_buf DATA_TYPE vec4<float> DATA
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+END
+SAMPLER sampler  ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only the first component is checked.
+EXPECT out_buf IDX 0  EQ 0.0
+EXPECT out_buf IDX 16 EQ 1.0
+EXPECT out_buf IDX 32 EQ 0.0
+EXPECT out_buf IDX 48 EQ 1.0
+

--- a/amber/images/read_image2d_r32i.amber
+++ b/amber/images/read_image2d_r32i.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, r32i) uniform iimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  ivec4 data = ivec4(gl_GlobalInvocationID.x,
+                     -3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     -gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global int4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagei(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE int32 WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<int32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only the first component is checked.
+EXPECT out_buf IDX 0  EQ 0 #-3 0  0
+EXPECT out_buf IDX 16 EQ 1 #-3 1  0
+EXPECT out_buf IDX 32 EQ 0 #-3 1 -1
+EXPECT out_buf IDX 48 EQ 1 #-3 2 -1
+

--- a/amber/images/read_image2d_r32ui.amber
+++ b/amber/images/read_image2d_r32ui.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, r32ui) uniform uimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  uvec4 data = uvec4(gl_GlobalInvocationID.x,
+                     3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global uint4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imageui(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE uint32 WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<uint32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only test the first component.
+EXPECT out_buf IDX 0  EQ 0
+EXPECT out_buf IDX 16 EQ 1
+EXPECT out_buf IDX 32 EQ 0
+EXPECT out_buf IDX 48 EQ 1
+

--- a/amber/images/read_image2d_rg32f.amber
+++ b/amber/images/read_image2d_rg32f.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rg32f) uniform image2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  vec4 data = vec4(gl_GlobalInvocationID.x,
+                   3.0,
+                   gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                   gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global float4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagef(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER out_buf DATA_TYPE vec4<float> DATA
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+END
+SAMPLER sampler  ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only the first two components are checked.
+EXPECT out_buf IDX 0  EQ 0.0 3.0
+EXPECT out_buf IDX 16 EQ 1.0 3.0
+EXPECT out_buf IDX 32 EQ 0.0 3.0
+EXPECT out_buf IDX 48 EQ 1.0 3.0
+

--- a/amber/images/read_image2d_rg32i.amber
+++ b/amber/images/read_image2d_rg32i.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rg32i) uniform iimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  ivec4 data = ivec4(gl_GlobalInvocationID.x,
+                     -3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     -gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global int4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagei(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<int32> WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<int32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only the first two components are checked.
+EXPECT out_buf IDX 0  EQ 0 -3 #0  0
+EXPECT out_buf IDX 16 EQ 1 -3 #1  0
+EXPECT out_buf IDX 32 EQ 0 -3 #1 -1
+EXPECT out_buf IDX 48 EQ 1 -3 #2 -1
+

--- a/amber/images/read_image2d_rg32ui.amber
+++ b/amber/images/read_image2d_rg32ui.amber
@@ -1,0 +1,56 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rg32ui) uniform uimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  uvec4 data = uvec4(gl_GlobalInvocationID.x,
+                     3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global uint4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imageui(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<uint32> WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<uint32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+# Only test the first two components.
+EXPECT out_buf IDX 0  EQ 0 3
+EXPECT out_buf IDX 16 EQ 1 3
+EXPECT out_buf IDX 32 EQ 0 3
+EXPECT out_buf IDX 48 EQ 1 3
+

--- a/amber/images/read_image2d_rgba32f.amber
+++ b/amber/images/read_image2d_rgba32f.amber
@@ -1,0 +1,54 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rgba32f) uniform image2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  vec4 data = vec4(gl_GlobalInvocationID.x,
+                   3.0,
+                   gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                   gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global float4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagef(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER out_buf DATA_TYPE vec4<float> DATA
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+END
+SAMPLER sampler  ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+EXPECT out_buf IDX 0  EQ 0.0 3.0 0.0 0.0
+EXPECT out_buf IDX 16 EQ 1.0 3.0 1.0 0.0
+EXPECT out_buf IDX 32 EQ 0.0 3.0 1.0 1.0
+EXPECT out_buf IDX 48 EQ 1.0 3.0 2.0 1.0

--- a/amber/images/read_image2d_rgba32i.amber
+++ b/amber/images/read_image2d_rgba32i.amber
@@ -1,0 +1,55 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rgba32i) uniform iimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  ivec4 data = ivec4(gl_GlobalInvocationID.x,
+                     -3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     -gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global int4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagei(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<int32> WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<int32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+EXPECT out_buf IDX 0  EQ 0 -3 0  0
+EXPECT out_buf IDX 16 EQ 1 -3 1  0
+EXPECT out_buf IDX 32 EQ 0 -3 1 -1
+EXPECT out_buf IDX 48 EQ 1 -3 2 -1
+

--- a/amber/images/read_image2d_rgba32ui.amber
+++ b/amber/images/read_image2d_rgba32ui.amber
@@ -1,0 +1,55 @@
+#!amber
+
+SHADER compute fill GLSL
+#version 450
+layout(set=0, binding=0, rgba32ui) uniform uimage2D im;
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  uvec4 data = uvec4(gl_GlobalInvocationID.x,
+                     3,
+                     gl_GlobalInvocationID.x + gl_GlobalInvocationID.y,
+                     gl_GlobalInvocationID.y);
+  imageStore(im, coord, data);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global uint4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imageui(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<uint32> WIDTH 2 HEIGHT 2 FILL 4
+BUFFER out_buf DATA_TYPE vec4<uint32> DATA
+2 2 2 2
+2 2 2 2
+2 2 2 2
+2 2 2 2
+END
+SAMPLER sampler ADDRESS_MODE_U clamp_to_edge ADDRESS_MODE_V clamp_to_edge
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE compute fill_pipe
+  ATTACH fill
+  BIND BUFFER texture AS storage_image DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN fill_pipe 2 2 1
+RUN read_pipe 2 2 1
+
+EXPECT out_buf IDX 0  EQ 0 3 0 0
+EXPECT out_buf IDX 16 EQ 1 3 1 0
+EXPECT out_buf IDX 32 EQ 0 3 1 1
+EXPECT out_buf IDX 48 EQ 1 3 2 1
+

--- a/amber/images/write_image2d_r32f.amber
+++ b/amber/images/write_image2d_r32f.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global float4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagef(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE float WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<float> DATA
+1.0 2.0 3.0 4.0
+2.0 3.0 4.0 1.0
+3.0 4.0 1.0 2.0
+4.0 1.0 2.0 3.0
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1.0
+EXPECT texture IDX 4  EQ 2.0
+EXPECT texture IDX 8  EQ 3.0
+EXPECT texture IDX 12 EQ 4.0
+

--- a/amber/images/write_image2d_r32f.amber
+++ b/amber/images/write_image2d_r32f.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<float> DATA
 4.0 1.0 2.0 3.0
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1.0
 EXPECT texture IDX 4  EQ 2.0

--- a/amber/images/write_image2d_r32i.amber
+++ b/amber/images/write_image2d_r32i.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global int4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagei(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE int32 WIDTH 2 HEIGHT 2 FILL 0
+BUFFER data DATA_TYPE vec4<int32> DATA
+-1 2 -3 4
+-2 3 -4 1
+-3 4 -1 2
+-4 1 -2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ -1
+EXPECT texture IDX 4  EQ -2
+EXPECT texture IDX 8  EQ -3
+EXPECT texture IDX 12 EQ -4
+

--- a/amber/images/write_image2d_r32i.amber
+++ b/amber/images/write_image2d_r32i.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<int32> DATA
 -4 1 -2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ -1
 EXPECT texture IDX 4  EQ -2

--- a/amber/images/write_image2d_r32ui.amber
+++ b/amber/images/write_image2d_r32ui.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<uint32> DATA
 4 1 2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1
 EXPECT texture IDX 4  EQ 2

--- a/amber/images/write_image2d_r32ui.amber
+++ b/amber/images/write_image2d_r32ui.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global uint4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imageui(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE uint32 WIDTH 2 HEIGHT 2 FILL 0
+BUFFER data DATA_TYPE vec4<uint32> DATA
+1 2 3 4
+2 3 4 1
+3 4 1 2
+4 1 2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1
+EXPECT texture IDX 4  EQ 2
+EXPECT texture IDX 8  EQ 3
+EXPECT texture IDX 12 EQ 4
+

--- a/amber/images/write_image2d_rg32f.amber
+++ b/amber/images/write_image2d_rg32f.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global float4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagef(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<float> DATA
+1.0 2.0 3.0 4.0
+2.0 3.0 4.0 1.0
+3.0 4.0 1.0 2.0
+4.0 1.0 2.0 3.0
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1.0 2.0
+EXPECT texture IDX 8  EQ 2.0 3.0
+EXPECT texture IDX 16 EQ 3.0 4.0
+EXPECT texture IDX 24 EQ 4.0 1.0
+

--- a/amber/images/write_image2d_rg32f.amber
+++ b/amber/images/write_image2d_rg32f.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<float> DATA
 4.0 1.0 2.0 3.0
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1.0 2.0
 EXPECT texture IDX 8  EQ 2.0 3.0

--- a/amber/images/write_image2d_rg32i.amber
+++ b/amber/images/write_image2d_rg32i.amber
@@ -1,0 +1,34 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global int4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagei(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<int32> WIDTH 2 HEIGHT 2 FILL 0
+BUFFER data DATA_TYPE vec4<int32> DATA
+-1 2 -3 4
+-2 3 -4 1
+-3 4 -1 2
+-4 1 -2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ -1 2
+EXPECT texture IDX 8  EQ -2 3
+EXPECT texture IDX 16 EQ -3 4
+EXPECT texture IDX 24 EQ -4 1
+
+

--- a/amber/images/write_image2d_rg32i.amber
+++ b/amber/images/write_image2d_rg32i.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<int32> DATA
 -4 1 -2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ -1 2
 EXPECT texture IDX 8  EQ -2 3

--- a/amber/images/write_image2d_rg32ui.amber
+++ b/amber/images/write_image2d_rg32ui.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<uint32> DATA
 4 1 2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1 2
 EXPECT texture IDX 8  EQ 2 3

--- a/amber/images/write_image2d_rg32ui.amber
+++ b/amber/images/write_image2d_rg32ui.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global uint4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imageui(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec2<uint32> WIDTH 2 HEIGHT 2 FILL 0
+BUFFER data DATA_TYPE vec4<uint32> DATA
+1 2 3 4
+2 3 4 1
+3 4 1 2
+4 1 2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1 2
+EXPECT texture IDX 8  EQ 2 3
+EXPECT texture IDX 16 EQ 3 4
+EXPECT texture IDX 24 EQ 4 1
+

--- a/amber/images/write_image2d_rgba32f.amber
+++ b/amber/images/write_image2d_rgba32f.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global float4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagef(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<float> DATA
+1.0 2.0 3.0 4.0
+2.0 3.0 4.0 1.0
+3.0 4.0 1.0 2.0
+4.0 1.0 2.0 3.0
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1.0 2.0 3.0 4.0
+EXPECT texture IDX 16 EQ 2.0 3.0 4.0 1.0
+EXPECT texture IDX 32 EQ 3.0 4.0 1.0 2.0
+EXPECT texture IDX 48 EQ 4.0 1.0 2.0 3.0
+

--- a/amber/images/write_image2d_rgba32f.amber
+++ b/amber/images/write_image2d_rgba32f.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<float> DATA
 4.0 1.0 2.0 3.0
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1.0 2.0 3.0 4.0
 EXPECT texture IDX 16 EQ 2.0 3.0 4.0 1.0

--- a/amber/images/write_image2d_rgba32i.amber
+++ b/amber/images/write_image2d_rgba32i.amber
@@ -1,0 +1,34 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global int4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagei(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<int32> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<int32> DATA
+-1 2 -3 4
+-2 3 -4 1
+-3 4 -1 2
+-4 1 -2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ -1 2 -3 4
+EXPECT texture IDX 16 EQ -2 3 -4 1
+EXPECT texture IDX 32 EQ -3 4 -1 2
+EXPECT texture IDX 48 EQ -4 1 -2 3
+
+

--- a/amber/images/write_image2d_rgba32i.amber
+++ b/amber/images/write_image2d_rgba32i.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<int32> DATA
 -4 1 -2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ -1 2 -3 4
 EXPECT texture IDX 16 EQ -2 3 -4 1

--- a/amber/images/write_image2d_rgba32ui.amber
+++ b/amber/images/write_image2d_rgba32ui.amber
@@ -1,0 +1,33 @@
+#!amber
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global uint4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imageui(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<uint32> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<uint32> DATA
+1 2 3 4
+2 3 4 1
+3 4 1 2
+4 1 2 3
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1 2 3 4
+EXPECT texture IDX 16 EQ 2 3 4 1
+EXPECT texture IDX 32 EQ 3 4 1 2
+EXPECT texture IDX 48 EQ 4 1 2 3
+

--- a/amber/images/write_image2d_rgba32ui.amber
+++ b/amber/images/write_image2d_rgba32ui.amber
@@ -18,13 +18,13 @@ BUFFER data DATA_TYPE vec4<uint32> DATA
 4 1 2 3
 END
 
-PIPELINE compute read_pipe
+PIPELINE compute write_pipe
   ATTACH write_imagef ENTRY_POINT foo
   BIND BUFFER data KERNEL ARG_NAME data
   BIND BUFFER texture KERNEL ARG_NAME image
 END
 
-RUN read_pipe 2 2 1
+RUN write_pipe 2 2 1
 
 EXPECT texture IDX 0  EQ 1 2 3 4
 EXPECT texture IDX 16 EQ 2 3 4 1


### PR DESCRIPTION
* New amber directory to contain Amber-based tests
* Added tests for 2D samped image reads and image writes
  * formats: r32(f|ui|i), rg32(f|ui|i) and rgba32(f|ui|i)

No bots runs these yet. Short-ish term plan would be to setup a Kokoro bot that runs these against ToT [Amber](https://github.com/google/amber) using Swiftshader (at least those that Swiftshader supports).