### PR TITLE
Don't add variable pointers due to images and samplers

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5064,7 +5064,11 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
         FunctionType *CalleeFTy = cast<FunctionType>(Call->getFunctionType());
         for (unsigned i = 0; i < CalleeFTy->getNumParams(); i++) {
           auto *operand = Call->getOperand(i);
-          if (operand->getType()->isPointerTy()) {
+          auto *operand_type = operand->getType();
+          // Images and samplers can be passed as function parameters without
+          // variable pointers.
+          if (operand_type->isPointerTy() && !IsImageType(operand_type) &&
+              !IsSamplerType(operand_type)) {
             auto sc =
                 GetStorageClass(operand->getType()->getPointerAddressSpace());
             if (sc == spv::StorageClassStorageBuffer) {

--- a/test/VariablePointers/function_call_image_param.cl
+++ b/test/VariablePointers/function_call_image_param.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void bar(write_only image2d_t image) {
+  write_imagef(image, (int2)(0, 0), (float4)(0.0));
+}
+
+kernel void foo(write_only image2d_t image) {
+  bar(image);
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK-NOT: OpExtension "SPV_KHR_variable_pointers"
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage
+// CHECK: OpFunctionParameter [[image]]

--- a/test/VariablePointers/function_call_sampler_param.cl
+++ b/test/VariablePointers/function_call_sampler_param.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+float4 bar(read_only image2d_t image, sampler_t sampler) {
+  return read_imagef(image, sampler, (float2)(0.0));
+}
+
+kernel void foo(read_only image2d_t image, sampler_t sampler, global float4* out) {
+  *out = bar(image, sampler);
+}
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK-NOT: OpExtension "SPV_KHR_variable_pointers"
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage
+// CHECK-DAG: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+// CHECK: OpFunctionParameter [[image]]
+// CHECK: OpFunctionParameter [[sampler]]
+


### PR DESCRIPTION
Fixes #438

* Do not add VariablePointersStorageBuffer capability due to image or
sampler function parameters
  * new tests