### PR TITLE
Fix generation of selection merges

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "master",
       "subdir" : "third_party/llvm",
-      "commit" : "acd7fe8636ab1d892a935ca747ed9bb6420e2253"
+      "commit" : "abe8de29c4ae5eca86f3594d2edd43b2fcbda623"
     },
     {
       "name" : "SPIRV-Headers",
@@ -14,7 +14,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "branch" : "master",
       "subdir" : "third_party/SPIRV-Headers",
-      "commit" : "af64a9e826bf5bb5fcd2434dd71be1e41e922563"
+      "commit" : "204cd131c42b90d129073719f2766293ce35c081"
     },
     {
       "name" : "SPIRV-Tools",
@@ -22,7 +22,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "branch" : "master",
       "subdir" : "third_party/SPIRV-Tools",
-      "commit" : "615918c91d1d6ae1620f3ab3c03de1acba3cce0e"
+      "commit" : "e82a428605f6ce0a07337b36f8ba3935c9f165ac"
     }
   ]
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphOrderedFunctions.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterConstants.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ComputeStructuredOrder.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ConstantEmitter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp

--- a/lib/ComputeStructuredOrder.cpp
+++ b/lib/ComputeStructuredOrder.cpp
@@ -1,0 +1,93 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ComputeStructuredOrder.h"
+
+using namespace clspv;
+using namespace llvm;
+
+void clspv::ComputeStructuredOrder(BasicBlock *block, DominatorTree *DT,
+                                   const LoopInfo &LI,
+                                   std::deque<BasicBlock *> *order,
+                                   DenseSet<BasicBlock *> *visited) {
+  if (!visited->insert(block).second)
+    return;
+
+  auto F = block->getParent();
+
+  // Identify the merge and continue blocks for special treatment.
+  const auto *terminator = block->getTerminator();
+  BasicBlock *continue_block = nullptr;
+  BasicBlock *merge_block = nullptr;
+  if (LI.isLoopHeader(block)) {
+    Loop *loop = LI.getLoopFor(block);
+    merge_block = loop->getExitBlock();
+
+    if (loop->isLoopLatch(block)) {
+      // The header is also the latch (i.e. a single block loop).
+      continue_block = block;
+    } else {
+      // The continue block satisfies the following conditions:
+      // 1. Is dominated by the header (true by construction at this point).
+      // 2. Dominates the latch block.
+      // We can assume the loop has multiple blocks since the single block loop
+      // is handled above. By construction the header always dominates the
+      // latch block, so we exclude that case specifically.
+      auto *header = loop->getHeader();
+      auto *latch = loop->getLoopLatch();
+      for (auto *bb : loop->blocks()) {
+        if (bb == header)
+          continue;
+
+        // Several block might dominate the latch, we can pick any.
+        if (DT->dominates(bb, latch))
+          continue_block = bb;
+      }
+    }
+    // At least the latch dominates itself so we will always find a continue
+    // block.
+    assert(continue_block && merge_block && "Bad loop");
+  } else if (terminator->getNumSuccessors() > 1) {
+    // This is potentially a selection case, but it could also be a conditional
+    // branch with one arm back to the loop header, which would make this block
+    // the latch block.
+    bool has_back_edge = false;
+
+    for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
+      if (LI.isLoopHeader(terminator->getSuccessor(i)))
+        has_back_edge = true;
+    }
+
+    if (!has_back_edge) {
+      // The cfg structurizer generates a cfg where the true branch goes into
+      // the then/else region and the false branch skips the region. Therefore,
+      // we use the false branch here as the merge.
+      merge_block = terminator->getSuccessor(1);
+    }
+  }
+
+  // Traverse merge and continue first.
+  if (merge_block) {
+    ComputeStructuredOrder(merge_block, DT, LI, order, visited);
+    if (continue_block)
+      ComputeStructuredOrder(continue_block, DT, LI, order, visited);
+  }
+  for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
+    auto *successor = terminator->getSuccessor(i);
+    if (successor != merge_block && successor != continue_block)
+      ComputeStructuredOrder(successor, DT, LI, order, visited);
+  }
+
+  order->push_front(block);
+}

--- a/lib/ComputeStructuredOrder.h
+++ b/lib/ComputeStructuredOrder.h
@@ -1,0 +1,40 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <deque>
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Dominators.h"
+
+namespace clspv {
+
+// Produce structured sorting from |block| into |order|.
+//
+// This order has the following properties:
+// * dominators come before all blocks they dominate
+// * a merge block follows all blocks that are in control constructs of the
+// associated header
+// * blocks in a loop construct precede the blocks in the associated continue
+// construct
+// * no interleaving; blocks in one construct A are mixed with blocks in
+// another construct B only if one is nested inside the other (without loss
+// of generality, A's header dominates all blocks in B, and all B's blocks
+// appear contiguously within A's blocks)
+void ComputeStructuredOrder(llvm::BasicBlock *block, llvm::DominatorTree *DT,
+                            const llvm::LoopInfo &LI,
+                            std::deque<llvm::BasicBlock *> *order,
+                            llvm::DenseSet<llvm::BasicBlock *> *visited);
+} // namespace clspv

--- a/lib/ReorderBasicBlocksPass.cpp
+++ b/lib/ReorderBasicBlocksPass.cpp
@@ -22,6 +22,7 @@
 
 #include "clspv/Option.h"
 
+#include "ComputeStructuredOrder.h"
 #include "Passes.h"
 
 using namespace llvm;
@@ -39,23 +40,6 @@ struct ReorderBasicBlocksPass : public FunctionPass {
   }
 
   bool runOnFunction(Function &F) override;
-
-private:
-  // Produce structured sorting from |block| into |order|.
-  //
-  // This order has the following properties:
-  // * dominators come before all blocks they dominate
-  // * a merge block follows all blocks that are in control constructs of the
-  // associated header
-  // * blocks in a loop construct precede the blocks in the associated continue
-  // construct
-  // * no interleaving; blocks in one construct A are mixed with blocks in
-  // another construct B only if one is nested inside the other (without loss
-  // of generality, A's header dominates all blocks in B, and all B's blocks
-  // appear contiguously within A's blocks)
-  void StructuredOrder(BasicBlock *block, const LoopInfo &LI,
-                       std::deque<BasicBlock *> *order,
-                       DenseSet<BasicBlock *> *visited);
 };
 } // namespace
 
@@ -69,83 +53,10 @@ FunctionPass *createReorderBasicBlocksPass() {
 }
 } // namespace clspv
 
-void ReorderBasicBlocksPass::StructuredOrder(BasicBlock *block,
-                                             const LoopInfo &LI,
-                                             std::deque<BasicBlock *> *order,
-                                             DenseSet<BasicBlock *> *visited) {
-  if (!visited->insert(block).second)
-    return;
-
-  // Identify the merge and continue blocks for special treatment.
-  const auto *terminator = block->getTerminator();
-  BasicBlock *continue_block = nullptr;
-  BasicBlock *merge_block = nullptr;
-  if (LI.isLoopHeader(block)) {
-    Loop *loop = LI.getLoopFor(block);
-    merge_block = loop->getExitBlock();
-
-    if (loop->isLoopLatch(block)) {
-      // The header is also the latch (i.e. a single block loop).
-      continue_block = block;
-    } else {
-      // The continue block satisfies the following conditions:
-      // 1. Is dominated by the header (true by construction at this point).
-      // 2. Dominates the latch block.
-      // We can assume the loop has multiple blocks since the single block loop
-      // is handled above. By construction the header always dominates the
-      // latch block, so we exclude that case specifically.
-      DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
-      auto *header = loop->getHeader();
-      auto *latch = loop->getLoopLatch();
-      for (auto *bb : loop->blocks()) {
-        if (bb == header)
-          continue;
-
-        // Several block might dominate the latch, we can pick any.
-        if (DT.dominates(bb, latch))
-          continue_block = bb;
-      }
-    }
-    // At least the latch dominates itself so we will always find a continue
-    // block.
-    assert(continue_block && merge_block && "Bad loop");
-  } else if (terminator->getNumSuccessors() > 1) {
-    // This is potentially a selection case, but it could also be a conditional
-    // branch with one arm back to the loop header, which would make this block
-    // the latch block.
-    bool has_back_edge = false;
-
-    for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
-      if (LI.isLoopHeader(terminator->getSuccessor(i)))
-        has_back_edge = true;
-    }
-
-    if (!has_back_edge) {
-      // The cfg structurizer generates a cfg where the true branch goes into
-      // the then/else region and the false branch skips the region. Therefore,
-      // we use the false branch here as the merge.
-      merge_block = terminator->getSuccessor(1);
-    }
-  }
-
-  // Traverse merge and continue first.
-  if (merge_block) {
-    StructuredOrder(merge_block, LI, order, visited);
-    if (continue_block)
-      StructuredOrder(continue_block, LI, order, visited);
-  }
-  for (unsigned i = 0; i < terminator->getNumSuccessors(); ++i) {
-    auto *successor = terminator->getSuccessor(i);
-    if (successor != merge_block && successor != continue_block)
-      StructuredOrder(successor, LI, order, visited);
-  }
-
-  order->push_front(block);
-}
-
 bool ReorderBasicBlocksPass::runOnFunction(Function &F) {
   bool Changed = false;
 
+  DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
   if (clspv::Option::HackBlockOrder()) {
     // Order basic blocks according to structured order. Structured subgraphs
     // will be ordered contiguously within the binary.
@@ -154,7 +65,7 @@ bool ReorderBasicBlocksPass::runOnFunction(Function &F) {
     const LoopInfo &LI = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
     std::deque<BasicBlock *> order;
     DenseSet<BasicBlock *> visited;
-    StructuredOrder(&*F.begin(), LI, &order, &visited);
+    clspv::ComputeStructuredOrder(&*F.begin(), &DT, LI, &order, &visited);
 
     for (unsigned i = 1; i != order.size(); ++i) {
       order[i]->moveAfter(order[i - 1]);
@@ -162,7 +73,6 @@ bool ReorderBasicBlocksPass::runOnFunction(Function &F) {
   } else {
     // spirv-val wants the order of basic blocks to follow dominance relation.
     // Reorder basic blocks according to dominance relation.
-    DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
 
     // Traverse dominator tree using depth first order. Reorder basic blocks
     // according to dominance relation.

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -52,6 +52,7 @@
 
 #include "ArgKind.h"
 #include "Builtins.h"
+#include "ComputeStructuredOrder.h"
 #include "ConstantEmitter.h"
 #include "Constants.h"
 #include "DescriptorCounter.h"
@@ -372,6 +373,9 @@ struct SPIRVProducerPass final : public ModulePass {
   // Populate UBO remapped type maps.
   void PopulateUBOTypeMaps(Module &module);
 
+  // Populate the merge and continue block maps.
+  void PopulateStructuredCFGMaps(Module &module);
+
   // Wrapped methods of DataLayout accessors. If |type| was remapped for UBOs,
   // uses the internal map, otherwise it falls back on the data layout.
   uint64_t GetTypeSizeInBits(Type *type, const DataLayout &DL);
@@ -541,6 +545,11 @@ private:
   // A mapping from a remapped type to its real sizes.
   DenseMap<Type *, std::tuple<uint64_t, uint64_t, uint64_t>>
       RemappedUBOTypeSizes;
+
+  // Maps basic block to its merge block.
+  DenseMap<BasicBlock *, BasicBlock *> MergeBlocks;
+  // Maps basic block to its continue block.
+  DenseMap<BasicBlock *, BasicBlock *> ContinueBlocks;
 };
 
 char SPIRVProducerPass::ID;
@@ -562,6 +571,7 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
   binaryOut = outputCInitList ? &binaryTempOut : &out;
 
   PopulateUBOTypeMaps(module);
+  PopulateStructuredCFGMaps(module);
 
   // SPIR-V always begins with its header information
   outputHeader();
@@ -4768,42 +4778,7 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
           getAnalysis<LoopInfoWrapperPass>(*Func).getLoopInfo();
 
       BasicBlock *BrBB = Br->getParent();
-      Loop *L = LI.getLoopFor(BrBB);
-      if (LI.isLoopHeader(BrBB)) {
-        Value *ContinueBB = nullptr;
-        Value *MergeBB = nullptr;
-
-        MergeBB = L->getExitBlock();
-        if (!MergeBB) {
-          // StructurizeCFG pass converts CFG into triangle shape and the cfg
-          // has regions with single entry/exit. As a result, loop should not
-          // have multiple exits.
-          llvm_unreachable("Loop has multiple exits???");
-        }
-
-        if (L->isLoopLatch(BrBB)) {
-          ContinueBB = BrBB;
-        } else {
-          // From SPIR-V spec 2.11, Continue Target must dominate that back-edge
-          // block.
-          BasicBlock *Header = L->getHeader();
-          BasicBlock *Latch = L->getLoopLatch();
-          for (BasicBlock *BB : L->blocks()) {
-            if (BB == Header) {
-              continue;
-            }
-
-            // Check whether block dominates block with back-edge.
-            if (DT.dominates(BB, Latch)) {
-              ContinueBB = BB;
-            }
-          }
-
-          if (!ContinueBB) {
-            llvm_unreachable("Wrong continue block from loop");
-          }
-        }
-
+      if (ContinueBlocks.count(BrBB)) {
         //
         // Generate OpLoopMerge.
         //
@@ -4812,41 +4787,29 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
         // Ops[2] = Selection Control
         SPIRVOperandList Ops;
 
-        // StructurizeCFG pass already manipulated CFG. Just use false block of
-        // branch instruction as merge block.
+        auto MergeBB = MergeBlocks[BrBB];
+        auto ContinueBB = ContinueBlocks[BrBB];
         uint32_t MergeBBID = VMap[MergeBB];
         uint32_t ContinueBBID = VMap[ContinueBB];
         Ops << MkId(MergeBBID) << MkId(ContinueBBID)
-            << MkNum(spv::SelectionControlMaskNone);
+            << MkNum(spv::LoopControlMaskNone);
 
         auto *MergeInst = new SPIRVInstruction(spv::OpLoopMerge, Ops);
         SPIRVInstList.insert(InsertPoint, MergeInst);
+      } else if (MergeBlocks.count(BrBB)) {
+        //
+        // Generate OpSelectionMerge.
+        //
+        // Ops[0] = Merge Block ID
+        // Ops[1] = Selection Control
+        SPIRVOperandList Ops;
 
-      } else if (Br->isConditional()) {
-        // Generate a selection merge unless this is a back-edge block.
-        bool HasBackedge = false;
-        while (L && !HasBackedge) {
-          if (L->isLoopLatch(BrBB)) {
-            HasBackedge = true;
-          }
-          L = L->getParentLoop();
-        }
-        if (!HasBackedge) {
-          //
-          // Generate OpSelectionMerge.
-          //
-          // Ops[0] = Merge Block ID
-          // Ops[1] = Selection Control
-          SPIRVOperandList Ops;
+        auto MergeBB = MergeBlocks[BrBB];
+        uint32_t MergeBBID = VMap[MergeBB];
+        Ops << MkId(MergeBBID) << MkNum(spv::SelectionControlMaskNone);
 
-          // StructurizeCFG pass already manipulated CFG. Just use false block
-          // of branch instruction as merge block.
-          uint32_t MergeBBID = VMap[Br->getSuccessor(1)];
-          Ops << MkId(MergeBBID) << MkNum(spv::SelectionControlMaskNone);
-
-          auto *MergeInst = new SPIRVInstruction(spv::OpSelectionMerge, Ops);
-          SPIRVInstList.insert(InsertPoint, MergeInst);
-        }
+        auto *MergeInst = new SPIRVInstruction(spv::OpSelectionMerge, Ops);
+        SPIRVInstList.insert(InsertPoint, MergeInst);
       }
 
       if (Br->isConditional()) {
@@ -5914,4 +5877,88 @@ bool SPIRVProducerPass::CalledWithCoherentResource(Argument &Arg) {
 
   // No coherent resource variables encountered.
   return false;
+}
+
+void SPIRVProducerPass::PopulateStructuredCFGMaps(Module &module) {
+  // First, track loop merges and continues.
+  DenseSet<BasicBlock *> LoopMergesAndContinues;
+  for (auto &F : module) {
+    if (F.isDeclaration())
+      continue;
+
+    DominatorTree &DT = getAnalysis<DominatorTreeWrapperPass>(F).getDomTree();
+    const LoopInfo &LI = getAnalysis<LoopInfoWrapperPass>(F).getLoopInfo();
+    std::deque<BasicBlock *> order;
+    DenseSet<BasicBlock *> visited;
+    clspv::ComputeStructuredOrder(&*F.begin(), &DT, LI, &order, &visited);
+
+    for (auto BB : order) {
+      auto terminator = BB->getTerminator();
+      auto branch = dyn_cast<BranchInst>(terminator);
+      auto L = LI.getLoopFor(BB);
+      if (LI.isLoopHeader(BB)) {
+        BasicBlock *ContinueBB = nullptr;
+        BasicBlock *MergeBB = nullptr;
+
+        MergeBB = L->getExitBlock();
+        if (!MergeBB) {
+          // StructurizeCFG pass converts CFG into triangle shape and the cfg
+          // has regions with single entry/exit. As a result, loop should not
+          // have multiple exits.
+          llvm_unreachable("Loop has multiple exits???");
+        }
+
+        if (L->isLoopLatch(BB)) {
+          ContinueBB = BB;
+        } else {
+          // From SPIR-V spec 2.11, Continue Target must dominate that back-edge
+          // block.
+          BasicBlock *Header = L->getHeader();
+          BasicBlock *Latch = L->getLoopLatch();
+          for (auto *loop_block : L->blocks()) {
+            if (loop_block == Header) {
+              continue;
+            }
+
+            // Check whether block dominates block with back-edge.
+            if (DT.dominates(loop_block, Latch)) {
+              ContinueBB = loop_block;
+            }
+          }
+
+          if (!ContinueBB) {
+            llvm_unreachable("Wrong continue block from loop");
+          }
+        }
+
+        // Record the continue and merge blocks.
+        MergeBlocks[BB] = MergeBB;
+        ContinueBlocks[BB] = ContinueBB;
+        LoopMergesAndContinues.insert(MergeBB);
+        LoopMergesAndContinues.insert(ContinueBB);
+      } else if (branch && branch->isConditional()) {
+        auto L = LI.getLoopFor(BB);
+        bool HasBackedge = false;
+        while (L && !HasBackedge) {
+          if (L->isLoopLatch(BB)) {
+            HasBackedge = true;
+          }
+          L = L->getParentLoop();
+        }
+
+        if (!HasBackedge) {
+          // Only need a merge if the branch doesn't include a loop break or
+          // continue.
+          auto true_bb = branch->getSuccessor(0);
+          auto false_bb = branch->getSuccessor(1);
+          if (!LoopMergesAndContinues.count(true_bb) &&
+              !LoopMergesAndContinues.count(false_bb)) {
+            // StructurizeCFG pass already manipulated CFG. Just use false block
+            // of branch instruction as merge block.
+            MergeBlocks[BB] = false_bb;
+          }
+        }
+      }
+    }
+  }
 }

--- a/test/loop_continue_no_selection_merge.cl
+++ b/test/loop_continue_no_selection_merge.cl
@@ -1,0 +1,38 @@
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpLoopMerge {{.*}} [[CONT:%[a-zA-Z0-9_]+]] None
+// CHECK-NEXT: OpBranchConditional {{%[a-zA-Z0-9_]+}} {{%[a-zA-Z0-9_]+}} [[FALSE:%[a-zA-Z0-9_]+]]
+// CHECK: [[FALSE]] = OpLabel
+// CHECK-NEXT: OpControlBarrier
+// No selection merge is necessary because this is effectively a continue
+// statement.
+// CHECK-NOT: OpSelectionMerge
+// CHECK: OpBranchConditional {{.*}} {{.*}} [[CONT]]
+
+__kernel void
+top_scan(__global uint * isums,
+         const int n,
+         __local uint * lmem)
+{
+    __local int s_seed;
+    s_seed = 0; barrier(CLK_LOCAL_MEM_FENCE);
+
+    int last_thread = (get_local_id(0) < n &&
+                      (get_local_id(0)+1) == n) ? 1 : 0;
+
+    for (int d = 0; d < 16; d++)
+    {
+        int idx = get_local_id(0);
+        lmem[idx] = 0;
+        if (last_thread)
+        {
+            s_seed += 42;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
+
+


### PR DESCRIPTION
Fixes #448

* Refactor structured order computation into a new file
* updates deps
* Modify SPIRVProducer pass to figure out merge and continues at the
start of the pass
  * this is based on traversing in structured order
  * do not generate selection merges if one side of the branch is a loop
  continue or merge
* add a new test

The SPIRV-Tools update also includes the new validator check.

ComputeStructuredOrder is effectively a move from ReorderBasicBlock::StructuredOrder.