### PR TITLE
Deprecate the sampler map

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -23,8 +23,8 @@ The following subjects are covered:
 The sampler map is deprecated. It is no longer necessary to specify a sampler
 map for literal samplers. Refer to the bindings generated for the literal
 samplers in descriptor map. The -samplermap option is still accepted, but
-support will be remove at later date. A single sampler binding is generated for
-each unique literal sampler in the program.
+support will be removed at later date. A single sampler binding is generated
+for each unique literal sampler in the program.
 
 ## SPIR-V Features
 

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -18,6 +18,14 @@ The following subjects are covered:
 - Restrictions on the OpenCL C language as is to be consumed by a Vulkan
   implementation.
 
+## Deprecation Notice
+
+The sampler map is deprecated. It is no longer necessary to specify a sampler
+map for literal samplers. Refer to the bindings generated for the literal
+samplers in descriptor map. The -samplermap option is still accepted, but
+support will be remove at later date. A single sampler binding is generated for
+each unique literal sampler in the program.
+
 ## SPIR-V Features
 
 The SPIR-V as produced from the OpenCL C language can make use of the following

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -116,6 +116,12 @@ bool CPlusPlus();
 // Returns true when images are supported.
 bool ImageSupport();
 
+// Returns true when using a sampler map.
+bool UseSamplerMap();
+
+// Sets whether or not to use the sampler map.
+void SetUseSamplerMap(bool use);
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -265,8 +265,6 @@ bool AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(Module &M) {
   if (init_fn) {
     // Copy users, to avoid modifying the list in place.
     SmallVector<User *, 8> users(init_fn->users());
-    if (!users.empty()) {
-    }
     for (auto user : users) {
       if (auto *call = dyn_cast<CallInst>(user)) {
         auto const_val = dyn_cast<ConstantInt>(call->getArgOperand(0));

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -148,7 +148,7 @@ static llvm::cl::opt<std::string> OutputFormat(
     llvm::cl::value_desc("format"));
 
 static llvm::cl::opt<std::string>
-    SamplerMap("samplermap", llvm::cl::desc("Literal sampler map"),
+    SamplerMap("samplermap", llvm::cl::desc("DEPRECATED - Literal sampler map"),
                llvm::cl::value_desc("filename"));
 
 static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
@@ -185,6 +185,7 @@ int ParseSamplerMap(const std::string &sampler_map,
     // Parse the sampler map from the provided string.
     samplerMapBuffer = llvm::MemoryBuffer::getMemBuffer(sampler_map);
 
+    clspv::Option::SetUseSamplerMap(true);
     if (!SamplerMap.empty()) {
       llvm::outs() << "Warning: -samplermap is ignored when the sampler map is "
                       "provided through a string.\n";
@@ -201,11 +202,17 @@ int ParseSamplerMap(const std::string &sampler_map,
       return -1;
     }
 
+    clspv::Option::SetUseSamplerMap(true);
     samplerMapBuffer = std::move(errorOrSamplerMapFile.get());
     if (0 == samplerMapBuffer->getBufferSize()) {
       llvm::errs() << "Error: Sampler map was an empty file!\n";
       return -1;
     }
+  }
+
+  if (clspv::Option::UseSamplerMap()) {
+    llvm::outs()
+        << "Warning: use of the sampler map is deprecated and unnecessary\n";
   }
 
   // No sampler map to parse.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -156,6 +156,8 @@ static llvm::cl::opt<bool>
 
 static llvm::cl::opt<bool> images("images", llvm::cl::init(true),
                                   llvm::cl::desc("Enable support for images"));
+
+static bool use_sampler_map = false;
 } // namespace
 
 namespace clspv {
@@ -189,6 +191,8 @@ bool KeepUnusedArguments() { return keep_unused_arguments; }
 bool Int8Support() { return int8_support; }
 bool CPlusPlus() { return cplusplus; }
 bool ImageSupport() { return images; }
+bool UseSamplerMap() { return use_sampler_map; }
+void SetUseSamplerMap(bool use) { use_sampler_map = use; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2508,7 +2508,7 @@ void SPIRVProducerPass::GenerateSamplers(Module &M) {
     //          i32 binding,
     //          i32 (index-into-sampler-map|sampler_mask))
     if (auto *call = dyn_cast<CallInst>(user)) {
-      const size_t third_param = static_cast<unsigned>(
+      const auto third_param = static_cast<unsigned>(
           dyn_cast<ConstantInt>(call->getArgOperand(2))->getZExtValue());
       auto sampler_value = third_param;
       if (clspv::Option::UseSamplerMap()) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2508,7 +2508,7 @@ void SPIRVProducerPass::GenerateSamplers(Module &M) {
     //          i32 binding,
     //          i32 (index-into-sampler-map|sampler_mask))
     if (auto *call = dyn_cast<CallInst>(user)) {
-      const size_t third_param = static_cast<size_t>(
+      const size_t third_param = static_cast<unsigned>(
           dyn_cast<ConstantInt>(call->getArgOperand(2))->getZExtValue());
       auto sampler_value = third_param;
       if (clspv::Option::UseSamplerMap()) {
@@ -4507,8 +4507,8 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
 
     if (Callee->getName().equals(clspv::LiteralSamplerFunction())) {
       // Map this to a load from the variable.
-      const auto third_param =
-          dyn_cast<ConstantInt>(Call->getArgOperand(2))->getZExtValue();
+      const auto third_param = static_cast<unsigned>(
+          dyn_cast<ConstantInt>(Call->getArgOperand(2))->getZExtValue());
       auto sampler_value = third_param;
       if (clspv::Option::UseSamplerMap()) {
         sampler_value = getSamplerMap()[third_param].first;

--- a/test/SamplerMap/KernelScopeSampler.cl
+++ b/test/SamplerMap/KernelScopeSampler.cl
@@ -1,7 +1,12 @@
 // RUN: clspv -samplermap %S/foo.samplermap %s -o %t.spv
-// RUN: spirv-dis -o %t2.spvasm %t.spv
-// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %s -o %t2.spv
+// RUN: spirv-dis -o %t2.spvasm %t2.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t2.spv
 
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[READ_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[FLOAT_TYPE_ID]] 2D 0 0 0 1 Unknown

--- a/test/SamplerMap/no_sampler_map_two_samplers.cl
+++ b/test/SamplerMap/no_sampler_map_two_samplers.cl
@@ -1,0 +1,40 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck -check-prefix MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+const sampler_t s0 =
+CLK_NORMALIZED_COORDS_TRUE | CLK_ADDRESS_REPEAT | CLK_FILTER_NEAREST;
+
+const sampler_t s1 =
+CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_REPEAT | CLK_FILTER_NEAREST;
+
+kernel void foo(read_only image2d_t i1, read_only image2d_t i2, global float4* f_out, global int4* i_out) {
+  *f_out = read_imagef(i1, s0, (float2)(0.0));
+  *i_out = read_imagei(i2, s1, (float2)(0.0));
+}
+
+//      MAP: sampler,23,samplerExpr,"CLK_NORMALIZED_COORDS_TRUE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST",descriptorSet,0,binding,1
+// MAP-NEXT: sampler,22,samplerExpr,"CLK_NORMALIZED_COORDS_FALSE|CLK_ADDRESS_REPEAT|CLK_FILTER_NEAREST",descriptorSet,0,binding,0
+
+
+// CHECK: OpDecorate [[S0:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[S0]] Binding 1
+// CHECK: OpDecorate [[S1:%[a-zA-Z0-9_]+]] DescriptorSet 0
+// CHECK: OpDecorate [[S1]] Binding 0
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 1
+// CHECK-DAG: [[v4int:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+// CHECK-DAG: [[float_image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[int_image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[float_sampled_image:%[a-zA-Z0-9_]+]] = OpTypeSampledImage [[float_image]]
+// CHECK-DAG: [[int_sampled_image:%[a-zA-Z0-9_]+]] = OpTypeSampledImage [[int_image]]
+// CHECK-DAG: [[ld_s0:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[S0]]
+// CHECK-DAG: [[ld_s1:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[S1]]
+// CHECK-DAG: [[ld_float_image:%[a-zA-Z0-9_]+]] = OpLoad [[float_image]]
+// CHECK-DAG: [[ld_int_image:%[a-zA-Z0-9_]+]] = OpLoad [[int_image]]
+// CHECK-DAG: OpSampledImage [[float_sampled_image]] [[ld_float_image]] [[ld_s0]]
+// CHECK-DAG: OpSampledImage [[int_sampled_image]] [[ld_int_image]] [[ld_s1]]

--- a/test/issue-157.cl
+++ b/test/issue-157.cl
@@ -1,7 +1,12 @@
 // RUN: clspv -samplermap=%S/issue-157.samplermap %s -o %t.spv
-// RUN: spirv-dis -o %t2.spvasm %t.spv
-// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %s -o %t2.spv
+// RUN: spirv-dis -o %t2.spvasm %t2.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t2.spv
 
 // CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: %[[double:[0-9a-zA-Z_]+]] = OpTypeFloat 64

--- a/test/sampler-360.cl
+++ b/test/sampler-360.cl
@@ -1,6 +1,9 @@
 // RUN: clspv %s -o %t.spv -samplermap=%s.map -descriptormap=%t.map
 // RUN: FileCheck %s < %t.map
 
+// RUN: clspv %s -o %t2.spv -samplermap=%s.map -descriptormap=%t2.map
+// RUN: FileCheck %s < %t2.map
+//
 // CHECK: samplerExpr
 // CHECK-NOT: samplerExpr
 


### PR DESCRIPTION
Contributes to #451

* Add a warning when a sampler map is provided (for both online and
offline compiles)
  * the sampler is still supported and works as before if it is provided
* Without a sampler map clspv now auto-generates bindings for literal
samplers based on the sampler literal
* updated sampler map tests to also test without a sampler map
* new test to verify consistency with the descriptor map