### PR TITLE
Improve image query generation

### DIFF
--- a/amber/images/read_only_sampled_image2d_queries.amber
+++ b/amber/images/read_only_sampled_image2d_queries.amber
@@ -1,0 +1,46 @@
+#!amber
+
+SHADER compute image_queries OPENCL-C
+kernel void foo(read_only image2d_t small, read_only image2d_t medium,
+                read_only image2d_t large, global int* out) {
+  int i = 0;
+  out[i++] = get_image_width(small);
+  out[i++] = get_image_height(small);
+  out[i++] = get_image_dim(small).x;
+  out[i++] = get_image_dim(small).y;
+
+  out[i++] = get_image_width(medium);
+  out[i++] = get_image_height(medium);
+  out[i++] = get_image_dim(medium).x;
+  out[i++] = get_image_dim(medium).y;
+
+  out[i++] = get_image_width(large);
+  out[i++] = get_image_height(large);
+  out[i++] = get_image_dim(large).x;
+  out[i++] = get_image_dim(large).y;
+}
+END
+
+BUFFER out_buf DATA_TYPE int32 SIZE 12 FILL 0
+BUFFER small_i DATA_TYPE vec4<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER medium_i DATA_TYPE vec4<float> WIDTH 16 HEIGHT 32 FILL 0.0
+BUFFER large_i DATA_TYPE vec4<float> WIDTH 2048 HEIGHT 1024 FILL 0.0
+
+PIPELINE compute query_pipe
+  ATTACH image_queries ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER small_i KERNEL ARG_NAME small
+  BIND BUFFER medium_i KERNEL ARG_NAME medium
+  BIND BUFFER large_i KERNEL ARG_NAME large
+END
+
+RUN query_pipe 1 1 1
+
+# Small image queries.
+EXPECT out_buf IDX 0 EQ 2 2 2 2
+
+# Medium image queries.
+EXPECT out_buf IDX 16 EQ 16 32 16 32
+
+# Large image queries.
+EXPECT out_buf IDX 32 EQ 2048 1024 2048 1024

--- a/amber/images/write_only_image2d_queries.amber
+++ b/amber/images/write_only_image2d_queries.amber
@@ -1,0 +1,47 @@
+#!amber
+
+SHADER compute image_queries OPENCL-C
+kernel void foo(write_only image2d_t small, write_only image2d_t medium,
+                write_only image2d_t large, global int* out) {
+  int i = 0;
+  out[i++] = get_image_width(small);
+  out[i++] = get_image_height(small);
+  out[i++] = get_image_dim(small).x;
+  out[i++] = get_image_dim(small).y;
+
+  out[i++] = get_image_width(medium);
+  out[i++] = get_image_height(medium);
+  out[i++] = get_image_dim(medium).x;
+  out[i++] = get_image_dim(medium).y;
+
+  out[i++] = get_image_width(large);
+  out[i++] = get_image_height(large);
+  out[i++] = get_image_dim(large).x;
+  out[i++] = get_image_dim(large).y;
+}
+END
+
+BUFFER out_buf DATA_TYPE int32 SIZE 12 FILL 0
+BUFFER small_i DATA_TYPE vec4<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER medium_i DATA_TYPE vec4<float> WIDTH 16 HEIGHT 32 FILL 0.0
+BUFFER large_i DATA_TYPE vec4<float> WIDTH 2048 HEIGHT 1024 FILL 0.0
+
+PIPELINE compute query_pipe
+  ATTACH image_queries ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER small_i KERNEL ARG_NAME small
+  BIND BUFFER medium_i KERNEL ARG_NAME medium
+  BIND BUFFER large_i KERNEL ARG_NAME large
+END
+
+RUN query_pipe 1 1 1
+
+# Small image queries.
+EXPECT out_buf IDX 0 EQ 2 2 2 2
+
+# Medium image queries.
+EXPECT out_buf IDX 16 EQ 16 32 16 32
+
+# Large image queries.
+EXPECT out_buf IDX 32 EQ 2048 1024 2048 1024
+

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -26,6 +26,8 @@
 #include "clspv/AddressSpace.h"
 #include "clspv/Option.h"
 
+#include "Types.h"
+
 using namespace llvm;
 
 namespace clspv {
@@ -113,69 +115,6 @@ ArgKind GetArgKindFromName(const std::string &name) {
 bool IsLocalPtr(llvm::Type *type) {
   return type->isPointerTy() &&
          type->getPointerAddressSpace() == clspv::AddressSpace::Local;
-}
-
-bool IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
-  bool isSamplerType = false;
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
-      if (STy->isOpaque()) {
-        if (STy->getName().equals("opencl.sampler_t")) {
-          isSamplerType = true;
-          if (struct_type_ptr)
-            *struct_type_ptr = STy;
-        }
-      }
-    }
-  }
-  return isSamplerType;
-}
-
-bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
-  bool isImageType = false;
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
-      if (STy->isOpaque()) {
-        if (STy->getName().startswith("opencl.image2d_ro_t") ||
-            STy->getName().startswith("opencl.image2d_wo_t") ||
-            STy->getName().startswith("opencl.image3d_ro_t") ||
-            STy->getName().startswith("opencl.image3d_wo_t")) {
-          isImageType = true;
-          if (struct_type_ptr)
-            *struct_type_ptr = STy;
-        }
-      }
-    }
-  }
-  return isImageType;
-}
-
-bool IsFloatImageType(Type *type) {
-  return IsImageType(type) && !IsIntImageType(type) && !IsUintImageType(type);
-}
-
-bool IsIntImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains(".int"))
-        return true;
-    }
-  }
-
-  return false;
-}
-
-bool IsUintImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains(".uint"))
-        return true;
-    }
-  }
-
-  return false;
 }
 
 ArgIdMapType AllocateArgSpecIds(Module &M) {

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -44,26 +44,6 @@ inline const char *GetArgKindNameForType(llvm::Type *type) {
 // Returns true if the given type is a pointer-to-local type.
 bool IsLocalPtr(llvm::Type *type);
 
-// Returns true if the given type is a sampler type.  If it is, then the
-// struct type is sent back through the ptr argument.
-bool IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
-
-// Returns true if the given type is a image type.  If it is, then the
-// struct type is sent back through the ptr argument.
-bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
-
-// Returns true if the given type is a float image type.
-// Before image specialization, all images are considered float images.
-bool IsFloatImageType(llvm::Type *type);
-
-// Returns true if the given type is an int image type.
-// Can only return true after image specialization.
-bool IsIntImageType(llvm::Type *type);
-
-// Returns true if the given type is an uint image type.
-// Can only return true after image specialization.
-bool IsUintImageType(llvm::Type *type);
-
 using ArgIdMapType = llvm::DenseMap<const llvm::Argument *, int>;
 
 // Returns a mapping from pointer-to-local Argument to a specialization constant

--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -100,5 +100,5 @@ bool clspv::IsGetImageDim(StringRef name) {
 
 bool clspv::IsImageQuery(StringRef name) {
   return clspv::IsGetImageHeight(name) || clspv::IsGetImageWidth(name) ||
-         clspv::IsGetImageDepth(name);
+         clspv::IsGetImageDepth(name) || clspv::IsGetImageDim(name);
 }

--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -18,7 +18,7 @@ using namespace llvm;
 
 bool clspv::IsImageBuiltin(StringRef name) {
   return clspv::IsSampledImageRead(name) || clspv::IsImageWrite(name) ||
-         clspv::IsGetImageHeight(name) || clspv::IsGetImageWidth(name);
+         clspv::IsImageQuery(name);
 }
 
 bool clspv::IsSampledImageRead(StringRef name) {
@@ -74,10 +74,31 @@ bool clspv::IsIntImageWrite(StringRef name) {
 
 bool clspv::IsGetImageHeight(StringRef name) {
   return name.startswith("_Z16get_image_height14ocl_image2d_ro") ||
-         name.startswith("_Z16get_image_height14ocl_image2d_wo");
+         name.startswith("_Z16get_image_height14ocl_image2d_wo") ||
+         name.startswith("_Z16get_image_height14ocl_image3d_ro") ||
+         name.startswith("_Z16get_image_height14ocl_image3d_wo");
 }
 
 bool clspv::IsGetImageWidth(StringRef name) {
   return name.startswith("_Z15get_image_width14ocl_image2d_ro") ||
-         name.startswith("_Z15get_image_width14ocl_image2d_wo");
+         name.startswith("_Z15get_image_width14ocl_image2d_wo") ||
+         name.startswith("_Z15get_image_width14ocl_image3d_ro") ||
+         name.startswith("_Z15get_image_width14ocl_image3d_wo");
+}
+
+bool clspv::IsGetImageDepth(StringRef name) {
+  return name.startswith("_Z15get_image_depth14ocl_image3d_ro") ||
+         name.startswith("_Z15get_image_depth14ocl_image3d_wo");
+}
+
+bool clspv::IsGetImageDim(StringRef name) {
+  return name.startswith("_Z13get_image_dim14ocl_image2d_ro") ||
+         name.startswith("_Z13get_image_dim14ocl_image2d_wo") ||
+         name.startswith("_Z13get_image_dim14ocl_image3d_ro") ||
+         name.startswith("_Z13get_image_dim14ocl_image3d_wo");
+}
+
+bool clspv::IsImageQuery(StringRef name) {
+  return clspv::IsGetImageHeight(name) || clspv::IsGetImageWidth(name) ||
+         clspv::IsGetImageDepth(name);
 }

--- a/lib/Builtins.h
+++ b/lib/Builtins.h
@@ -86,6 +86,24 @@ inline bool IsGetImageWidth(llvm::Function *f) {
   return IsGetImageWidth(f->getName());
 }
 
+// Returns true if the function is an OpenCL image depth query.
+bool IsGetImageDepth(llvm::StringRef name);
+inline bool IsGetImageDepth(llvm::Function *f) {
+  return IsGetImageDepth(f->getName());
+}
+
+// Returns true if the function is an OpenCL image dim query.
+bool IsGetImageDim(llvm::StringRef name);
+inline bool IsGetImageDim(llvm::Function *f) {
+  return IsGetImageDim(f->getName());
+}
+
+// Returns true if the function is an OpenCL image query.
+bool IsImageQuery(llvm::StringRef name);
+inline bool IsImageQuery(llvm::Function *f) {
+  return IsImageQuery(f->getName());
+}
+
 } // namespace clspv
 
 #endif // CLSPV_LIB_BUILTINS_H_

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/SpecializeImageTypes.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatSelectCondition.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UBOTypeTransformPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoBoolPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoByvalPass.cpp

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4704,9 +4704,9 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       // May require an extra instruction to create the appropriate result of
       // the builtin function.
       if (clspv::IsGetImageDim(Callee)) {
-        // get_image_dim returns an int2 for any 2D image (even arrayed) and an
-        // int4 for 3D images.
         if (dim == 3) {
+          // get_image_dim returns an int4 for 3D images.
+          //
           // Reset value map entry since we generated an intermediate
           // instruction.
           VMap[&I] = nextID;
@@ -4724,6 +4724,10 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
               new SPIRVInstruction(spv::OpCompositeConstruct, nextID++, Ops);
           SPIRVInstList.push_back(Inst);
         } else if (dim != components) {
+          // get_image_dim return an int2 regardless of the arrayedness of the
+          // image. If the image is arrayed an element must be dropped from the
+          // query result.
+          //
           // Reset value map entry since we generated an intermediate
           // instruction.
           VMap[&I] = nextID;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4689,16 +4689,16 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       }
       uint32_t ImageID = VMap[Image];
       Ops << MkId(SizesTypeID) << MkId(ImageID);
-      spv::Op opcode = spv::OpImageQuerySize;
+      spv::Op query_opcode = spv::OpImageQuerySize;
       if (clspv::IsSampledImageType(Image->getType())) {
-        opcode = spv::OpImageQuerySizeLod;
+        query_opcode = spv::OpImageQuerySizeLod;
         // Need explicit 0 for Lod operand.
         Constant *CstInt0 = ConstantInt::get(Context, APInt(32, 0));
         Ops << MkId(VMap[CstInt0]);
       }
 
       uint32_t SizesID = nextID++;
-      auto *QueryInst = new SPIRVInstruction(opcode, SizesID, Ops);
+      auto *QueryInst = new SPIRVInstruction(query_opcode, SizesID, Ops);
       SPIRVInstList.push_back(QueryInst);
 
       // May require an extra instruction to create the appropriate result of

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -22,10 +22,10 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "ArgKind.h"
 #include "Builtins.h"
 #include "Constants.h"
 #include "Passes.h"
+#include "Types.h"
 
 using namespace clspv;
 using namespace llvm;

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -1,0 +1,110 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Types.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/DerivedTypes.h"
+
+using namespace clspv;
+using namespace llvm;
+
+bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
+  bool isSamplerType = false;
+  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
+    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
+      if (STy->isOpaque()) {
+        if (STy->getName().equals("opencl.sampler_t")) {
+          isSamplerType = true;
+          if (struct_type_ptr)
+            *struct_type_ptr = STy;
+        }
+      }
+    }
+  }
+  return isSamplerType;
+}
+
+bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
+  bool isImageType = false;
+  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
+    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
+      if (STy->isOpaque()) {
+        if (STy->getName().startswith("opencl.image2d_ro_t") ||
+            STy->getName().startswith("opencl.image2d_wo_t") ||
+            STy->getName().startswith("opencl.image3d_ro_t") ||
+            STy->getName().startswith("opencl.image3d_wo_t")) {
+          isImageType = true;
+          if (struct_type_ptr)
+            *struct_type_ptr = STy;
+        }
+      }
+    }
+  }
+  return isImageType;
+}
+
+uint32_t clspv::ImageDimensionality(Type *type) {
+  Type *ty = nullptr;
+  if (IsImageType(type, &ty)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
+      if (struct_ty->getName().contains("image2d"))
+        return 2;
+      if (struct_ty->getName().contains("image3d"))
+        return 3;
+    }
+  }
+
+  return 0;
+}
+
+bool clspv::IsSampledImageType(Type *type) {
+  Type *ty = nullptr;
+  if (IsImageType(type, &ty)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
+      if (struct_ty->getName().contains(".sampled"))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+bool clspv::IsFloatImageType(Type *type) {
+  return IsImageType(type) && !IsIntImageType(type) && !IsUintImageType(type);
+}
+
+bool clspv::IsIntImageType(Type *type) {
+  Type *ty = nullptr;
+  if (IsImageType(type, &ty)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
+      if (struct_ty->getName().contains(".int"))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+bool clspv::IsUintImageType(Type *type) {
+  Type *ty = nullptr;
+  if (IsImageType(type, &ty)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
+      if (struct_ty->getName().contains(".uint"))
+        return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -1,0 +1,52 @@
+// Copyright 2019 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_LIB_TYPES_H
+#define CLSPV_LIB_TYPES_H
+
+#include "llvm/IR/Type.h"
+
+namespace clspv {
+
+// Returns true if the given type is a sampler type.  If it is, then the
+// struct type is sent back through the ptr argument.
+bool IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
+
+// Returns true if the given type is a image type.  If it is, then the
+// struct type is sent back through the ptr argument.
+bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
+
+// Returns the dimensionality of the image type. If |type| is not an image,
+// returns 0.
+uint32_t ImageDimensionality(llvm::Type *type);
+
+// Returns true if the given type is a sampled image type. Can only return true
+// after image specialization.
+bool IsSampledImageType(llvm::Type *type);
+
+// Returns true if the given type is a float image type.
+// Before image specialization, all images are considered float images.
+bool IsFloatImageType(llvm::Type *type);
+
+// Returns true if the given type is an int image type.
+// Can only return true after image specialization.
+bool IsIntImageType(llvm::Type *type);
+
+// Returns true if the given type is an uint image type.
+// Can only return true after image specialization.
+bool IsUintImageType(llvm::Type *type);
+
+} // namespace clspv
+
+#endif

--- a/test/ImageBuiltins/get_image_depth_image3d_readonly.cl
+++ b/test/ImageBuiltins/get_image_depth_image3d_readonly.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_only image3d_t im)
+{
+  *out = get_image_depth(im);
+}
+
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v3uint]] [[_18]] [[uint_0]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 2
+// CHECK: OpStore {{.*}} [[_20]]

--- a/test/ImageBuiltins/get_image_depth_image3d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_depth_image3d_writeonly.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, write_only image3d_t im)
+{
+  *out = get_image_depth(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 2
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_dim_image2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_dim_image2d_readonly.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int2* out, read_only image2d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v2uint]] [[_18]] [[uint_0]]
+// CHECK: OpStore {{.*}} [[_19]]
+

--- a/test/ImageBuiltins/get_image_dim_image2d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_dim_image2d_writeonly.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int2* out, write_only image2d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: OpStore {{.*}} [[_19]]
+

--- a/test/ImageBuiltins/get_image_dim_image3d_readonly.cl
+++ b/test/ImageBuiltins/get_image_dim_image3d_readonly.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int4* out, read_only image3d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v3uint]] [[_18]] [[uint_0]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4uint]] [[_19]] [[uint_0]]
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_dim_image3d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_dim_image3d_writeonly.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int4* out, write_only image3d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4uint]] [[_19]] [[uint_0]]
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_height_image2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_readonly.cl
@@ -1,8 +1,7 @@
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// #219: Sampled images cannot be queried in Vulkan.
-// RUN: not spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
 foo(global int* out, read_only image2d_t im)
@@ -14,7 +13,8 @@ foo(global int* out, read_only image2d_t im)
 // CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
-// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v2uint]] [[_18]] [[uint_0]]
 // CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 1
 // CHECK: OpStore {{.*}} [[_20]]

--- a/test/ImageBuiltins/get_image_height_image3d_readonly.cl
+++ b/test/ImageBuiltins/get_image_height_image3d_readonly.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_only image3d_t im)
+{
+  *out = get_image_height(im);
+}
+
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v3uint]] [[_18]] [[uint_0]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 1
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_height_image3d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_height_image3d_writeonly.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, write_only image3d_t im)
+{
+  *out = get_image_height(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 1
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_width_image3d_readonly.cl
+++ b/test/ImageBuiltins/get_image_width_image3d_readonly.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_only image3d_t im)
+{
+  *out = get_image_width(im);
+}
+
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v3uint]] [[_18]] [[uint_0]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 0
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_width_image3d_writeonly.cl
+++ b/test/ImageBuiltins/get_image_width_image3d_writeonly.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, write_only image3d_t im)
+{
+  *out = get_image_width(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 0
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
+++ b/test/ImageBuiltins/get_image_width_imaged2d_readonly.cl
@@ -1,8 +1,7 @@
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// #219: Sampled images cannot be queried in Vulkan.
-// RUN: not spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
 foo(global int* out, read_only image2d_t im)
@@ -14,7 +13,8 @@ foo(global int* out, read_only image2d_t im)
 // CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
-// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySizeLod [[_v2uint]] [[_18]] [[uint_0]]
 // CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 0
 // CHECK: OpStore {{.*}} [[_20]]

--- a/test/SpecializeImageTypes/image2d_int_get_image_dim.ll
+++ b/test/SpecializeImageTypes/image2d_int_get_image_dim.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_wo_t.int]] = type opaque
+; CHECK: declare spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>, <4 x i32>) [[ATTRS]]
+; CHECK: define spir_kernel void @write_int
+; CHECK: call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_wo_t = type opaque
+
+define spir_kernel void @write_int(%opencl.image2d_wo_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x i32>, <4 x i32> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i(%opencl.image2d_wo_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> %ld) #2
+  %dim = tail call spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_wo(%opencl.image2d_wo_t addrspace(1)* %image)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i(%opencl.image2d_wo_t addrspace(1)*, <2 x i32>, <4 x i32>) local_unnamed_addr #1
+
+declare spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_wo(%opencl.image2d_wo_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image2d_int_sampled_get_image_dim.ll
+++ b/test/SpecializeImageTypes/image2d_int_sampled_get_image_dim.ll
@@ -1,0 +1,36 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_ro_t.int.sampled]] = type opaque
+; CHECK: declare spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>) [[ATTRS]]
+; CHECK: define spir_kernel void @read_int
+; CHECK: call spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @read_int(%opencl.image2d_ro_t addrspace(1)* %image, <2 x float> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %0 = tail call %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32 23) #2
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %image, %opencl.sampler_t addrspace(2)* %0, <2 x float> %coord) #3
+  %dim = tail call spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %image)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>) local_unnamed_addr #1
+
+declare spir_func <2 x i32> @_Z13get_image_dim14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)*) #1
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) local_unnamed_addr
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_get_image_depth.ll
+++ b/test/SpecializeImageTypes/image3d_float_get_image_depth.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_wo_t.float]] = type opaque
+; CHECK: declare spir_func i32 @_Z15get_image_depth14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <4 x i32>, <4 x float>) [[ATTRS]]
+; CHECK: define spir_kernel void @write_float
+; CHECK: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z15get_image_depth14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_wo_t = type opaque
+
+define spir_kernel void @write_float(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x float>, <4 x float> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> %ld) #2
+  %h = tail call spir_func i32 @_Z15get_image_depth14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)* %image)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)*, <4 x i32>, <4 x float>) local_unnamed_addr #1
+
+declare spir_func i32 @_Z15get_image_depth14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_get_image_height.ll
+++ b/test/SpecializeImageTypes/image3d_float_get_image_height.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_wo_t.float]] = type opaque
+; CHECK: declare spir_func i32 @_Z16get_image_height14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <4 x i32>, <4 x float>) [[ATTRS]]
+; CHECK: define spir_kernel void @write_float
+; CHECK: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z16get_image_height14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_wo_t = type opaque
+
+define spir_kernel void @write_float(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x float>, <4 x float> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> %ld) #2
+  %h = tail call spir_func i32 @_Z16get_image_height14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)* %image)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)*, <4 x i32>, <4 x float>) local_unnamed_addr #1
+
+declare spir_func i32 @_Z16get_image_height14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_get_image_width.ll
+++ b/test/SpecializeImageTypes/image3d_float_get_image_width.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_wo_t.float]] = type opaque
+; CHECK: declare spir_func i32 @_Z15get_image_width14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <4 x i32>, <4 x float>) [[ATTRS]]
+; CHECK: define spir_kernel void @write_float
+; CHECK: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z15get_image_width14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_wo_t = type opaque
+
+define spir_kernel void @write_float(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x float>, <4 x float> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x float> %ld) #2
+  %h = tail call spir_func i32 @_Z15get_image_width14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)* %image)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(%opencl.image3d_wo_t addrspace(1)*, <4 x i32>, <4 x float>) local_unnamed_addr #1
+
+declare spir_func i32 @_Z15get_image_width14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_sampled_get_image_depth.ll
+++ b/test/SpecializeImageTypes/image3d_float_sampled_get_image_depth.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_ro_t.float.sampled]] = type opaque
+; CHECK: declare spir_func i32 @_Z15get_image_depth14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_float
+; CHECK: call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z15get_image_depth14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @read_float(%opencl.image3d_ro_t addrspace(1)* %image, <4 x float> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %0 = tail call %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32 23) #2
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %image, %opencl.sampler_t addrspace(2)* %0, <4 x float> %coord) #3
+  %h = tail call spir_func i32 @_Z15get_image_depth14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)* %image)
+  store <4 x float> %call, <4 x float> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) local_unnamed_addr #1
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) local_unnamed_addr
+
+declare spir_func i32 @_Z15get_image_depth14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_sampled_get_image_height.ll
+++ b/test/SpecializeImageTypes/image3d_float_sampled_get_image_height.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_ro_t.float.sampled]] = type opaque
+; CHECK: declare spir_func i32 @_Z16get_image_height14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_float
+; CHECK: call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z16get_image_height14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @read_float(%opencl.image3d_ro_t addrspace(1)* %image, <4 x float> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %0 = tail call %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32 23) #2
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %image, %opencl.sampler_t addrspace(2)* %0, <4 x float> %coord) #3
+  %h = tail call spir_func i32 @_Z16get_image_height14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)* %image)
+  store <4 x float> %call, <4 x float> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) local_unnamed_addr #1
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) local_unnamed_addr
+
+declare spir_func i32 @_Z16get_image_height14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_float_sampled_get_image_width.ll
+++ b/test/SpecializeImageTypes/image3d_float_sampled_get_image_width.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_ro_t.float.sampled]] = type opaque
+; CHECK: declare spir_func i32 @_Z15get_image_width14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_float
+; CHECK: call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func i32 @_Z15get_image_width14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image)
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @read_float(%opencl.image3d_ro_t addrspace(1)* %image, <4 x float> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %0 = tail call %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32 23) #2
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %image, %opencl.sampler_t addrspace(2)* %0, <4 x float> %coord) #3
+  %h = tail call spir_func i32 @_Z15get_image_width14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)* %image)
+  store <4 x float> %call, <4 x float> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) local_unnamed_addr #1
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) local_unnamed_addr
+
+declare spir_func i32 @_Z15get_image_width14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_int_get_image_dim.ll
+++ b/test/SpecializeImageTypes/image3d_int_get_image_dim.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_wo_t.int]] = type opaque
+; CHECK: declare spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <4 x i32>, <4 x i32>) [[ATTRS]]
+; CHECK: define spir_kernel void @write_int
+; CHECK: call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_wo.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_wo_t = type opaque
+
+define spir_kernel void @write_int(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x i32>, <4 x i32> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_(%opencl.image3d_wo_t addrspace(1)* %image, <4 x i32> %coord, <4 x i32> %ld) #2
+  %dim = tail call spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)* %image)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_(%opencl.image3d_wo_t addrspace(1)*, <4 x i32>, <4 x i32>) local_unnamed_addr #1
+
+declare spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_wo(%opencl.image3d_wo_t addrspace(1)*) #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/image3d_int_sampled_get_image_dim.ll
+++ b/test/SpecializeImageTypes/image3d_int_sampled_get_image_dim.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image3d_ro_t.int.sampled]] = type opaque
+; CHECK: declare spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)*) [[ATTRS:#[0-9]+]]
+; CHECK: declare spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) [[ATTRS]]
+; CHECK: define spir_kernel void @read_int
+; CHECK: call spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: call spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_ro.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image3d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @read_int(%opencl.image3d_ro_t addrspace(1)* %image, <4 x float> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %0 = tail call %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32 23) #2
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %image, %opencl.sampler_t addrspace(2)* %0, <4 x float> %coord) #3
+  %dim = tail call spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)* %image)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x float>) local_unnamed_addr #1
+
+declare spir_func <4 x i32> @_Z13get_image_dim14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*) #1
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) local_unnamed_addr
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+


### PR DESCRIPTION
Fixes #219

* Move type functions from ArgKind.{cpp,h} into Types.{cpp,h}
* New type method to get the dimensionality of an image
* extend support for get_image_width and get_image_height to 3D images
* add support for get_image_depth
* add support for get_image_dim for 2D and 3D images
* new function to check if a function is an image query
* Image queries now generate OpImageQuerySizeLod for sampled images
  * generalized spirv generation for image queries
* fix tests that previously did not validate
* new tests newly handled builtins
* amber tests for 2d image queries