### PR TITLE
Support sampled read_image{f,i,ui} with integer coordinates for 2D/3D images

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -670,9 +670,5 @@ The `printf()` built-in function **must not** be used.
 
 #### Image Read and Write Functions
 
-The `get_image_channel_data_type()`, `get_image_channel_order()`,
-`read_imagei()`, `read_imageui()`, `write_imagei()` and `write_imageui()`
+The `get_image_channel_data_type()` and `get_image_channel_order()`
 built-in functions **must not** be used.
-
-The versions of the `read_imagef()` built-in functions that use integer vector
-types to specify which coordinate to sample **must not** be used.

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -204,7 +204,7 @@ struct ReplaceOpenCLBuiltinPass final : public ModulePass {
   bool replaceVstoreHalf(Module &M);
   bool replaceVstoreHalf2(Module &M);
   bool replaceVstoreHalf4(Module &M);
-  bool replaceReadImageF(Module &M);
+  bool replaceSampledReadImageWithIntCoords(Module &M);
   bool replaceAtomics(Module &M);
   bool replaceCross(Module &M);
   bool replaceFract(Module &M);
@@ -258,7 +258,7 @@ bool ReplaceOpenCLBuiltinPass::runOnModule(Module &M) {
   Changed |= replaceVstoreHalf(M);
   Changed |= replaceVstoreHalf2(M);
   Changed |= replaceVstoreHalf4(M);
-  Changed |= replaceReadImageF(M);
+  Changed |= replaceSampledReadImageWithIntCoords(M);
   Changed |= replaceAtomics(M);
   Changed |= replaceCross(M);
   Changed |= replaceFract(M);
@@ -2682,14 +2682,27 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf4(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceReadImageF(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(Module &M) {
   bool Changed = false;
 
   const std::map<const char *, const char *> Map = {
+      // TODO 1D, 1Darray
+      // 2D
+      {"_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_i",
+       "_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f"},
+      {"_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_i",
+       "_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f"},
       {"_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_i",
        "_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f"},
-      {"_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv4_f"}};
+      // TODO 2D array
+      // 3D
+      {"_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_i",
+       "_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f"},
+      {"_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_i",
+       "_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_f"},
+      {"_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i",
+       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f"}
+  };
 
   for (auto Pair : Map) {
     // If we find a function with the matching name.

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -2701,8 +2701,7 @@ bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(Module &M) {
       {"_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_i",
        "_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_f"},
       {"_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f"}
-  };
+       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f"}};
 
   for (auto Pair : Map) {
     // If we find a function with the matching name.

--- a/test/ImageBuiltins/sampled_2d_3d_read_image_with_int_coords.ll
+++ b/test/ImageBuiltins/sampled_2d_3d_read_image_with_int_coords.ll
@@ -1,0 +1,56 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %0 = sitofp <2 x i32> <i32 3, i32 7> to <2 x float>
+; CHECK: call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x float> %0)
+; CHECK: %2 = sitofp <2 x i32> <i32 3, i32 7> to <2 x float>
+; CHECK: call <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x float> %2)
+; CHECK: %4 = sitofp <2 x i32> <i32 3, i32 7> to <2 x float>
+; CHECK: call <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x float> %4)
+; CHECK: %6 = sitofp <4 x i32> <i32 3, i32 7, i32 5, i32 0> to <4 x float>
+; CHECK: call <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x float> %6)
+; CHECK: %8 = sitofp <4 x i32> <i32 3, i32 7, i32 5, i32 0> to <4 x float>
+; CHECK: call <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x float> %8)
+; CHECK: %10 = sitofp <4 x i32> <i32 3, i32 7, i32 5, i32 0> to <4 x float>
+; CHECK: call <4 x i32> @_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_f(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x float> %10)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.sampler_t = type opaque
+%opencl.image2d_ro_t = type opaque
+%opencl.image3d_ro_t = type opaque
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @test(%opencl.sampler_t addrspace(2)* %sampler, %opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.image3d_ro_t addrspace(1)* %im3d) local_unnamed_addr #0 {
+entry:
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x i32> <i32 3, i32 7>) #1
+  %call2 = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x i32> <i32 3, i32 7>) #1
+  %call4 = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.sampler_t addrspace(2)* %sampler, <2 x i32> <i32 3, i32 7>) #1
+  %call6 = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x i32> <i32 3, i32 7, i32 5, i32 0>) #1
+  %call8 = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x i32> <i32 3, i32 7, i32 5, i32 0>) #1
+  %call10 = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, %opencl.sampler_t addrspace(2)* %sampler, <4 x i32> <i32 3, i32 7, i32 5, i32 0>) #1
+  ret void
+}
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_i(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_i(%opencl.image3d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <4 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind }
+attributes #1 = { convergent nounwind readonly }
+


### PR DESCRIPTION
Also update the docs to reflect recent changes to image support.

AFAICT the _Z11read_imagef14ocl_image2d_ro11ocl_samplerDv4_i built-in
function I've removed doesn't exist in the OpenCL 1.2 spec.