### PR TITLE
Unsampled reads

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -187,7 +187,7 @@ bool AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(Module &M) {
     outs() << "Allocate literal sampler descriptors\n";
   }
   bool Changed = false;
-  auto init_fn = M.getFunction("__translate_sampler_initializer");
+  auto init_fn = M.getFunction(clspv::TranslateSamplerInitializerFunction());
   if (!init_fn)
     return Changed;
 

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -50,6 +50,11 @@ inline std::string SPIRVOpIntrinsicFunction() { return "spirv.op."; }
 // 0, 1 and 2 are reserved for workgroup size.
 inline int FirstLocalSpecId() { return 3; }
 
+// Name of the literal sampler initializer function.
+inline std::string TranslateSamplerInitializerFunction() {
+  return "__translate_sampler_initializer";
+}
+
 } // namespace clspv
 
 #endif

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -29,6 +29,7 @@
 
 #include "spirv/1.0/spirv.hpp"
 
+#include "clspv/AddressSpace.h"
 #include "clspv/Option.h"
 
 #include "Constants.h"
@@ -2737,7 +2738,8 @@ bool ReplaceOpenCLBuiltinPass::replaceUnsampledReadImage(Module &M) {
             if (!sampler_type) {
               sampler_type =
                   StructType::create(M.getContext(), "opencl.sampler_t");
-              sampler_type = sampler_type->getPointerTo(2);
+              sampler_type =
+                  sampler_type->getPointerTo(clspv::AddressSpace::Constant);
             }
             auto fn_type = FunctionType::get(
                 sampler_type, {Type::getInt32Ty(M.getContext())}, false);

--- a/lib/UndoTranslateSamplerFoldPass.cpp
+++ b/lib/UndoTranslateSamplerFoldPass.cpp
@@ -65,7 +65,7 @@ bool UndoTranslateSamplerFoldPass::runOnModule(Module &M) {
         BadCalls.push_back(CI);
       } else {
         Arg->print(errs());
-        llvm_unreachable("Unhandled argument to " +
+        llvm_unreachable(std::string("Unhandled argument to ") +
                          clspv::TranslateSamplerInitializerFunction());
       }
     }

--- a/lib/UndoTranslateSamplerFoldPass.cpp
+++ b/lib/UndoTranslateSamplerFoldPass.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
+#include "Constants.h"
 #include "Passes.h"
 
 using namespace llvm;
@@ -45,7 +46,7 @@ ModulePass *createUndoTranslateSamplerFoldPass() {
 } // namespace clspv
 
 bool UndoTranslateSamplerFoldPass::runOnModule(Module &M) {
-  auto F = M.getFunction("__translate_sampler_initializer");
+  auto F = M.getFunction(clspv::TranslateSamplerInitializerFunction());
 
   if (!F) {
     return false;
@@ -64,8 +65,8 @@ bool UndoTranslateSamplerFoldPass::runOnModule(Module &M) {
         BadCalls.push_back(CI);
       } else {
         Arg->print(errs());
-        llvm_unreachable(
-            "Unhandled argument to __translate_sampler_initializer!");
+        llvm_unreachable("Unhandled argument to " +
+                         clspv::TranslateSamplerInitializerFunction());
       }
     }
   }

--- a/lib/UndoTranslateSamplerFoldPass.cpp
+++ b/lib/UndoTranslateSamplerFoldPass.cpp
@@ -65,8 +65,9 @@ bool UndoTranslateSamplerFoldPass::runOnModule(Module &M) {
         BadCalls.push_back(CI);
       } else {
         Arg->print(errs());
-        llvm_unreachable(std::string("Unhandled argument to ") +
-                         clspv::TranslateSamplerInitializerFunction());
+        std::string msg = "Unhandled argument to ";
+        msg += clspv::TranslateSamplerInitializerFunction();
+        llvm_unreachable(msg.c_str());
       }
     }
   }

--- a/test/ImageBuiltins/unsampled_read_image.ll
+++ b/test/ImageBuiltins/unsampled_read_image.ll
@@ -1,0 +1,99 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: [[sampler:%opencl.sampler_t]] = type opaque
+
+; CHECK: @readf(
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC:@__translate_sampler_initializer]](i32 16)
+; CHECK: call <4 x float> @_Z11read_imagef14ocl_image1d_ro11ocl_samplerf({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+
+; CHECK: @readui(
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z12read_imageui14ocl_image1d_ro11ocl_samplerf({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+
+; CHECK: @readi(
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z11read_imagei14ocl_image1d_ro11ocl_samplerf({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+; CHECK: [[trans:%[a-zA-Z0-9_]+]] = call [[sampler]] addrspace(2)* [[FUNC]](i32 16)
+; CHECK: call <4 x i32> @_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f({{.*}}, [[sampler]] addrspace(2)* [[trans]],
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image1d_ro_t = type opaque
+%opencl.image2d_ro_t = type opaque
+%opencl.image3d_ro_t = type opaque
+
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+; Function Attrs: convergent nounwind
+define spir_kernel void @readf(%opencl.image1d_ro_t addrspace(1)* %im1d, %opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.image3d_ro_t addrspace(1)* %im3d, <4 x float> addrspace(1)* %out) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+entry:
+  %call = call spir_func <4 x float> @_Z11read_imagef14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)* %im1d, i32 0)
+  %call1 = call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, <2 x i32> zeroinitializer)
+  %call3 = call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, <4 x i32> zeroinitializer)
+  ret void
+}
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)*, i32)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)*, <2 x i32>)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)*, <4 x i32>)
+; Function Attrs: convergent nounwind
+define spir_kernel void @readui(%opencl.image1d_ro_t addrspace(1)* %im1d, %opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.image3d_ro_t addrspace(1)* %im3d, <4 x i32> addrspace(1)* %out) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !8 !kernel_arg_base_type !9 !kernel_arg_type_qual !7 {
+entry:
+  %call = call spir_func <4 x i32> @_Z12read_imageui14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)* %im1d, i32 0)
+  %call1 = call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, <2 x i32> zeroinitializer)
+  %call3 = call spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, <4 x i32> zeroinitializer)
+  ret void
+}
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)*, i32)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)*, <2 x i32>)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)*, <4 x i32>)
+; Function Attrs: convergent nounwind
+define spir_kernel void @readi(%opencl.image1d_ro_t addrspace(1)* %im1d, %opencl.image2d_ro_t addrspace(1)* %im2d, %opencl.image3d_ro_t addrspace(1)* %im3d, <4 x i32> addrspace(1)* %out) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !10 !kernel_arg_base_type !11 !kernel_arg_type_qual !7 {
+entry:
+  %call = call spir_func <4 x i32> @_Z11read_imagei14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)* %im1d, i32 0)
+  %call1 = call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)* %im2d, <2 x i32> zeroinitializer)
+  %call3 = call spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)* %im3d, <4 x i32> zeroinitializer)
+  ret void
+}
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image1d_roi(%opencl.image1d_ro_t addrspace(1)*, i32)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i(%opencl.image2d_ro_t addrspace(1)*, <2 x i32>)
+; Function Attrs: convergent nounwind readonly
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image3d_roDv4_i(%opencl.image3d_ro_t addrspace(1)*, <4 x i32>)
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 10.0.0 (https://github.com/llvm/llvm-project abe8de29c4ae5eca86f3594d2edd43b2fcbda623)"}
+!3 = !{i32 1, i32 1, i32 1, i32 1}
+!4 = !{!"read_only", !"read_only", !"read_only", !"none"}
+!5 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"float4*"}
+!6 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"float __attribute__((ext_vector_type(4)))*"}
+!7 = !{!"", !"", !"", !""}
+!8 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"uint4*"}
+!9 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"uint __attribute__((ext_vector_type(4)))*"}
+!10 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"int4*"}
+!11 = !{!"image1d_t", !"image2d_t", !"image3d_t", !"int __attribute__((ext_vector_type(4)))*"}
+
+

--- a/test/ImageBuiltins/unsampled_read_image_descriptor_map.cl
+++ b/test/ImageBuiltins/unsampled_read_image_descriptor_map.cl
@@ -1,0 +1,36 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map
+// RUN: FileCheck %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+//      CHECK: sampler,16,samplerExpr,"CLK_NORMALIZED_COORDS_FALSE|CLK_ADDRESS_NONE|CLK_FILTER_NEAREST",descriptorSet,0,binding,0
+// CHECK-NEXT: kernel,readf,arg,im1d,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readf,arg,im2d,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readf,arg,im3d,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readf,arg,out,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,buffer
+// CHECK-NEXT: kernel,readui,arg,im1d,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readui,arg,im2d,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readui,arg,im3d,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readui,arg,out,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,buffer
+// CHECK-NEXT: kernel,readi,arg,im1d,argOrdinal,0,descriptorSet,1,binding,0,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readi,arg,im2d,argOrdinal,1,descriptorSet,1,binding,1,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readi,arg,im3d,argOrdinal,2,descriptorSet,1,binding,2,offset,0,argKind,ro_image
+// CHECK-NEXT: kernel,readi,arg,out,argOrdinal,3,descriptorSet,1,binding,3,offset,0,argKind,buffer
+
+kernel void readf(read_only image1d_t im1d, read_only image2d_t im2d, read_only image3d_t im3d, global float4* out) {
+  out[0] = read_imagef(im1d, 0);
+  out[1] = read_imagef(im2d, (int2)(0));
+  out[2] = read_imagef(im3d, (int4)(0));
+}
+
+kernel void readui(read_only image1d_t im1d, read_only image2d_t im2d, read_only image3d_t im3d, global uint4* out) {
+  out[0] = read_imageui(im1d, 0);
+  out[1] = read_imageui(im2d, (int2)(0));
+  out[2] = read_imageui(im3d, (int4)(0));
+}
+
+kernel void readi(read_only image1d_t im1d, read_only image2d_t im2d, read_only image3d_t im3d, global int4* out) {
+  out[0] = read_imagei(im1d, 0);
+  out[1] = read_imagei(im2d, (int2)(0));
+  out[2] = read_imagei(im3d, (int4)(0));
+}
+


### PR DESCRIPTION
Fixes #464

* Support unsampled image reads for 1D, 2D and 3D images
  * calls are translated to sampled reads with a literal sampler using
  CLK_ADDRESS_NONE | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE
* Add tests
* Refactor direct uses of string literal for sampler initializer with a function