### PR TITLE
Refactor checks about pointers in structs

### DIFF
--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -93,7 +93,7 @@ private:
           return true;
       }
     }
- 
+
     seen->erase(canonical.getTypePtr());
     return false;
   }

--- a/test/Structs/kernel_arg_has_pointer_in_struct.cl
+++ b/test/Structs/kernel_arg_has_pointer_in_struct.cl
@@ -1,0 +1,9 @@
+// RUN: clspv -verify %s
+
+struct T {
+  global int* ptr;
+};
+
+kernel void foo(global struct T* t) { //expected-error{{structures may not contain pointers}}
+  *t->ptr = 0;
+}

--- a/test/Structs/mutual_recursion_error.cl
+++ b/test/Structs/mutual_recursion_error.cl
@@ -10,7 +10,7 @@ typedef struct T {
   S* ps;
 } T;
 
-kernel void foo(global S* s) { //expected-error{{structures may not contain pointers}}
+kernel void foo(global S* s) { //expected-error{{recursive structures are not supported}}
   s->a = 1;
 }
 

--- a/test/Structs/ptr_in_struct.cl
+++ b/test/Structs/ptr_in_struct.cl
@@ -1,0 +1,16 @@
+// RUN: clspv -verify %s -w
+// expected-no-diagnostics
+
+struct T {
+  global int* ptr;
+};
+
+void bar(struct T* t) {
+  *t->ptr = 42;
+}
+
+kernel void foo(global int* out) {
+  struct T t;
+  t.ptr = out;
+  bar(&t);
+}

--- a/test/Structs/ptr_in_struct2.cl
+++ b/test/Structs/ptr_in_struct2.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -verify %s -w
+// expected-no-diagnostics
+
+struct T {
+  global int* ptr;
+};
+
+struct T bar(global int* out) {
+  struct T t;
+  t.ptr = out;
+  return t;
+}
+
+kernel void foo(global int* out) {
+  struct T t = bar(out);
+  t.ptr = 42;
+}


### PR DESCRIPTION
Fixes #468

* Move the check about pointers in structs to only happen for kernel
arguments
* Add a new check to prevent recursive struct definitions
* New and updated tests