### PR TITLE
Fix warning in fetch_sources.py

### DIFF
--- a/utils/fetch_sources.py
+++ b/utils/fetch_sources.py
@@ -84,7 +84,7 @@ class GoodCommit(object):
     def GetUrl(self, style='https'):
         """Returns the URL for the repository."""
         host = SITE_TO_HOST[self.site]
-        sep = '/' if (style is 'https') else ':'
+        sep = '/' if (style == 'https') else ':'
         return '{style}://{host}{sep}{subrepo}'.format(
                     style=style,
                     host=host,


### PR DESCRIPTION
Newer versions of python report the following:

utils/fetch_sources.py:87: SyntaxWarning: "is" with a literal. Did you mean "=="?

Signed-off-by: Kévin Petit <kpet@free.fr>