### PR TITLE
Add support for -cl-std option

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -110,9 +110,6 @@ bool KeepUnusedArguments();
 // Returns true if clspv should allow 8-bit integers.
 bool Int8Support();
 
-// Returns true when compiling C++.
-bool CPlusPlus();
-
 // Returns true when images are supported.
 bool ImageSupport();
 
@@ -121,6 +118,24 @@ bool UseSamplerMap();
 
 // Sets whether or not to use the sampler map.
 void SetUseSamplerMap(bool use);
+
+// Returns the source language.
+enum class SourceLanguage {
+  Unknown,
+  OpenCL_C_10,
+  OpenCL_C_11,
+  OpenCL_C_12,
+  OpenCL_C_20,
+  OpenCL_CPP
+};
+
+SourceLanguage Language();
+
+// Returns true when the source language makes use of the generic address space.
+static bool LanguageUsesGenericAddressSpace() {
+  return (Language() == SourceLanguage::OpenCL_CPP) ||
+         ((Language() == SourceLanguage::OpenCL_C_20));
+}
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/CommandLine.h"
 
 #include "Passes.h"
+#include "clspv/Option.h"
 
 namespace {
 
@@ -150,9 +151,19 @@ llvm::cl::opt<bool> keep_unused_arguments(
 llvm::cl::opt<bool> int8_support("int8", llvm::cl::init(true),
                                  llvm::cl::desc("Allow 8-bit integers"));
 
-static llvm::cl::opt<bool>
-    cplusplus("c++", llvm::cl::init(false),
-              llvm::cl::desc("Enable experimental C++ support"));
+llvm::cl::opt<clspv::Option::SourceLanguage> cl_std(
+    "cl-std", llvm::cl::desc("Select OpenCL standard"),
+    llvm::cl::init(clspv::Option::SourceLanguage::OpenCL_C_12),
+    llvm::cl::values(clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_10,
+                                "CL1.0", "OpenCL C 1.0"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_11,
+                                "CL1.1", "OpenCL C 1.1"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_12,
+                                "CL1.2", "OpenCL C 1.2"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_20,
+                                "CL2.0", "OpenCL C 2.0"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_CPP,
+                                "CLC++", "C++ for OpenCL")));
 
 static llvm::cl::opt<bool> images("images", llvm::cl::init(true),
                                   llvm::cl::desc("Enable support for images"));
@@ -189,10 +200,10 @@ bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
 bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 bool KeepUnusedArguments() { return keep_unused_arguments; }
 bool Int8Support() { return int8_support; }
-bool CPlusPlus() { return cplusplus; }
 bool ImageSupport() { return images; }
 bool UseSamplerMap() { return use_sampler_map; }
 void SetUseSamplerMap(bool use) { use_sampler_map = use; }
+SourceLanguage Language() { return cl_std; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3546,10 +3546,25 @@ void SPIRVProducerPass::GenerateModuleInfo(Module &module) {
   // Ops[1] = Version (LiteralNum)
   //
   Ops.clear();
-  if (clspv::Option::CPlusPlus()) {
-    Ops << MkNum(spv::SourceLanguageOpenCL_CPP) << MkNum(100);
-  } else {
+  switch (clspv::Option::Language()) {
+  case clspv::Option::SourceLanguage::OpenCL_C_10:
+    Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(100);
+    break;
+  case clspv::Option::SourceLanguage::OpenCL_C_11:
+    Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(110);
+    break;
+  case clspv::Option::SourceLanguage::OpenCL_C_12:
     Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(120);
+    break;
+  case clspv::Option::SourceLanguage::OpenCL_C_20:
+    Ops << MkNum(spv::SourceLanguageOpenCL_C) << MkNum(200);
+    break;
+  case clspv::Option::SourceLanguage::OpenCL_CPP:
+    Ops << MkNum(spv::SourceLanguageOpenCL_CPP) << MkNum(100);
+    break;
+  default:
+    Ops << MkNum(spv::SourceLanguageUnknown) << MkNum(0);
+    break;
   }
 
   auto *OpenSourceInst = new SPIRVInstruction(spv::OpSource, Ops);

--- a/test/CPlusPlus/generic-addrspace.cl
+++ b/test/CPlusPlus/generic-addrspace.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -c++ -inline-entry-points %s -o %t.spv
+// RUN: clspv -cl-std=CLC++ -inline-entry-points %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CPlusPlus/issue-357.cl
+++ b/test/CPlusPlus/issue-357.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.map %s -o %t.spv
+// RUN: clspv -cl-std=CLC++ -inline-entry-points -descriptormap=%t.map %s -o %t.spv
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 // RUN: FileCheck %s -check-prefix=MAP < %t.map
 

--- a/test/CPlusPlus/kernel-overload.cl
+++ b/test/CPlusPlus/kernel-overload.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -w -c++ -inline-entry-points -verify %s
+// RUN: clspv -w -cl-std=CLC++ -inline-entry-points -verify %s
 
 void kernel test(global int* ptr) {} //expected-note{{previous definition is here}}
 void kernel test(local int* ptr) {}

--- a/test/CPlusPlus/object-and-overload.cl
+++ b/test/CPlusPlus/object-and-overload.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: clspv -cl-std=CLC++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
 // RUN: FileCheck %s < %t.dmap -check-prefix=MAP
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/CPlusPlus/opsource.cl
+++ b/test/CPlusPlus/opsource.cl
@@ -1,0 +1,9 @@
+// RUN: clspv -cl-std=CLC++ -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpSource OpenCL_CPP 100
+
+void kernel test() {}
+

--- a/test/CPlusPlus/template.cl
+++ b/test/CPlusPlus/template.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -c++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: clspv -cl-std=CLC++ -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
 // RUN: FileCheck %s < %t.dmap -check-prefix=MAP
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm

--- a/test/opsource.cl
+++ b/test/opsource.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv -cl-std=CL1.0 %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK10 %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv -cl-std=CL1.1 %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK11 %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv -cl-std=CL1.2 %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK12 %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK20 %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpSource OpenCL_C 120
+
+// CHECK10: OpSource OpenCL_C 100
+// CHECK11: OpSource OpenCL_C 110
+// CHECK12: OpSource OpenCL_C 120
+// CHECK20: OpSource OpenCL_C 200
+
+void kernel test() {}
+


### PR DESCRIPTION
Match what Clang does except that:
- lowercase aliases of the language names are not supported
  (they are not described in the OpenCL specification)
- the default standard is OpenCL C 1.2

Remove -c++ (replaced by -cl-std=CLC++).

Turn on address space inferencing when compiling as OpenCL C 2.0.

Signed-off-by: Kévin Petit <kpet@free.fr>