### PR TITLE
Don't add int64 types due to literal operands

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1255,6 +1255,39 @@ void SPIRVProducerPass::FindTypePerFunc(Function &F) {
         continue;
       }
 
+      // #497: InsertValue and ExtractValue map to OpCompositeExtract which
+      // takes literal values for indices. As a result don't map the type of
+      // indices.
+      if (I.getOpcode() == Instruction::ExtractValue) {
+        FindType(I.getOperand(0)->getType());
+        continue;
+      }
+      if (I.getOpcode() == Instruction::InsertValue) {
+        FindType(I.getOperand(0)->getType());
+        FindType(I.getOperand(1)->getType());
+        continue;
+      }
+
+      // #497: InsertElement and ExtractElement map to OpCompositeExtract if
+      // the index is a constant. In such a case don't map the index type.
+      if (I.getOpcode() == Instruction::ExtractElement) {
+        FindType(I.getOperand(0)->getType());
+        Value *op1 = I.getOperand(1);
+        if (!isa<Constant>(op1) || isa<GlobalValue>(op1)) {
+          FindType(op1->getType());
+        }
+        continue;
+      }
+      if (I.getOpcode() == Instruction::InsertElement) {
+        FindType(I.getOperand(0)->getType());
+        FindType(I.getOperand(1)->getType());
+        Value *op2 = I.getOperand(2);
+        if (!isa<Constant>(op2) || isa<GlobalValue>(op2)) {
+          FindType(op2->getType());
+        }
+        continue;
+      }
+
       // Work through the operands of the instruction.
       for (unsigned i = 0; i < I.getNumOperands(); i++) {
         Value *const Op = I.getOperand(i);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1255,9 +1255,9 @@ void SPIRVProducerPass::FindTypePerFunc(Function &F) {
         continue;
       }
 
-      // #497: InsertValue and ExtractValue map to OpCompositeExtract which
-      // takes literal values for indices. As a result don't map the type of
-      // indices.
+      // #497: InsertValue and ExtractValue map to OpCompositeInsert and
+      // OpCompositeExtract which takes literal values for indices. As a result
+      // don't map the type of indices.
       if (I.getOpcode() == Instruction::ExtractValue) {
         FindType(I.getOperand(0)->getType());
         continue;

--- a/test/no_int64_due_to_index_literal.cl
+++ b/test/no_int64_due_to_index_literal.cl
@@ -1,3 +1,17 @@
+// Copyright 2018 The MACE Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // RUN: clspv %s -o %t.spv
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm

--- a/test/no_int64_due_to_index_literal.cl
+++ b/test/no_int64_due_to_index_literal.cl
@@ -1,0 +1,36 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-NOT: OpCapability Int64
+// CHECK: OpCompositeExtract
+
+const sampler_t SAMPLER =
+    CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+__kernel void arg_image_to_buffer(__global float *output,
+                                  __private const int count,
+                                  __read_only image2d_t input) {
+  int w = get_global_id(0);
+  int h = get_global_id(1);
+
+  const int offset = (w << 2);
+
+  int2 coord = (int2)(w, h);
+  float4 values = read_imagef(input, SAMPLER, coord);
+  const int size = count - offset;
+  if (size < 4) {
+    switch (size) {
+      case 3:
+        output[offset+2] = values.s2;
+      case 2:
+        output[offset+1] = values.s1;
+      case 1:
+        output[offset] = values.s0;
+    }
+  } else {
+    vstore4(values, 0, output + offset);
+  }
+}
+


### PR DESCRIPTION
Fixes #497

* Do not map types for operands that end up as literal values in SPIR-V
* Add a test to ensure Int64 capability is not added

I believe the i64 come from some sort canonicalization LLVM performs.