### PR TITLE
Fix stores to widening pointer casts

### DIFF
--- a/test/PointerCasts/store_cast_char_to_short.ll
+++ b/test/PointerCasts/store_cast_char_to_short.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t -ReplacePointerBitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[lshr0:%[a-zA-Z0-9_.]+]] = lshr i16 %s, 0
+; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i16 [[lshr0]] to i8
+; CHECK: [[lshr1:%[a-zA-Z0-9_.]+]] = lshr i16 %s, 8
+; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i16 [[lshr1]] to i8
+; CHECK: [[gep0:%[a-zA-Z0-9_.]+]] = getelementptr i8, i8 addrspace(1)* %a, i32 0
+; CHECK: store i8 [[trunc0]], i8 addrspace(1)* [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_.]+]] = getelementptr i8, i8 addrspace(1)* %a, i32 1
+; CHECK: store i8 [[trunc1]], i8 addrspace(1)* [[gep1]]
+define spir_kernel void @foo(i8 addrspace(1)* %a, i16 %s) {
+entry:
+  %0 = bitcast i8 addrspace(1)* %a to i16 addrspace(1)*
+  %arrayidx = getelementptr inbounds i16, i16 addrspace(1)* %0, i32 0
+  store i16 %s, i16 addrspace(1)* %arrayidx, align 2
+  ret void
+}
+

--- a/test/PointerCasts/store_cast_int_to_long.ll
+++ b/test/PointerCasts/store_cast_int_to_long.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t -ReplacePointerBitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[lshr0:%[a-zA-Z0-9_.]+]] = lshr i64 %s, 0
+; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr0]] to i32
+; CHECK: [[lshr1:%[a-zA-Z0-9_.]+]] = lshr i64 %s, 32
+; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr1]] to i32
+; CHECK: [[gep0:%[a-zA-Z0-9_.]+]] = getelementptr i32, i32 addrspace(1)* %a, i32 0
+; CHECK: store i32 [[trunc0]], i32 addrspace(1)* [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_.]+]] = getelementptr i32, i32 addrspace(1)* %a, i32 1
+; CHECK: store i32 [[trunc1]], i32 addrspace(1)* [[gep1]]
+define spir_kernel void @foo(i32 addrspace(1)* %a, i64 %s) {
+entry:
+  %0 = bitcast i32 addrspace(1)* %a to i64 addrspace(1)*
+  %arrayidx = getelementptr inbounds i64, i64 addrspace(1)* %0, i32 0
+  store i64 %s, i64 addrspace(1)* %arrayidx, align 2
+  ret void
+}
+

--- a/test/PointerCasts/store_cast_short_to_float.ll
+++ b/test/PointerCasts/store_cast_short_to_float.ll
@@ -8,12 +8,10 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to i32
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[cast]], 0
-; CHECK: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[shr]], 65535
-; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i32 [[and]] to i16
+; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i32 [[shr]] to i16
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to i32
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[cast]], 16
-; CHECK: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[shr]], 65535
-; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i32 [[and]] to i16
+; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i32 [[shr]] to i16
 ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, i16 addrspace(1)* %soa, i32 %2
 ; CHECK: store i16 [[trunc0]], i16 addrspace(1)* [[gep]]
 ; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 %2, 1


### PR DESCRIPTION
Fixes #504

* Make sure the operand types match for the generated `and` and `lshr` instructions
* Add a test