### PR TITLE
Builtins::Lookup interface - phase2

### DIFF
--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -109,6 +109,7 @@ size_t GetParameterType(const std::string &mangled_name,
       type_info->type_id = Type::FloatTyID;
       type_info->is_signed = true;
       type_info->byte_len = 2;
+      return pos;
     } else {
 #ifdef DEBUG
       llvm::outs() << "Func: " << mangled_name << "\n";
@@ -255,6 +256,11 @@ Builtins::FunctionInfo::getParameter(size_t _arg) const {
   return params_[_arg];
 }
 
+// Test for OCL Sampler parameter type
+bool Builtins::ParamTypeInfo::isSampler() const {
+  return type_id == Type::StructTyID && name == "ocl_sampler";
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ////  Lookup interface
 ////   - only demangle once for any name encountered
@@ -283,7 +289,7 @@ bool Builtins::IsFloatSampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImagef) {
     const auto &pi = fi.getParameter(1);
-    return pi.name == "ocl_sampler";
+    return pi.isSampler();
   }
   return false;
 }
@@ -292,7 +298,7 @@ bool Builtins::IsUintSampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImageui) {
     const auto &pi = fi.getParameter(1);
-    return pi.name == "ocl_sampler";
+    return pi.isSampler();
   }
   return false;
 }
@@ -301,7 +307,7 @@ bool Builtins::IsIntSampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImagei) {
     const auto &pi = fi.getParameter(1);
-    return pi.name == "ocl_sampler";
+    return pi.isSampler();
   }
   return false;
 }
@@ -315,7 +321,7 @@ bool Builtins::IsFloatUnsampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImagef) {
     const auto &pi = fi.getParameter(1);
-    return pi.name != "ocl_sampler";
+    return !pi.isSampler();
   }
   return false;
 }
@@ -324,7 +330,7 @@ bool Builtins::IsUintUnsampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImageui) {
     const auto &pi = fi.getParameter(1);
-    return pi.name != "ocl_sampler";
+    return !pi.isSampler();
   }
   return false;
 }
@@ -333,7 +339,7 @@ bool Builtins::IsIntUnsampledImageRead(StringRef _name) {
   const auto &fi = Lookup(_name);
   if (fi.getType() == kReadImagei) {
     const auto &pi = fi.getParameter(1);
-    return pi.name != "ocl_sampler";
+    return !pi.isSampler();
   }
   return false;
 }

--- a/lib/Builtins.h
+++ b/lib/Builtins.h
@@ -32,6 +32,8 @@ struct ParamTypeInfo {
   int byte_len = 0;                                  // element byte length
   int vector_size = 0; // number of elements (0 == not a vector)
   std::string name;    // struct name
+
+  bool isSampler() const;
 };
 
 class FunctionInfo {

--- a/lib/Builtins.h
+++ b/lib/Builtins.h
@@ -29,7 +29,7 @@ namespace Builtins {
 struct ParamTypeInfo {
   bool is_signed = false;                            // is element type signed
   llvm::Type::TypeID type_id = llvm::Type::VoidTyID; // element type
-  int byte_len = 0;                                  // element byte length
+  uint32_t byte_len = 0;                             // element byte length
   int vector_size = 0; // number of elements (0 == not a vector)
   std::string name;    // struct name
 

--- a/lib/OpenCLInlinerPass.cpp
+++ b/lib/OpenCLInlinerPass.cpp
@@ -60,8 +60,7 @@ bool OpenCLInlinerPass::runOnModule(Module &M) {
         if (CallInst *CI = dyn_cast<CallInst>(U)) {
           // If the called function doesn't take an argument or is using a
           // constant argument, add the call to the list of to-be-inlined calls.
-          if (func_info.getType() == Builtins::kGetWorkDim ||
-              isa<Constant>(CI->getArgOperand(0))) {
+          if (F.arg_empty() || isa<Constant>(CI->getArgOperand(0))) {
             Calls.push_back(CI);
           }
         }

--- a/lib/OpenCLInlinerPass.cpp
+++ b/lib/OpenCLInlinerPass.cpp
@@ -19,9 +19,11 @@
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
+#include "Builtins.h"
 #include "Passes.h"
 
 using namespace llvm;
+using namespace clspv;
 
 #define DEBUG_TYPE "openclinliner"
 
@@ -43,26 +45,23 @@ ModulePass *createOpenCLInlinerPass() { return new OpenCLInlinerPass(); }
 } // namespace clspv
 
 bool OpenCLInlinerPass::runOnModule(Module &M) {
-  auto WorkDimName = "_Z12get_work_dimv";
-  StringRef FuncNames[] = {"_Z13get_global_idj",     "_Z14get_local_sizej",
-                           "_Z12get_local_idj",      "_Z14get_num_groupsj",
-                           "_Z12get_group_idj",      "_Z15get_global_sizej",
-                           "_Z17get_global_offsetj", WorkDimName};
   bool changed = false;
-
-  for (StringRef FuncName : FuncNames) {
-    if (Function *F = M.getFunction(FuncName)) {
+  std::list<Function *> func_list;
+  for (auto &F : M.getFunctionList()) {
+    // process only WorkItem functions
+    auto &func_info = Builtins::Lookup(&F);
+    if (func_info.getType() > Builtins::kType_WorkItem_Start &&
+        func_info.getType() < Builtins::kType_WorkItem_End) {
       SmallVector<CallInst *, 4> Calls;
 
       // Walk the users of the function.
-      for (User *U : F->users()) {
+      for (User *U : F.users()) {
         // Find only the calls to the function.
         if (CallInst *CI = dyn_cast<CallInst>(U)) {
           // If the called function doesn't take an argument or is using a
           // constant argument, add the call to the list of to-be-inlined calls.
-          if (CI->getCalledFunction()->getName() == WorkDimName) {
-            Calls.push_back(CI);
-          } else if (isa<Constant>(CI->getArgOperand(0))) {
+          if (func_info.getType() == Builtins::kGetWorkDim ||
+              isa<Constant>(CI->getArgOperand(0))) {
             Calls.push_back(CI);
           }
         }
@@ -72,13 +71,16 @@ bool OpenCLInlinerPass::runOnModule(Module &M) {
         InlineFunctionInfo info;
         changed |= InlineFunction(CI, info).isSuccess();
       }
-
-      // If we inlined all the calls to the function, remove it.
-      if (0 == F->getNumUses()) {
+      func_list.push_front(&F);
+    }
+  }
+  if (func_list.size() != 0) {
+    // remove dead
+    for (auto *F : func_list) {
+      if (F->use_empty()) {
         F->eraseFromParent();
       }
     }
   }
-
   return changed;
 }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -27,7 +27,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/unified1/spirv.hpp"
+#include "spirv/1.0/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
@@ -175,7 +175,7 @@ bool ReplaceOpenCLBuiltinPass::runOnModule(Module &M) {
   std::list<Function *> func_list;
   for (auto &F : M.getFunctionList()) {
     // process only function declarations
-    if (F.empty() && runOnFunction(F)) {
+    if (F.isDeclaration() && runOnFunction(F)) {
       func_list.push_front(&F);
     }
   }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -27,117 +27,24 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
 #include "clspv/Option.h"
 
+#include "Builtins.h"
 #include "Constants.h"
 #include "Passes.h"
 #include "SPIRVOp.h"
 #include "Types.h"
 
+using namespace clspv;
 using namespace llvm;
 
 #define DEBUG_TYPE "ReplaceOpenCLBuiltin"
 
 namespace {
-
-struct ArgTypeInfo {
-  enum class SignedNess { None, Unsigned, Signed };
-  SignedNess signedness;
-};
-
-struct FunctionInfo {
-  StringRef name;
-  std::vector<ArgTypeInfo> argTypeInfos;
-
-  bool isArgSigned(size_t arg) const {
-    assert(argTypeInfos.size() > arg);
-    return argTypeInfos[arg].signedness == ArgTypeInfo::SignedNess::Signed;
-  }
-
-  static FunctionInfo getFromMangledName(StringRef name) {
-    FunctionInfo fi;
-    if (!getFromMangledNameCheck(name, &fi)) {
-      llvm_unreachable("Can't parse mangled function name!");
-    }
-    return fi;
-  }
-
-  static bool getFromMangledNameCheck(StringRef name, FunctionInfo *finfo) {
-    if (!name.consume_front("_Z")) {
-      return false;
-    }
-    size_t nameLen;
-    if (name.consumeInteger(10, nameLen)) {
-      return false;
-    }
-
-    finfo->name = name.take_front(nameLen);
-    name = name.drop_front(nameLen);
-
-    ArgTypeInfo prev_ti;
-
-    while (name.size() != 0) {
-
-      ArgTypeInfo ti;
-
-      // Try parsing a vector prefix
-      if (name.consume_front("Dv")) {
-        int numElems;
-        if (name.consumeInteger(10, numElems)) {
-          return false;
-        }
-
-        if (!name.consume_front("_")) {
-          return false;
-        }
-      }
-
-      // Parse the base type
-      if (name.consume_front("Dh")) {
-        ti.signedness = ArgTypeInfo::SignedNess::None;
-      } else {
-        char typeCode = name.front();
-        name = name.drop_front(1);
-        switch (typeCode) {
-        case 'c': // char
-        case 'a': // signed char
-        case 's': // short
-        case 'i': // int
-        case 'l': // long
-          ti.signedness = ArgTypeInfo::SignedNess::Signed;
-          break;
-        case 'h': // unsigned char
-        case 't': // unsigned short
-        case 'j': // unsigned int
-        case 'm': // unsigned long
-          ti.signedness = ArgTypeInfo::SignedNess::Unsigned;
-          break;
-        case 'f':
-          ti.signedness = ArgTypeInfo::SignedNess::None;
-          break;
-        case 'S':
-          ti = prev_ti;
-          if (!name.consume_front("_")) {
-            return false;
-          }
-          break;
-        default:
-          return false;
-        }
-      }
-
-      finfo->argTypeInfos.push_back(ti);
-
-      prev_ti = ti;
-    }
-
-    return true;
-  };
-};
 
 uint32_t clz(uint32_t v) {
   uint32_t r;
@@ -159,14 +66,6 @@ uint32_t clz(uint32_t v) {
   return r;
 }
 
-Type *getBoolOrBoolVectorTy(LLVMContext &C, unsigned elements) {
-  if (1 == elements) {
-    return Type::getInt1Ty(C);
-  } else {
-    return VectorType::get(Type::getInt1Ty(C), elements);
-  }
-}
-
 Type *getIntOrIntVectorTyForCast(LLVMContext &C, Type *Ty) {
   Type *IntTy = Type::getIntNTy(C, Ty->getScalarSizeInBits());
   if (Ty->isVectorTy()) {
@@ -175,53 +74,91 @@ Type *getIntOrIntVectorTyForCast(LLVMContext &C, Type *Ty) {
   return IntTy;
 }
 
+bool replaceCallsWithValue(Function &F,
+                           std::function<Value *(CallInst *)> Replacer) {
+
+  bool Changed = false;
+
+  SmallVector<Instruction *, 4> ToRemoves;
+
+  // Walk the users of the function.
+  for (auto &U : F.uses()) {
+    if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+
+      auto NewValue = Replacer(CI);
+
+      if (NewValue != nullptr) {
+        CI->replaceAllUsesWith(NewValue);
+
+        // Lastly, remember to remove the user.
+        ToRemoves.push_back(CI);
+      }
+    }
+  }
+
+  Changed = !ToRemoves.empty();
+
+  // And cleanup the calls we don't use anymore.
+  for (auto V : ToRemoves) {
+    V->eraseFromParent();
+  }
+
+  return Changed;
+}
+
 struct ReplaceOpenCLBuiltinPass final : public ModulePass {
   static char ID;
   ReplaceOpenCLBuiltinPass() : ModulePass(ID) {}
 
   bool runOnModule(Module &M) override;
-  bool replaceAbs(Module &M);
-  bool replaceAbsDiff(Module &M);
-  bool replaceCopysign(Module &M);
-  bool replaceRecip(Module &M);
-  bool replaceDivide(Module &M);
-  bool replaceDot(Module &M);
-  bool replaceExp10(Module &M);
-  bool replaceFmod(Module &M);
-  bool replaceLog10(Module &M);
-  bool replaceBarrier(Module &M);
-  bool replaceMemFence(Module &M);
-  bool replaceRelational(Module &M);
-  bool replaceIsInfAndIsNan(Module &M);
-  bool replaceIsFinite(Module &M);
-  bool replaceAllAndAny(Module &M);
-  bool replaceUpsample(Module &M);
-  bool replaceRotate(Module &M);
-  bool replaceConvert(Module &M);
-  bool replaceMulHiMadHi(Module &M);
-  bool replaceSelect(Module &M);
-  bool replaceBitSelect(Module &M);
-  bool replaceStepSmoothStep(Module &M);
-  bool replaceSignbit(Module &M);
-  bool replaceMadandMad24andMul24(Module &M);
-  bool replaceVloadHalf(Module &M);
-  bool replaceVloadHalf2(Module &M);
-  bool replaceVloadHalf4(Module &M);
-  bool replaceClspvVloadaHalf2(Module &M);
-  bool replaceClspvVloadaHalf4(Module &M);
-  bool replaceVstoreHalf(Module &M);
-  bool replaceVstoreHalf2(Module &M);
-  bool replaceVstoreHalf4(Module &M);
-  bool replaceHalfReadImage(Module &M);
-  bool replaceHalfWriteImage(Module &M);
-  bool replaceUnsampledReadImage(Module &M);
-  bool replaceSampledReadImageWithIntCoords(Module &M);
-  bool replaceAtomics(Module &M);
-  bool replaceCross(Module &M);
-  bool replaceFract(Module &M);
-  bool replaceVload(Module &M);
-  bool replaceVstore(Module &M);
+  bool runOnFunction(Function &F);
+  bool replaceAbs(Function &F);
+  bool replaceAbsDiff(Function &F, bool is_signed);
+  bool replaceCopysign(Function &F);
+  bool replaceRecip(Function &F);
+  bool replaceDivide(Function &F);
+  bool replaceDot(Function &F);
+  bool replaceFmod(Function &F);
+  bool replaceExp10(Function &F, const std::string &basename, int vec_size,
+                    int byte_len);
+  bool replaceLog10(Function &F, const std::string &basename, int vec_size,
+                    int byte_len);
+  bool replaceBarrier(Function &F);
+  bool replaceMemFence(Function &F, uint32_t semantics);
+  bool replaceRelational(Function &F, CmpInst::Predicate P, int32_t C);
+  bool replaceIsInfAndIsNan(Function &F, spv::Op SPIRVOp, int32_t isvec);
+  bool replaceIsFinite(Function &F);
+  bool replaceAllAndAny(Function &F, spv::Op SPIRVOp);
+  bool replaceUpsample(Function &F);
+  bool replaceRotate(Function &F);
+  bool replaceConvert(Function &F, bool SrcIsSigned, bool DstIsSigned);
+  bool replaceMulHi(Function &F, bool is_signed, bool is_mad = false);
+  bool replaceSelect(Function &F);
+  bool replaceBitSelect(Function &F);
+  bool replaceStep(Function &F, bool is_smooth, int vec_size);
+  bool replaceSignbit(Function &F, bool is_vec);
+  bool replaceMul(Function &F, bool is_float, bool is_mad);
+  bool replaceVloadHalf(Function &F, const std::string &name, int vec_size);
+  bool replaceVloadHalf(Function &F);
+  bool replaceVloadHalf2(Function &F);
+  bool replaceVloadHalf4(Function &F);
+  bool replaceClspvVloadaHalf2(Function &F);
+  bool replaceClspvVloadaHalf4(Function &F);
+  bool replaceVstoreHalf(Function &F, int vec_size);
+  bool replaceVstoreHalf(Function &F);
+  bool replaceVstoreHalf2(Function &F);
+  bool replaceVstoreHalf4(Function &F);
+  bool replaceHalfReadImage(Function &F);
+  bool replaceHalfWriteImage(Function &F);
+  bool replaceSampledReadImageWithIntCoords(Function &F);
+  bool replaceAtomics(Function &F, spv::Op Op);
+  bool replaceAtomics(Function &F, llvm::AtomicRMWInst::BinOp Op);
+  bool replaceCross(Function &F);
+  bool replaceFract(Function &F, int vec_size);
+  bool replaceVload(Function &F);
+  bool replaceVstore(Function &F);
 };
+
 } // namespace
 
 char ReplaceOpenCLBuiltinPass::ID = 0;
@@ -235,123 +172,248 @@ ModulePass *createReplaceOpenCLBuiltinPass() {
 } // namespace clspv
 
 bool ReplaceOpenCLBuiltinPass::runOnModule(Module &M) {
-  bool Changed = false;
-
-  Changed |= replaceAbs(M);
-  Changed |= replaceAbsDiff(M);
-  Changed |= replaceCopysign(M);
-  Changed |= replaceRecip(M);
-  Changed |= replaceDivide(M);
-  Changed |= replaceDot(M);
-  Changed |= replaceExp10(M);
-  Changed |= replaceFmod(M);
-  Changed |= replaceLog10(M);
-  Changed |= replaceBarrier(M);
-  Changed |= replaceMemFence(M);
-  Changed |= replaceRelational(M);
-  Changed |= replaceIsInfAndIsNan(M);
-  Changed |= replaceIsFinite(M);
-  Changed |= replaceAllAndAny(M);
-  Changed |= replaceUpsample(M);
-  Changed |= replaceRotate(M);
-  Changed |= replaceConvert(M);
-  Changed |= replaceMulHiMadHi(M);
-  Changed |= replaceSelect(M);
-  Changed |= replaceBitSelect(M);
-  Changed |= replaceStepSmoothStep(M);
-  Changed |= replaceSignbit(M);
-  Changed |= replaceMadandMad24andMul24(M);
-  Changed |= replaceVloadHalf(M);
-  Changed |= replaceVloadHalf2(M);
-  Changed |= replaceVloadHalf4(M);
-  Changed |= replaceClspvVloadaHalf2(M);
-  Changed |= replaceClspvVloadaHalf4(M);
-  Changed |= replaceVstoreHalf(M);
-  Changed |= replaceVstoreHalf2(M);
-  Changed |= replaceVstoreHalf4(M);
-  // Replace the half image builtins before handling other image builtins.
-  Changed |= replaceHalfReadImage(M);
-  Changed |= replaceHalfWriteImage(M);
-  Changed |= replaceSampledReadImageWithIntCoords(M);
-  Changed |= replaceAtomics(M);
-  Changed |= replaceCross(M);
-  Changed |= replaceFract(M);
-  Changed |= replaceVload(M);
-  Changed |= replaceVstore(M);
-
-  return Changed;
-}
-
-bool replaceCallsWithValue(Module &M, std::vector<const char *> Names,
-                           std::function<Value *(CallInst *)> Replacer) {
-
-  bool Changed = false;
-
-  for (auto Name : Names) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Name)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          auto NewValue = Replacer(CI);
-
-          if (NewValue != nullptr) {
-            CI->replaceAllUsesWith(NewValue);
-          }
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+  std::list<Function *> func_list;
+  for (auto &F : M.getFunctionList()) {
+    // process only function declarations
+    if (F.empty() && runOnFunction(F)) {
+      func_list.push_front(&F);
     }
   }
-
-  return Changed;
+  if (func_list.size() != 0) {
+    // recursively convert functions, but first remove dead
+    for (auto *F : func_list) {
+      if (F->use_empty()) {
+        F->eraseFromParent();
+      }
+    }
+    runOnModule(M);
+    return true;
+  }
+  return false;
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceAbs(Module &M) {
+bool ReplaceOpenCLBuiltinPass::runOnFunction(Function &F) {
+  auto &FI = Builtins::Lookup(&F);
+  switch (FI.getType()) {
+  case Builtins::kAbs:
+    if (!FI.getParameter(0).is_signed) {
+      return replaceAbs(F);
+    }
+    break;
+  case Builtins::kAbsDiff:
+    return replaceAbsDiff(F, FI.getParameter(0).is_signed);
+  case Builtins::kCopysign:
+    return replaceCopysign(F);
 
-  std::vector<const char *> Names = {
-      "_Z3absh", "_Z3absDv2_h", "_Z3absDv3_h", "_Z3absDv4_h",
-      "_Z3abst", "_Z3absDv2_t", "_Z3absDv3_t", "_Z3absDv4_t",
-      "_Z3absj", "_Z3absDv2_j", "_Z3absDv3_j", "_Z3absDv4_j",
-      "_Z3absm", "_Z3absDv2_m", "_Z3absDv3_m", "_Z3absDv4_m",
-  };
+  case Builtins::kHalfRecip:
+  case Builtins::kNativeRecip:
+    return replaceRecip(F);
 
-  return replaceCallsWithValue(M, Names,
+  case Builtins::kHalfDivide:
+  case Builtins::kNativeDivide:
+    return replaceDivide(F);
+
+  case Builtins::kDot:
+    return replaceDot(F);
+
+  case Builtins::kExp10:
+  case Builtins::kHalfExp10:
+  case Builtins::kNativeExp10: {
+    auto &P0 = FI.getParameter(0);
+    return replaceExp10(F, FI.getName(), P0.vector_size, P0.byte_len);
+  }
+
+  case Builtins::kLog10:
+  case Builtins::kHalfLog10:
+  case Builtins::kNativeLog10: {
+    auto &P0 = FI.getParameter(0);
+    return replaceLog10(F, FI.getName(), P0.vector_size, P0.byte_len);
+  }
+
+  case Builtins::kFmod:
+    return replaceFmod(F);
+
+  case Builtins::kBarrier:
+  case Builtins::kWorkGroupBarrier:
+    return replaceBarrier(F);
+
+  case Builtins::kMemFence:
+    return replaceMemFence(F, spv::MemorySemanticsSequentiallyConsistentMask);
+  case Builtins::kReadMemFence:
+    return replaceMemFence(F, spv::MemorySemanticsAcquireMask);
+  case Builtins::kWriteMemFence:
+    return replaceMemFence(F, spv::MemorySemanticsReleaseMask);
+
+    // Relational
+  case Builtins::kIsequal:
+    return replaceRelational(F, CmpInst::FCMP_OEQ,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+  case Builtins::kIsgreater:
+    return replaceRelational(F, CmpInst::FCMP_OGT,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+  case Builtins::kIsgreaterequal:
+    return replaceRelational(F, CmpInst::FCMP_OGE,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+  case Builtins::kIsless:
+    return replaceRelational(F, CmpInst::FCMP_OLT,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+  case Builtins::kIslessequal:
+    return replaceRelational(F, CmpInst::FCMP_OLE,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+  case Builtins::kIsnotequal:
+    return replaceRelational(F, CmpInst::FCMP_ONE,
+                             FI.getParameter(0).vector_size ? -1 : 1);
+
+  case Builtins::kIsinf: {
+    bool is_vec = FI.getParameter(0).vector_size != 0;
+    return replaceIsInfAndIsNan(F, spv::OpIsInf, is_vec ? -1 : 1);
+  }
+  case Builtins::kIsnan: {
+    bool is_vec = FI.getParameter(0).vector_size != 0;
+    return replaceIsInfAndIsNan(F, spv::OpIsNan, is_vec ? -1 : 1);
+  }
+
+  case Builtins::kIsfinite:
+    return replaceIsFinite(F);
+
+  case Builtins::kAll: {
+    bool is_vec = FI.getParameter(0).vector_size != 0;
+    return replaceAllAndAny(F, !is_vec ? spv::OpNop : spv::OpAll);
+  }
+  case Builtins::kAny: {
+    bool is_vec = FI.getParameter(0).vector_size != 0;
+    return replaceAllAndAny(F, !is_vec ? spv::OpNop : spv::OpAny);
+  }
+
+  case Builtins::kUpsample:
+    return replaceUpsample(F);
+
+  case Builtins::kRotate:
+    return replaceRotate(F);
+
+  case Builtins::kConvert:
+    return replaceConvert(F, FI.getParameter(0).is_signed,
+                          FI.getReturnType().is_signed);
+
+  case Builtins::kAtomicInc:
+    return replaceAtomics(F, spv::OpAtomicIIncrement);
+  case Builtins::kAtomicDec:
+    return replaceAtomics(F, spv::OpAtomicIDecrement);
+  case Builtins::kAtomicCmpxchg:
+    return replaceAtomics(F, spv::OpAtomicCompareExchange);
+  case Builtins::kAtomicAdd:
+    return replaceAtomics(F, llvm::AtomicRMWInst::Add);
+  case Builtins::kAtomicSub:
+    return replaceAtomics(F, llvm::AtomicRMWInst::Sub);
+  case Builtins::kAtomicXchg:
+    return replaceAtomics(F, llvm::AtomicRMWInst::Xchg);
+  case Builtins::kAtomicMin:
+    return replaceAtomics(F, FI.getParameter(0).is_signed
+                                 ? llvm::AtomicRMWInst::Min
+                                 : llvm::AtomicRMWInst::UMin);
+  case Builtins::kAtomicMax:
+    return replaceAtomics(F, FI.getParameter(0).is_signed
+                                 ? llvm::AtomicRMWInst::Max
+                                 : llvm::AtomicRMWInst::UMax);
+  case Builtins::kAtomicAnd:
+    return replaceAtomics(F, llvm::AtomicRMWInst::And);
+  case Builtins::kAtomicOr:
+    return replaceAtomics(F, llvm::AtomicRMWInst::Or);
+  case Builtins::kAtomicXor:
+    return replaceAtomics(F, llvm::AtomicRMWInst::Xor);
+
+  case Builtins::kCross:
+    if (FI.getParameter(0).vector_size == 4) {
+      return replaceCross(F);
+    }
+    break;
+
+  case Builtins::kFract:
+    if (FI.getParameterCount()) {
+      return replaceFract(F, FI.getParameter(0).vector_size);
+    }
+    break;
+
+  case Builtins::kMadHi:
+    return replaceMulHi(F, FI.getParameter(0).is_signed, true);
+  case Builtins::kMulHi:
+    return replaceMulHi(F, FI.getParameter(0).is_signed, false);
+
+  case Builtins::kMad:
+  case Builtins::kMad24:
+    return replaceMul(F, FI.getParameter(0).type_id == llvm::Type::FloatTyID,
+                      true);
+  case Builtins::kMul24:
+    return replaceMul(F, FI.getParameter(0).type_id == llvm::Type::FloatTyID,
+                      false);
+
+  case Builtins::kSelect:
+    return replaceSelect(F);
+
+  case Builtins::kBitselect:
+    return replaceBitSelect(F);
+
+  case Builtins::kVload:
+    return replaceVload(F);
+
+  case Builtins::kVloadaHalf:
+  case Builtins::kVloadHalf:
+    return replaceVloadHalf(F, FI.getName(), FI.getParameter(0).vector_size);
+
+  case Builtins::kVstore:
+    return replaceVstore(F);
+
+  case Builtins::kVstoreHalf:
+  case Builtins::kVstoreaHalf:
+    return replaceVstoreHalf(F, FI.getParameter(0).vector_size);
+
+  case Builtins::kSmoothstep: {
+    int vec_size = FI.getLastParameter().vector_size;
+    if (FI.getParameter(0).vector_size == 0 && vec_size != 0) {
+      return replaceStep(F, true, vec_size);
+    }
+    break;
+  }
+  case Builtins::kStep: {
+    int vec_size = FI.getLastParameter().vector_size;
+    if (FI.getParameter(0).vector_size == 0 && vec_size != 0) {
+      return replaceStep(F, false, vec_size);
+    }
+    break;
+  }
+
+  case Builtins::kSignbit:
+    return replaceSignbit(F, FI.getParameter(0).vector_size != 0);
+
+  case Builtins::kReadImageh:
+    return replaceHalfReadImage(F);
+  case Builtins::kReadImagef:
+  case Builtins::kReadImagei:
+  case Builtins::kReadImageui: {
+    if (FI.getParameter(1).isSampler() &&
+        FI.getParameter(2).type_id == llvm::Type::IntegerTyID) {
+      return replaceSampledReadImageWithIntCoords(F);
+    }
+    break;
+  }
+
+  case Builtins::kWriteImageh:
+    return replaceHalfWriteImage(F);
+
+  default:
+    break;
+  }
+
+  return false;
+}
+
+bool ReplaceOpenCLBuiltinPass::replaceAbs(Function &F) {
+  return replaceCallsWithValue(F,
                                [](CallInst *CI) { return CI->getOperand(0); });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceAbsDiff(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z8abs_diffcc",      "_Z8abs_diffDv2_cS_", "_Z8abs_diffDv3_cS_",
-      "_Z8abs_diffDv4_cS_", "_Z8abs_diffhh",      "_Z8abs_diffDv2_hS_",
-      "_Z8abs_diffDv3_hS_", "_Z8abs_diffDv4_hS_", "_Z8abs_diffss",
-      "_Z8abs_diffDv2_sS_", "_Z8abs_diffDv3_sS_", "_Z8abs_diffDv4_sS_",
-      "_Z8abs_difftt",      "_Z8abs_diffDv2_tS_", "_Z8abs_diffDv3_tS_",
-      "_Z8abs_diffDv4_tS_", "_Z8abs_diffii",      "_Z8abs_diffDv2_iS_",
-      "_Z8abs_diffDv3_iS_", "_Z8abs_diffDv4_iS_", "_Z8abs_diffjj",
-      "_Z8abs_diffDv2_jS_", "_Z8abs_diffDv3_jS_", "_Z8abs_diffDv4_jS_",
-      "_Z8abs_diffll",      "_Z8abs_diffDv2_lS_", "_Z8abs_diffDv3_lS_",
-      "_Z8abs_diffDv4_lS_", "_Z8abs_diffmm",      "_Z8abs_diffDv2_mS_",
-      "_Z8abs_diffDv3_mS_", "_Z8abs_diffDv4_mS_",
-  };
-
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceAbsDiff(Function &F, bool is_signed) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     auto XValue = CI->getOperand(0);
     auto YValue = CI->getOperand(1);
 
@@ -359,10 +421,8 @@ bool ReplaceOpenCLBuiltinPass::replaceAbsDiff(Module &M) {
     auto XmY = Builder.CreateSub(XValue, YValue);
     auto YmX = Builder.CreateSub(YValue, XValue);
 
-    Value *Cmp;
-    auto F = CI->getCalledFunction();
-    auto finfo = FunctionInfo::getFromMangledName(F->getName());
-    if (finfo.isArgSigned(0)) {
+    Value *Cmp = nullptr;
+    if (is_signed) {
       Cmp = Builder.CreateICmpSGT(YValue, XValue);
     } else {
       Cmp = Builder.CreateICmpUGT(YValue, XValue);
@@ -372,22 +432,14 @@ bool ReplaceOpenCLBuiltinPass::replaceAbsDiff(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceCopysign(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z8copysignff",
-      "_Z8copysignDv2_fS_",
-      "_Z8copysignDv3_fS_",
-      "_Z8copysignDv4_fS_",
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceCopysign(Function &F) {
+  return replaceCallsWithValue(F, [&F](CallInst *CI) {
     auto XValue = CI->getOperand(0);
     auto YValue = CI->getOperand(1);
 
     auto Ty = XValue->getType();
 
-    Type *IntTy = Type::getIntNTy(M.getContext(), Ty->getScalarSizeInBits());
+    Type *IntTy = Type::getIntNTy(F.getContext(), Ty->getScalarSizeInBits());
     if (Ty->isVectorTy()) {
       IntTy = VectorType::get(IntTy, Ty->getVectorNumElements());
     }
@@ -418,15 +470,8 @@ bool ReplaceOpenCLBuiltinPass::replaceCopysign(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceRecip(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z10half_recipf",       "_Z12native_recipf",     "_Z10half_recipDv2_f",
-      "_Z12native_recipDv2_f", "_Z10half_recipDv3_f",   "_Z12native_recipDv3_f",
-      "_Z10half_recipDv4_f",   "_Z12native_recipDv4_f",
-  };
-
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceRecip(Function &F) {
+  return replaceCallsWithValue(F, [](CallInst *CI) {
     // Recip has one arg.
     auto Arg = CI->getOperand(0);
     auto Cst1 = ConstantFP::get(Arg->getType(), 1.0);
@@ -434,34 +479,20 @@ bool ReplaceOpenCLBuiltinPass::replaceRecip(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceDivide(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z11half_divideff",      "_Z13native_divideff",
-      "_Z11half_divideDv2_fS_", "_Z13native_divideDv2_fS_",
-      "_Z11half_divideDv3_fS_", "_Z13native_divideDv3_fS_",
-      "_Z11half_divideDv4_fS_", "_Z13native_divideDv4_fS_",
-  };
-
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceDivide(Function &F) {
+  return replaceCallsWithValue(F, [](CallInst *CI) {
     auto Op0 = CI->getOperand(0);
     auto Op1 = CI->getOperand(1);
     return BinaryOperator::Create(Instruction::FDiv, Op0, Op1, "", CI);
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceDot(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z3dotff",   "_Z3dotDv2_fS_",  "_Z3dotDv3_fS_",  "_Z3dotDv4_fS_",
-      "_Z3dotDhDh", "_Z3dotDv2_DhS_", "_Z3dotDv3_DhS_", "_Z3dotDv4_DhS_",
-  };
-
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceDot(Function &F) {
+  return replaceCallsWithValue(F, [](CallInst *CI) {
     auto Op0 = CI->getOperand(0);
     auto Op1 = CI->getOperand(1);
 
-    Value *V;
+    Value *V = nullptr;
     if (Op0->getType()->isVectorTy()) {
       V = clspv::InsertSPIRVOp(CI, spv::OpDot, {Attribute::ReadNone},
                                CI->getType(), {Op0, Op1});
@@ -473,157 +504,100 @@ bool ReplaceOpenCLBuiltinPass::replaceDot(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceExp10(Module &M) {
-  bool Changed = false;
-
-  const std::map<const char *, const char *> Map = {
-      {"_Z5exp10f", "_Z3expf"},
-      {"_Z10half_exp10f", "_Z8half_expf"},
-      {"_Z12native_exp10f", "_Z10native_expf"},
-      {"_Z5exp10Dv2_f", "_Z3expDv2_f"},
-      {"_Z10half_exp10Dv2_f", "_Z8half_expDv2_f"},
-      {"_Z12native_exp10Dv2_f", "_Z10native_expDv2_f"},
-      {"_Z5exp10Dv3_f", "_Z3expDv3_f"},
-      {"_Z10half_exp10Dv3_f", "_Z8half_expDv3_f"},
-      {"_Z12native_exp10Dv3_f", "_Z10native_expDv3_f"},
-      {"_Z5exp10Dv4_f", "_Z3expDv4_f"},
-      {"_Z10half_exp10Dv4_f", "_Z8half_expDv4_f"},
-      {"_Z12native_exp10Dv4_f", "_Z10native_expDv4_f"}};
-
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto NewF = M.getOrInsertFunction(Pair.second, F->getFunctionType());
-
-          auto Arg = CI->getOperand(0);
-
-          // Constant of the natural log of 10 (ln(10)).
-          const double Ln10 =
-              2.302585092994045684017991454684364207601101488628772976033;
-
-          auto Mul = BinaryOperator::Create(
-              Instruction::FMul, ConstantFP::get(Arg->getType(), Ln10), Arg, "",
-              CI);
-
-          auto NewCI = CallInst::Create(NewF, Mul, "", CI);
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
+bool ReplaceOpenCLBuiltinPass::replaceExp10(Function &F,
+                                            const std::string &basename,
+                                            int vec_size, int byte_len) {
+  // convert to natural
+  auto slen = basename.length() - 2;
+  std::string NewFName = "_Z" + std::to_string(slen) + basename.substr(0, slen);
+  if (vec_size) {
+    NewFName += "Dv" + std::to_string(vec_size) + "_";
+  }
+  switch (byte_len) {
+  case 4:
+    NewFName += "f";
+    break;
+  case 8:
+    NewFName += "d";
+    break;
+  default:
+    llvm_unreachable("Unsupported exp10 byte length");
+    break;
   }
 
-  return Changed;
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    auto NewF = M.getOrInsertFunction(NewFName, F.getFunctionType());
+
+    auto Arg = CI->getOperand(0);
+
+    // Constant of the natural log of 10 (ln(10)).
+    const double Ln10 =
+        2.302585092994045684017991454684364207601101488628772976033;
+
+    auto Mul = BinaryOperator::Create(
+        Instruction::FMul, ConstantFP::get(Arg->getType(), Ln10), Arg, "", CI);
+
+    return CallInst::Create(NewF, Mul, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceFmod(Module &M) {
-
-  std::vector<const char *> Names = {
-      "_Z4fmodff",
-      "_Z4fmodDv2_fS_",
-      "_Z4fmodDv3_fS_",
-      "_Z4fmodDv4_fS_",
-  };
-
+bool ReplaceOpenCLBuiltinPass::replaceFmod(Function &F) {
   // OpenCL fmod(x,y) is x - y * trunc(x/y)
   // The sign for a non-zero result is taken from x.
   // (Try an example.)
   // So translate to FRem
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+  return replaceCallsWithValue(F, [](CallInst *CI) {
     auto Op0 = CI->getOperand(0);
     auto Op1 = CI->getOperand(1);
     return BinaryOperator::Create(Instruction::FRem, Op0, Op1, "", CI);
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceLog10(Module &M) {
-  bool Changed = false;
-
-  const std::map<const char *, const char *> Map = {
-      {"_Z5log10f", "_Z3logf"},
-      {"_Z10half_log10f", "_Z8half_logf"},
-      {"_Z12native_log10f", "_Z10native_logf"},
-      {"_Z5log10Dv2_f", "_Z3logDv2_f"},
-      {"_Z10half_log10Dv2_f", "_Z8half_logDv2_f"},
-      {"_Z12native_log10Dv2_f", "_Z10native_logDv2_f"},
-      {"_Z5log10Dv3_f", "_Z3logDv3_f"},
-      {"_Z10half_log10Dv3_f", "_Z8half_logDv3_f"},
-      {"_Z12native_log10Dv3_f", "_Z10native_logDv3_f"},
-      {"_Z5log10Dv4_f", "_Z3logDv4_f"},
-      {"_Z10half_log10Dv4_f", "_Z8half_logDv4_f"},
-      {"_Z12native_log10Dv4_f", "_Z10native_logDv4_f"}};
-
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto NewF = M.getOrInsertFunction(Pair.second, F->getFunctionType());
-
-          auto Arg = CI->getOperand(0);
-
-          // Constant of the reciprocal of the natural log of 10 (ln(10)).
-          const double Ln10 =
-              0.434294481903251827651128918916605082294397005803666566114;
-
-          auto NewCI = CallInst::Create(NewF, Arg, "", CI);
-
-          auto Mul = BinaryOperator::Create(
-              Instruction::FMul, ConstantFP::get(Arg->getType(), Ln10), NewCI,
-              "", CI);
-
-          CI->replaceAllUsesWith(Mul);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
+bool ReplaceOpenCLBuiltinPass::replaceLog10(Function &F,
+                                            const std::string &basename,
+                                            int vec_size, int byte_len) {
+  // convert to natural
+  auto slen = basename.length() - 2;
+  std::string NewFName = "_Z" + std::to_string(slen) + basename.substr(0, slen);
+  if (vec_size) {
+    NewFName += "Dv" + std::to_string(vec_size) + "_";
+  }
+  switch (byte_len) {
+  case 4:
+    NewFName += "f";
+    break;
+  case 8:
+    NewFName += "d";
+    break;
+  default:
+    llvm_unreachable("Unsupported log10 byte length");
+    break;
   }
 
-  return Changed;
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    auto NewF = M.getOrInsertFunction(NewFName, F.getFunctionType());
+
+    auto Arg = CI->getOperand(0);
+
+    // Constant of the reciprocal of the natural log of 10 (ln(10)).
+    const double Ln10 =
+        0.434294481903251827651128918916605082294397005803666566114;
+
+    auto NewCI = CallInst::Create(NewF, Arg, "", CI);
+
+    return BinaryOperator::Create(Instruction::FMul,
+                                  ConstantFP::get(Arg->getType(), Ln10), NewCI,
+                                  "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceBarrier(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceBarrier(Function &F) {
 
   enum { CLK_LOCAL_MEM_FENCE = 0x01, CLK_GLOBAL_MEM_FENCE = 0x02 };
 
-  const std::vector<const char *> Names = {"_Z7barrierj",
-                                           // OpenCL 2.0 alias for barrier.
-                                           "_Z18work_group_barrierj"};
-
-  return replaceCallsWithValue(M, Names, [](CallInst *CI) {
+  return replaceCallsWithValue(F, [](CallInst *CI) {
     auto Arg = CI->getOperand(0);
 
     // We need to map the OpenCL constants to the SPIR-V equivalents.
@@ -681,251 +655,110 @@ bool ReplaceOpenCLBuiltinPass::replaceBarrier(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceMemFence(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceMemFence(Function &F,
+                                               uint32_t semantics) {
 
-  enum { CLK_LOCAL_MEM_FENCE = 0x01, CLK_GLOBAL_MEM_FENCE = 0x02 };
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    enum { CLK_LOCAL_MEM_FENCE = 0x01, CLK_GLOBAL_MEM_FENCE = 0x02 };
 
-  using Tuple = std::tuple<spv::Op, unsigned>;
-  const std::map<const char *, Tuple> Map = {
-      {"_Z9mem_fencej", Tuple(spv::OpMemoryBarrier,
-                              spv::MemorySemanticsSequentiallyConsistentMask)},
-      {"_Z14read_mem_fencej",
-       Tuple(spv::OpMemoryBarrier, spv::MemorySemanticsAcquireMask)},
-      {"_Z15write_mem_fencej",
-       Tuple(spv::OpMemoryBarrier, spv::MemorySemanticsReleaseMask)}};
+    auto Arg = CI->getOperand(0);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    // We need to map the OpenCL constants to the SPIR-V equivalents.
+    const auto LocalMemFence =
+        ConstantInt::get(Arg->getType(), CLK_LOCAL_MEM_FENCE);
+    const auto GlobalMemFence =
+        ConstantInt::get(Arg->getType(), CLK_GLOBAL_MEM_FENCE);
+    const auto ConstantMemorySemantics =
+        ConstantInt::get(Arg->getType(), semantics);
+    const auto ConstantScopeDevice =
+        ConstantInt::get(Arg->getType(), spv::ScopeDevice);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+    // Map CLK_LOCAL_MEM_FENCE to MemorySemanticsWorkgroupMemoryMask.
+    const auto LocalMemFenceMask =
+        BinaryOperator::Create(Instruction::And, LocalMemFence, Arg, "", CI);
+    const auto WorkgroupShiftAmount =
+        clz(spv::MemorySemanticsWorkgroupMemoryMask) - clz(CLK_LOCAL_MEM_FENCE);
+    const auto MemorySemanticsWorkgroup = BinaryOperator::Create(
+        Instruction::Shl, LocalMemFenceMask,
+        ConstantInt::get(Arg->getType(), WorkgroupShiftAmount), "", CI);
 
-          auto Arg = CI->getOperand(0);
+    // Map CLK_GLOBAL_MEM_FENCE to MemorySemanticsUniformMemoryMask.
+    const auto GlobalMemFenceMask =
+        BinaryOperator::Create(Instruction::And, GlobalMemFence, Arg, "", CI);
+    const auto UniformShiftAmount =
+        clz(spv::MemorySemanticsUniformMemoryMask) - clz(CLK_GLOBAL_MEM_FENCE);
+    const auto MemorySemanticsUniform = BinaryOperator::Create(
+        Instruction::Shl, GlobalMemFenceMask,
+        ConstantInt::get(Arg->getType(), UniformShiftAmount), "", CI);
 
-          // We need to map the OpenCL constants to the SPIR-V equivalents.
-          const auto LocalMemFence =
-              ConstantInt::get(Arg->getType(), CLK_LOCAL_MEM_FENCE);
-          const auto GlobalMemFence =
-              ConstantInt::get(Arg->getType(), CLK_GLOBAL_MEM_FENCE);
-          const auto ConstantMemorySemantics =
-              ConstantInt::get(Arg->getType(), std::get<1>(Pair.second));
-          const auto ConstantScopeDevice =
-              ConstantInt::get(Arg->getType(), spv::ScopeDevice);
+    // And combine the above together, also adding in
+    // MemorySemanticsSequentiallyConsistentMask.
+    auto MemorySemantics =
+        BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
+                               ConstantMemorySemantics, "", CI);
+    MemorySemantics = BinaryOperator::Create(Instruction::Or, MemorySemantics,
+                                             MemorySemanticsUniform, "", CI);
 
-          // Map CLK_LOCAL_MEM_FENCE to MemorySemanticsWorkgroupMemoryMask.
-          const auto LocalMemFenceMask = BinaryOperator::Create(
-              Instruction::And, LocalMemFence, Arg, "", CI);
-          const auto WorkgroupShiftAmount =
-              clz(spv::MemorySemanticsWorkgroupMemoryMask) -
-              clz(CLK_LOCAL_MEM_FENCE);
-          const auto MemorySemanticsWorkgroup = BinaryOperator::Create(
-              Instruction::Shl, LocalMemFenceMask,
-              ConstantInt::get(Arg->getType(), WorkgroupShiftAmount), "", CI);
+    // Memory Scope is always device.
+    const auto MemoryScope = ConstantScopeDevice;
 
-          // Map CLK_GLOBAL_MEM_FENCE to MemorySemanticsUniformMemoryMask.
-          const auto GlobalMemFenceMask = BinaryOperator::Create(
-              Instruction::And, GlobalMemFence, Arg, "", CI);
-          const auto UniformShiftAmount =
-              clz(spv::MemorySemanticsUniformMemoryMask) -
-              clz(CLK_GLOBAL_MEM_FENCE);
-          const auto MemorySemanticsUniform = BinaryOperator::Create(
-              Instruction::Shl, GlobalMemFenceMask,
-              ConstantInt::get(Arg->getType(), UniformShiftAmount), "", CI);
-
-          // And combine the above together, also adding in
-          // MemorySemanticsSequentiallyConsistentMask.
-          auto MemorySemantics =
-              BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
-                                     ConstantMemorySemantics, "", CI);
-          MemorySemantics = BinaryOperator::Create(
-              Instruction::Or, MemorySemantics, MemorySemanticsUniform, "", CI);
-
-          // Memory Scope is always device.
-          const auto MemoryScope = ConstantScopeDevice;
-
-          const auto SPIRVOp = std::get<0>(Pair.second);
-          auto NewCI = clspv::InsertSPIRVOp(CI, SPIRVOp, {}, CI->getType(),
-                                            {MemoryScope, MemorySemantics});
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return clspv::InsertSPIRVOp(CI, spv::OpMemoryBarrier, {}, CI->getType(),
+                                {MemoryScope, MemorySemantics});
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceRelational(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceRelational(Function &F,
+                                                 CmpInst::Predicate P,
+                                                 int32_t C) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    // The predicate to use in the CmpInst.
+    auto Predicate = P;
 
-  const std::map<const char *, std::pair<CmpInst::Predicate, int32_t>> Map = {
-      {"_Z7isequalff", {CmpInst::FCMP_OEQ, 1}},
-      {"_Z7isequalDv2_fS_", {CmpInst::FCMP_OEQ, -1}},
-      {"_Z7isequalDv3_fS_", {CmpInst::FCMP_OEQ, -1}},
-      {"_Z7isequalDv4_fS_", {CmpInst::FCMP_OEQ, -1}},
-      {"_Z9isgreaterff", {CmpInst::FCMP_OGT, 1}},
-      {"_Z9isgreaterDv2_fS_", {CmpInst::FCMP_OGT, -1}},
-      {"_Z9isgreaterDv3_fS_", {CmpInst::FCMP_OGT, -1}},
-      {"_Z9isgreaterDv4_fS_", {CmpInst::FCMP_OGT, -1}},
-      {"_Z14isgreaterequalff", {CmpInst::FCMP_OGE, 1}},
-      {"_Z14isgreaterequalDv2_fS_", {CmpInst::FCMP_OGE, -1}},
-      {"_Z14isgreaterequalDv3_fS_", {CmpInst::FCMP_OGE, -1}},
-      {"_Z14isgreaterequalDv4_fS_", {CmpInst::FCMP_OGE, -1}},
-      {"_Z6islessff", {CmpInst::FCMP_OLT, 1}},
-      {"_Z6islessDv2_fS_", {CmpInst::FCMP_OLT, -1}},
-      {"_Z6islessDv3_fS_", {CmpInst::FCMP_OLT, -1}},
-      {"_Z6islessDv4_fS_", {CmpInst::FCMP_OLT, -1}},
-      {"_Z11islessequalff", {CmpInst::FCMP_OLE, 1}},
-      {"_Z11islessequalDv2_fS_", {CmpInst::FCMP_OLE, -1}},
-      {"_Z11islessequalDv3_fS_", {CmpInst::FCMP_OLE, -1}},
-      {"_Z11islessequalDv4_fS_", {CmpInst::FCMP_OLE, -1}},
-      {"_Z10isnotequalff", {CmpInst::FCMP_ONE, 1}},
-      {"_Z10isnotequalDv2_fS_", {CmpInst::FCMP_ONE, -1}},
-      {"_Z10isnotequalDv3_fS_", {CmpInst::FCMP_ONE, -1}},
-      {"_Z10isnotequalDv4_fS_", {CmpInst::FCMP_ONE, -1}},
-  };
+    // The value to return for true.
+    auto TrueValue = ConstantInt::getSigned(CI->getType(), C);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    // The value to return for false.
+    auto FalseValue = Constant::getNullValue(CI->getType());
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          // The predicate to use in the CmpInst.
-          auto Predicate = Pair.second.first;
+    auto Arg1 = CI->getOperand(0);
+    auto Arg2 = CI->getOperand(1);
 
-          // The value to return for true.
-          auto TrueValue =
-              ConstantInt::getSigned(CI->getType(), Pair.second.second);
+    const auto Cmp =
+        CmpInst::Create(Instruction::FCmp, Predicate, Arg1, Arg2, "", CI);
 
-          // The value to return for false.
-          auto FalseValue = Constant::getNullValue(CI->getType());
-
-          auto Arg1 = CI->getOperand(0);
-          auto Arg2 = CI->getOperand(1);
-
-          const auto Cmp =
-              CmpInst::Create(Instruction::FCmp, Predicate, Arg1, Arg2, "", CI);
-
-          const auto Select =
-              SelectInst::Create(Cmp, TrueValue, FalseValue, "", CI);
-
-          CI->replaceAllUsesWith(Select);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return SelectInst::Create(Cmp, TrueValue, FalseValue, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceIsInfAndIsNan(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceIsInfAndIsNan(Function &F,
+                                                    spv::Op SPIRVOp,
+                                                    int32_t C) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    const auto CITy = CI->getType();
 
-  const std::map<const char *, std::pair<spv::Op, int32_t>> Map = {
-      {"_Z5isinff", {spv::OpIsInf, 1}},
-      {"_Z5isinfDv2_f", {spv::OpIsInf, -1}},
-      {"_Z5isinfDv3_f", {spv::OpIsInf, -1}},
-      {"_Z5isinfDv4_f", {spv::OpIsInf, -1}},
-      {"_Z5isnanf", {spv::OpIsNan, 1}},
-      {"_Z5isnanDv2_f", {spv::OpIsNan, -1}},
-      {"_Z5isnanDv3_f", {spv::OpIsNan, -1}},
-      {"_Z5isnanDv4_f", {spv::OpIsNan, -1}},
-  };
+    // The value to return for true.
+    auto TrueValue = ConstantInt::getSigned(CITy, C);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    // The value to return for false.
+    auto FalseValue = Constant::getNullValue(CITy);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          const auto CITy = CI->getType();
-
-          auto SPIRVOp = Pair.second.first;
-
-          // The value to return for true.
-          auto TrueValue = ConstantInt::getSigned(CITy, Pair.second.second);
-
-          // The value to return for false.
-          auto FalseValue = Constant::getNullValue(CITy);
-
-          const auto CorrespondingBoolTy = getBoolOrBoolVectorTy(
-              M.getContext(),
-              CITy->isVectorTy() ? CITy->getVectorNumElements() : 1);
-
-          auto NewCI =
-              clspv::InsertSPIRVOp(CI, SPIRVOp, {Attribute::ReadNone},
-                                   CorrespondingBoolTy, {CI->getOperand(0)});
-
-          const auto Select =
-              SelectInst::Create(NewCI, TrueValue, FalseValue, "", CI);
-
-          CI->replaceAllUsesWith(Select);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    Type *CorrespondingBoolTy = Type::getInt1Ty(M.getContext());
+    if (CITy->isVectorTy()) {
+      CorrespondingBoolTy = VectorType::get(Type::getInt1Ty(M.getContext()),
+                                            CITy->getVectorNumElements());
     }
-  }
 
-  return Changed;
+    auto NewCI = clspv::InsertSPIRVOp(CI, SPIRVOp, {Attribute::ReadNone},
+                                      CorrespondingBoolTy, {CI->getOperand(0)});
+
+    return SelectInst::Create(NewCI, TrueValue, FalseValue, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceIsFinite(Module &M) {
-  std::vector<const char *> Names = {
-      "_Z8isfiniteh",     "_Z8isfiniteDv2_h", "_Z8isfiniteDv3_h",
-      "_Z8isfiniteDv4_h", "_Z8isfinitef",     "_Z8isfiniteDv2_f",
-      "_Z8isfiniteDv3_f", "_Z8isfiniteDv4_f", "_Z8isfinited",
-      "_Z8isfiniteDv2_d", "_Z8isfiniteDv3_d", "_Z8isfiniteDv4_d",
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceIsFinite(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     auto &C = M.getContext();
     auto Val = CI->getOperand(0);
     auto ValTy = Val->getType();
@@ -936,7 +769,7 @@ bool ReplaceOpenCLBuiltinPass::replaceIsFinite(Module &M) {
 
     // Create Mask
     auto ScalarSize = ValTy->getScalarSizeInBits();
-    Value *InfMask;
+    Value *InfMask = nullptr;
     switch (ScalarSize) {
     case 16:
       InfMask = ConstantInt::get(IntTy, 0x7C00U);
@@ -961,7 +794,7 @@ bool ReplaceOpenCLBuiltinPass::replaceIsFinite(Module &M) {
     auto Cmp = Builder.CreateICmp(CmpInst::ICMP_EQ, InfBits, InfMask);
 
     auto RetFalse = ConstantInt::get(RetTy, 0);
-    Value *RetTrue;
+    Value *RetTrue = nullptr;
     if (ValTy->isVectorTy()) {
       RetTrue = ConstantInt::getSigned(RetTy, -1);
     } else {
@@ -971,1296 +804,729 @@ bool ReplaceOpenCLBuiltinPass::replaceIsFinite(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceAllAndAny(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceAllAndAny(Function &F, spv::Op SPIRVOp) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    auto Arg = CI->getOperand(0);
 
-  const std::map<const char *, spv::Op> Map = {
-      // all
-      {"_Z3allc", spv::OpNop},
-      {"_Z3allDv2_c", spv::OpAll},
-      {"_Z3allDv3_c", spv::OpAll},
-      {"_Z3allDv4_c", spv::OpAll},
-      {"_Z3alls", spv::OpNop},
-      {"_Z3allDv2_s", spv::OpAll},
-      {"_Z3allDv3_s", spv::OpAll},
-      {"_Z3allDv4_s", spv::OpAll},
-      {"_Z3alli", spv::OpNop},
-      {"_Z3allDv2_i", spv::OpAll},
-      {"_Z3allDv3_i", spv::OpAll},
-      {"_Z3allDv4_i", spv::OpAll},
-      {"_Z3alll", spv::OpNop},
-      {"_Z3allDv2_l", spv::OpAll},
-      {"_Z3allDv3_l", spv::OpAll},
-      {"_Z3allDv4_l", spv::OpAll},
+    Value *V = nullptr;
 
-      // any
-      {"_Z3anyc", spv::OpNop},
-      {"_Z3anyDv2_c", spv::OpAny},
-      {"_Z3anyDv3_c", spv::OpAny},
-      {"_Z3anyDv4_c", spv::OpAny},
-      {"_Z3anys", spv::OpNop},
-      {"_Z3anyDv2_s", spv::OpAny},
-      {"_Z3anyDv3_s", spv::OpAny},
-      {"_Z3anyDv4_s", spv::OpAny},
-      {"_Z3anyi", spv::OpNop},
-      {"_Z3anyDv2_i", spv::OpAny},
-      {"_Z3anyDv3_i", spv::OpAny},
-      {"_Z3anyDv4_i", spv::OpAny},
-      {"_Z3anyl", spv::OpNop},
-      {"_Z3anyDv2_l", spv::OpAny},
-      {"_Z3anyDv3_l", spv::OpAny},
-      {"_Z3anyDv4_l", spv::OpAny},
-  };
+    // If the argument is a 32-bit int, just use a shift
+    if (Arg->getType() == Type::getInt32Ty(M.getContext())) {
+      V = BinaryOperator::Create(Instruction::LShr, Arg,
+                                 ConstantInt::get(Arg->getType(), 31), "", CI);
+    } else {
+      // The value for zero to compare against.
+      const auto ZeroValue = Constant::getNullValue(Arg->getType());
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+      // The value to return for true.
+      const auto TrueValue = ConstantInt::get(CI->getType(), 1);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+      // The value to return for false.
+      const auto FalseValue = Constant::getNullValue(CI->getType());
 
-          auto Arg = CI->getOperand(0);
+      const auto Cmp = CmpInst::Create(Instruction::ICmp, CmpInst::ICMP_SLT,
+                                       Arg, ZeroValue, "", CI);
 
-          Value *V;
+      Value *SelectSource = nullptr;
 
-          // If the argument is a 32-bit int, just use a shift
-          if (Arg->getType() == Type::getInt32Ty(M.getContext())) {
-            V = BinaryOperator::Create(Instruction::LShr, Arg,
-                                       ConstantInt::get(Arg->getType(), 31), "",
-                                       CI);
-          } else {
-            // The value for zero to compare against.
-            const auto ZeroValue = Constant::getNullValue(Arg->getType());
+      // If we have a function to call, call it!
+      if (SPIRVOp != spv::OpNop) {
 
-            // The value to return for true.
-            const auto TrueValue = ConstantInt::get(CI->getType(), 1);
+        const auto BoolTy = Type::getInt1Ty(M.getContext());
 
-            // The value to return for false.
-            const auto FalseValue = Constant::getNullValue(CI->getType());
+        const auto NewCI = clspv::InsertSPIRVOp(
+            CI, SPIRVOp, {Attribute::ReadNone}, BoolTy, {Cmp});
+        SelectSource = NewCI;
 
-            const auto Cmp = CmpInst::Create(
-                Instruction::ICmp, CmpInst::ICMP_SLT, Arg, ZeroValue, "", CI);
-
-            Value *SelectSource;
-
-            // If we have a function to call, call it!
-            const auto SPIRVOp = Pair.second;
-
-            if (SPIRVOp != spv::OpNop) {
-
-              const auto BoolTy = Type::getInt1Ty(M.getContext());
-
-              const auto NewCI = clspv::InsertSPIRVOp(
-                  CI, SPIRVOp, {Attribute::ReadNone}, BoolTy, {Cmp});
-              SelectSource = NewCI;
-
-            } else {
-              SelectSource = Cmp;
-            }
-
-            V = SelectInst::Create(SelectSource, TrueValue, FalseValue, "", CI);
-          }
-
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
+      } else {
+        SelectSource = Cmp;
       }
 
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+      V = SelectInst::Create(SelectSource, TrueValue, FalseValue, "", CI);
     }
-  }
-
-  return Changed;
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceUpsample(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceUpsample(Function &F) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    // Get arguments
+    auto HiValue = CI->getOperand(0);
+    auto LoValue = CI->getOperand(1);
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    // Skip symbols whose name doesn't match
-    if (!SymVal.getKey().startswith("_Z8upsample")) {
-      continue;
+    // Don't touch overloads that aren't in OpenCL C
+    auto HiType = HiValue->getType();
+    auto LoType = LoValue->getType();
+
+    if (HiType != LoType) {
+      return nullptr;
     }
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
 
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          // Get arguments
-          auto HiValue = CI->getOperand(0);
-          auto LoValue = CI->getOperand(1);
-
-          // Don't touch overloads that aren't in OpenCL C
-          auto HiType = HiValue->getType();
-          auto LoType = LoValue->getType();
-
-          if (HiType != LoType) {
-            continue;
-          }
-
-          if (!HiType->isIntOrIntVectorTy()) {
-            continue;
-          }
-
-          if (HiType->getScalarSizeInBits() * 2 !=
-              CI->getType()->getScalarSizeInBits()) {
-            continue;
-          }
-
-          if ((HiType->getScalarSizeInBits() != 8) &&
-              (HiType->getScalarSizeInBits() != 16) &&
-              (HiType->getScalarSizeInBits() != 32)) {
-            continue;
-          }
-
-          if (HiType->isVectorTy()) {
-            if ((HiType->getVectorNumElements() != 2) &&
-                (HiType->getVectorNumElements() != 3) &&
-                (HiType->getVectorNumElements() != 4) &&
-                (HiType->getVectorNumElements() != 8) &&
-                (HiType->getVectorNumElements() != 16)) {
-              continue;
-            }
-          }
-
-          // Convert both operands to the result type
-          auto HiCast =
-              CastInst::CreateZExtOrBitCast(HiValue, CI->getType(), "", CI);
-          auto LoCast =
-              CastInst::CreateZExtOrBitCast(LoValue, CI->getType(), "", CI);
-
-          // Shift high operand
-          auto ShiftAmount =
-              ConstantInt::get(CI->getType(), HiType->getScalarSizeInBits());
-          auto HiShifted = BinaryOperator::Create(Instruction::Shl, HiCast,
-                                                  ShiftAmount, "", CI);
-
-          // OR both results
-          Value *V = BinaryOperator::Create(Instruction::Or, HiShifted, LoCast,
-                                            "", CI);
-
-          // Replace call with the expression
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    if (!HiType->isIntOrIntVectorTy()) {
+      return nullptr;
     }
-  }
 
-  return Changed;
+    if (HiType->getScalarSizeInBits() * 2 !=
+        CI->getType()->getScalarSizeInBits()) {
+      return nullptr;
+    }
+
+    if ((HiType->getScalarSizeInBits() != 8) &&
+        (HiType->getScalarSizeInBits() != 16) &&
+        (HiType->getScalarSizeInBits() != 32)) {
+      return nullptr;
+    }
+
+    if (HiType->isVectorTy()) {
+      if ((HiType->getVectorNumElements() != 2) &&
+          (HiType->getVectorNumElements() != 3) &&
+          (HiType->getVectorNumElements() != 4) &&
+          (HiType->getVectorNumElements() != 8) &&
+          (HiType->getVectorNumElements() != 16)) {
+        return nullptr;
+      }
+    }
+
+    // Convert both operands to the result type
+    auto HiCast = CastInst::CreateZExtOrBitCast(HiValue, CI->getType(), "", CI);
+    auto LoCast = CastInst::CreateZExtOrBitCast(LoValue, CI->getType(), "", CI);
+
+    // Shift high operand
+    auto ShiftAmount =
+        ConstantInt::get(CI->getType(), HiType->getScalarSizeInBits());
+    auto HiShifted =
+        BinaryOperator::Create(Instruction::Shl, HiCast, ShiftAmount, "", CI);
+
+    // OR both results
+    return BinaryOperator::Create(Instruction::Or, HiShifted, LoCast, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceRotate(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceRotate(Function &F) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    // Get arguments
+    auto SrcValue = CI->getOperand(0);
+    auto RotAmount = CI->getOperand(1);
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    // Skip symbols whose name doesn't match
-    if (!SymVal.getKey().startswith("_Z6rotate")) {
-      continue;
+    // Don't touch overloads that aren't in OpenCL C
+    auto SrcType = SrcValue->getType();
+    auto RotType = RotAmount->getType();
+
+    if ((SrcType != RotType) || (CI->getType() != SrcType)) {
+      return nullptr;
     }
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
 
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          // Get arguments
-          auto SrcValue = CI->getOperand(0);
-          auto RotAmount = CI->getOperand(1);
-
-          // Don't touch overloads that aren't in OpenCL C
-          auto SrcType = SrcValue->getType();
-          auto RotType = RotAmount->getType();
-
-          if ((SrcType != RotType) || (CI->getType() != SrcType)) {
-            continue;
-          }
-
-          if (!SrcType->isIntOrIntVectorTy()) {
-            continue;
-          }
-
-          if ((SrcType->getScalarSizeInBits() != 8) &&
-              (SrcType->getScalarSizeInBits() != 16) &&
-              (SrcType->getScalarSizeInBits() != 32) &&
-              (SrcType->getScalarSizeInBits() != 64)) {
-            continue;
-          }
-
-          if (SrcType->isVectorTy()) {
-            if ((SrcType->getVectorNumElements() != 2) &&
-                (SrcType->getVectorNumElements() != 3) &&
-                (SrcType->getVectorNumElements() != 4) &&
-                (SrcType->getVectorNumElements() != 8) &&
-                (SrcType->getVectorNumElements() != 16)) {
-              continue;
-            }
-          }
-
-          // The approach used is to shift the top bits down, the bottom bits up
-          // and OR the two shifted values.
-
-          // The rotation amount is to be treated modulo the element size.
-          // Since SPIR-V shift ops don't support this, let's apply the
-          // modulo ahead of shifting. The element size is always a power of
-          // two so we can just AND with a mask.
-          auto ModMask =
-              ConstantInt::get(SrcType, SrcType->getScalarSizeInBits() - 1);
-          RotAmount = BinaryOperator::Create(Instruction::And, RotAmount,
-                                             ModMask, "", CI);
-
-          // Let's calc the amount by which to shift top bits down
-          auto ScalarSize =
-              ConstantInt::get(SrcType, SrcType->getScalarSizeInBits());
-          auto DownAmount = BinaryOperator::Create(Instruction::Sub, ScalarSize,
-                                                   RotAmount, "", CI);
-
-          // Now shift the bottom bits up and the top bits down
-          auto LoRotated = BinaryOperator::Create(Instruction::Shl, SrcValue,
-                                                  RotAmount, "", CI);
-          auto HiRotated = BinaryOperator::Create(Instruction::LShr, SrcValue,
-                                                  DownAmount, "", CI);
-
-          // Finally OR the two shifted values
-          Value *V = BinaryOperator::Create(Instruction::Or, LoRotated,
-                                            HiRotated, "", CI);
-
-          // Replace call with the expression
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    if (!SrcType->isIntOrIntVectorTy()) {
+      return nullptr;
     }
-  }
 
-  return Changed;
+    if ((SrcType->getScalarSizeInBits() != 8) &&
+        (SrcType->getScalarSizeInBits() != 16) &&
+        (SrcType->getScalarSizeInBits() != 32) &&
+        (SrcType->getScalarSizeInBits() != 64)) {
+      return nullptr;
+    }
+
+    if (SrcType->isVectorTy()) {
+      if ((SrcType->getVectorNumElements() != 2) &&
+          (SrcType->getVectorNumElements() != 3) &&
+          (SrcType->getVectorNumElements() != 4) &&
+          (SrcType->getVectorNumElements() != 8) &&
+          (SrcType->getVectorNumElements() != 16)) {
+        return nullptr;
+      }
+    }
+
+    // The approach used is to shift the top bits down, the bottom bits up
+    // and OR the two shifted values.
+
+    // The rotation amount is to be treated modulo the element size.
+    // Since SPIR-V shift ops don't support this, let's apply the
+    // modulo ahead of shifting. The element size is always a power of
+    // two so we can just AND with a mask.
+    auto ModMask =
+        ConstantInt::get(SrcType, SrcType->getScalarSizeInBits() - 1);
+    RotAmount =
+        BinaryOperator::Create(Instruction::And, RotAmount, ModMask, "", CI);
+
+    // Let's calc the amount by which to shift top bits down
+    auto ScalarSize = ConstantInt::get(SrcType, SrcType->getScalarSizeInBits());
+    auto DownAmount =
+        BinaryOperator::Create(Instruction::Sub, ScalarSize, RotAmount, "", CI);
+
+    // Now shift the bottom bits up and the top bits down
+    auto LoRotated =
+        BinaryOperator::Create(Instruction::Shl, SrcValue, RotAmount, "", CI);
+    auto HiRotated =
+        BinaryOperator::Create(Instruction::LShr, SrcValue, DownAmount, "", CI);
+
+    // Finally OR the two shifted values
+    return BinaryOperator::Create(Instruction::Or, LoRotated, HiRotated, "",
+                                  CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceConvert(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceConvert(Function &F, bool SrcIsSigned,
+                                              bool DstIsSigned) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    Value *V = nullptr;
+    // Get arguments
+    auto SrcValue = CI->getOperand(0);
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
+    // Don't touch overloads that aren't in OpenCL C
+    auto SrcType = SrcValue->getType();
+    auto DstType = CI->getType();
 
-    // Skip symbols whose name obviously doesn't match
-    if (!SymVal.getKey().contains("convert_")) {
-      continue;
+    if ((SrcType->isVectorTy() && !DstType->isVectorTy()) ||
+        (!SrcType->isVectorTy() && DstType->isVectorTy())) {
+      return V;
     }
 
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
+    if (SrcType->isVectorTy()) {
 
-      // Get info from the mangled name
-      FunctionInfo finfo;
-      bool parsed = FunctionInfo::getFromMangledNameCheck(F->getName(), &finfo);
-
-      // All functions of interest are handled by our mangled name parser
-      if (!parsed) {
-        continue;
+      if (SrcType->getVectorNumElements() != DstType->getVectorNumElements()) {
+        return V;
       }
 
-      // Move on if this isn't a call to convert_
-      if (!finfo.name.startswith("convert_")) {
-        continue;
+      if ((SrcType->getVectorNumElements() != 2) &&
+          (SrcType->getVectorNumElements() != 3) &&
+          (SrcType->getVectorNumElements() != 4) &&
+          (SrcType->getVectorNumElements() != 8) &&
+          (SrcType->getVectorNumElements() != 16)) {
+        return V;
       }
-
-      // Extract the destination type from the function name
-      StringRef DstTypeName = finfo.name;
-      DstTypeName.consume_front("convert_");
-
-      auto DstSignedNess =
-          StringSwitch<ArgTypeInfo::SignedNess>(DstTypeName)
-              .StartsWith("char", ArgTypeInfo::SignedNess::Signed)
-              .StartsWith("short", ArgTypeInfo::SignedNess::Signed)
-              .StartsWith("int", ArgTypeInfo::SignedNess::Signed)
-              .StartsWith("long", ArgTypeInfo::SignedNess::Signed)
-              .StartsWith("uchar", ArgTypeInfo::SignedNess::Unsigned)
-              .StartsWith("ushort", ArgTypeInfo::SignedNess::Unsigned)
-              .StartsWith("uint", ArgTypeInfo::SignedNess::Unsigned)
-              .StartsWith("ulong", ArgTypeInfo::SignedNess::Unsigned)
-              .Default(ArgTypeInfo::SignedNess::None);
-
-      bool DstIsSigned = DstSignedNess == ArgTypeInfo::SignedNess::Signed;
-      bool SrcIsSigned = finfo.isArgSigned(0);
-
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          // Get arguments
-          auto SrcValue = CI->getOperand(0);
-
-          // Don't touch overloads that aren't in OpenCL C
-          auto SrcType = SrcValue->getType();
-          auto DstType = CI->getType();
-
-          if ((SrcType->isVectorTy() && !DstType->isVectorTy()) ||
-              (!SrcType->isVectorTy() && DstType->isVectorTy())) {
-            continue;
-          }
-
-          if (SrcType->isVectorTy()) {
-
-            if (SrcType->getVectorNumElements() !=
-                DstType->getVectorNumElements()) {
-              continue;
-            }
-
-            if ((SrcType->getVectorNumElements() != 2) &&
-                (SrcType->getVectorNumElements() != 3) &&
-                (SrcType->getVectorNumElements() != 4) &&
-                (SrcType->getVectorNumElements() != 8) &&
-                (SrcType->getVectorNumElements() != 16)) {
-              continue;
-            }
-          }
-
-          bool SrcIsFloat = SrcType->getScalarType()->isFloatingPointTy();
-          bool DstIsFloat = DstType->getScalarType()->isFloatingPointTy();
-
-          bool SrcIsInt = SrcType->isIntOrIntVectorTy();
-          bool DstIsInt = DstType->isIntOrIntVectorTy();
-
-          Value *V;
-          if (SrcType == DstType && DstIsSigned == SrcIsSigned) {
-            // Unnecessary cast operation.
-            V = SrcValue;
-          } else if (SrcIsFloat && DstIsFloat) {
-            V = CastInst::CreateFPCast(SrcValue, DstType, "", CI);
-          } else if (SrcIsFloat && DstIsInt) {
-            if (DstIsSigned) {
-              V = CastInst::Create(Instruction::FPToSI, SrcValue, DstType, "",
-                                   CI);
-            } else {
-              V = CastInst::Create(Instruction::FPToUI, SrcValue, DstType, "",
-                                   CI);
-            }
-          } else if (SrcIsInt && DstIsFloat) {
-            if (SrcIsSigned) {
-              V = CastInst::Create(Instruction::SIToFP, SrcValue, DstType, "",
-                                   CI);
-            } else {
-              V = CastInst::Create(Instruction::UIToFP, SrcValue, DstType, "",
-                                   CI);
-            }
-          } else if (SrcIsInt && DstIsInt) {
-            V = CastInst::CreateIntegerCast(SrcValue, DstType, SrcIsSigned, "",
-                                            CI);
-          } else {
-            // Not something we're supposed to handle, just move on
-            continue;
-          }
-
-          // Replace call with the expression
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
     }
-  }
 
-  return Changed;
+    bool SrcIsFloat = SrcType->getScalarType()->isFloatingPointTy();
+    bool DstIsFloat = DstType->getScalarType()->isFloatingPointTy();
+
+    bool SrcIsInt = SrcType->isIntOrIntVectorTy();
+    bool DstIsInt = DstType->isIntOrIntVectorTy();
+
+    if (SrcType == DstType && DstIsSigned == SrcIsSigned) {
+      // Unnecessary cast operation.
+      V = SrcValue;
+    } else if (SrcIsFloat && DstIsFloat) {
+      V = CastInst::CreateFPCast(SrcValue, DstType, "", CI);
+    } else if (SrcIsFloat && DstIsInt) {
+      if (DstIsSigned) {
+        V = CastInst::Create(Instruction::FPToSI, SrcValue, DstType, "", CI);
+      } else {
+        V = CastInst::Create(Instruction::FPToUI, SrcValue, DstType, "", CI);
+      }
+    } else if (SrcIsInt && DstIsFloat) {
+      if (SrcIsSigned) {
+        V = CastInst::Create(Instruction::SIToFP, SrcValue, DstType, "", CI);
+      } else {
+        V = CastInst::Create(Instruction::UIToFP, SrcValue, DstType, "", CI);
+      }
+    } else if (SrcIsInt && DstIsInt) {
+      V = CastInst::CreateIntegerCast(SrcValue, DstType, SrcIsSigned, "", CI);
+    } else {
+      // Not something we're supposed to handle, just move on
+    }
+
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceMulHiMadHi(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceMulHi(Function &F, bool is_signed,
+                                            bool is_mad) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    Value *V = nullptr;
+    // Get arguments
+    auto AValue = CI->getOperand(0);
+    auto BValue = CI->getOperand(1);
+    auto CValue = CI->getOperand(2);
 
-  SmallVector<Function *, 4> FnWorklist;
+    // Don't touch overloads that aren't in OpenCL C
+    auto AType = AValue->getType();
+    auto BType = BValue->getType();
+    auto CType = CValue->getType();
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    bool isMad = SymVal.getKey().startswith("_Z6mad_hi");
-    bool isMul = SymVal.getKey().startswith("_Z6mul_hi");
-
-    // Skip symbols whose name doesn't match
-    if (!isMad && !isMul) {
-      continue;
+    if ((AType != BType) || (CI->getType() != AType) ||
+        (is_mad && (AType != CType))) {
+      return V;
     }
 
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
-      FnWorklist.push_back(F);
+    if (!AType->isIntOrIntVectorTy()) {
+      return V;
     }
-  }
 
-  for (auto F : FnWorklist) {
-    SmallVector<Instruction *, 4> ToRemoves;
+    if ((AType->getScalarSizeInBits() != 8) &&
+        (AType->getScalarSizeInBits() != 16) &&
+        (AType->getScalarSizeInBits() != 32) &&
+        (AType->getScalarSizeInBits() != 64)) {
+      return V;
+    }
 
-    bool isMad = F->getName().startswith("_Z6mad_hi");
-    // Walk the users of the function.
-    for (auto &U : F->uses()) {
-      if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-        // Get arguments
-        auto AValue = CI->getOperand(0);
-        auto BValue = CI->getOperand(1);
-        auto CValue = CI->getOperand(2);
-
-        // Don't touch overloads that aren't in OpenCL C
-        auto AType = AValue->getType();
-        auto BType = BValue->getType();
-        auto CType = CValue->getType();
-
-        if ((AType != BType) || (CI->getType() != AType) ||
-            (isMad && (AType != CType))) {
-          continue;
-        }
-
-        if (!AType->isIntOrIntVectorTy()) {
-          continue;
-        }
-
-        if ((AType->getScalarSizeInBits() != 8) &&
-            (AType->getScalarSizeInBits() != 16) &&
-            (AType->getScalarSizeInBits() != 32) &&
-            (AType->getScalarSizeInBits() != 64)) {
-          continue;
-        }
-
-        if (AType->isVectorTy()) {
-          if ((AType->getVectorNumElements() != 2) &&
-              (AType->getVectorNumElements() != 3) &&
-              (AType->getVectorNumElements() != 4) &&
-              (AType->getVectorNumElements() != 8) &&
-              (AType->getVectorNumElements() != 16)) {
-            continue;
-          }
-        }
-
-        // Get infos from the mangled OpenCL built-in function name
-        auto finfo = FunctionInfo::getFromMangledName(F->getName());
-
-        // Select the appropriate signed/unsigned SPIR-V op
-        spv::Op opcode;
-        if (finfo.isArgSigned(0)) {
-          opcode = spv::OpSMulExtended;
-        } else {
-          opcode = spv::OpUMulExtended;
-        }
-
-        // Our SPIR-V op returns a struct, create a type for it
-        SmallVector<Type *, 2> TwoValueType = {AType, AType};
-        auto ExMulRetType = StructType::create(TwoValueType);
-
-        // Call the SPIR-V op
-        auto Call = clspv::InsertSPIRVOp(CI, opcode, {Attribute::ReadNone},
-                                         ExMulRetType, {AValue, BValue});
-
-        // Get the high part of the result
-        unsigned Idxs[] = {1};
-        Value *V = ExtractValueInst::Create(Call, Idxs, "", CI);
-
-        // If we're handling a mad_hi, add the third argument to the result
-        if (isMad) {
-          V = BinaryOperator::Create(Instruction::Add, V, CValue, "", CI);
-        }
-
-        // Replace call with the expression
-        CI->replaceAllUsesWith(V);
-
-        // Lastly, remember to remove the user.
-        ToRemoves.push_back(CI);
+    if (AType->isVectorTy()) {
+      if ((AType->getVectorNumElements() != 2) &&
+          (AType->getVectorNumElements() != 3) &&
+          (AType->getVectorNumElements() != 4) &&
+          (AType->getVectorNumElements() != 8) &&
+          (AType->getVectorNumElements() != 16)) {
+        return V;
       }
     }
 
-    Changed = !ToRemoves.empty();
+    // Our SPIR-V op returns a struct, create a type for it
+    SmallVector<Type *, 2> TwoValueType = {AType, AType};
+    auto ExMulRetType = StructType::create(TwoValueType);
 
-    // And cleanup the calls we don't use anymore.
-    for (auto V : ToRemoves) {
-      V->eraseFromParent();
+    // Select the appropriate signed/unsigned SPIR-V op
+    spv::Op opcode = is_signed ? spv::OpSMulExtended : spv::OpUMulExtended;
+
+    // Call the SPIR-V op
+    auto Call = clspv::InsertSPIRVOp(CI, opcode, {Attribute::ReadNone},
+                                     ExMulRetType, {AValue, BValue});
+
+    // Get the high part of the result
+    unsigned Idxs[] = {1};
+    V = ExtractValueInst::Create(Call, Idxs, "", CI);
+
+    // If we're handling a mad_hi, add the third argument to the result
+    if (is_mad) {
+      V = BinaryOperator::Create(Instruction::Add, V, CValue, "", CI);
     }
 
-    // And remove the function we don't need either too.
-    F->eraseFromParent();
-  }
-
-  return Changed;
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceSelect(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceSelect(Function &F) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    // Get arguments
+    auto FalseValue = CI->getOperand(0);
+    auto TrueValue = CI->getOperand(1);
+    auto PredicateValue = CI->getOperand(2);
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    // Skip symbols whose name doesn't match
-    if (!SymVal.getKey().startswith("_Z6select")) {
-      continue;
+    // Don't touch overloads that aren't in OpenCL C
+    auto FalseType = FalseValue->getType();
+    auto TrueType = TrueValue->getType();
+    auto PredicateType = PredicateValue->getType();
+
+    if (FalseType != TrueType) {
+      return nullptr;
     }
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
 
-      SmallVector<Instruction *, 4> ToRemoves;
+    if (!PredicateType->isIntOrIntVectorTy()) {
+      return nullptr;
+    }
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+    if (!FalseType->isIntOrIntVectorTy() &&
+        !FalseType->getScalarType()->isFloatingPointTy()) {
+      return nullptr;
+    }
 
-          // Get arguments
-          auto FalseValue = CI->getOperand(0);
-          auto TrueValue = CI->getOperand(1);
-          auto PredicateValue = CI->getOperand(2);
+    if (FalseType->isVectorTy() && !PredicateType->isVectorTy()) {
+      return nullptr;
+    }
 
-          // Don't touch overloads that aren't in OpenCL C
-          auto FalseType = FalseValue->getType();
-          auto TrueType = TrueValue->getType();
-          auto PredicateType = PredicateValue->getType();
+    if (FalseType->getScalarSizeInBits() !=
+        PredicateType->getScalarSizeInBits()) {
+      return nullptr;
+    }
 
-          if (FalseType != TrueType) {
-            continue;
-          }
-
-          if (!PredicateType->isIntOrIntVectorTy()) {
-            continue;
-          }
-
-          if (!FalseType->isIntOrIntVectorTy() &&
-              !FalseType->getScalarType()->isFloatingPointTy()) {
-            continue;
-          }
-
-          if (FalseType->isVectorTy() && !PredicateType->isVectorTy()) {
-            continue;
-          }
-
-          if (FalseType->getScalarSizeInBits() !=
-              PredicateType->getScalarSizeInBits()) {
-            continue;
-          }
-
-          if (FalseType->isVectorTy()) {
-            if (FalseType->getVectorNumElements() !=
-                PredicateType->getVectorNumElements()) {
-              continue;
-            }
-
-            if ((FalseType->getVectorNumElements() != 2) &&
-                (FalseType->getVectorNumElements() != 3) &&
-                (FalseType->getVectorNumElements() != 4) &&
-                (FalseType->getVectorNumElements() != 8) &&
-                (FalseType->getVectorNumElements() != 16)) {
-              continue;
-            }
-          }
-
-          // Create constant
-          const auto ZeroValue = Constant::getNullValue(PredicateType);
-
-          // Scalar and vector are to be treated differently
-          CmpInst::Predicate Pred;
-          if (PredicateType->isVectorTy()) {
-            Pred = CmpInst::ICMP_SLT;
-          } else {
-            Pred = CmpInst::ICMP_NE;
-          }
-
-          // Create comparison instruction
-          auto Cmp = CmpInst::Create(Instruction::ICmp, Pred, PredicateValue,
-                                     ZeroValue, "", CI);
-
-          // Create select
-          Value *V = SelectInst::Create(Cmp, TrueValue, FalseValue, "", CI);
-
-          // Replace call with the selection
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
+    if (FalseType->isVectorTy()) {
+      if (FalseType->getVectorNumElements() !=
+          PredicateType->getVectorNumElements()) {
+        return nullptr;
       }
 
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
+      if ((FalseType->getVectorNumElements() != 2) &&
+          (FalseType->getVectorNumElements() != 3) &&
+          (FalseType->getVectorNumElements() != 4) &&
+          (FalseType->getVectorNumElements() != 8) &&
+          (FalseType->getVectorNumElements() != 16)) {
+        return nullptr;
       }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
     }
-  }
 
-  return Changed;
+    // Create constant
+    const auto ZeroValue = Constant::getNullValue(PredicateType);
+
+    // Scalar and vector are to be treated differently
+    CmpInst::Predicate Pred;
+    if (PredicateType->isVectorTy()) {
+      Pred = CmpInst::ICMP_SLT;
+    } else {
+      Pred = CmpInst::ICMP_NE;
+    }
+
+    // Create comparison instruction
+    auto Cmp = CmpInst::Create(Instruction::ICmp, Pred, PredicateValue,
+                               ZeroValue, "", CI);
+
+    // Create select
+    return SelectInst::Create(Cmp, TrueValue, FalseValue, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceBitSelect(Module &M) {
-  bool Changed = false;
-
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    // Skip symbols whose name doesn't match
-    if (!SymVal.getKey().startswith("_Z9bitselect")) {
-      continue;
+bool ReplaceOpenCLBuiltinPass::replaceBitSelect(Function &F) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    Value *V = nullptr;
+    if (CI->getNumOperands() != 4) {
+      return V;
     }
-    // Is there a function going by that name?
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
 
-      SmallVector<Instruction *, 4> ToRemoves;
+    // Get arguments
+    auto FalseValue = CI->getOperand(0);
+    auto TrueValue = CI->getOperand(1);
+    auto PredicateValue = CI->getOperand(2);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+    // Don't touch overloads that aren't in OpenCL C
+    auto FalseType = FalseValue->getType();
+    auto TrueType = TrueValue->getType();
+    auto PredicateType = PredicateValue->getType();
 
-          if (CI->getNumOperands() != 4) {
-            continue;
-          }
-
-          // Get arguments
-          auto FalseValue = CI->getOperand(0);
-          auto TrueValue = CI->getOperand(1);
-          auto PredicateValue = CI->getOperand(2);
-
-          // Don't touch overloads that aren't in OpenCL C
-          auto FalseType = FalseValue->getType();
-          auto TrueType = TrueValue->getType();
-          auto PredicateType = PredicateValue->getType();
-
-          if ((FalseType != TrueType) || (PredicateType != TrueType)) {
-            continue;
-          }
-
-          if (TrueType->isVectorTy()) {
-            if (!TrueType->getScalarType()->isFloatingPointTy() &&
-                !TrueType->getScalarType()->isIntegerTy()) {
-              continue;
-            }
-            if ((TrueType->getVectorNumElements() != 2) &&
-                (TrueType->getVectorNumElements() != 3) &&
-                (TrueType->getVectorNumElements() != 4) &&
-                (TrueType->getVectorNumElements() != 8) &&
-                (TrueType->getVectorNumElements() != 16)) {
-              continue;
-            }
-          }
-
-          // Remember the type of the operands
-          auto OpType = TrueType;
-
-          // The actual bit selection will always be done on an integer type,
-          // declare it here
-          Type *BitType;
-
-          // If the operands are float, then bitcast them to int
-          if (OpType->getScalarType()->isFloatingPointTy()) {
-
-            // First create the new type
-            BitType = getIntOrIntVectorTyForCast(M.getContext(), OpType);
-
-            // Then bitcast all operands
-            PredicateValue =
-                CastInst::CreateZExtOrBitCast(PredicateValue, BitType, "", CI);
-            FalseValue =
-                CastInst::CreateZExtOrBitCast(FalseValue, BitType, "", CI);
-            TrueValue =
-                CastInst::CreateZExtOrBitCast(TrueValue, BitType, "", CI);
-
-          } else {
-            // The operands have an integer type, use it directly
-            BitType = OpType;
-          }
-
-          // All the operands are now always integers
-          // implement as (c & b) | (~c & a)
-
-          // Create our negated predicate value
-          auto AllOnes = Constant::getAllOnesValue(BitType);
-          auto NotPredicateValue = BinaryOperator::Create(
-              Instruction::Xor, PredicateValue, AllOnes, "", CI);
-
-          // Then put everything together
-          auto BitsFalse = BinaryOperator::Create(
-              Instruction::And, NotPredicateValue, FalseValue, "", CI);
-          auto BitsTrue = BinaryOperator::Create(
-              Instruction::And, PredicateValue, TrueValue, "", CI);
-
-          Value *V = BinaryOperator::Create(Instruction::Or, BitsFalse,
-                                            BitsTrue, "", CI);
-
-          // If we were dealing with a floating point type, we must bitcast
-          // the result back to that
-          if (OpType->getScalarType()->isFloatingPointTy()) {
-            V = CastInst::CreateZExtOrBitCast(V, OpType, "", CI);
-          }
-
-          // Replace call with our new code
-          CI->replaceAllUsesWith(V);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    if ((FalseType != TrueType) || (PredicateType != TrueType)) {
+      return V;
     }
-  }
 
-  return Changed;
+    if (TrueType->isVectorTy()) {
+      if (!TrueType->getScalarType()->isFloatingPointTy() &&
+          !TrueType->getScalarType()->isIntegerTy()) {
+        return V;
+      }
+      if ((TrueType->getVectorNumElements() != 2) &&
+          (TrueType->getVectorNumElements() != 3) &&
+          (TrueType->getVectorNumElements() != 4) &&
+          (TrueType->getVectorNumElements() != 8) &&
+          (TrueType->getVectorNumElements() != 16)) {
+        return V;
+      }
+    }
+
+    // Remember the type of the operands
+    auto OpType = TrueType;
+
+    // The actual bit selection will always be done on an integer type,
+    // declare it here
+    Type *BitType;
+
+    // If the operands are float, then bitcast them to int
+    if (OpType->getScalarType()->isFloatingPointTy()) {
+
+      // First create the new type
+      BitType = getIntOrIntVectorTyForCast(F.getContext(), OpType);
+
+      // Then bitcast all operands
+      PredicateValue =
+          CastInst::CreateZExtOrBitCast(PredicateValue, BitType, "", CI);
+      FalseValue = CastInst::CreateZExtOrBitCast(FalseValue, BitType, "", CI);
+      TrueValue = CastInst::CreateZExtOrBitCast(TrueValue, BitType, "", CI);
+
+    } else {
+      // The operands have an integer type, use it directly
+      BitType = OpType;
+    }
+
+    // All the operands are now always integers
+    // implement as (c & b) | (~c & a)
+
+    // Create our negated predicate value
+    auto AllOnes = Constant::getAllOnesValue(BitType);
+    auto NotPredicateValue = BinaryOperator::Create(
+        Instruction::Xor, PredicateValue, AllOnes, "", CI);
+
+    // Then put everything together
+    auto BitsFalse = BinaryOperator::Create(Instruction::And, NotPredicateValue,
+                                            FalseValue, "", CI);
+    auto BitsTrue = BinaryOperator::Create(Instruction::And, PredicateValue,
+                                           TrueValue, "", CI);
+
+    V = BinaryOperator::Create(Instruction::Or, BitsFalse, BitsTrue, "", CI);
+
+    // If we were dealing with a floating point type, we must bitcast
+    // the result back to that
+    if (OpType->getScalarType()->isFloatingPointTy()) {
+      V = CastInst::CreateZExtOrBitCast(V, OpType, "", CI);
+    }
+
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceStepSmoothStep(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceStep(Function &F, bool is_smooth,
+                                           int vec_size) {
+  // convert to vector versions
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    SmallVector<Value *, 2> ArgsToSplat = {CI->getOperand(0)};
+    Value *VectorArg = nullptr;
 
-  const std::map<const char *, const char *> Map = {
-      {"_Z4stepfDv2_f", "_Z4stepDv2_fS_"},
-      {"_Z4stepfDv3_f", "_Z4stepDv3_fS_"},
-      {"_Z4stepfDv4_f", "_Z4stepDv4_fS_"},
-      {"_Z10smoothstepffDv2_f", "_Z10smoothstepDv2_fS_S_"},
-      {"_Z10smoothstepffDv3_f", "_Z10smoothstepDv3_fS_S_"},
-      {"_Z10smoothstepffDv4_f", "_Z10smoothstepDv4_fS_S_"},
-  };
-
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          auto ReplacementFn = Pair.second;
-
-          SmallVector<Value *, 2> ArgsToSplat = {CI->getOperand(0)};
-          Value *VectorArg;
-
-          // First figure out which function we're dealing with
-          if (F->getName().startswith("_Z10smoothstep")) {
-            ArgsToSplat.push_back(CI->getOperand(1));
-            VectorArg = CI->getOperand(2);
-          } else {
-            VectorArg = CI->getOperand(1);
-          }
-
-          // Splat arguments that need to be
-          SmallVector<Value *, 2> SplatArgs;
-          auto VecType = VectorArg->getType();
-
-          for (auto arg : ArgsToSplat) {
-            Value *NewVectorArg = UndefValue::get(VecType);
-            for (auto i = 0; i < VecType->getVectorNumElements(); i++) {
-              auto index =
-                  ConstantInt::get(Type::getInt32Ty(M.getContext()), i);
-              NewVectorArg =
-                  InsertElementInst::Create(NewVectorArg, arg, index, "", CI);
-            }
-            SplatArgs.push_back(NewVectorArg);
-          }
-
-          // Replace the call with the vector/vector flavour
-          SmallVector<Type *, 3> NewArgTypes(ArgsToSplat.size() + 1, VecType);
-          const auto NewFType =
-              FunctionType::get(CI->getType(), NewArgTypes, false);
-
-          const auto NewF = M.getOrInsertFunction(ReplacementFn, NewFType);
-
-          SmallVector<Value *, 3> NewArgs;
-          for (auto arg : SplatArgs) {
-            NewArgs.push_back(arg);
-          }
-          NewArgs.push_back(VectorArg);
-
-          const auto NewCI = CallInst::Create(NewF, NewArgs, "", CI);
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    std::string NewFName = "_Z";
+    if (is_smooth) {
+      NewFName += std::to_string(10) + "smoothstepDv" +
+                  std::to_string(vec_size) + "_fS_S_";
+    } else {
+      NewFName +=
+          std::to_string(4) + "stepDv" + std::to_string(vec_size) + "_fS_";
     }
-  }
 
-  return Changed;
+    // First figure out which function we're dealing with
+    if (is_smooth) {
+      ArgsToSplat.push_back(CI->getOperand(1));
+      VectorArg = CI->getOperand(2);
+    } else {
+      VectorArg = CI->getOperand(1);
+    }
+
+    // Splat arguments that need to be
+    SmallVector<Value *, 2> SplatArgs;
+    auto VecType = VectorArg->getType();
+
+    for (auto arg : ArgsToSplat) {
+      Value *NewVectorArg = UndefValue::get(VecType);
+      for (auto i = 0; i < VecType->getVectorNumElements(); i++) {
+        auto index = ConstantInt::get(Type::getInt32Ty(M.getContext()), i);
+        NewVectorArg =
+            InsertElementInst::Create(NewVectorArg, arg, index, "", CI);
+      }
+      SplatArgs.push_back(NewVectorArg);
+    }
+
+    // Replace the call with the vector/vector flavour
+    SmallVector<Type *, 3> NewArgTypes(ArgsToSplat.size() + 1, VecType);
+    const auto NewFType = FunctionType::get(CI->getType(), NewArgTypes, false);
+
+    const auto NewF = M.getOrInsertFunction(NewFName, NewFType);
+
+    SmallVector<Value *, 3> NewArgs;
+    for (auto arg : SplatArgs) {
+      NewArgs.push_back(arg);
+    }
+    NewArgs.push_back(VectorArg);
+
+    return CallInst::Create(NewF, NewArgs, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceSignbit(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceSignbit(Function &F, bool is_vec) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    auto Arg = CI->getOperand(0);
+    auto Op = is_vec ? Instruction::AShr : Instruction::LShr;
 
-  const std::map<const char *, Instruction::BinaryOps> Map = {
-      {"_Z7signbitf", Instruction::LShr},
-      {"_Z7signbitDv2_f", Instruction::AShr},
-      {"_Z7signbitDv3_f", Instruction::AShr},
-      {"_Z7signbitDv4_f", Instruction::AShr},
-  };
+    auto Bitcast = CastInst::CreateZExtOrBitCast(Arg, CI->getType(), "", CI);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto Arg = CI->getOperand(0);
-
-          auto Bitcast =
-              CastInst::CreateZExtOrBitCast(Arg, CI->getType(), "", CI);
-
-          auto Shr = BinaryOperator::Create(Pair.second, Bitcast,
-                                            ConstantInt::get(CI->getType(), 31),
-                                            "", CI);
-
-          CI->replaceAllUsesWith(Shr);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return BinaryOperator::Create(Op, Bitcast,
+                                  ConstantInt::get(CI->getType(), 31), "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceMadandMad24andMul24(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceMul(Function &F, bool is_float,
+                                          bool is_mad) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    // The multiply instruction to use.
+    auto MulInst = is_float ? Instruction::FMul : Instruction::Mul;
 
-  const std::map<const char *,
-                 std::pair<Instruction::BinaryOps, Instruction::BinaryOps>>
-      Map = {
-          {"_Z3madfff", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv2_fS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv3_fS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv4_fS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDhDhDh", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv2_DhS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv3_DhS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z3madDv4_DhS_S_", {Instruction::FMul, Instruction::FAdd}},
-          {"_Z5mad24iii", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv2_iS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv3_iS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv4_iS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24jjj", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv2_jS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv3_jS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mad24Dv4_jS_S_", {Instruction::Mul, Instruction::Add}},
-          {"_Z5mul24ii", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv2_iS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv3_iS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv4_iS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24jj", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv2_jS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv3_jS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-          {"_Z5mul24Dv4_jS_", {Instruction::Mul, Instruction::BinaryOpsEnd}},
-      };
+    SmallVector<Value *, 8> Args(CI->arg_begin(), CI->arg_end());
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    Value *V = BinaryOperator::Create(MulInst, CI->getArgOperand(0),
+                                      CI->getArgOperand(1), "", CI);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          // The multiply instruction to use.
-          auto MulInst = Pair.second.first;
+    if (is_mad) {
+      // The add instruction to use.
+      auto AddInst = is_float ? Instruction::FAdd : Instruction::Add;
 
-          // The add instruction to use.
-          auto AddInst = Pair.second.second;
-
-          SmallVector<Value *, 8> Args(CI->arg_begin(), CI->arg_end());
-
-          auto I = BinaryOperator::Create(MulInst, CI->getArgOperand(0),
-                                          CI->getArgOperand(1), "", CI);
-
-          if (Instruction::BinaryOpsEnd != AddInst) {
-            I = BinaryOperator::Create(AddInst, I, CI->getArgOperand(2), "",
-                                       CI);
-          }
-
-          CI->replaceAllUsesWith(I);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+      V = BinaryOperator::Create(AddInst, V, CI->getArgOperand(2), "", CI);
     }
-  }
 
-  return Changed;
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVstore(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceVstore(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    Value *V = nullptr;
+    auto data = CI->getOperand(0);
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    if (!SymVal.getKey().contains("vstore"))
-      continue;
-    if (SymVal.getKey().contains("vstore_"))
-      continue;
-    if (SymVal.getKey().contains("vstorea"))
-      continue;
+    auto data_type = data->getType();
+    if (!data_type->isVectorTy())
+      return V;
 
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    auto elems = data_type->getVectorNumElements();
+    if (elems != 2 && elems != 3 && elems != 4 && elems != 8 && elems != 16)
+      return V;
 
-      auto fname = F->getName();
-      if (!fname.consume_front("_Z"))
-        continue;
-      size_t name_len;
-      if (fname.consumeInteger(10, name_len))
-        continue;
-      std::string name = fname.take_front(name_len).str();
+    auto offset = CI->getOperand(1);
+    auto ptr = CI->getOperand(2);
+    auto ptr_type = ptr->getType();
+    auto pointee_type = ptr_type->getPointerElementType();
+    if (pointee_type != data_type->getVectorElementType())
+      return V;
 
-      bool ok = StringSwitch<bool>(name)
-                    .Case("vstore2", true)
-                    .Case("vstore3", true)
-                    .Case("vstore4", true)
-                    .Case("vstore8", true)
-                    .Case("vstore16", true)
-                    .Default(false);
-      if (!ok)
-        continue;
-
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto data = CI->getOperand(0);
-
-          auto data_type = data->getType();
-          if (!data_type->isVectorTy())
-            continue;
-
-          auto elems = data_type->getVectorNumElements();
-          if (elems != 2 && elems != 3 && elems != 4 && elems != 8 &&
-              elems != 16)
-            continue;
-
-          auto offset = CI->getOperand(1);
-          auto ptr = CI->getOperand(2);
-          auto ptr_type = ptr->getType();
-          auto pointee_type = ptr_type->getPointerElementType();
-          if (pointee_type != data_type->getVectorElementType())
-            continue;
-
-          // Avoid pointer casts. Instead generate the correct number of stores
-          // and rely on drivers to coalesce appropriately.
-          IRBuilder<> builder(CI);
-          auto elems_const = builder.getInt32(elems);
-          auto adjust = builder.CreateMul(offset, elems_const);
-          for (auto i = 0; i < elems; ++i) {
-            auto idx = builder.getInt32(i);
-            auto add = builder.CreateAdd(adjust, idx);
-            auto gep = builder.CreateGEP(ptr, add);
-            auto extract = builder.CreateExtractElement(data, i);
-            auto store = builder.CreateStore(extract, gep);
-          }
-
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-      F->eraseFromParent();
+    // Avoid pointer casts. Instead generate the correct number of stores
+    // and rely on drivers to coalesce appropriately.
+    IRBuilder<> builder(CI);
+    auto elems_const = builder.getInt32(elems);
+    auto adjust = builder.CreateMul(offset, elems_const);
+    for (auto i = 0; i < elems; ++i) {
+      auto idx = builder.getInt32(i);
+      auto add = builder.CreateAdd(adjust, idx);
+      auto gep = builder.CreateGEP(ptr, add);
+      auto extract = builder.CreateExtractElement(data, i);
+      V = builder.CreateStore(extract, gep);
     }
-  }
-
-  return Changed;
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVload(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceVload(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
+    Value *V = nullptr;
+    auto ret_type = F.getReturnType();
+    if (!ret_type->isVectorTy())
+      return V;
 
-  for (auto const &SymVal : M.getValueSymbolTable()) {
-    if (!SymVal.getKey().contains("vload"))
-      continue;
-    if (SymVal.getKey().contains("vload_"))
-      continue;
-    if (SymVal.getKey().contains("vloada"))
-      continue;
+    auto elems = ret_type->getVectorNumElements();
+    if (elems != 2 && elems != 3 && elems != 4 && elems != 8 && elems != 16)
+      return V;
 
-    if (auto F = dyn_cast<Function>(SymVal.getValue())) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    auto offset = CI->getOperand(0);
+    auto ptr = CI->getOperand(1);
+    auto ptr_type = ptr->getType();
+    auto pointee_type = ptr_type->getPointerElementType();
+    if (pointee_type != ret_type->getVectorElementType())
+      return V;
 
-      auto fname = F->getName();
-      if (!fname.consume_front("_Z"))
-        continue;
-      size_t name_len;
-      if (fname.consumeInteger(10, name_len))
-        continue;
-      std::string name = fname.take_front(name_len).str();
-
-      bool ok = StringSwitch<bool>(name)
-                    .Case("vload2", true)
-                    .Case("vload3", true)
-                    .Case("vload4", true)
-                    .Case("vload8", true)
-                    .Case("vload16", true)
-                    .Default(false);
-      if (!ok)
-        continue;
-
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto ret_type = F->getReturnType();
-          if (!ret_type->isVectorTy())
-            continue;
-
-          auto elems = ret_type->getVectorNumElements();
-          if (elems != 2 && elems != 3 && elems != 4 && elems != 8 &&
-              elems != 16)
-            continue;
-
-          auto offset = CI->getOperand(0);
-          auto ptr = CI->getOperand(1);
-          auto ptr_type = ptr->getType();
-          auto pointee_type = ptr_type->getPointerElementType();
-          if (pointee_type != ret_type->getVectorElementType())
-            continue;
-
-          // Avoid pointer casts. Instead generate the correct number of loads
-          // and rely on drivers to coalesce appropriately.
-          IRBuilder<> builder(CI);
-          auto elems_const = builder.getInt32(elems);
-          Value *insert = UndefValue::get(ret_type);
-          auto adjust = builder.CreateMul(offset, elems_const);
-          for (auto i = 0; i < elems; ++i) {
-            auto idx = builder.getInt32(i);
-            auto add = builder.CreateAdd(adjust, idx);
-            auto gep = builder.CreateGEP(ptr, add);
-            auto load = builder.CreateLoad(gep);
-            insert = builder.CreateInsertElement(insert, load, i);
-          }
-
-          CI->replaceAllUsesWith(insert);
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-      F->eraseFromParent();
+    // Avoid pointer casts. Instead generate the correct number of loads
+    // and rely on drivers to coalesce appropriately.
+    IRBuilder<> builder(CI);
+    auto elems_const = builder.getInt32(elems);
+    V = UndefValue::get(ret_type);
+    auto adjust = builder.CreateMul(offset, elems_const);
+    for (auto i = 0; i < elems; ++i) {
+      auto idx = builder.getInt32(i);
+      auto add = builder.CreateAdd(adjust, idx);
+      auto gep = builder.CreateGEP(ptr, add);
+      auto load = builder.CreateLoad(gep);
+      V = builder.CreateInsertElement(V, load, i);
     }
-  }
-
-  return Changed;
+    return V;
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Module &M) {
-  bool Changed = false;
-
-  const std::vector<const char *> Map = {"_Z10vload_halfjPU3AS1KDh",
-                                         "_Z10vload_halfjPU3AS2KDh"};
-
-  for (auto Name : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Name)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          // The index argument from vload_half.
-          auto Arg0 = CI->getOperand(0);
-
-          // The pointer argument from vload_half.
-          auto Arg1 = CI->getOperand(1);
-
-          auto IntTy = Type::getInt32Ty(M.getContext());
-          auto Float2Ty = VectorType::get(Type::getFloatTy(M.getContext()), 2);
-          auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
-
-          // Our intrinsic to unpack a float2 from an int.
-          auto SPIRVIntrinsic = "spirv.unpack.v2f16";
-
-          auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-          if (clspv::Option::F16BitStorage()) {
-            auto ShortTy = Type::getInt16Ty(M.getContext());
-            auto ShortPointerTy = PointerType::get(
-                ShortTy, Arg1->getType()->getPointerAddressSpace());
-
-            // Cast the half* pointer to short*.
-            auto Cast =
-                CastInst::CreatePointerCast(Arg1, ShortPointerTy, "", CI);
-
-            // Index into the correct address of the casted pointer.
-            auto Index = GetElementPtrInst::Create(ShortTy, Cast, Arg0, "", CI);
-
-            // Load from the short* we casted to.
-            auto Load = new LoadInst(Index, "", CI);
-
-            // ZExt the short -> int.
-            auto ZExt = CastInst::CreateZExtOrBitCast(Load, IntTy, "", CI);
-
-            // Get our float2.
-            auto Call = CallInst::Create(NewF, ZExt, "", CI);
-
-            // Extract out the bottom element which is our float result.
-            auto Extract = ExtractElementInst::Create(
-                Call, ConstantInt::get(IntTy, 0), "", CI);
-
-            CI->replaceAllUsesWith(Extract);
-          } else {
-            // Assume the pointer argument points to storage aligned to 32bits
-            // or more.
-            // TODO(dneto): Do more analysis to make sure this is true?
-            //
-            // Replace call vstore_half(i32 %index, half addrspace(1) %base)
-            // with:
-            //
-            //   %base_i32_ptr = bitcast half addrspace(1)* %base to i32
-            //   addrspace(1)* %index_is_odd32 = and i32 %index, 1 %index_i32 =
-            //   lshr i32 %index, 1 %in_ptr = getlementptr i32, i32
-            //   addrspace(1)* %base_i32_ptr, %index_i32 %value_i32 = load i32,
-            //   i32 addrspace(1)* %in_ptr %converted = call <2 x float>
-            //   @spirv.unpack.v2f16(i32 %value_i32) %value = extractelement <2
-            //   x float> %converted, %index_is_odd32
-
-            auto IntPointerTy = PointerType::get(
-                IntTy, Arg1->getType()->getPointerAddressSpace());
-
-            // Cast the base pointer to int*.
-            // In a valid call (according to assumptions), this should get
-            // optimized away in the simplify GEP pass.
-            auto Cast = CastInst::CreatePointerCast(Arg1, IntPointerTy, "", CI);
-
-            auto One = ConstantInt::get(IntTy, 1);
-            auto IndexIsOdd = BinaryOperator::CreateAnd(Arg0, One, "", CI);
-            auto IndexIntoI32 = BinaryOperator::CreateLShr(Arg0, One, "", CI);
-
-            // Index into the correct address of the casted pointer.
-            auto Ptr =
-                GetElementPtrInst::Create(IntTy, Cast, IndexIntoI32, "", CI);
-
-            // Load from the int* we casted to.
-            auto Load = new LoadInst(Ptr, "", CI);
-
-            // Get our float2.
-            auto Call = CallInst::Create(NewF, Load, "", CI);
-
-            // Extract out the float result, where the element number is
-            // determined by whether the original index was even or odd.
-            auto Extract = ExtractElementInst::Create(Call, IndexIsOdd, "", CI);
-
-            CI->replaceAllUsesWith(Extract);
-          }
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
+bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F,
+                                                const std::string &name,
+                                                int vec_size) {
+  bool is_clspv_version = !name.compare(0, 8, "__clspv_");
+  if (!vec_size) {
+    // deduce vec_size from last character of name (e.g. vload_half4)
+    vec_size = std::atoi(&name.back());
   }
-
-  return Changed;
+  switch (vec_size) {
+  case 2:
+    return is_clspv_version ? replaceClspvVloadaHalf2(F) : replaceVloadHalf2(F);
+  case 4:
+    return is_clspv_version ? replaceClspvVloadaHalf4(F) : replaceVloadHalf4(F);
+  case 0:
+    if (!is_clspv_version) {
+      return replaceVloadHalf(F);
+    }
+  default:
+    llvm_unreachable("Unsupported vload_half vector size");
+    break;
+  }
+  return false;
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVloadHalf2(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    // The index argument from vload_half.
+    auto Arg0 = CI->getOperand(0);
 
-  const std::vector<const char *> Names = {
-      "_Z11vload_half2jPU3AS1KDh",
-      "_Z12vloada_half2jPU3AS1KDh", // vloada_half2 global
-      "_Z11vload_half2jPU3AS2KDh",
-      "_Z12vloada_half2jPU3AS2KDh", // vloada_half2 constant
-  };
+    // The pointer argument from vload_half.
+    auto Arg1 = CI->getOperand(1);
 
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+    auto IntTy = Type::getInt32Ty(M.getContext());
+    auto Float2Ty = VectorType::get(Type::getFloatTy(M.getContext()), 2);
+    auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
+
+    // Our intrinsic to unpack a float2 from an int.
+    auto SPIRVIntrinsic = "spirv.unpack.v2f16";
+
+    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
+
+    Value *V = nullptr;
+
+    if (clspv::Option::F16BitStorage()) {
+      auto ShortTy = Type::getInt16Ty(M.getContext());
+      auto ShortPointerTy =
+          PointerType::get(ShortTy, Arg1->getType()->getPointerAddressSpace());
+
+      // Cast the half* pointer to short*.
+      auto Cast = CastInst::CreatePointerCast(Arg1, ShortPointerTy, "", CI);
+
+      // Index into the correct address of the casted pointer.
+      auto Index = GetElementPtrInst::Create(ShortTy, Cast, Arg0, "", CI);
+
+      // Load from the short* we casted to.
+      auto Load = new LoadInst(Index, "", CI);
+
+      // ZExt the short -> int.
+      auto ZExt = CastInst::CreateZExtOrBitCast(Load, IntTy, "", CI);
+
+      // Get our float2.
+      auto Call = CallInst::Create(NewF, ZExt, "", CI);
+
+      // Extract out the bottom element which is our float result.
+      V = ExtractElementInst::Create(Call, ConstantInt::get(IntTy, 0), "", CI);
+    } else {
+      // Assume the pointer argument points to storage aligned to 32bits
+      // or more.
+      // TODO(dneto): Do more analysis to make sure this is true?
+      //
+      // Replace call vstore_half(i32 %index, half addrspace(1) %base)
+      // with:
+      //
+      //   %base_i32_ptr = bitcast half addrspace(1)* %base to i32
+      //   addrspace(1)* %index_is_odd32 = and i32 %index, 1 %index_i32 =
+      //   lshr i32 %index, 1 %in_ptr = getlementptr i32, i32
+      //   addrspace(1)* %base_i32_ptr, %index_i32 %value_i32 = load i32,
+      //   i32 addrspace(1)* %in_ptr %converted = call <2 x float>
+      //   @spirv.unpack.v2f16(i32 %value_i32) %value = extractelement <2
+      //   x float> %converted, %index_is_odd32
+
+      auto IntPointerTy =
+          PointerType::get(IntTy, Arg1->getType()->getPointerAddressSpace());
+
+      // Cast the base pointer to int*.
+      // In a valid call (according to assumptions), this should get
+      // optimized away in the simplify GEP pass.
+      auto Cast = CastInst::CreatePointerCast(Arg1, IntPointerTy, "", CI);
+
+      auto One = ConstantInt::get(IntTy, 1);
+      auto IndexIsOdd = BinaryOperator::CreateAnd(Arg0, One, "", CI);
+      auto IndexIntoI32 = BinaryOperator::CreateLShr(Arg0, One, "", CI);
+
+      // Index into the correct address of the casted pointer.
+      auto Ptr = GetElementPtrInst::Create(IntTy, Cast, IndexIntoI32, "", CI);
+
+      // Load from the int* we casted to.
+      auto Load = new LoadInst(Ptr, "", CI);
+
+      // Get our float2.
+      auto Call = CallInst::Create(NewF, Load, "", CI);
+
+      // Extract out the float result, where the element number is
+      // determined by whether the original index was even or odd.
+      V = ExtractElementInst::Create(Call, IndexIsOdd, "", CI);
+    }
+    return V;
+  });
+}
+
+bool ReplaceOpenCLBuiltinPass::replaceVloadHalf2(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     // The index argument from vload_half.
     auto Arg0 = CI->getOperand(0);
 
@@ -2292,16 +1558,9 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf2(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVloadHalf4(Module &M) {
-
-  const std::vector<const char *> Names = {
-      "_Z11vload_half4jPU3AS1KDh",
-      "_Z12vloada_half4jPU3AS1KDh",
-      "_Z11vload_half4jPU3AS2KDh",
-      "_Z12vloada_half4jPU3AS2KDh",
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceVloadHalf4(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     // The index argument from vload_half.
     auto Arg0 = CI->getOperand(0);
 
@@ -2351,20 +1610,15 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf4(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf2(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf2(Function &F) {
 
   // Replace __clspv_vloada_half2(uint Index, global uint* Ptr) with:
   //
   //    %u = load i32 %ptr
   //    %fxy = call <2 x float> Unpack2xHalf(u)
   //    %result = shufflevector %fxy %fzw <4 x i32> <0, 1, 2, 3>
-  const std::vector<const char *> Names = {
-      "_Z20__clspv_vloada_half2jPU3AS1Kj", // global
-      "_Z20__clspv_vloada_half2jPU3AS3Kj", // local
-      "_Z20__clspv_vloada_half2jPKj",      // private
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     auto Index = CI->getOperand(0);
     auto Ptr = CI->getOperand(1);
 
@@ -2385,7 +1639,7 @@ bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf2(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf4(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf4(Function &F) {
 
   // Replace __clspv_vloada_half4(uint Index, global uint2* Ptr) with:
   //
@@ -2395,13 +1649,8 @@ bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf4(Module &M) {
   //    %fxy = call <2 x float> Unpack2xHalf(uint)
   //    %fzw = call <2 x float> Unpack2xHalf(uint)
   //    %result = shufflevector %fxy %fzw <4 x i32> <0, 1, 2, 3>
-  const std::vector<const char *> Names = {
-      "_Z20__clspv_vloada_half4jPU3AS1KDv2_j", // global
-      "_Z20__clspv_vloada_half4jPU3AS3KDv2_j", // local
-      "_Z20__clspv_vloada_half4jPKDv2_j",      // private
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     auto Index = CI->getOperand(0);
     auto Ptr = CI->getOperand(1);
 
@@ -2440,13 +1689,24 @@ bool ReplaceOpenCLBuiltinPass::replaceClspvVloadaHalf4(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F, int vec_size) {
+  switch (vec_size) {
+  case 0:
+    return replaceVstoreHalf(F);
+  case 2:
+    return replaceVstoreHalf2(F);
+  case 4:
+    return replaceVstoreHalf4(F);
+  default:
+    llvm_unreachable("Unsupported vstore_half vector size");
+    break;
+  }
+  return false;
+}
 
-  const std::vector<const char *> Names = {"_Z11vstore_halffjPU3AS1Dh",
-                                           "_Z15vstore_half_rtefjPU3AS1Dh",
-                                           "_Z15vstore_half_rtzfjPU3AS1Dh"};
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     // The value to store.
     auto Arg0 = CI->getOperand(0);
 
@@ -2473,7 +1733,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Module &M) {
     // Pack the float2 -> half2 (in an int).
     auto X = CallInst::Create(NewF, TempVec, "", CI);
 
-    Value *Ret;
+    Value *V = nullptr;
     if (clspv::Option::F16BitStorage()) {
       auto ShortTy = Type::getInt16Ty(M.getContext());
       auto ShortPointerTy =
@@ -2489,7 +1749,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Module &M) {
       auto Index = GetElementPtrInst::Create(ShortTy, Cast, Arg1, "", CI);
 
       // Store to the int* we casted to.
-      Ret = new StoreInst(Trunc, Index, CI);
+      V = new StoreInst(Trunc, Index, CI);
     } else {
       // We can only write to 32-bit aligned words.
       //
@@ -2567,31 +1827,19 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Module &M) {
       SmallVector<Value *, 5> Params{OutPtr, ConstantScopeDevice,
                                      ConstantMemorySemantics, ValueToXor};
       CallInst::Create(NewF, Params, "store_halfword_xor_trick", CI);
-      Ret = nullptr;
+
+      // Return a Nop so the old Call is removed
+      Function *donothing = Intrinsic::getDeclaration(&M, Intrinsic::donothing);
+      V = CallInst::Create(donothing, {}, "", CI);
     }
 
-    return Ret;
+    return V;
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf2(Module &M) {
-
-  const std::vector<const char *> Names = {
-      "_Z12vstore_half2Dv2_fjPU3AS1Dh",
-      "_Z13vstorea_half2Dv2_fjPU3AS1Dh", // vstorea global
-      "_Z13vstorea_half2Dv2_fjPU3AS3Dh", // vstorea local
-      "_Z13vstorea_half2Dv2_fjPDh",      // vstorea private
-      "_Z16vstore_half2_rteDv2_fjPU3AS1Dh",
-      "_Z17vstorea_half2_rteDv2_fjPU3AS1Dh", // vstorea global
-      "_Z17vstorea_half2_rteDv2_fjPU3AS3Dh", // vstorea local
-      "_Z17vstorea_half2_rteDv2_fjPDh",      // vstorea private
-      "_Z16vstore_half2_rtzDv2_fjPU3AS1Dh",
-      "_Z17vstorea_half2_rtzDv2_fjPU3AS1Dh", // vstorea global
-      "_Z17vstorea_half2_rtzDv2_fjPU3AS3Dh", // vstorea local
-      "_Z17vstorea_half2_rtzDv2_fjPDh",      // vstorea private
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf2(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     // The value to store.
     auto Arg0 = CI->getOperand(0);
 
@@ -2626,24 +1874,9 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf2(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf4(Module &M) {
-
-  const std::vector<const char *> Names = {
-      "_Z12vstore_half4Dv4_fjPU3AS1Dh",
-      "_Z13vstorea_half4Dv4_fjPU3AS1Dh", // global
-      "_Z13vstorea_half4Dv4_fjPU3AS3Dh", // local
-      "_Z13vstorea_half4Dv4_fjPDh",      // private
-      "_Z16vstore_half4_rteDv4_fjPU3AS1Dh",
-      "_Z17vstorea_half4_rteDv4_fjPU3AS1Dh", // global
-      "_Z17vstorea_half4_rteDv4_fjPU3AS3Dh", // local
-      "_Z17vstorea_half4_rteDv4_fjPDh",      // private
-      "_Z16vstore_half4_rtzDv4_fjPU3AS1Dh",
-      "_Z17vstorea_half4_rtzDv4_fjPU3AS1Dh", // global
-      "_Z17vstorea_half4_rtzDv4_fjPU3AS3Dh", // local
-      "_Z17vstorea_half4_rtzDv4_fjPDh",      // private
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf4(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     // The value to store.
     auto Arg0 = CI->getOperand(0);
 
@@ -2701,470 +1934,161 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf4(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceHalfReadImage(Module &M) {
-  bool Changed = false;
-  const std::map<const char *, const char *> Map = {
-      // 1D
-      {"_Z11read_imageh14ocl_image1d_roi", "_Z11read_imagef14ocl_image1d_roi"},
-      {"_Z11read_imageh14ocl_image1d_ro11ocl_sampleri",
-       "_Z11read_imagef14ocl_image1d_ro11ocl_sampleri"},
-      {"_Z11read_imageh14ocl_image1d_ro11ocl_samplerf",
-       "_Z11read_imagef14ocl_image1d_ro11ocl_samplerf"},
-      // 1D array
-      {"_Z11read_imageh20ocl_image1d_array_roDv2_i",
-       "_Z11read_imagef20ocl_image1d_array_roDv2_i"},
-      {"_Z11read_imageh20ocl_image1d_array_ro11ocl_samplerDv2_i",
-       "_Z11read_imagef20ocl_image1d_array_ro11ocl_samplerDv2_i"},
-      {"_Z11read_imageh20ocl_image1d_array_ro11ocl_samplerDv2_f",
-       "_Z11read_imagef20ocl_image1d_array_ro11ocl_samplerDv2_f"},
-      // 2D
-      {"_Z11read_imageh14ocl_image2d_roDv2_i",
-       "_Z11read_imagef14ocl_image2d_roDv2_i"},
-      {"_Z11read_imageh14ocl_image2d_ro11ocl_samplerDv2_i",
-       "_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_i"},
-      {"_Z11read_imageh14ocl_image2d_ro11ocl_samplerDv2_f",
-       "_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f"},
-      // 2D array
-      {"_Z11read_imageh20ocl_image2d_array_roDv4_i",
-       "_Z11read_imagef20ocl_image2d_array_roDv4_i"},
-      {"_Z11read_imageh20ocl_image2d_array_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef20ocl_image2d_array_ro11ocl_samplerDv4_i"},
-      {"_Z11read_imageh20ocl_image2d_array_ro11ocl_samplerDv4_f",
-       "_Z11read_imagef20ocl_image2d_array_ro11ocl_samplerDv4_f"},
-      // 3D
-      {"_Z11read_imageh14ocl_image3d_roDv4_i",
-       "_Z11read_imagef14ocl_image3d_roDv4_i"},
-      {"_Z11read_imageh14ocl_image3d_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i"},
-      {"_Z11read_imageh14ocl_image3d_ro11ocl_samplerDv4_f",
-       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f"}};
-
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          SmallVector<Type *, 3> types;
-          SmallVector<Value *, 3> args;
-          for (auto i = 0; i < CI->getNumArgOperands(); ++i) {
-            types.push_back(CI->getArgOperand(i)->getType());
-            args.push_back(CI->getArgOperand(i));
-          }
-
-          auto NewFType = FunctionType::get(
-              VectorType::get(Type::getFloatTy(M.getContext()),
-                              CI->getType()->getVectorNumElements()),
-              types, false);
-
-          auto NewF = M.getOrInsertFunction(Pair.second, NewFType);
-
-          auto NewCI = CallInst::Create(NewF, args, "", CI);
-
-          // Convert to the half type.
-          auto Cast = CastInst::CreateFPCast(NewCI, CI->getType(), "", CI);
-
-          CI->replaceAllUsesWith(Cast);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+bool ReplaceOpenCLBuiltinPass::replaceHalfReadImage(Function &F) {
+  // convert half to float
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    SmallVector<Type *, 3> types;
+    SmallVector<Value *, 3> args;
+    for (auto i = 0; i < CI->getNumArgOperands(); ++i) {
+      types.push_back(CI->getArgOperand(i)->getType());
+      args.push_back(CI->getArgOperand(i));
     }
-  }
 
-  return Changed;
+    auto NewFType = FunctionType::get(
+        VectorType::get(Type::getFloatTy(M.getContext()),
+                        CI->getType()->getVectorNumElements()),
+        types, false);
+
+    std::string NewFName = "_Z11read_imagef";
+    NewFName += F.getName().str().substr(15);
+
+    auto NewF = M.getOrInsertFunction(NewFName, NewFType);
+
+    auto NewCI = CallInst::Create(NewF, args, "", CI);
+
+    // Convert to the half type.
+    return CastInst::CreateFPCast(NewCI, CI->getType(), "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceHalfWriteImage(Module &M) {
-  bool Changed = false;
-  const std::map<const char *, const char *> Map = {
-      // 1D
-      {"_Z12write_imageh14ocl_image1d_woiDv4_Dh",
-       "_Z12write_imagef14ocl_image1d_woiDv4_f"},
-      // 1D array
-      {"_Z12write_imageh20ocl_image1d_array_woDv2_iDv4_Dh",
-       "_Z12write_imagef20ocl_image1d_array_woDv2_iDv4_f"},
-      // 2D
-      {"_Z12write_imageh14ocl_image2d_woDv2_iDv4_Dh",
-       "_Z12write_imagef14ocl_image2d_woDv2_iDv4_f"},
-      // 2D array
-      {"_Z12write_imageh20ocl_image2d_array_woDv4_iDv4_Dh",
-       "_Z12write_imagef20ocl_image2d_array_woDv4_iDv4_f"},
-      // 3D
-      {"_Z12write_imageh14ocl_image3d_woDv4_iDv4_Dh",
-       "_Z12write_imagef14ocl_image3d_woDv4_iDv4_f"}};
+bool ReplaceOpenCLBuiltinPass::replaceHalfWriteImage(Function &F) {
+  // convert half to float
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    SmallVector<Type *, 3> types(3);
+    SmallVector<Value *, 3> args(3);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    // Image
+    types[0] = CI->getArgOperand(0)->getType();
+    args[0] = CI->getArgOperand(0);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          SmallVector<Type *, 3> types(3);
-          SmallVector<Value *, 3> args(3);
+    // Coord
+    types[1] = CI->getArgOperand(1)->getType();
+    args[1] = CI->getArgOperand(1);
 
-          // Image
-          types[0] = CI->getArgOperand(0)->getType();
-          args[0] = CI->getArgOperand(0);
+    // Data
+    types[2] = VectorType::get(
+        Type::getFloatTy(M.getContext()),
+        CI->getArgOperand(2)->getType()->getVectorNumElements());
 
-          // Coord
-          types[1] = CI->getArgOperand(1)->getType();
-          args[1] = CI->getArgOperand(1);
+    auto NewFType =
+        FunctionType::get(Type::getVoidTy(M.getContext()), types, false);
 
-          // Data
-          types[2] = VectorType::get(
-              Type::getFloatTy(M.getContext()),
-              CI->getArgOperand(2)->getType()->getVectorNumElements());
+    int slen = F.getName().size();
+    std::string NewFName = "_Z12write_imagef";
+    NewFName += F.getName().str().substr(16, slen - 16 - 2) + "f";
 
-          auto NewFType =
-              FunctionType::get(Type::getVoidTy(M.getContext()), types, false);
+    auto NewF = M.getOrInsertFunction(NewFName, NewFType);
 
-          auto NewF = M.getOrInsertFunction(Pair.second, NewFType);
+    // Convert data to the float type.
+    auto Cast = CastInst::CreateFPCast(CI->getArgOperand(2), types[2], "", CI);
+    args[2] = Cast;
 
-          // Convert data to the float type.
-          auto Cast =
-              CastInst::CreateFPCast(CI->getArgOperand(2), types[2], "", CI);
-          args[2] = Cast;
-
-          auto NewCI = CallInst::Create(NewF, args, "", CI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return CallInst::Create(NewF, args, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(
+    Function &F) {
+  // convert read_image with int coords to float coords
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    // The image.
+    auto Arg0 = CI->getOperand(0);
 
-  const std::map<const char *, const char *> Map = {
-      // 1D
-      {"_Z11read_imagei14ocl_image1d_ro11ocl_sampleri",
-       "_Z11read_imagei14ocl_image1d_ro11ocl_samplerf"},
-      {"_Z12read_imageui14ocl_image1d_ro11ocl_sampleri",
-       "_Z12read_imageui14ocl_image1d_ro11ocl_samplerf"},
-      {"_Z11read_imagef14ocl_image1d_ro11ocl_sampleri",
-       "_Z11read_imagef14ocl_image1d_ro11ocl_samplerf"},
-      // 1D array
-      {"_Z11read_imagei20ocl_image1d_array_ro11ocl_samplerDv2_i",
-       "_Z11read_imagei20ocl_image1d_array_ro11ocl_samplerDv2_f"},
-      {"_Z12read_imageui20ocl_image1d_array_ro11ocl_samplerDv2_i",
-       "_Z12read_imageui20ocl_image1d_array_ro11ocl_samplerDv2_f"},
-      {"_Z11read_imagef20ocl_image1d_array_ro11ocl_samplerDv2_i",
-       "_Z11read_imagef20ocl_image1d_array_ro11ocl_samplerDv2_f"},
-      // 2D
-      {"_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_i",
-       "_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f"},
-      {"_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_i",
-       "_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f"},
-      {"_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_i",
-       "_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f"},
-      // 2D array
-      {"_Z11read_imagei20ocl_image2d_array_ro11ocl_samplerDv4_i",
-       "_Z11read_imagei20ocl_image2d_array_ro11ocl_samplerDv4_f"},
-      {"_Z12read_imageui20ocl_image2d_array_ro11ocl_samplerDv4_i",
-       "_Z12read_imageui20ocl_image2d_array_ro11ocl_samplerDv4_f"},
-      {"_Z11read_imagef20ocl_image2d_array_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef20ocl_image2d_array_ro11ocl_samplerDv4_f"},
-      // 3D
-      {"_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_i",
-       "_Z11read_imagei14ocl_image3d_ro11ocl_samplerDv4_f"},
-      {"_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_i",
-       "_Z12read_imageui14ocl_image3d_ro11ocl_samplerDv4_f"},
-      {"_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i",
-       "_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f"}};
+    // The sampler.
+    auto Arg1 = CI->getOperand(1);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    // The coordinate (integer type that we can't handle).
+    auto Arg2 = CI->getOperand(2);
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          // The image.
-          auto Arg0 = CI->getOperand(0);
-
-          // The sampler.
-          auto Arg1 = CI->getOperand(1);
-
-          // The coordinate (integer type that we can't handle).
-          auto Arg2 = CI->getOperand(2);
-
-          uint32_t dim = clspv::ImageDimensionality(Arg0->getType());
-          uint32_t components =
-              dim + (clspv::IsArrayImageType(Arg0->getType()) ? 1 : 0);
-          Type *float_ty = nullptr;
-          if (components == 1) {
-            float_ty = Type::getFloatTy(M.getContext());
-          } else {
-            float_ty = VectorType::get(Type::getFloatTy(M.getContext()),
-                                       Arg2->getType()->getVectorNumElements());
-          }
-
-          auto NewFType = FunctionType::get(
-              CI->getType(), {Arg0->getType(), Arg1->getType(), float_ty},
-              false);
-
-          auto NewF = M.getOrInsertFunction(Pair.second, NewFType);
-
-          auto Cast =
-              CastInst::Create(Instruction::SIToFP, Arg2, float_ty, "", CI);
-
-          auto NewCI = CallInst::Create(NewF, {Arg0, Arg1, Cast}, "", CI);
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    uint32_t dim = clspv::ImageDimensionality(Arg0->getType());
+    uint32_t components =
+        dim + (clspv::IsArrayImageType(Arg0->getType()) ? 1 : 0);
+    Type *float_ty = nullptr;
+    if (components == 1) {
+      float_ty = Type::getFloatTy(M.getContext());
+    } else {
+      float_ty = VectorType::get(Type::getFloatTy(M.getContext()),
+                                 Arg2->getType()->getVectorNumElements());
     }
-  }
 
-  return Changed;
+    auto NewFType = FunctionType::get(
+        CI->getType(), {Arg0->getType(), Arg1->getType(), float_ty}, false);
+
+    std::string NewFName = F.getName().str();
+    NewFName[NewFName.length() - 1] = 'f';
+
+    auto NewF = M.getOrInsertFunction(NewFName, NewFType);
+
+    auto Cast = CastInst::Create(Instruction::SIToFP, Arg2, float_ty, "", CI);
+
+    return CallInst::Create(NewF, {Arg0, Arg1, Cast}, "", CI);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceAtomics(Module &M) {
-  bool Changed = false;
+bool ReplaceOpenCLBuiltinPass::replaceAtomics(Function &F, spv::Op Op) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    auto IntTy = Type::getInt32Ty(F.getContext());
 
-  const std::map<const char *, spv::Op> Map = {
-      {"_Z8atom_incPU3AS1Vi", spv::OpAtomicIIncrement},
-      {"_Z8atom_incPU3AS3Vi", spv::OpAtomicIIncrement},
-      {"_Z8atom_incPU3AS1Vj", spv::OpAtomicIIncrement},
-      {"_Z8atom_incPU3AS3Vj", spv::OpAtomicIIncrement},
-      {"_Z8atom_decPU3AS1Vi", spv::OpAtomicIDecrement},
-      {"_Z8atom_decPU3AS3Vi", spv::OpAtomicIDecrement},
-      {"_Z8atom_decPU3AS1Vj", spv::OpAtomicIDecrement},
-      {"_Z8atom_decPU3AS3Vj", spv::OpAtomicIDecrement},
-      {"_Z12atom_cmpxchgPU3AS1Viii", spv::OpAtomicCompareExchange},
-      {"_Z12atom_cmpxchgPU3AS3Viii", spv::OpAtomicCompareExchange},
-      {"_Z12atom_cmpxchgPU3AS1Vjjj", spv::OpAtomicCompareExchange},
-      {"_Z12atom_cmpxchgPU3AS3Vjjj", spv::OpAtomicCompareExchange},
-      {"_Z10atomic_incPU3AS1Vi", spv::OpAtomicIIncrement},
-      {"_Z10atomic_incPU3AS3Vi", spv::OpAtomicIIncrement},
-      {"_Z10atomic_incPU3AS1Vj", spv::OpAtomicIIncrement},
-      {"_Z10atomic_incPU3AS3Vj", spv::OpAtomicIIncrement},
-      {"_Z10atomic_decPU3AS1Vi", spv::OpAtomicIDecrement},
-      {"_Z10atomic_decPU3AS3Vi", spv::OpAtomicIDecrement},
-      {"_Z10atomic_decPU3AS1Vj", spv::OpAtomicIDecrement},
-      {"_Z10atomic_decPU3AS3Vj", spv::OpAtomicIDecrement},
-      {"_Z14atomic_cmpxchgPU3AS1Viii", spv::OpAtomicCompareExchange},
-      {"_Z14atomic_cmpxchgPU3AS3Viii", spv::OpAtomicCompareExchange},
-      {"_Z14atomic_cmpxchgPU3AS1Vjjj", spv::OpAtomicCompareExchange},
-      {"_Z14atomic_cmpxchgPU3AS3Vjjj", spv::OpAtomicCompareExchange}};
+    // We need to map the OpenCL constants to the SPIR-V equivalents.
+    const auto ConstantScopeDevice = ConstantInt::get(IntTy, spv::ScopeDevice);
+    const auto ConstantMemorySemantics = ConstantInt::get(
+        IntTy, spv::MemorySemanticsUniformMemoryMask |
+                   spv::MemorySemanticsSequentiallyConsistentMask);
 
-  for (auto Pair : Map) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
+    SmallVector<Value *, 5> Params;
 
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+    // The pointer.
+    Params.push_back(CI->getArgOperand(0));
 
-          auto IntTy = Type::getInt32Ty(M.getContext());
+    // The memory scope.
+    Params.push_back(ConstantScopeDevice);
 
-          // We need to map the OpenCL constants to the SPIR-V equivalents.
-          const auto ConstantScopeDevice =
-              ConstantInt::get(IntTy, spv::ScopeDevice);
-          const auto ConstantMemorySemantics = ConstantInt::get(
-              IntTy, spv::MemorySemanticsUniformMemoryMask |
-                         spv::MemorySemanticsSequentiallyConsistentMask);
+    // The memory semantics.
+    Params.push_back(ConstantMemorySemantics);
 
-          SmallVector<Value *, 5> Params;
+    if (2 < CI->getNumArgOperands()) {
+      // The unequal memory semantics.
+      Params.push_back(ConstantMemorySemantics);
 
-          // The pointer.
-          Params.push_back(CI->getArgOperand(0));
+      // The value.
+      Params.push_back(CI->getArgOperand(2));
 
-          // The memory scope.
-          Params.push_back(ConstantScopeDevice);
-
-          // The memory semantics.
-          Params.push_back(ConstantMemorySemantics);
-
-          if (2 < CI->getNumArgOperands()) {
-            // The unequal memory semantics.
-            Params.push_back(ConstantMemorySemantics);
-
-            // The value.
-            Params.push_back(CI->getArgOperand(2));
-
-            // The comparator.
-            Params.push_back(CI->getArgOperand(1));
-          } else if (1 < CI->getNumArgOperands()) {
-            // The value.
-            Params.push_back(CI->getArgOperand(1));
-          }
-
-          auto NewCI =
-              clspv::InsertSPIRVOp(CI, Pair.second, {}, CI->getType(), Params);
-
-          CI->replaceAllUsesWith(NewCI);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+      // The comparator.
+      Params.push_back(CI->getArgOperand(1));
+    } else if (1 < CI->getNumArgOperands()) {
+      // The value.
+      Params.push_back(CI->getArgOperand(1));
     }
-  }
 
-  const std::map<const char *, llvm::AtomicRMWInst::BinOp> Map2 = {
-      {"_Z8atom_addPU3AS1Vii", llvm::AtomicRMWInst::Add},
-      {"_Z8atom_addPU3AS3Vii", llvm::AtomicRMWInst::Add},
-      {"_Z8atom_addPU3AS1Vjj", llvm::AtomicRMWInst::Add},
-      {"_Z8atom_addPU3AS3Vjj", llvm::AtomicRMWInst::Add},
-      {"_Z8atom_subPU3AS1Vii", llvm::AtomicRMWInst::Sub},
-      {"_Z8atom_subPU3AS3Vii", llvm::AtomicRMWInst::Sub},
-      {"_Z8atom_subPU3AS1Vjj", llvm::AtomicRMWInst::Sub},
-      {"_Z8atom_subPU3AS3Vjj", llvm::AtomicRMWInst::Sub},
-      {"_Z9atom_xchgPU3AS1Vii", llvm::AtomicRMWInst::Xchg},
-      {"_Z9atom_xchgPU3AS3Vii", llvm::AtomicRMWInst::Xchg},
-      {"_Z9atom_xchgPU3AS1Vjj", llvm::AtomicRMWInst::Xchg},
-      {"_Z9atom_xchgPU3AS3Vjj", llvm::AtomicRMWInst::Xchg},
-      {"_Z8atom_minPU3AS1Vii", llvm::AtomicRMWInst::Min},
-      {"_Z8atom_minPU3AS3Vii", llvm::AtomicRMWInst::Min},
-      {"_Z8atom_minPU3AS1Vjj", llvm::AtomicRMWInst::UMin},
-      {"_Z8atom_minPU3AS3Vjj", llvm::AtomicRMWInst::UMin},
-      {"_Z8atom_maxPU3AS1Vii", llvm::AtomicRMWInst::Max},
-      {"_Z8atom_maxPU3AS3Vii", llvm::AtomicRMWInst::Max},
-      {"_Z8atom_maxPU3AS1Vjj", llvm::AtomicRMWInst::UMax},
-      {"_Z8atom_maxPU3AS3Vjj", llvm::AtomicRMWInst::UMax},
-      {"_Z8atom_andPU3AS1Vii", llvm::AtomicRMWInst::And},
-      {"_Z8atom_andPU3AS3Vii", llvm::AtomicRMWInst::And},
-      {"_Z8atom_andPU3AS1Vjj", llvm::AtomicRMWInst::And},
-      {"_Z8atom_andPU3AS3Vjj", llvm::AtomicRMWInst::And},
-      {"_Z7atom_orPU3AS1Vii", llvm::AtomicRMWInst::Or},
-      {"_Z7atom_orPU3AS3Vii", llvm::AtomicRMWInst::Or},
-      {"_Z7atom_orPU3AS1Vjj", llvm::AtomicRMWInst::Or},
-      {"_Z7atom_orPU3AS3Vjj", llvm::AtomicRMWInst::Or},
-      {"_Z8atom_xorPU3AS1Vii", llvm::AtomicRMWInst::Xor},
-      {"_Z8atom_xorPU3AS3Vii", llvm::AtomicRMWInst::Xor},
-      {"_Z8atom_xorPU3AS1Vjj", llvm::AtomicRMWInst::Xor},
-      {"_Z8atom_xorPU3AS3Vjj", llvm::AtomicRMWInst::Xor},
-      {"_Z10atomic_addPU3AS1Vii", llvm::AtomicRMWInst::Add},
-      {"_Z10atomic_addPU3AS3Vii", llvm::AtomicRMWInst::Add},
-      {"_Z10atomic_addPU3AS1Vjj", llvm::AtomicRMWInst::Add},
-      {"_Z10atomic_addPU3AS3Vjj", llvm::AtomicRMWInst::Add},
-      {"_Z10atomic_subPU3AS1Vii", llvm::AtomicRMWInst::Sub},
-      {"_Z10atomic_subPU3AS3Vii", llvm::AtomicRMWInst::Sub},
-      {"_Z10atomic_subPU3AS1Vjj", llvm::AtomicRMWInst::Sub},
-      {"_Z10atomic_subPU3AS3Vjj", llvm::AtomicRMWInst::Sub},
-      {"_Z11atomic_xchgPU3AS1Vii", llvm::AtomicRMWInst::Xchg},
-      {"_Z11atomic_xchgPU3AS3Vii", llvm::AtomicRMWInst::Xchg},
-      {"_Z11atomic_xchgPU3AS1Vjj", llvm::AtomicRMWInst::Xchg},
-      {"_Z11atomic_xchgPU3AS3Vjj", llvm::AtomicRMWInst::Xchg},
-      {"_Z10atomic_minPU3AS1Vii", llvm::AtomicRMWInst::Min},
-      {"_Z10atomic_minPU3AS3Vii", llvm::AtomicRMWInst::Min},
-      {"_Z10atomic_minPU3AS1Vjj", llvm::AtomicRMWInst::UMin},
-      {"_Z10atomic_minPU3AS3Vjj", llvm::AtomicRMWInst::UMin},
-      {"_Z10atomic_maxPU3AS1Vii", llvm::AtomicRMWInst::Max},
-      {"_Z10atomic_maxPU3AS3Vii", llvm::AtomicRMWInst::Max},
-      {"_Z10atomic_maxPU3AS1Vjj", llvm::AtomicRMWInst::UMax},
-      {"_Z10atomic_maxPU3AS3Vjj", llvm::AtomicRMWInst::UMax},
-      {"_Z10atomic_andPU3AS1Vii", llvm::AtomicRMWInst::And},
-      {"_Z10atomic_andPU3AS3Vii", llvm::AtomicRMWInst::And},
-      {"_Z10atomic_andPU3AS1Vjj", llvm::AtomicRMWInst::And},
-      {"_Z10atomic_andPU3AS3Vjj", llvm::AtomicRMWInst::And},
-      {"_Z9atomic_orPU3AS1Vii", llvm::AtomicRMWInst::Or},
-      {"_Z9atomic_orPU3AS3Vii", llvm::AtomicRMWInst::Or},
-      {"_Z9atomic_orPU3AS1Vjj", llvm::AtomicRMWInst::Or},
-      {"_Z9atomic_orPU3AS3Vjj", llvm::AtomicRMWInst::Or},
-      {"_Z10atomic_xorPU3AS1Vii", llvm::AtomicRMWInst::Xor},
-      {"_Z10atomic_xorPU3AS3Vii", llvm::AtomicRMWInst::Xor},
-      {"_Z10atomic_xorPU3AS1Vjj", llvm::AtomicRMWInst::Xor},
-      {"_Z10atomic_xorPU3AS3Vjj", llvm::AtomicRMWInst::Xor}};
-
-  for (auto Pair : Map2) {
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(Pair.first)) {
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-          auto AtomicOp = new AtomicRMWInst(
-              Pair.second, CI->getArgOperand(0), CI->getArgOperand(1),
-              AtomicOrdering::SequentiallyConsistent, SyncScope::System, CI);
-
-          CI->replaceAllUsesWith(AtomicOp);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      Changed = !ToRemoves.empty();
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
-    }
-  }
-
-  return Changed;
+    return clspv::InsertSPIRVOp(CI, Op, {}, CI->getType(), Params);
+  });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceCross(Module &M) {
+bool ReplaceOpenCLBuiltinPass::replaceAtomics(Function &F,
+                                              llvm::AtomicRMWInst::BinOp Op) {
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    return new AtomicRMWInst(Op, CI->getArgOperand(0), CI->getArgOperand(1),
+                             AtomicOrdering::SequentiallyConsistent,
+                             SyncScope::System, CI);
+  });
+}
 
-  std::vector<const char *> Names = {
-      "_Z5crossDv4_fS_",
-  };
-
-  return replaceCallsWithValue(M, Names, [&M](CallInst *CI) {
+bool ReplaceOpenCLBuiltinPass::replaceCross(Function &F) {
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
     auto IntTy = Type::getInt32Ty(M.getContext());
     auto FloatTy = Type::getFloatTy(M.getContext());
 
@@ -3200,9 +2124,7 @@ bool ReplaceOpenCLBuiltinPass::replaceCross(Module &M) {
   });
 }
 
-bool ReplaceOpenCLBuiltinPass::replaceFract(Module &M) {
-  bool Changed = false;
-
+bool ReplaceOpenCLBuiltinPass::replaceFract(Function &F, int vec_size) {
   // OpenCL's   float result = fract(float x, float* ptr)
   //
   // In the LLVM domain:
@@ -3229,140 +2151,101 @@ bool ReplaceOpenCLBuiltinPass::replaceFract(Module &M) {
 
   // Mapping from the fract builtin to the floor, fmin, and clspv.fract builtins
   // we need.  The clspv.fract builtin is the same as GLSL.std.450 Fract.
-  using QuadType =
-      std::tuple<const char *, const char *, const char *, const char *>;
-  auto make_quad = [](const char *a, const char *b, const char *c,
-                      const char *d) {
-    return std::tuple<const char *, const char *, const char *, const char *>(
-        a, b, c, d);
-  };
-  const std::vector<QuadType> Functions = {
-      make_quad("_Z5fractfPf", "_Z5floorff", "_Z4fminff", "clspv.fract.f"),
-      make_quad("_Z5fractDv2_fPS_", "_Z5floorDv2_f", "_Z4fminDv2_ff",
-                "clspv.fract.v2f"),
-      make_quad("_Z5fractDv3_fPS_", "_Z5floorDv3_f", "_Z4fminDv3_ff",
-                "clspv.fract.v3f"),
-      make_quad("_Z5fractDv4_fPS_", "_Z5floorDv4_f", "_Z4fminDv4_ff",
-                "clspv.fract.v4f"),
-  };
 
-  for (auto &quad : Functions) {
-    const StringRef fract_name(std::get<0>(quad));
+  Module &M = *F.getParent();
+  return replaceCallsWithValue(F, [&](CallInst *CI) {
+    auto &Context = M.getContext();
 
-    // If we find a function with the matching name.
-    if (auto F = M.getFunction(fract_name)) {
-      if (F->use_begin() == F->use_end())
-        continue;
-
-      // We have some uses.
-      Changed = true;
-
-      auto &Context = M.getContext();
-
-      const StringRef floor_name(std::get<1>(quad));
-      const StringRef fmin_name(std::get<2>(quad));
-      const StringRef clspv_fract_name(std::get<3>(quad));
-
-      // This is either float or a float vector.  All the float-like
-      // types are this type.
-      auto result_ty = F->getReturnType();
-
-      Function *fmin_fn = M.getFunction(fmin_name);
-      if (!fmin_fn) {
-        // Make the fmin function.
-        FunctionType *fn_ty =
-            FunctionType::get(result_ty, {result_ty, result_ty}, false);
-        fmin_fn =
-            cast<Function>(M.getOrInsertFunction(fmin_name, fn_ty).getCallee());
-        fmin_fn->addFnAttr(Attribute::ReadNone);
-        fmin_fn->setCallingConv(CallingConv::SPIR_FUNC);
-      }
-
-      Function *floor_fn = M.getFunction(floor_name);
-      if (!floor_fn) {
-        // Make the floor function.
-        FunctionType *fn_ty = FunctionType::get(result_ty, {result_ty}, false);
-        floor_fn = cast<Function>(
-            M.getOrInsertFunction(floor_name, fn_ty).getCallee());
-        floor_fn->addFnAttr(Attribute::ReadNone);
-        floor_fn->setCallingConv(CallingConv::SPIR_FUNC);
-      }
-
-      Function *clspv_fract_fn = M.getFunction(clspv_fract_name);
-      if (!clspv_fract_fn) {
-        // Make the clspv_fract function.
-        FunctionType *fn_ty = FunctionType::get(result_ty, {result_ty}, false);
-        clspv_fract_fn = cast<Function>(
-            M.getOrInsertFunction(clspv_fract_name, fn_ty).getCallee());
-        clspv_fract_fn->addFnAttr(Attribute::ReadNone);
-        clspv_fract_fn->setCallingConv(CallingConv::SPIR_FUNC);
-      }
-
-      // Number of significant significand bits, whether represented or not.
-      unsigned num_significand_bits;
-      switch (result_ty->getScalarType()->getTypeID()) {
-      case Type::HalfTyID:
-        num_significand_bits = 11;
-        break;
-      case Type::FloatTyID:
-        num_significand_bits = 24;
-        break;
-      case Type::DoubleTyID:
-        num_significand_bits = 53;
-        break;
-      default:
-        assert(false && "Unhandled float type when processing fract builtin");
-        break;
-      }
-      // Beware that the disassembler displays this value as
-      //   OpConstant %float 1
-      // which is not quite right.
-      const double kJustUnderOneScalar =
-          ldexp(double((1 << num_significand_bits) - 1), -num_significand_bits);
-
-      Constant *just_under_one =
-          ConstantFP::get(result_ty->getScalarType(), kJustUnderOneScalar);
-      if (result_ty->isVectorTy()) {
-        just_under_one = ConstantVector::getSplat(
-            {result_ty->getVectorNumElements(), false}, just_under_one);
-      }
-
-      IRBuilder<> Builder(Context);
-
-      SmallVector<Instruction *, 4> ToRemoves;
-
-      // Walk the users of the function.
-      for (auto &U : F->uses()) {
-        if (auto CI = dyn_cast<CallInst>(U.getUser())) {
-
-          Builder.SetInsertPoint(CI);
-          auto arg = CI->getArgOperand(0);
-          auto ptr = CI->getArgOperand(1);
-
-          // Compute floor result and store it.
-          auto floor = Builder.CreateCall(floor_fn, {arg});
-          Builder.CreateStore(floor, ptr);
-
-          auto fract_intermediate = Builder.CreateCall(clspv_fract_fn, arg);
-          auto fract_result =
-              Builder.CreateCall(fmin_fn, {fract_intermediate, just_under_one});
-
-          CI->replaceAllUsesWith(fract_result);
-
-          // Lastly, remember to remove the user.
-          ToRemoves.push_back(CI);
-        }
-      }
-
-      // And cleanup the calls we don't use anymore.
-      for (auto V : ToRemoves) {
-        V->eraseFromParent();
-      }
-
-      // And remove the function we don't need either too.
-      F->eraseFromParent();
+    std::string floor_name = "_Z5floor";
+    std::string fmin_name = "_Z4fmin";
+    std::string clspv_fract_name = "clspv.fract.";
+    if (vec_size) {
+      floor_name += "Dv" + std::to_string(vec_size) + "_f";
+      fmin_name += "Dv" + std::to_string(vec_size) + "_f";
+      clspv_fract_name += "v" + std::to_string(vec_size) + "f";
+    } else {
+      floor_name += "ff";
+      fmin_name += "ff";
+      clspv_fract_name += "f";
     }
-  }
 
-  return Changed;
+    // This is either float or a float vector.  All the float-like
+    // types are this type.
+    auto result_ty = F.getReturnType();
+
+    Function *fmin_fn = M.getFunction(fmin_name);
+    if (!fmin_fn) {
+      // Make the fmin function.
+      FunctionType *fn_ty =
+          FunctionType::get(result_ty, {result_ty, result_ty}, false);
+      fmin_fn =
+          cast<Function>(M.getOrInsertFunction(fmin_name, fn_ty).getCallee());
+      fmin_fn->addFnAttr(Attribute::ReadNone);
+      fmin_fn->setCallingConv(CallingConv::SPIR_FUNC);
+    }
+
+    Function *floor_fn = M.getFunction(floor_name);
+    if (!floor_fn) {
+      // Make the floor function.
+      FunctionType *fn_ty = FunctionType::get(result_ty, {result_ty}, false);
+      floor_fn =
+          cast<Function>(M.getOrInsertFunction(floor_name, fn_ty).getCallee());
+      floor_fn->addFnAttr(Attribute::ReadNone);
+      floor_fn->setCallingConv(CallingConv::SPIR_FUNC);
+    }
+
+    Function *clspv_fract_fn = M.getFunction(clspv_fract_name);
+    if (!clspv_fract_fn) {
+      // Make the clspv_fract function.
+      FunctionType *fn_ty = FunctionType::get(result_ty, {result_ty}, false);
+      clspv_fract_fn = cast<Function>(
+          M.getOrInsertFunction(clspv_fract_name, fn_ty).getCallee());
+      clspv_fract_fn->addFnAttr(Attribute::ReadNone);
+      clspv_fract_fn->setCallingConv(CallingConv::SPIR_FUNC);
+    }
+
+    // Number of significant significand bits, whether represented or not.
+    unsigned num_significand_bits;
+    switch (result_ty->getScalarType()->getTypeID()) {
+    case Type::HalfTyID:
+      num_significand_bits = 11;
+      break;
+    case Type::FloatTyID:
+      num_significand_bits = 24;
+      break;
+    case Type::DoubleTyID:
+      num_significand_bits = 53;
+      break;
+    default:
+      llvm_unreachable("Unhandled float type when processing fract builtin");
+      break;
+    }
+    // Beware that the disassembler displays this value as
+    //   OpConstant %float 1
+    // which is not quite right.
+    const double kJustUnderOneScalar =
+        ldexp(double((1 << num_significand_bits) - 1), -num_significand_bits);
+
+    Constant *just_under_one =
+        ConstantFP::get(result_ty->getScalarType(), kJustUnderOneScalar);
+    if (result_ty->isVectorTy()) {
+      just_under_one = ConstantVector::getSplat(
+          {result_ty->getVectorNumElements(), false}, just_under_one);
+    }
+
+    IRBuilder<> Builder(CI);
+
+    auto arg = CI->getArgOperand(0);
+    auto ptr = CI->getArgOperand(1);
+
+    // Compute floor result and store it.
+    auto floor = Builder.CreateCall(floor_fn, {arg});
+    Builder.CreateStore(floor, ptr);
+
+    auto fract_intermediate = Builder.CreateCall(clspv_fract_fn, arg);
+    auto fract_result =
+        Builder.CreateCall(fmin_fn, {fract_intermediate, just_under_one});
+
+    return fract_result;
+  });
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -43,7 +43,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
@@ -340,6 +340,7 @@ struct SPIRVProducerPass final : public ModulePass {
   ValueList &getEntryPointInterfacesVec() { return EntryPointInterfacesVec; };
   uint32_t &getOpExtInstImportID() { return OpExtInstImportID; };
   std::vector<uint32_t> &getBuiltinDimVec() { return BuiltinDimensionVec; };
+
   bool hasVariablePointersStorageBuffer() {
     return HasVariablePointersStorageBuffer;
   }
@@ -753,8 +754,9 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
 void SPIRVProducerPass::outputHeader() {
   binaryOut->write(reinterpret_cast<const char *>(&spv::MagicNumber),
                    sizeof(spv::MagicNumber));
-  binaryOut->write(reinterpret_cast<const char *>(&spv::Version),
-                   sizeof(spv::Version));
+
+  const uint32_t version = 0x00010000; // SPIR-V 1.0
+  binaryOut->write(reinterpret_cast<const char *>(&version), sizeof(version));
 
   // use Google's vendor ID
   const uint32_t vendor = 21 << 16;
@@ -842,14 +844,10 @@ void SPIRVProducerPass::GenerateLLVMIRInfo(Module &M, const DataLayout &DL) {
           if (IsSampledImageRead(callee_name)) {
             // All sampled reads need a floating point 0 for the Lod operand.
             FindConstant(ConstantFP::get(Context, APFloat(0.0f)));
-          }
-
-          if (IsUnsampledImageRead(callee_name)) {
+          } else if (IsUnsampledImageRead(callee_name)) {
             // All unsampled reads need an integer 0 for the Lod operand.
             FindConstant(ConstantInt::get(Context, APInt(32, 0)));
-          }
-
-          if (IsImageQuery(callee_name)) {
+          } else if (IsImageQuery(callee_name)) {
             Type *ImageTy = Call->getOperand(0)->getType();
             const uint32_t dim = ImageDimensionality(ImageTy);
             uint32_t components =
@@ -4978,9 +4976,8 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       break;
     }
 
-    // read_image (with a sampler) is converted to OpSampledImage and
-    // OpImageSampleExplicitLod.  Additionally, OpTypeSampledImage is
-    // generated.
+    // read_image is converted to OpSampledImage and OpImageSampleExplicitLod.
+    // Additionally, OpTypeSampledImage is generated.
     if (IsSampledImageRead(Callee)) {
       //
       // Generate OpSampledImage.
@@ -5433,6 +5430,9 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
           new SPIRVInstruction(spv::OpPhi, std::get<2>(*DeferredInst), Ops));
     } else if (CallInst *Call = dyn_cast<CallInst>(Inst)) {
       Function *Callee = Call->getCalledFunction();
+      LLVMContext &Context = Callee->getContext();
+      auto IntTy = Type::getInt32Ty(Context);
+      auto callee_code = Builtins::Lookup(Callee);
       auto callee_name = Callee->getName();
       glsl::ExtInst EInst = getDirectOrIndirectExtInstEnum(callee_name);
 
@@ -5466,9 +5466,6 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
           // Generate one more instruction that uses the result of the extended
           // instruction.  Its result id is one more than the id of the
           // extended instruction.
-          LLVMContext &Context =
-              Call->getParent()->getParent()->getParent()->getContext();
-
           auto generate_extra_inst = [this, &Context, &Call, &DeferredInst,
                                       &VMap, &SPIRVInstList, &InsertPoint](
                                          spv::Op opcode, Constant *constant) {
@@ -5498,8 +5495,7 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
 
           switch (IndirectExtInst) {
           case glsl::ExtInstFindUMsb: // Implementing clz
-            generate_extra_inst(
-                spv::OpISub, ConstantInt::get(Type::getInt32Ty(Context), 31));
+            generate_extra_inst(spv::OpISub, ConstantInt::get(IntTy, 31));
             break;
           case glsl::ExtInstAcos:  // Implementing acospi
           case glsl::ExtInstAsin:  // Implementing asinpi
@@ -5515,7 +5511,7 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
           }
         }
 
-      } else if (callee_name.startswith("_Z8popcount")) {
+      } else if (callee_code == Builtins::kPopcount) {
         //
         // Generate OpBitCount
         //
@@ -5691,240 +5687,172 @@ void SPIRVProducerPass::HandleDeferredDecorations(const DataLayout &DL) {
 }
 
 glsl::ExtInst SPIRVProducerPass::getExtInstEnum(StringRef Name) {
+
+  const auto &fi = Builtins::Lookup(Name);
+  switch (fi) {
+  case Builtins::kClamp: {
+    auto param_type = fi.getParameter(0);
+    if (param_type.type_id == Type::FloatTyID) {
+      return glsl::ExtInst::ExtInstFClamp;
+    }
+    return param_type.is_signed ? glsl::ExtInst::ExtInstSClamp
+                                : glsl::ExtInst::ExtInstUClamp;
+  }
+  case Builtins::kMax: {
+    auto param_type = fi.getParameter(0);
+    if (param_type.type_id == Type::FloatTyID) {
+      return glsl::ExtInst::ExtInstFMax;
+    }
+    return param_type.is_signed ? glsl::ExtInst::ExtInstSMax
+                                : glsl::ExtInst::ExtInstUMax;
+  }
+  case Builtins::kMin: {
+    auto param_type = fi.getParameter(0);
+    if (param_type.type_id == Type::FloatTyID) {
+      return glsl::ExtInst::ExtInstFMin;
+    }
+    return param_type.is_signed ? glsl::ExtInst::ExtInstSMin
+                                : glsl::ExtInst::ExtInstUMin;
+  }
+  case Builtins::kAbs:
+    return glsl::ExtInst::ExtInstSAbs;
+  case Builtins::kFmax:
+    return glsl::ExtInst::ExtInstFMax;
+  case Builtins::kFmin:
+    return glsl::ExtInst::ExtInstFMin;
+  case Builtins::kDegrees:
+    return glsl::ExtInst::ExtInstDegrees;
+  case Builtins::kRadians:
+    return glsl::ExtInst::ExtInstRadians;
+  case Builtins::kMix:
+    return glsl::ExtInst::ExtInstFMix;
+  case Builtins::kAcos:
+  case Builtins::kAcospi:
+    return glsl::ExtInst::ExtInstAcos;
+  case Builtins::kAcosh:
+    return glsl::ExtInst::ExtInstAcosh;
+  case Builtins::kAsin:
+  case Builtins::kAsinpi:
+    return glsl::ExtInst::ExtInstAsin;
+  case Builtins::kAsinh:
+    return glsl::ExtInst::ExtInstAsinh;
+  case Builtins::kAtan:
+  case Builtins::kAtanpi:
+    return glsl::ExtInst::ExtInstAtan;
+  case Builtins::kAtanh:
+    return glsl::ExtInst::ExtInstAtanh;
+  case Builtins::kAtan2:
+  case Builtins::kAtan2pi:
+    return glsl::ExtInst::ExtInstAtan2;
+  case Builtins::kCeil:
+    return glsl::ExtInst::ExtInstCeil;
+  case Builtins::kSin:
+  case Builtins::kHalfSin:
+  case Builtins::kNativeSin:
+    return glsl::ExtInst::ExtInstSin;
+  case Builtins::kSinh:
+    return glsl::ExtInst::ExtInstSinh;
+  case Builtins::kCos:
+  case Builtins::kHalfCos:
+  case Builtins::kNativeCos:
+    return glsl::ExtInst::ExtInstCos;
+  case Builtins::kCosh:
+    return glsl::ExtInst::ExtInstCosh;
+  case Builtins::kTan:
+  case Builtins::kHalfTan:
+  case Builtins::kNativeTan:
+    return glsl::ExtInst::ExtInstTan;
+  case Builtins::kTanh:
+    return glsl::ExtInst::ExtInstTanh;
+  case Builtins::kExp:
+  case Builtins::kHalfExp:
+  case Builtins::kNativeExp:
+    return glsl::ExtInst::ExtInstExp;
+  case Builtins::kExp2:
+  case Builtins::kHalfExp2:
+  case Builtins::kNativeExp2:
+    return glsl::ExtInst::ExtInstExp2;
+  case Builtins::kLog:
+  case Builtins::kHalfLog:
+  case Builtins::kNativeLog:
+    return glsl::ExtInst::ExtInstLog;
+  case Builtins::kLog2:
+  case Builtins::kHalfLog2:
+  case Builtins::kNativeLog2:
+    return glsl::ExtInst::ExtInstLog2;
+  case Builtins::kFabs:
+    return glsl::ExtInst::ExtInstFAbs;
+  case Builtins::kFma:
+    return glsl::ExtInst::ExtInstFma;
+  case Builtins::kFloor:
+    return glsl::ExtInst::ExtInstFloor;
+  case Builtins::kLdexp:
+    return glsl::ExtInst::ExtInstLdexp;
+  case Builtins::kPow:
+  case Builtins::kPowr:
+  case Builtins::kHalfPowr:
+  case Builtins::kNativePowr:
+    return glsl::ExtInst::ExtInstPow;
+  case Builtins::kRound:
+    return glsl::ExtInst::ExtInstRound;
+  case Builtins::kSqrt:
+  case Builtins::kHalfSqrt:
+  case Builtins::kNativeSqrt:
+    return glsl::ExtInst::ExtInstSqrt;
+  case Builtins::kRsqrt:
+  case Builtins::kHalfRsqrt:
+  case Builtins::kNativeRsqrt:
+    return glsl::ExtInst::ExtInstInverseSqrt;
+  case Builtins::kTrunc:
+    return glsl::ExtInst::ExtInstTrunc;
+  case Builtins::kFrexp:
+    return glsl::ExtInst::ExtInstFrexp;
+  case Builtins::kFract:
+    return glsl::ExtInst::ExtInstFract;
+  case Builtins::kSign:
+    return glsl::ExtInst::ExtInstFSign;
+  case Builtins::kLength:
+  case Builtins::kFastLength:
+    return glsl::ExtInst::ExtInstLength;
+  case Builtins::kDistance:
+  case Builtins::kFastDistance:
+    return glsl::ExtInst::ExtInstDistance;
+  case Builtins::kStep:
+    return glsl::ExtInst::ExtInstStep;
+  case Builtins::kSmoothstep:
+    return glsl::ExtInst::ExtInstSmoothStep;
+  case Builtins::kCross:
+    return glsl::ExtInst::ExtInstCross;
+  case Builtins::kNormalize:
+  case Builtins::kFastNormalize:
+    return glsl::ExtInst::ExtInstNormalize;
+  default:
+    break;
+  }
+
   return StringSwitch<glsl::ExtInst>(Name)
-      .Case("_Z3absc", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv2_c", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv3_c", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv4_c", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3abss", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv2_s", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv3_s", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv4_s", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absi", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv2_i", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv3_i", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv4_i", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absl", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv2_l", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv3_l", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z3absDv4_l", glsl::ExtInst::ExtInstSAbs)
-      .Case("_Z5clampccc", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv2_cS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv3_cS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv4_cS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clamphhh", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv2_hS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv3_hS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv4_hS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampsss", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv2_sS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv3_sS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv4_sS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampttt", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv2_tS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv3_tS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv4_tS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampiii", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv2_iS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv3_iS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv4_iS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampjjj", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv2_jS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv3_jS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv4_jS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clamplll", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv2_lS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv3_lS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampDv4_lS_S_", glsl::ExtInst::ExtInstSClamp)
-      .Case("_Z5clampmmm", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv2_mS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv3_mS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampDv4_mS_S_", glsl::ExtInst::ExtInstUClamp)
-      .Case("_Z5clampfff", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv2_fS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv3_fS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv4_fS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDhDhDh", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv2_DhS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv3_DhS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z5clampDv4_DhS_S_", glsl::ExtInst::ExtInstFClamp)
-      .Case("_Z3maxcc", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv2_cS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv3_cS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv4_cS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxhh", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv2_hS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv3_hS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv4_hS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxss", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv2_sS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv3_sS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv4_sS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxtt", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv2_tS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv3_tS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv4_tS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxii", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv2_iS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv3_iS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv4_iS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxjj", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv2_jS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv3_jS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv4_jS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxll", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv2_lS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv3_lS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxDv4_lS_", glsl::ExtInst::ExtInstSMax)
-      .Case("_Z3maxmm", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv2_mS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv3_mS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxDv4_mS_", glsl::ExtInst::ExtInstUMax)
-      .Case("_Z3maxff", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv2_fS_", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv3_fS_", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv4_fS_", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDhDh", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv2_DhS_", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv3_DhS_", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3maxDv4_DhS_", glsl::ExtInst::ExtInstFMax)
-      .StartsWith("_Z4fmax", glsl::ExtInst::ExtInstFMax)
-      .Case("_Z3mincc", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv2_cS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv3_cS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv4_cS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minhh", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv2_hS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv3_hS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv4_hS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minss", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv2_sS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv3_sS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv4_sS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3mintt", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv2_tS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv3_tS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv4_tS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minii", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv2_iS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv3_iS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv4_iS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minjj", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv2_jS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv3_jS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv4_jS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minll", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv2_lS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv3_lS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minDv4_lS_", glsl::ExtInst::ExtInstSMin)
-      .Case("_Z3minmm", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv2_mS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv3_mS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minDv4_mS_", glsl::ExtInst::ExtInstUMin)
-      .Case("_Z3minff", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv2_fS_", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv3_fS_", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv4_fS_", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDhDh", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv2_DhS_", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv3_DhS_", glsl::ExtInst::ExtInstFMin)
-      .Case("_Z3minDv4_DhS_", glsl::ExtInst::ExtInstFMin)
-      .StartsWith("_Z4fmin", glsl::ExtInst::ExtInstFMin)
-      .StartsWith("_Z7degrees", glsl::ExtInst::ExtInstDegrees)
-      .StartsWith("_Z7radians", glsl::ExtInst::ExtInstRadians)
-      .StartsWith("_Z3mix", glsl::ExtInst::ExtInstFMix)
-      .StartsWith("_Z4acos", glsl::ExtInst::ExtInstAcos)
-      .StartsWith("_Z5acosh", glsl::ExtInst::ExtInstAcosh)
-      .StartsWith("_Z4asin", glsl::ExtInst::ExtInstAsin)
-      .StartsWith("_Z5asinh", glsl::ExtInst::ExtInstAsinh)
-      .StartsWith("_Z4atan", glsl::ExtInst::ExtInstAtan)
-      .StartsWith("_Z5atan2", glsl::ExtInst::ExtInstAtan2)
-      .StartsWith("_Z5atanh", glsl::ExtInst::ExtInstAtanh)
-      .StartsWith("_Z4ceil", glsl::ExtInst::ExtInstCeil)
-      .StartsWith("_Z3sin", glsl::ExtInst::ExtInstSin)
-      .StartsWith("_Z4sinh", glsl::ExtInst::ExtInstSinh)
-      .StartsWith("_Z8half_sin", glsl::ExtInst::ExtInstSin)
-      .StartsWith("_Z10native_sin", glsl::ExtInst::ExtInstSin)
-      .StartsWith("_Z3cos", glsl::ExtInst::ExtInstCos)
-      .StartsWith("_Z4cosh", glsl::ExtInst::ExtInstCosh)
-      .StartsWith("_Z8half_cos", glsl::ExtInst::ExtInstCos)
-      .StartsWith("_Z10native_cos", glsl::ExtInst::ExtInstCos)
-      .StartsWith("_Z3tan", glsl::ExtInst::ExtInstTan)
-      .StartsWith("_Z4tanh", glsl::ExtInst::ExtInstTanh)
-      .StartsWith("_Z8half_tan", glsl::ExtInst::ExtInstTan)
-      .StartsWith("_Z10native_tan", glsl::ExtInst::ExtInstTan)
-      .StartsWith("_Z3exp", glsl::ExtInst::ExtInstExp)
-      .StartsWith("_Z8half_exp", glsl::ExtInst::ExtInstExp)
-      .StartsWith("_Z10native_exp", glsl::ExtInst::ExtInstExp)
-      .StartsWith("_Z4exp2", glsl::ExtInst::ExtInstExp2)
-      .StartsWith("_Z9half_exp2", glsl::ExtInst::ExtInstExp2)
-      .StartsWith("_Z11native_exp2", glsl::ExtInst::ExtInstExp2)
-      .StartsWith("_Z3log", glsl::ExtInst::ExtInstLog)
-      .StartsWith("_Z8half_log", glsl::ExtInst::ExtInstLog)
-      .StartsWith("_Z10native_log", glsl::ExtInst::ExtInstLog)
-      .StartsWith("_Z4log2", glsl::ExtInst::ExtInstLog2)
-      .StartsWith("_Z9half_log2", glsl::ExtInst::ExtInstLog2)
-      .StartsWith("_Z11native_log2", glsl::ExtInst::ExtInstLog2)
-      .StartsWith("_Z4fabs", glsl::ExtInst::ExtInstFAbs)
-      .StartsWith("_Z3fma", glsl::ExtInst::ExtInstFma)
-      .StartsWith("_Z5floor", glsl::ExtInst::ExtInstFloor)
-      .StartsWith("_Z5ldexp", glsl::ExtInst::ExtInstLdexp)
-      .StartsWith("_Z3pow", glsl::ExtInst::ExtInstPow)
-      .StartsWith("_Z4powr", glsl::ExtInst::ExtInstPow)
-      .StartsWith("_Z9half_powr", glsl::ExtInst::ExtInstPow)
-      .StartsWith("_Z11native_powr", glsl::ExtInst::ExtInstPow)
-      .StartsWith("_Z5round", glsl::ExtInst::ExtInstRound)
-      .StartsWith("_Z4sqrt", glsl::ExtInst::ExtInstSqrt)
-      .StartsWith("_Z9half_sqrt", glsl::ExtInst::ExtInstSqrt)
-      .StartsWith("_Z11native_sqrt", glsl::ExtInst::ExtInstSqrt)
-      .StartsWith("_Z5rsqrt", glsl::ExtInst::ExtInstInverseSqrt)
-      .StartsWith("_Z10half_rsqrt", glsl::ExtInst::ExtInstInverseSqrt)
-      .StartsWith("_Z12native_rsqrt", glsl::ExtInst::ExtInstInverseSqrt)
-      .StartsWith("_Z5trunc", glsl::ExtInst::ExtInstTrunc)
-      .StartsWith("_Z5frexp", glsl::ExtInst::ExtInstFrexp)
-      .StartsWith("_Z4sign", glsl::ExtInst::ExtInstFSign)
-      .StartsWith("_Z6length", glsl::ExtInst::ExtInstLength)
-      .StartsWith("_Z11fast_length", glsl::ExtInst::ExtInstLength)
-      .StartsWith("_Z8distance", glsl::ExtInst::ExtInstDistance)
-      .StartsWith("_Z13fast_distance", glsl::ExtInst::ExtInstDistance)
-      .StartsWith("_Z4step", glsl::ExtInst::ExtInstStep)
-      .StartsWith("_Z10smoothstep", glsl::ExtInst::ExtInstSmoothStep)
-      .Case("_Z5crossDv3_fS_", glsl::ExtInst::ExtInstCross)
-      .StartsWith("_Z9normalize", glsl::ExtInst::ExtInstNormalize)
-      .StartsWith("_Z14fast_normalize", glsl::ExtInst::ExtInstNormalize)
       .StartsWith("llvm.fmuladd.", glsl::ExtInst::ExtInstFma)
       .Case("spirv.unpack.v2f16", glsl::ExtInst::ExtInstUnpackHalf2x16)
       .Case("spirv.pack.v2f16", glsl::ExtInst::ExtInstPackHalf2x16)
-      .Case("clspv.fract.f", glsl::ExtInst::ExtInstFract)
-      .Case("clspv.fract.v2f", glsl::ExtInst::ExtInstFract)
-      .Case("clspv.fract.v3f", glsl::ExtInst::ExtInstFract)
-      .Case("clspv.fract.v4f", glsl::ExtInst::ExtInstFract)
       .Default(kGlslExtInstBad);
 }
 
 glsl::ExtInst SPIRVProducerPass::getIndirectExtInstEnum(StringRef Name) {
-  // Check indirect cases.
-  return StringSwitch<glsl::ExtInst>(Name)
-      .StartsWith("_Z3clz", glsl::ExtInst::ExtInstFindUMsb)
-      // Use exact match on float arg because these need a multiply
-      // of a constant of the right floating point type.
-      .Case("_Z6acospif", glsl::ExtInst::ExtInstAcos)
-      .Case("_Z6acospiDv2_f", glsl::ExtInst::ExtInstAcos)
-      .Case("_Z6acospiDv3_f", glsl::ExtInst::ExtInstAcos)
-      .Case("_Z6acospiDv4_f", glsl::ExtInst::ExtInstAcos)
-      .Case("_Z6asinpif", glsl::ExtInst::ExtInstAsin)
-      .Case("_Z6asinpiDv2_f", glsl::ExtInst::ExtInstAsin)
-      .Case("_Z6asinpiDv3_f", glsl::ExtInst::ExtInstAsin)
-      .Case("_Z6asinpiDv4_f", glsl::ExtInst::ExtInstAsin)
-      .Case("_Z6atanpif", glsl::ExtInst::ExtInstAtan)
-      .Case("_Z6atanpiDv2_f", glsl::ExtInst::ExtInstAtan)
-      .Case("_Z6atanpiDv3_f", glsl::ExtInst::ExtInstAtan)
-      .Case("_Z6atanpiDv4_f", glsl::ExtInst::ExtInstAtan)
-      .Case("_Z7atan2piff", glsl::ExtInst::ExtInstAtan2)
-      .Case("_Z7atan2piDv2_fS_", glsl::ExtInst::ExtInstAtan2)
-      .Case("_Z7atan2piDv3_fS_", glsl::ExtInst::ExtInstAtan2)
-      .Case("_Z7atan2piDv4_fS_", glsl::ExtInst::ExtInstAtan2)
-      .Default(kGlslExtInstBad);
+  switch (Builtins::Lookup(Name)) {
+  case Builtins::kClz:
+    return glsl::ExtInst::ExtInstFindUMsb;
+  case Builtins::kAcospi:
+    return glsl::ExtInst::ExtInstAcos;
+  case Builtins::kAsinpi:
+    return glsl::ExtInst::ExtInstAsin;
+  case Builtins::kAtanpi:
+    return glsl::ExtInst::ExtInstAtan;
+  case Builtins::kAtan2pi:
+    return glsl::ExtInst::ExtInstAtan2;
+  default:
+    break;
+  }
+  return kGlslExtInstBad;
 }
 
 glsl::ExtInst

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -43,7 +43,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/unified1/spirv.hpp"
+#include "spirv/1.0/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
@@ -755,7 +755,7 @@ void SPIRVProducerPass::outputHeader() {
   binaryOut->write(reinterpret_cast<const char *>(&spv::MagicNumber),
                    sizeof(spv::MagicNumber));
 
-  const uint32_t version = 0x00010000; // SPIR-V 1.0
+  const uint32_t version = spv::Version; // SPIR-V 1.0
   binaryOut->write(reinterpret_cast<const char *>(&version), sizeof(version));
 
   // use Google's vendor ID

--- a/lib/SplatArgPass.cpp
+++ b/lib/SplatArgPass.cpp
@@ -12,26 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <list>
+
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "Builtins.h"
 #include "Passes.h"
 
+using namespace clspv;
 using namespace llvm;
 
 #define DEBUG_TYPE "splatarg"
 
 namespace {
+
 struct SplatArgPass : public ModulePass {
   static char ID;
   SplatArgPass() : ModulePass(ID) {}
 
-  const char *getSplatName(StringRef Name);
+  std::string getSplatName(const Builtins::FunctionInfo &func_info,
+                           const Builtins::ParamTypeInfo &param_info,
+                           bool three_params);
+  Function *getReplacementFunction(Function &F, const std::string &NewCallName);
+  void replaceCall(Function *NewCallee, CallInst *Call);
+
   bool runOnModule(Module &M) override;
 };
+
 } // namespace
 
 char SplatArgPass::ID = 0;
@@ -41,184 +52,142 @@ namespace clspv {
 llvm::ModulePass *createSplatArgPass() { return new SplatArgPass(); }
 } // namespace clspv
 
-const char *SplatArgPass::getSplatName(StringRef Name) {
-  if (Name.equals("_Z5clampDv2_iii")) {
-    return "_Z5clampDv2_iS_S_";
-  } else if (Name.equals("_Z5clampDv3_iii")) {
-    return "_Z5clampDv3_iS_S_";
-  } else if (Name.equals("_Z5clampDv4_iii")) {
-    return "_Z5clampDv4_iS_S_";
-  } else if (Name.equals("_Z5clampDv2_jjj")) {
-    return "_Z5clampDv2_jS_S_";
-  } else if (Name.equals("_Z5clampDv3_jjj")) {
-    return "_Z5clampDv3_jS_S_";
-  } else if (Name.equals("_Z5clampDv4_jjj")) {
-    return "_Z5clampDv4_jS_S_";
-  } else if (Name.equals("_Z5clampDv2_fff")) {
-    return "_Z5clampDv2_fS_S_";
-  } else if (Name.equals("_Z5clampDv3_fff")) {
-    return "_Z5clampDv3_fS_S_";
-  } else if (Name.equals("_Z5clampDv4_fff")) {
-    return "_Z5clampDv4_fS_S_";
-  } else if (Name.equals("_Z5clampDv2_DhDhDh")) {
-    return "_Z5clampDv2_DhS_S_";
-  } else if (Name.equals("_Z5clampDv3_DhDhDh")) {
-    return "_Z5clampDv3_DhS_S_";
-  } else if (Name.equals("_Z5clampDv4_DhDhDh")) {
-    return "_Z5clampDv4_DhS_S_";
+namespace {
+int log2i(int val) {
+  if (val <= 0)
+    return -1;
+  int log2 = 0;
+  while (val >>= 1)
+    log2++;
+  return log2;
+}
+} // namespace
 
-  } else if (Name.equals("_Z3maxDv2_ii")) {
-    return "_Z3maxDv2_iS_";
-  } else if (Name.equals("_Z3maxDv3_ii")) {
-    return "_Z3maxDv3_iS_";
-  } else if (Name.equals("_Z3maxDv4_ii")) {
-    return "_Z3maxDv4_iS_";
-  } else if (Name.equals("_Z3maxDv2_jj")) {
-    return "_Z3maxDv2_jS_";
-  } else if (Name.equals("_Z3maxDv3_jj")) {
-    return "_Z3maxDv3_jS_";
-  } else if (Name.equals("_Z3maxDv4_jj")) {
-    return "_Z3maxDv4_jS_";
-  } else if (Name.equals("_Z3maxDv2_ff")) {
-    return "_Z3maxDv2_fS_";
-  } else if (Name.equals("_Z3maxDv3_ff")) {
-    return "_Z3maxDv3_fS_";
-  } else if (Name.equals("_Z3maxDv4_ff")) {
-    return "_Z3maxDv4_fS_";
-  } else if (Name.equals("_Z3maxDv2_DhDh")) {
-    return "_Z3maxDv2_DhS_";
-  } else if (Name.equals("_Z3maxDv3_DhDh")) {
-    return "_Z3maxDv3_DhS_";
-  } else if (Name.equals("_Z3maxDv4_DhDh")) {
-    return "_Z3maxDv4_DhS_";
-  } else if (Name.equals("_Z4fmaxDv2_ff")) {
-    return "_Z4fmaxDv2_fS_";
-  } else if (Name.equals("_Z4fmaxDv3_ff")) {
-    return "_Z4fmaxDv3_fS_";
-  } else if (Name.equals("_Z4fmaxDv4_ff")) {
-    return "_Z4fmaxDv4_fS_";
-  } else if (Name.equals("_Z4fmaxDv2_DhDh")) {
-    return "_Z4fmaxDv2_DhS_";
-  } else if (Name.equals("_Z4fmaxDv3_DhDh")) {
-    return "_Z4fmaxDv3_DhS_";
-  } else if (Name.equals("_Z4fmaxDv4_DhDh")) {
-    return "_Z4fmaxDv4_DhS_";
+// Programmatically convert mangled_name to vectorized version
+std::string
+SplatArgPass::getSplatName(const Builtins::FunctionInfo &func_info,
+                           const Builtins::ParamTypeInfo &param_info,
+                           bool three_params) {
+  const char *type_code = "f";
+  int index = log2i(param_info.byte_len);
+  assert(index >= 0 && index <= 3);
+  const char *signed_int_type_tbl[] = {"c", "s", "i", "l"};
+  const char *unsigned_int_type_tbl[] = {"h", "t", "j", "m"};
+  const char *float_type_tbl[] = {"", "Dh", "f", "d"};
+  switch (param_info.type_id) {
+  case Type::IntegerTyID:
+    type_code = param_info.is_signed ? signed_int_type_tbl[index]
+                                     : unsigned_int_type_tbl[index];
+    break;
+  case Type::FloatTyID:
+    if (index == 0)
+      llvm_unreachable("Unsupported float type");
+    type_code = float_type_tbl[index];
+    break;
+  default:
+    llvm_unreachable("Unsupported type");
+  }
+  const auto &func_name = func_info.getName();
+  return "_Z" + std::to_string(func_name.size()) + func_name + "Dv" +
+         std::to_string(param_info.vector_size) + "_" + type_code +
+         (three_params ? "S_S_" : "S_");
+}
 
-  } else if (Name.equals("_Z3minDv2_ii")) {
-    return "_Z3minDv2_iS_";
-  } else if (Name.equals("_Z3minDv3_ii")) {
-    return "_Z3minDv3_iS_";
-  } else if (Name.equals("_Z3minDv4_ii")) {
-    return "_Z3minDv4_iS_";
-  } else if (Name.equals("_Z3minDv2_jj")) {
-    return "_Z3minDv2_jS_";
-  } else if (Name.equals("_Z3minDv3_jj")) {
-    return "_Z3minDv3_jS_";
-  } else if (Name.equals("_Z3minDv4_jj")) {
-    return "_Z3minDv4_jS_";
-  } else if (Name.equals("_Z3minDv2_ff")) {
-    return "_Z3minDv2_fS_";
-  } else if (Name.equals("_Z3minDv3_ff")) {
-    return "_Z3minDv3_fS_";
-  } else if (Name.equals("_Z3minDv4_ff")) {
-    return "_Z3minDv4_fS_";
-  } else if (Name.equals("_Z3minDv2_DhDh")) {
-    return "_Z3minDv2_DhS_";
-  } else if (Name.equals("_Z3minDv3_DhDh")) {
-    return "_Z3minDv3_DhS_";
-  } else if (Name.equals("_Z3minDv4_DhDh")) {
-    return "_Z3minDv4_DhS_";
-  } else if (Name.equals("_Z4fminDv2_ff")) {
-    return "_Z4fminDv2_fS_";
-  } else if (Name.equals("_Z4fminDv3_ff")) {
-    return "_Z4fminDv3_fS_";
-  } else if (Name.equals("_Z4fminDv4_ff")) {
-    return "_Z4fminDv4_fS_";
-  } else if (Name.equals("_Z4fminDv2_DhDh")) {
-    return "_Z4fminDv2_DhS_";
-  } else if (Name.equals("_Z4fminDv3_DhDh")) {
-    return "_Z4fminDv3_DhS_";
-  } else if (Name.equals("_Z4fminDv4_DhDh")) {
-    return "_Z4fminDv4_DhS_";
+// Create replacement function once
+Function *SplatArgPass::getReplacementFunction(Function &F,
+                                               const std::string &NewCallName) {
+  Module *M = F.getParent();
+  FunctionType *CalleeTy = F.getFunctionType();
 
-  } else if (Name.equals("_Z3mixDv2_fS_f")) {
-    return "_Z3mixDv2_fS_S_";
-  } else if (Name.equals("_Z3mixDv3_fS_f")) {
-    return "_Z3mixDv3_fS_S_";
-  } else if (Name.equals("_Z3mixDv4_fS_f")) {
-    return "_Z3mixDv4_fS_S_";
-  } else if (Name.equals("_Z3mixDv2_DhS_Dh")) {
-    return "_Z3mixDv2_DhS_S_";
-  } else if (Name.equals("_Z3mixDv3_DhS_Dh")) {
-    return "_Z3mixDv3_DhS_S_";
-  } else if (Name.equals("_Z3mixDv4_DhS_Dh")) {
-    return "_Z3mixDv4_DhS_S_";
+  // Create new callee function type with vector type.
+  Type *VectorType = F.getArg(0)->getType();
+  SmallVector<Type *, 4> NewCalleeParamTys;
+  for (auto ai = F.arg_begin(); ai != F.arg_end(); ++ai) {
+    auto &Arg = *ai;
+    if (Arg.getType()->isVectorTy()) {
+      NewCalleeParamTys.push_back(Arg.getType());
+    } else {
+      NewCalleeParamTys.push_back(VectorType);
+    }
   }
 
-  return nullptr;
+  FunctionType *NewCalleeTy =
+      FunctionType::get(F.getReturnType(), NewCalleeParamTys, false);
+
+  // Create new callee function declaration with new function type.
+  Function *NewCallee = cast<Function>(
+      M->getOrInsertFunction(NewCallName, NewCalleeTy).getCallee());
+  NewCallee->setCallingConv(CallingConv::SPIR_FUNC);
+
+  return NewCallee;
+}
+
+// Replace each callee to vectorized version
+//  - also vectorize parameters
+void SplatArgPass::replaceCall(Function *NewCallee, CallInst *Call) {
+  Function *Callee = Call->getCalledFunction();
+  FunctionType *CalleeTy = Callee->getFunctionType();
+  VectorType *VTy = cast<VectorType>(Call->getType());
+
+  // Change target of call instruction.
+  Call->setCalledFunction(NewCallee);
+
+  // Change operands of call instruction.
+  IRBuilder<> Builder(Call);
+  for (unsigned i = 0; i < CalleeTy->getNumParams(); i++) {
+    if (!CalleeTy->getParamType(i)->isVectorTy()) {
+      Value *NewArg = Builder.CreateVectorSplat(
+          VTy->getNumElements(), Call->getArgOperand(i), "arg_splat");
+      Call->setArgOperand(i, NewArg);
+    }
+  }
+
+  Call->setCallingConv(CallingConv::SPIR_FUNC);
 }
 
 bool SplatArgPass::runOnModule(Module &M) {
-  bool Changed = false;
-
-  SmallVector<CallInst *, 16> WorkList;
-  for (Function &F : M) {
-    for (BasicBlock &BB : F) {
-      for (Instruction &I : BB) {
-        if (CallInst *Call = dyn_cast<CallInst>(&I)) {
-          Function *Callee = Call->getCalledFunction();
-          if (Callee) {
-            // If min/max/mix/clamp function call has scalar type argument, we
-            // need to splat the scalar type one to vector type.
-            if (getSplatName(Callee->getName())) {
-              WorkList.push_back(Call);
-              Changed = true;
-            }
+  std::list<Function *> func_list;
+  for (auto &F : M) {
+    // process only function declarations
+    if (F.empty() && !F.use_empty()) {
+      auto &func_info = Builtins::Lookup(&F);
+      bool has_3_params = false;
+      switch (func_info.getType()) {
+      case Builtins::kClamp:
+      case Builtins::kMix:
+        has_3_params = true;
+      case Builtins::kMax:
+      case Builtins::kFmax:
+      case Builtins::kMin:
+      case Builtins::kFmin: {
+        auto &param_info = func_info.getParameter(0);
+        uint vec_size = param_info.vector_size;
+        bool last_is_scalar = func_info.getLastParameter().vector_size == 0;
+        if (vec_size != 0 && last_is_scalar) {
+          std::string NewFName =
+              getSplatName(func_info, param_info, has_3_params);
+          Function *NewCallee = getReplacementFunction(F, NewFName);
+          // Replace the users of the function.
+          for (User *U : F.users()) {
+            replaceCall(NewCallee, dyn_cast<CallInst>(U));
           }
+          func_list.push_front(&F);
         }
+        break;
+      }
+      default:
+        break;
       }
     }
   }
-
-  for (CallInst *Call : WorkList) {
-    Function *Callee = Call->getCalledFunction();
-    FunctionType *CalleeTy = Callee->getFunctionType();
-
-    // Create new callee function type with vector type.
-    SmallVector<Type *, 4> NewCalleeParamTys;
-    for (const auto &Arg : Callee->args()) {
-      if (Arg.getType()->isVectorTy()) {
-        NewCalleeParamTys.push_back(Arg.getType());
-      } else {
-        NewCalleeParamTys.push_back(Call->getType());
+  if (func_list.size() != 0) {
+    // remove dead
+    for (auto *F : func_list) {
+      if (F->use_empty()) {
+        F->eraseFromParent();
       }
     }
-
-    FunctionType *NewCalleeTy =
-        FunctionType::get(Call->getType(), NewCalleeParamTys, false);
-
-    // Create new callee function declaration with new function type.
-    StringRef NewCallName(getSplatName(Callee->getName()));
-    Function *NewCallee = cast<Function>(
-        M.getOrInsertFunction(NewCallName, NewCalleeTy).getCallee());
-    NewCallee->setCallingConv(CallingConv::SPIR_FUNC);
-
-    // Change target of call instruction.
-    Call->setCalledFunction(NewCalleeTy, NewCallee);
-
-    // Change operands of call instruction.
-    IRBuilder<> Builder(Call);
-    for (unsigned i = 0; i < CalleeTy->getNumParams(); i++) {
-      if (!CalleeTy->getParamType(i)->isVectorTy()) {
-        VectorType *VTy = cast<VectorType>(Call->getType());
-        Value *NewArg = Builder.CreateVectorSplat(
-            VTy->getNumElements(), Call->getArgOperand(i), "arg_splat");
-        Call->setArgOperand(i, NewArg);
-      }
-    }
-
-    Call->setCallingConv(CallingConv::SPIR_FUNC);
+    return true;
   }
-
-  return Changed;
+  return false;
 }

--- a/lib/SplatArgPass.cpp
+++ b/lib/SplatArgPass.cpp
@@ -161,7 +161,7 @@ bool SplatArgPass::runOnModule(Module &M) {
       case Builtins::kMin:
       case Builtins::kFmin: {
         auto &param_info = func_info.getParameter(0);
-        uint vec_size = param_info.vector_size;
+        uint32_t vec_size = param_info.vector_size;
         bool last_is_scalar = func_info.getLastParameter().vector_size == 0;
         if (vec_size != 0 && last_is_scalar) {
           std::string NewFName =


### PR DESCRIPTION
* Updated usage in SPIRVProducer, replaced StringSwitch
* Converted SplatArgPass, programmatically generate new function call based on FunctionInfo
* Converted all ReplaceOpenCLBuiltinPass
  * Iterate once over Module->getFunctionList(), switch on FunctionInfo type
  * Changed all replace methods to create a Replacer lambda
* Links to #510