### PR TITLE
Use unified1 version of spirv

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 set(CLSPV_GENERATED_INCLUDES_DIR ${CLSPV_BINARY_DIR}/include/clspv)
 
-set(SPIRV_C_STRINGS_INPUT_FILE ${SPIRV_HEADERS_SOURCE_DIR}/include/spirv/1.0/spirv.hpp)
+set(SPIRV_C_STRINGS_INPUT_FILE ${SPIRV_HEADERS_SOURCE_DIR}/include/spirv/unified1/spirv.hpp)
 set(SPIRV_C_STRINGS_OUTPUT_FILE ${CLSPV_GENERATED_INCLUDES_DIR}/spirv_c_strings.hpp)
 set(SPIRV_C_STRINGS_NAMESPACE spv)
 set(SPIRV_C_STRINGS_PYTHON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spirv_c_strings.py)
@@ -71,7 +71,7 @@ add_custom_target(clspv_baked_opencl_header
   DEPENDS ${STRIP_BANNED_OPENCL_FEATURES_OUTPUT_FILE} ${BAKE_FILE_OUTPUT_FILE}
 )
 
-set(SPIRV_GLSL_INPUT_FILE ${SPIRV_HEADERS_SOURCE_DIR}/include/spirv/1.0/extinst.glsl.std.450.grammar.json)
+set(SPIRV_GLSL_INPUT_FILE ${SPIRV_HEADERS_SOURCE_DIR}/include/spirv/unified1/extinst.glsl.std.450.grammar.json)
 set(SPIRV_GLSL_OUTPUT_FILE ${CLSPV_GENERATED_INCLUDES_DIR}/spirv_glsl.hpp)
 set(SSPIRV_GLSL_PYTHON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spirv_glsl.py)
 

--- a/cmake/spirv_c_strings.py
+++ b/cmake/spirv_c_strings.py
@@ -130,7 +130,7 @@ def main():
         header_blocker = re.sub("[^A-Z]", "_", header_blocker)
         output.write("#ifndef %s\n" % header_blocker)
         output.write("#define %s\n" % header_blocker)
-        output.write("#include \"spirv/1.0/spirv.hpp\"\n")
+        output.write("#include \"spirv/unified1/spirv.hpp\"\n")
         output.write("namespace %s{\n" % args.namespace)
         for line in content:
             output.write(line)

--- a/cmake/spirv_c_strings.py
+++ b/cmake/spirv_c_strings.py
@@ -80,14 +80,26 @@ def main():
     args = parser.parse_args()
 
     lines = list()
+    seen = dict()
+    enum_re = re.compile("[a-zA-Z][a-zA-Z0-9_]+ = ([0-9][0-9a-fA-Fx]*),");
     with open(args.input_file, "r") as input:
         for line in input:
+            # Special cases for 16-bit storage capabilities.
             if line.find("CapabilityStorageUniformBufferBlock16 = 4433") != -1:
                 continue
             if line.find("CapabilityStorageUniform16 = 4434") != -1:
                 continue
-            if line.find("CapabilityShaderViewportIndexLayerNV = 5254") != -1:
-                continue
+
+            # Otherwise, do not add aliases.
+            match = re.search(enum_re, line)
+            if match is not None:
+                num = match.group(1)
+                if num not in seen:
+                    seen[num] = 1
+                else:
+                    continue
+            else:
+                seen.clear()
             lines.append(line)
 
     content = list()

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "Passes.h"
 

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -27,7 +27,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"

--- a/lib/SPIRVOp.h
+++ b/lib/SPIRVOp.h
@@ -18,7 +18,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 namespace clspv {
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -43,7 +43,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#include "spirv/1.0/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 
 #include "clspv/AddressSpace.h"
 #include "clspv/DescriptorMap.h"
@@ -754,9 +754,9 @@ bool SPIRVProducerPass::runOnModule(Module &module) {
 void SPIRVProducerPass::outputHeader() {
   binaryOut->write(reinterpret_cast<const char *>(&spv::MagicNumber),
                    sizeof(spv::MagicNumber));
-
-  const uint32_t version = spv::Version; // SPIR-V 1.0
-  binaryOut->write(reinterpret_cast<const char *>(&version), sizeof(version));
+  const uint32_t spv_version = 0x10000; // SPIR-V 1.0
+  binaryOut->write(reinterpret_cast<const char *>(&spv_version),
+                   sizeof(spv_version));
 
   // use Google's vendor ID
   const uint32_t vendor = 21 << 16;


### PR DESCRIPTION
* Output always targets SPIR-V 1.0
* Fix cmake auto-generated files to also use unified1 version
  * generally avoid duplicate enum values in spirv_c_strings.py

Supercedes #421 