### PR TITLE
Fix VariablePointer capability generation

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -75,8 +75,9 @@ namespace {
 cl::opt<bool> ShowResourceVars("show-rv", cl::init(false), cl::Hidden,
                                cl::desc("Show resource variable creation"));
 
-cl::opt<bool> ShowProducerIR("show-producer-ir", cl::init(false), cl::ReallyHidden,
-                             cl::desc("Dump the IR at the start of SPIRVProducer"));
+cl::opt<bool>
+    ShowProducerIR("show-producer-ir", cl::init(false), cl::ReallyHidden,
+                   cl::desc("Dump the IR at the start of SPIRVProducer"));
 
 // These hacks exist to help transition code generation algorithms
 // without making huge noise in detailed test output.

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -75,6 +75,9 @@ namespace {
 cl::opt<bool> ShowResourceVars("show-rv", cl::init(false), cl::Hidden,
                                cl::desc("Show resource variable creation"));
 
+cl::opt<bool> ShowProducerIR("show-producer-ir", cl::init(false), cl::ReallyHidden,
+                             cl::desc("Dump the IR at the start of SPIRVProducer"));
+
 // These hacks exist to help transition code generation algorithms
 // without making huge noise in detailed test output.
 const bool Hack_generate_runtime_array_stride_early = true;
@@ -635,6 +638,9 @@ ModulePass *createSPIRVProducerPass(
 } // namespace clspv
 
 bool SPIRVProducerPass::runOnModule(Module &module) {
+  if (ShowProducerIR) {
+    llvm::outs() << module << "\n";
+  }
   binaryOut = outputCInitList ? &binaryTempOut : &out;
 
   PopulateUBOTypeMaps(module);
@@ -5404,7 +5410,8 @@ void SPIRVProducerPass::HandleDeferredInstruction() {
                              new SPIRVInstruction(spv::OpBranch, Ops));
       }
     } else if (PHINode *PHI = dyn_cast<PHINode>(Inst)) {
-      if (PHI->getType()->isPointerTy()) {
+      if (PHI->getType()->isPointerTy() && !IsSamplerType(PHI->getType()) &&
+          !IsImageType(PHI->getType())) {
         // OpPhi on pointers requires variable pointers.
         setVariablePointersCapabilities(
             PHI->getType()->getPointerAddressSpace());

--- a/test/VariablePointers/sampler.cl
+++ b/test/VariablePointers/sampler.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-NOT: OpCapability VariablePointers
+// CHECK-NOT: OpExtension "SPV_KHR_variable_pointers"
+
+const sampler_t sampler =
+  CLK_NORMALIZED_COORDS_FALSE | \
+  CLK_ADDRESS_CLAMP_TO_EDGE |
+  CLK_FILTER_NEAREST;
+
+kernel void foo(read_only image2d_t im1, read_only image2d_t im2)
+{
+  for (int l = 0; l < 30; ++l) {
+    float4 s = read_imagef(im1, sampler, (int2)(0,0));
+  }
+
+  float4 w = read_imagef(im2, sampler, (int2)(0, 0));
+}
+


### PR DESCRIPTION
* Don't add variable pointer capabilities due to phis of images and
samplers
  * TODO: never generate those anyways
* Add an option to dump IR before SPIRVProducerPass