### PR TITLE
Add attributes to functions pass

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,7 +14,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "branch" : "master",
       "subdir" : "third_party/SPIRV-Headers",
-      "commit" : "30ef660ce2e666f7ae925598b8a267f4da6d33aa"
+      "commit" : "f8bf11a0253a32375c32cad92c841237b96696c0"
     },
     {
       "name" : "SPIRV-Tools",
@@ -22,7 +22,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "branch" : "master",
       "subdir" : "third_party/SPIRV-Tools",
-      "commit" : "1fe9bcc10824c1fa35bd9b697188340132d39213"
+      "commit" : "1346dd5de119d603686e260daf08f36958909a23"
     }
   ]
 }

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -397,4 +397,8 @@ llvm::ModulePass *createSpecializeImageTypesPass();
 /// * Add a block to split a continue block used a merge block.
 llvm::FunctionPass *createFixupStructuredCFGPass();
 
+/// Adds attributes to intrinsic and builtin functions to produce a better
+/// optimization outcome.
+llvm::ModulePass *createAddFunctionAttributesPass();
+
 } // namespace clspv

--- a/lib/AddFunctionAttributesPass.cpp
+++ b/lib/AddFunctionAttributesPass.cpp
@@ -1,0 +1,58 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+#include "Constants.h"
+#include "Passes.h"
+
+#define DEBUG_TYPE "addfunctionattributes"
+
+using namespace llvm;
+
+namespace {
+class AddFunctionAttributesPass : public ModulePass {
+public:
+  static char ID;
+  AddFunctionAttributesPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+};
+}
+
+char AddFunctionAttributesPass::ID = 0;
+INITIALIZE_PASS(AddFunctionAttributesPass, "AddFunctionAttributes",
+                "Add function attributes to builtin functions", false, false)
+
+namespace clspv {
+ModulePass *createAddFunctionAttributesPass() {
+  return new AddFunctionAttributesPass();
+}
+}
+
+bool AddFunctionAttributesPass::runOnModule(Module &M) {
+  bool changed = false;
+
+  // Add ReadNone and Speculatable to literal sampler functions to avoid loop
+  // optimizations producing phis with them.
+  if (auto F = M.getFunction(clspv::TranslateSamplerInitializerFunction())) {
+    F->addFnAttr(Attribute::AttrKind::ReadNone);
+    F->addFnAttr(Attribute::AttrKind::Speculatable);
+    changed = true;
+  }
+
+  return changed;
+}

--- a/lib/AddFunctionAttributesPass.cpp
+++ b/lib/AddFunctionAttributesPass.cpp
@@ -31,7 +31,7 @@ public:
 
   bool runOnModule(Module &M) override;
 };
-}
+} // namespace
 
 char AddFunctionAttributesPass::ID = 0;
 INITIALIZE_PASS(AddFunctionAttributesPass, "AddFunctionAttributes",
@@ -41,7 +41,7 @@ namespace clspv {
 ModulePass *createAddFunctionAttributesPass() {
   return new AddFunctionAttributesPass();
 }
-}
+} // namespace clspv
 
 bool AddFunctionAttributesPass::runOnModule(Module &M) {
   bool changed = false;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(clspv_core
 # defined here.  This must be loadable by LLVM opt for testing individual
 # passes.
 add_library(clspv_passes
+  ${CMAKE_CURRENT_SOURCE_DIR}/AddFunctionAttributesPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/AllocateDescriptorsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Builtins.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -609,6 +609,7 @@ int PopulatePassManager(
   }
 
   pm->add(clspv::createZeroInitializeAllocasPass());
+  pm->add(clspv::createAddFunctionAttributesPass());
   pm->add(clspv::createDeclarePushConstantsPass());
   pm->add(clspv::createDefineOpenCLWorkItemBuiltinsPass());
 

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -17,6 +17,7 @@
 namespace llvm {
 
 void initializeClspvPasses(PassRegistry &r) {
+  initializeAddFunctionAttributesPassPass(r);
   initializeAllocateDescriptorsPassPass(r);
   initializeClusterModuleScopeConstantVarsPass(r);
   initializeClusterPodKernelArgumentsPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -20,6 +20,7 @@ class PassRegistry;
 
 // Individual pass initializers.  See the documentation for
 // initializeClspvPasses() in include/clspv/Passes.h.
+void initializeAddFunctionAttributesPassPass(PassRegistry &);
 void initializeAllocateDescriptorsPassPass(PassRegistry &);
 void initializeClusterModuleScopeConstantVarsPass(PassRegistry &);
 void initializeClusterPodKernelArgumentsPassPass(PassRegistry &);

--- a/test/AddFunctionAttributes/no_sampler_phi.cl
+++ b/test/AddFunctionAttributes/no_sampler_phi.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]]
+// CHECK-NOT: OpPhi [[sampler]]
+
+const sampler_t sampler =
+  CLK_NORMALIZED_COORDS_FALSE | \
+  CLK_ADDRESS_CLAMP_TO_EDGE |
+  CLK_FILTER_NEAREST;
+
+kernel void foo(read_only image2d_t im1, read_only image2d_t im2)
+{
+  for (int l = 0; l < 30; ++l) {
+    float4 s = read_imagef(im1, sampler, (int2)(0,0));
+  }
+
+  float4 w = read_imagef(im2, sampler, (int2)(0, 0));
+}
+

--- a/test/AddFunctionAttributes/translate_literal_sampler.ll
+++ b/test/AddFunctionAttributes/translate_literal_sampler.ll
@@ -1,0 +1,13 @@
+; RUN: clspv-opt -AddFunctionAttributes %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32) [[ATTR:#[0-9]+]]
+; CHECK: attributes [[ATTR]] = { readnone speculatable }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.sampler_t = type opaque
+
+declare %opencl.sampler_t addrspace(2)* @__translate_sampler_initializer(i32)
+


### PR DESCRIPTION
Fixes #538

* Add a new pass early in the flow to add function attributes as
necessary
  * Currently adds readnone and speculatable to
  __translate_sampler_initializer to prevent later optimizations from
  creating phis of samplers
  * add tests
* update spirv headers and tools