### PR TITLE
POD arguments in push constants

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -304,7 +304,7 @@ implementation limit for push constants. This is validated at the start of the c
 Note: Module scope push constanst are currently incompatible with plain-old-data
 arguments sent as push constants.
 
-TODO(alan-baker): fix this.
+TODO(alan-baker): See #529 for the overall plan to address this.
 
 The descriptor map entry for kernel arguments will not contain `descriptorSet` or
 `binding` entries. For example, an integer arg `f` to kernel `foo` might look like:

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -92,11 +92,17 @@ following way:
   types, set `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
 - If the argument to the kernel is a plain-old-data type, the matching Vulkan
   descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER` by default.
-  If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
+  If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`. If the
+  option `-pod-pushconstant` is used the arg is instead passed via push
+  constants.
+
+Note: `-pod-ubo` and `-pod-pushconstant` are exclusive options.
 
 Note: If `-cluster-pod-kernel-args` is used, then all plain-old-data kernel
 arguments are collected into a single structure to be passed in to the compute
 shader as a single storage buffer resource.
+
+Note: `-pod-pushconstant` requires `-cluster-pod-kernel-args` to be specified.
 
 ## OpenCL C Modifications
 
@@ -211,6 +217,7 @@ plain-old-data types, the fields are:
   - `buffer_ubo` - OpenCL constant buffer. Sent in a uniform buffer.
   - `pod` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a storage buffer.
   - `pod_ubo` - Plain Old Data, e.g. a scalar, vector, or structure. Sent in a uniform buffer.
+  - `pod_pushconstant` - Plain Old Data, e.g. a scalar, vector or structure. Sent in push constants.
   - `ro_image` - Read-only image
   - `wo_image` - Write-only image
   - `sampler` - Sampler
@@ -279,7 +286,25 @@ be faster to read in the shader.
 When option `-pod-ubo` is used, the descriptor map list the `argKind` of a plain-old-data
 argument as `pod_ubo` rather than the default of `pod`.
 
-TODO(dneto):  A push-constant might even be faster, but space is very limited.
+#### Sending in plain-old-data kernel arguments in push constants
+
+Normally plain-old-data arguments are passed into the kernel via a storage buffer.
+Use the option `-pod-pushconstant` to pass these parameters in via push constants. The
+option `-cluster-pod-kernel-args` must also be specified. Push constants are intended
+to provide a fast read path and should be faster to access than a buffer.
+
+When the option `-pod-pushconstant` is used, the descriptor map lists the `argKind` of
+plain-old-data arguments as `pod_pushconstant` rather than the default of `pod`. There
+is no `descriptorset` or `binding` information for push constants.
+
+Note: Vulkan implementations have limited push constant storage (default is 128B).
+clspv provides the option `-max-pushconstant-size` to specify (in bytes) the
+implementation limit for push constants. This is validated at the start of the compile.
+
+Note: Module scope push constanst are currently incompatible with plain-old-data
+arguments sent as push constants.
+
+TODO(alan-baker): fix this.
 
 #### Sending in pointer-to-constant kernel arguments in uniform buffers
 
@@ -425,7 +450,7 @@ Take a closer look at the hexadecimal bytes in the example. They are:
 - `0000c03f`: the float value 1.5
 - `000000000000000000000000`: 12 zero bytes representing the zero-initialized third Foo value.
 
-#### Push constants
+#### Module Scope Push constants
 
 Some features, when enabled, require values to be passed by the application via
 push constants. For each value requested by clspv, an entry will be present in

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -306,6 +306,11 @@ arguments sent as push constants.
 
 TODO(alan-baker): fix this.
 
+The descriptor map entry for kernel arguments will not contain `descriptorSet` or
+`binding` entries. For example, an integer arg `f` to kernel `foo` might look like:
+
+  kernel,foo,arg,f,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+
 #### Sending in pointer-to-constant kernel arguments in uniform buffers
 
 Normally pointer-to-constant kernel arguments are passed into the kernel via a storage

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -92,8 +92,8 @@ following way:
   types, set `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
 - If the argument to the kernel is a plain-old-data type, the matching Vulkan
   descriptor set type is `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER` by default.
-  If option `-pod-ubo` is used the `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`. If the
-  option `-pod-pushconstant` is used the arg is instead passed via push
+  If the option `-pod-ubo` is used the descriptor set type is`VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER`.
+  If the option `-pod-pushconstant` is used the arg is instead passed via push
   constants.
 
 Note: `-pod-ubo` and `-pod-pushconstant` are exclusive options.

--- a/include/clspv/ArgKind.h
+++ b/include/clspv/ArgKind.h
@@ -25,6 +25,7 @@ enum class ArgKind : int {
   Local,
   Pod,
   PodUBO,
+  PodPushConstant,
   ReadOnlyImage,
   WriteOnlyImage,
   Sampler,

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -81,7 +81,8 @@ bool PodArgsInUniformBuffer();
 // constant interface.
 bool PodArgsInPushConstants();
 
-// Returns true if POD kernel arguments should be clustered into a single interface.
+// Returns true if POD kernel arguments should be clustered into a single
+// interface.
 bool ClusterPodKernelArgs();
 
 // Returns true if SPIR-V IDs for functions should be emitted to stderr during

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -77,6 +77,13 @@ bool ModuleConstantsInStorageBuffer();
 // Returns true if POD kernel arguments should be passed in via uniform buffers.
 bool PodArgsInUniformBuffer();
 
+// Returns true if POD kernel arguments should be passed in via the push
+// constant interface.
+bool PodArgsInPushConstants();
+
+// Returns true if POD kernel arguments should be clustered into a single interface.
+bool ClusterPodKernelArgs();
+
 // Returns true if SPIR-V IDs for functions should be emitted to stderr during
 // code generation.
 bool ShowIDs();
@@ -94,6 +101,11 @@ bool ConstantArgsInUniformBuffer();
 // calculate the size of UBO arrays for constant arguments if
 // ConstantArgsInUniformBuffer returns true.
 uint64_t MaxUniformBufferSize();
+
+// Returns the maximum push constant interface size. This size is specified in
+// bytes and is used to validate the the size of the POD kernel interface
+// passed as push constants.
+uint32_t MaxPushConstantsSize();
 
 // Returns true if clspv should allow UBOs that do not satisfy the restriction
 // that ArrayStride is a multiple of array alignment.

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -77,6 +77,8 @@ const char *GetArgKindName(ArgKind kind) {
     return "pod";
   case ArgKind::PodUBO:
     return "pod_ubo";
+  case ArgKind::PodPushConstant:
+    return "pod_pushconstant";
   case ArgKind::ReadOnlyImage:
     return "ro_image";
   case ArgKind::WriteOnlyImage:
@@ -100,6 +102,8 @@ ArgKind GetArgKindFromName(const std::string &name) {
     return ArgKind::Pod;
   } else if (name == "pod_ubo") {
     return ArgKind::PodUBO;
+  } else if (name == "pod_pushconstant") {
+    return ArgKind::PodPushConstant;
   } else if (name == "ro_image") {
     return ArgKind::ReadOnlyImage;
   } else if (name == "wo_image") {

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -58,7 +58,12 @@ ArgKind GetArgKindForType(Type *type) {
       break;
     }
   } else {
-    return ArgKind::Pod;
+    if (clspv::Option::PodArgsInUniformBuffer())
+      return ArgKind::PodUBO;
+    else if (clspv::Option::PodArgsInPushConstants())
+      return ArgKind::PodPushConstant;
+    else
+      return ArgKind::Pod;
   }
   errs() << "Unhandled case in clspv::GetArgKindNameForType: " << *type << "\n";
   llvm_unreachable("Unhandled case in clspv::GetArgKindNameForType");

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -297,12 +297,6 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
         auto *arg_size_md =
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.arg_size));
         auto argKindName = GetArgKindName(arg_mapping.arg_kind);
-        if (arg_mapping.arg_kind == clspv::ArgKind::Pod) {
-          if (clspv::Option::PodArgsInUniformBuffer())
-            argKindName = GetArgKindName(clspv::ArgKind::PodUBO);
-          else if (clspv::Option::PodArgsInPushConstants())
-            argKindName = GetArgKindName(clspv::ArgKind::PodPushConstant);
-        }
         auto *argtype_md = MDString::get(Context, argKindName);
         auto *spec_id_md =
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.spec_id));

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -240,7 +240,8 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
     // Then attributes for non-POD parameters
     for (auto &rinfo : RemapInfo) {
       bool argIsPod = rinfo.arg_kind == clspv::ArgKind::Pod ||
-                      rinfo.arg_kind == clspv::ArgKind::PodUBO;
+                      rinfo.arg_kind == clspv::ArgKind::PodUBO ||
+                      rinfo.arg_kind == clspv::ArgKind::PodPushConstant;
       if (!argIsPod && Attributes.hasParamAttrs(rinfo.old_index)) {
         auto idx = rinfo.new_index + AttributeList::FirstArgIndex;
         auto attrs = Attributes.getParamAttributes(rinfo.old_index);
@@ -296,6 +297,12 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
         auto *arg_size_md =
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.arg_size));
         auto argKindName = GetArgKindName(arg_mapping.arg_kind);
+        if (arg_mapping.arg_kind == clspv::ArgKind::Pod) {
+          if (clspv::Option::PodArgsInUniformBuffer())
+            argKindName = GetArgKindName(clspv::ArgKind::PodUBO);
+          else if (clspv::Option::PodArgsInPushConstants())
+            argKindName = GetArgKindName(clspv::ArgKind::PodPushConstant);
+        }
         auto *argtype_md = MDString::get(Context, argKindName);
         auto *spec_id_md =
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.spec_id));

--- a/lib/DescriptorMap.cpp
+++ b/lib/DescriptorMap.cpp
@@ -106,9 +106,9 @@ std::ostream &operator<<(std::ostream &str, const DescriptorMapEntry &entry) {
           << ",arrayElemSize," << kernel_data.local_element_size
           << ",arrayNumElemSpecId," << kernel_data.local_spec_id;
     } else if (kernel_data.arg_kind == ArgKind::PodPushConstant) {
-      str << ",offset," << kernel_data.pod_offset
-          << ",argKind," << GetArgKindName(kernel_data.arg_kind)
-          << ",argSize," << kernel_data.pod_arg_size;
+      str << ",offset," << kernel_data.pod_offset << ",argKind,"
+          << GetArgKindName(kernel_data.arg_kind) << ",argSize,"
+          << kernel_data.pod_arg_size;
     } else {
       str << ",descriptorSet," << entry.descriptor_set << ",binding,"
           << entry.binding << ",offset,";

--- a/lib/DescriptorMap.cpp
+++ b/lib/DescriptorMap.cpp
@@ -105,6 +105,10 @@ std::ostream &operator<<(std::ostream &str, const DescriptorMapEntry &entry) {
       str << ",argKind," << GetArgKindName(kernel_data.arg_kind)
           << ",arrayElemSize," << kernel_data.local_element_size
           << ",arrayNumElemSpecId," << kernel_data.local_spec_id;
+    } else if (kernel_data.arg_kind == ArgKind::PodPushConstant) {
+      str << ",offset," << kernel_data.pod_offset
+          << ",argKind," << GetArgKindName(kernel_data.arg_kind)
+          << ",argSize," << kernel_data.pod_arg_size;
     } else {
       str << ",descriptorSet," << entry.descriptor_set << ",binding,"
           << entry.binding << ",offset,";

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -580,9 +580,10 @@ public:
                 }
                 FieldDecl *field_decl = FieldDecl::Create(
                     FD->getASTContext(),
-                    Decl::castToDeclContext(clustered_args), P->getSourceRange().getBegin(),
-                    P->getSourceRange().getEnd(), P->getIdentifier(), P->getType(), nullptr,
-                    nullptr, false, ICIS_NoInit);
+                    Decl::castToDeclContext(clustered_args),
+                    P->getSourceRange().getBegin(),
+                    P->getSourceRange().getEnd(), P->getIdentifier(),
+                    P->getType(), nullptr, nullptr, false, ICIS_NoInit);
                 field_decl->setAccess(AS_public);
                 clustered_args->addDecl(field_decl);
               } else {
@@ -603,7 +604,8 @@ public:
           if (clustered_args) {
             clustered_args->completeDefinition();
             if (!clustered_args->field_empty()) {
-              auto record_type = FD->getASTContext().getRecordType(clustered_args);
+              auto record_type =
+                  FD->getASTContext().getRecordType(clustered_args);
               if (!IsSupportedLayout(record_type, 0, SSBO, FD->getASTContext(),
                                      FD->getSourceRange(),
                                      FD->getSourceRange())) {

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -112,6 +112,11 @@ llvm::cl::opt<bool>
     pod_ubo("pod-ubo", llvm::cl::init(false),
             llvm::cl::desc("POD kernel arguments are in uniform buffers"));
 
+llvm::cl::opt<bool> pod_pushconstant(
+    "pod-pushconstant",
+    llvm::cl::desc("POD kernel arguments are in the push constant interface"),
+    llvm::cl::init(false));
+
 llvm::cl::opt<bool> module_constants_in_storage_buffer(
     "module-constants-in-storage-buffer", llvm::cl::init(false),
     llvm::cl::desc(
@@ -130,6 +135,11 @@ llvm::cl::opt<bool> constant_args_in_uniform_buffer(
 llvm::cl::opt<int> maximum_ubo_size(
     "max-ubo-size", llvm::cl::init(64 << 10),
     llvm::cl::desc("Specify the maximum UBO array size in bytes."));
+
+llvm::cl::opt<int> maximum_pushconstant_size(
+    "max-pushconstant-size", llvm::cl::init(128),
+    llvm::cl::desc(
+        "Specify the maximum push constant interface size in bytes."));
 
 llvm::cl::opt<bool> relaxed_ubo_layout(
     "relaxed-ubo-layout",
@@ -181,6 +191,14 @@ static llvm::cl::opt<bool>
                   llvm::cl::desc("Enable support for global offsets"));
 
 static bool use_sampler_map = false;
+
+static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
+    "cluster-pod-kernel-args", llvm::cl::init(false),
+    llvm::cl::desc("Collect plain-old-data kernel arguments into a struct in "
+                   "a single storage buffer, using a binding number after "
+                   "other arguments. Use this to reduce storage buffer "
+                   "descriptors."));
+
 } // namespace
 
 namespace clspv {
@@ -205,9 +223,11 @@ bool ModuleConstantsInStorageBuffer() {
   return module_constants_in_storage_buffer;
 }
 bool PodArgsInUniformBuffer() { return pod_ubo; }
+bool PodArgsInPushConstants() { return pod_pushconstant; }
 bool ShowIDs() { return show_ids; }
 bool ConstantArgsInUniformBuffer() { return constant_args_in_uniform_buffer; }
 uint64_t MaxUniformBufferSize() { return maximum_ubo_size; }
+uint32_t MaxPushConstantSize() { return maximum_pushconstant_size; }
 bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
 bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 bool KeepUnusedArguments() { return keep_unused_arguments; }
@@ -219,6 +239,7 @@ SourceLanguage Language() { return cl_std; }
 bool ScalarBlockLayout() { return scalar_block_layout; }
 bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
+bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -227,7 +227,7 @@ bool PodArgsInPushConstants() { return pod_pushconstant; }
 bool ShowIDs() { return show_ids; }
 bool ConstantArgsInUniformBuffer() { return constant_args_in_uniform_buffer; }
 uint64_t MaxUniformBufferSize() { return maximum_ubo_size; }
-uint32_t MaxPushConstantSize() { return maximum_pushconstant_size; }
+uint32_t MaxPushConstantsSize() { return maximum_pushconstant_size; }
 bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
 bool Std430UniformBufferLayout() { return std430_ubo_layout; }
 bool KeepUnusedArguments() { return keep_unused_arguments; }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1871,12 +1871,7 @@ SPIRVProducerPass::GetStorageClassForArgKind(clspv::ArgKind arg_kind) const {
   case clspv::ArgKind::BufferUBO:
     return spv::StorageClassUniform;
   case clspv::ArgKind::Pod:
-    if (clspv::Option::PodArgsInUniformBuffer())
-      return spv::StorageClassUniform;
-    else if (clspv::Option::PodArgsInPushConstants())
-      return spv::StorageClassPushConstant;
-    else
-      return spv::StorageClassStorageBuffer;
+    return spv::StorageClassStorageBuffer;
   case clspv::ArgKind::PodUBO:
     return spv::StorageClassUniform;
   case clspv::ArgKind::PodPushConstant:

--- a/test/PushConstant/arrays.cl
+++ b/test/PushConstant/arrays.cl
@@ -1,0 +1,7 @@
+// RUN: clspv %s -verify -cluster-pod-kernel-args -pod-pushconstant -w
+
+struct A {
+  int a[4];
+};
+
+kernel void foo(struct A a) {} //expected-error{{arrays are not supported in push constants currently}}

--- a/test/PushConstant/max_size_execeed_cluster.cl
+++ b/test/PushConstant/max_size_execeed_cluster.cl
@@ -1,0 +1,3 @@
+// RUN: clspv %s -verify -pod-pushconstant -cluster-pod-kernel-args -max-pushconstant-size=24 -w
+
+kernel void foo(int a, int4 b) {} //expected-error{{max push constant size exceeded}}

--- a/test/PushConstant/max_size_exeeded.cl
+++ b/test/PushConstant/max_size_exeeded.cl
@@ -1,0 +1,3 @@
+// RUN: clspv %s -verify -pod-pushconstant -cluster-pod-kernel-args -max-pushconstant-size=8 -w
+
+kernel void foo(global int* data, int4 pod) { } //expected-error{{max push constant size exceeded}}

--- a/test/PushConstant/two_ints.cl
+++ b/test/PushConstant/two_ints.cl
@@ -1,0 +1,30 @@
+// RUN: clspv %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpDecorate {{.*}} Block
+// CHECK: OpMemberDecorate [[cluster:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[cluster]] 1 Offset 4
+// CHECK: OpMemberDecorate [[block:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[block]] Block
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[cluster]] = OpTypeStruct [[int]] [[int]]
+// CHECK-DAG: [[block]] = OpTypeStruct [[cluster]]
+// CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[block]]
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[ptr]] PushConstant
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: OpIAdd [[int]] [[x]] [[y]]
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,x,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,foo,arg,y,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+
+kernel void foo(global int* out, int x, int y) {
+  *out = x + y;
+}

--- a/test/PushConstant/two_kernels_different_pc.cl
+++ b/test/PushConstant/two_kernels_different_pc.cl
@@ -18,7 +18,7 @@
 //      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,x,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NEXT: kernel,foo,arg,y,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
-// MAP-NEXT: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+//      MAP: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,bar,arg,a,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NEXT: kernel,bar,arg,b,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
 

--- a/test/PushConstant/two_kernels_different_pc.cl
+++ b/test/PushConstant/two_kernels_different_pc.cl
@@ -1,0 +1,31 @@
+// RUN: clspv %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[foo_cluster:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int]] [[int]]
+// CHECK-DAG: [[foo_block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[foo_cluster]]
+// CHECK-DAG: [[foo_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[foo_block]]
+// CHECK-DAG: [[foo_var:%[a-zA-Z0-9_]+]] = OpVariable [[foo_ptr]] PushConstant
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[bar_cluster:%[a-zA-Z0-9_]+]] = OpTypeStruct [[float]] [[float]]
+// CHECK-DAG: [[bar_block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[bar_cluster]]
+// CHECK-DAG: [[bar_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[bar_block]]
+// CHECK-DAG: [[bar_var:%[a-zA-Z0-9_]+]] = OpVariable [[bar_ptr]] PushConstant
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,x,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,foo,arg,y,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,bar,arg,a,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,bar,arg,b,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+
+kernel void foo(global int* out, int x, int y) {
+  *out = x + y;
+}
+
+kernel void bar(global float *out, float a, float b) {
+  *out = a + b;
+}

--- a/test/PushConstant/two_kernels_share_pc.cl
+++ b/test/PushConstant/two_kernels_share_pc.cl
@@ -1,0 +1,43 @@
+// RUN: clspv %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpDecorate {{.*}} Block
+// CHECK: OpMemberDecorate [[cluster:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[cluster]] 1 Offset 4
+// CHECK: OpMemberDecorate [[block:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpDecorate [[block]] Block
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[cluster]] = OpTypeStruct [[int]] [[int]]
+// CHECK-DAG: [[block]] = OpTypeStruct [[cluster]]
+// CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[block]]
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[ptr]] PushConstant
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: OpIAdd [[int]] [[x]] [[y]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: OpIAdd [[int]] [[x]] [[y]]
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,x,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,foo,arg,y,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,bar,arg,a,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,bar,arg,b,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+
+kernel void foo(global int* out, int x, int y) {
+  *out = x + y;
+}
+
+kernel void bar(global int* out, int a, int b) {
+  *out = a + b;
+}
+

--- a/test/PushConstant/two_kernels_share_pc.cl
+++ b/test/PushConstant/two_kernels_share_pc.cl
@@ -29,7 +29,7 @@
 //      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,x,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NEXT: kernel,foo,arg,y,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
-// MAP-NEXT: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+//      MAP: kernel,bar,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,bar,arg,a,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NEXT: kernel,bar,arg,b,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
 


### PR DESCRIPTION
Contributes to #529 

Support passing POD arguments via push constants.

New options:
* -pod-pushconstant: instruct the compiler to pass pod args in push constants
  * requires clustered pod args 
  * cannot be used with module scope push constants
  * cannot be used with ubo pod args
  * does not support arrays currently
* -max-pushconstant-size: specify the max size of push constants
  * verified in the frontend
  * default to Vulkan minimum of 128B

Changes:
* updated docs
*  cluster pod kernel args now records pod arg kinds correctly
  * simplified uses throughout the flow since it is more reliable now
*  allocate descriptors can allocate push constant pods