### PR TITLE
Report all kernels in the descriptor map

### DIFF
--- a/include/clspv/DescriptorMap.h
+++ b/include/clspv/DescriptorMap.h
@@ -50,7 +50,7 @@ const unsigned kSamplerFilterMask = 0x30;
 
 struct DescriptorMapEntry {
   // Type of the entry.
-  enum Kind { Sampler, KernelArg, Constant, PushConstant } kind;
+  enum Kind { Sampler, KernelArg, KernelDecl, Constant, PushConstant } kind;
 
   // Common data.
   uint32_t descriptor_set;
@@ -75,6 +75,10 @@ struct DescriptorMapEntry {
     uint32_t pod_arg_size;
   } kernel_arg_data;
 
+  struct KernelDeclData {
+    std::string kernel_name;
+  } kernel_decl_data;
+
   struct ConstantData {
     ArgKind constant_kind;
     std::string hex_bytes;
@@ -97,6 +101,10 @@ struct DescriptorMapEntry {
   DescriptorMapEntry(KernelArgData &&data, uint32_t ds, uint32_t b)
       : kind(KernelArg), descriptor_set(ds), binding(b),
         kernel_arg_data(std::move(data)) {}
+
+  DescriptorMapEntry(KernelDeclData &&data)
+      : kind(KernelDecl), descriptor_set(-1), binding(-1),
+        kernel_decl_data(std::move(data)) {}
 
   DescriptorMapEntry(SamplerData &&data, uint32_t ds, uint32_t b)
       : kind(Sampler), descriptor_set(ds), binding(b),

--- a/lib/DescriptorMap.cpp
+++ b/lib/DescriptorMap.cpp
@@ -31,6 +31,9 @@ std::ostream &operator<<(std::ostream &str,
   case DescriptorMapEntry::Kind::KernelArg:
     str << "kernel";
     break;
+  case DescriptorMapEntry::Kind::KernelDecl:
+    str << "kernel_decl";
+    break;
   case DescriptorMapEntry::Kind::Constant:
     str << "constant";
     break;
@@ -117,6 +120,11 @@ std::ostream &operator<<(std::ostream &str, const DescriptorMapEntry &entry) {
         str << ",argSize," << kernel_data.pod_arg_size;
       }
     }
+    break;
+  }
+  case DescriptorMapEntry::Kind::KernelDecl: {
+    const auto &kernel_data = entry.kernel_decl_data;
+    str << kernel_data.kernel_name;
     break;
   }
   case DescriptorMapEntry::Kind::Constant: {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3369,6 +3369,11 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(const DataLayout &DL,
   if (F.getCallingConv() != CallingConv::SPIR_KERNEL) {
     return;
   }
+  // Add entries for each kernel
+  version0::DescriptorMapEntry::KernelDeclData kernel_decl_data = {
+      F.getName().str()};
+  descriptorMapEntries->emplace_back(std::move(kernel_decl_data));
+
   // Gather the list of resources that are used by this function's arguments.
   auto &resource_var_at_index = FunctionToResourceVarsMap[&F];
 

--- a/test/DirectResourceAccess/common_global_into_helper.cl
+++ b/test/DirectResourceAccess/common_global_into_helper.cl
@@ -5,9 +5,9 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 //      MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
-// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+//      MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+//      MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+//      MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 // MAP-NONE: kernel
 
 float core(global float *arr, int n) {

--- a/test/ImageBuiltins/unsampled_read_image_descriptor_map.cl
+++ b/test/ImageBuiltins/unsampled_read_image_descriptor_map.cl
@@ -2,19 +2,19 @@
 // RUN: FileCheck %s < %t.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-//  CHECK-NOT: sampler
-//      CHECK: kernel,readf,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readf,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readf,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readf,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
-// CHECK-NEXT: kernel,readui,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readui,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readui,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readui,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
-// CHECK-NEXT: kernel,readi,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readi,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readi,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
-// CHECK-NEXT: kernel,readi,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
+// CHECK-NOT: sampler
+// CHECK: kernel,readf,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
+// CHECK: kernel,readf,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
+// CHECK: kernel,readf,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
+// CHECK: kernel,readf,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
+// CHECK: kernel,readui,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
+// CHECK: kernel,readui,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
+// CHECK: kernel,readui,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
+// CHECK: kernel,readui,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
+// CHECK: kernel,readi,arg,im1d,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
+// CHECK: kernel,readi,arg,im2d,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
+// CHECK: kernel,readi,arg,im3d,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,ro_image
+// CHECK: kernel,readi,arg,out,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,buffer
 
 kernel void readf(read_only image1d_t im1d, read_only image2d_t im2d, read_only image3d_t im3d, global float4* out) {
   out[0] = read_imagef(im1d, 0);

--- a/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
@@ -19,7 +19,7 @@ void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
 
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,2a0000000d0000000000000005000000
-// MAP-NEXT: kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 
 
 // CHECK:  OpDecorate [[_18:%[0-9a-zA-Z_]+]] DescriptorSet 1

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -12,6 +12,6 @@ __constant Foo ppp[3] = {{'a', 0x1234abcd, 1.0}, {'b', 0xffffffff, 1.5}, {0}};
 kernel void foo(global uint* A, uint i) { *A = ppp[i].a; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,61000000cdab34120000803f62000000ffffffff0000c03f000000000000000000000000
-// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -9,5 +9,5 @@ __constant uint ppp[2][3] = {{1,2,3}, {5}};
 kernel void foo(global uint* A, uint i) { *A = ppp[i][i]; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,010000000200000003000000050000000000000000000000
-// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -11,5 +11,5 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
 
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,0100000002000000030000000000000005000000050000000500000000000000
-// MAP-NEXT: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4

--- a/test/descriptor_set_default.cl
+++ b/test/descriptor_set_default.cl
@@ -7,11 +7,11 @@
 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
-// MAP-NEXT: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
 
-// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0
+// MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0
 // MAP-NOT: kernel
 
 

--- a/test/descriptor_set_distinct.cl
+++ b/test/descriptor_set_distinct.cl
@@ -5,11 +5,11 @@
 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
-// MAP-NEXT: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
 
-// MAP-NEXT: kernel,bar,arg,B,argOrdinal,0,descriptorSet,1,binding,0,offset,0
-// MAP-NEXT: kernel,bar,arg,m,argOrdinal,1,descriptorSet,1,binding,1,offset,0
+// MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,1,binding,0,offset,0
+// MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,1,binding,1,offset,0
 // MAP-NOT: kernel
 
 

--- a/test/kernel-decl-dmap.cl
+++ b/test/kernel-decl-dmap.cl
@@ -1,0 +1,11 @@
+// RUN: clspv -descriptormap=%t.dmap %s -o %t.spv
+// RUN: FileCheck %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: kernel_decl,with_args
+// CHECK: kernel,with_args,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// CHECK: kernel_decl,without_args
+
+void kernel with_args(global int *out) {}
+void kernel without_args() {}
+


### PR DESCRIPTION
This make it easier for clvk to support kernel with no arguments.

Fixes #536.

Signed-off-by: Kévin Petit <kpet@free.fr>