### PR TITLE
Add a new pass to undo harmful instcombines

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -401,4 +401,8 @@ llvm::FunctionPass *createFixupStructuredCFGPass();
 /// optimization outcome.
 llvm::ModulePass *createAddFunctionAttributesPass();
 
+/// Undo specific instcombine transformations that are harmful to generating
+/// SPIR-V.
+llvm::ModulePass *createUndoInstCombinePass();
+
 } // namespace clspv

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoBoolPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoByvalPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoGetElementPtrConstantExprPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/UndoInstCombinePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoSRetPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoTranslateSamplerFoldPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoTruncatedSwitchConditionPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -683,6 +683,7 @@ int PopulatePassManager(
   // HideConstantLoadsPass.
   pm->add(clspv::createUnhideConstantLoadsPass());
 
+  pm->add(clspv::createUndoInstCombinePass());
   pm->add(clspv::createFunctionInternalizerPass());
   pm->add(clspv::createReplaceLLVMIntrinsicsPass());
   pm->add(clspv::createUndoBoolPass());

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -50,6 +50,7 @@ void initializeClspvPasses(PassRegistry &r) {
   initializeUndoBoolPassPass(r);
   initializeUndoByvalPassPass(r);
   initializeUndoGetElementPtrConstantExprPassPass(r);
+  initializeUndoInstCombinePassPass(r);
   initializeUndoSRetPassPass(r);
   initializeUndoTranslateSamplerFoldPassPass(r);
   initializeUndoTruncatedSwitchConditionPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -53,6 +53,7 @@ void initializeUBOTypeTransformPassPass(PassRegistry &);
 void initializeUndoBoolPassPass(PassRegistry &);
 void initializeUndoByvalPassPass(PassRegistry &);
 void initializeUndoGetElementPtrConstantExprPassPass(PassRegistry &);
+void initializeUndoInstCombinePassPass(PassRegistry &);
 void initializeUndoSRetPassPass(PassRegistry &);
 void initializeUndoTranslateSamplerFoldPassPass(PassRegistry &);
 void initializeUndoTruncatedSwitchConditionPassPass(PassRegistry &);

--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -1,0 +1,232 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "llvm/ADT/UniqueVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+#include "Passes.h"
+
+#define DEBUG_TYPE "undoinstcombine"
+
+using namespace llvm;
+
+namespace {
+class UndoInstCombinePass : public ModulePass {
+public:
+  static char ID;
+  UndoInstCombinePass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+
+private:
+  bool runOnFunction(Function &F);
+
+  // Undoes wide vector casts that are used in an extract, for example:
+  //  %cast = bitcast <4 x i32> %src to <16 x i8>
+  //  %extract = extractelement <16 x i8> %cast, i32 4
+  //
+  // With:
+  //  %extract = extractelement <4 x i32> %src, i32 1
+  //  %trunc = trunc i32 %extract to i8
+  bool UndoWideVectorExtractCast(Instruction *inst);
+
+  // Undoes wide vector casts that are used in a shuffle, for example:
+  //  %cast = bitcast <4 x i32> %src to <16 x i8>
+  //  %s = shufflevector <16 x i8> %cast, <16 x i8> undef,
+  //                       <2 x i8> <i32 4, i32 8>
+  //
+  // With:
+  //  %extract0 = <4 x i32> %src, i32 1
+  //  %trunc0 = trunc i32 %extract0 to i8
+  //  %insert0 = insertelement <2 x i8> zeroinitializer, i8 %trunc0, i32 0
+  //  %extract1 = <4 x i32> %src, i32 2
+  //  %trunc1 = trunc i32 %extract1 to i8
+  //  %insert1 = insertelement <2 x i8> %insert0, i8 %trunc1, i32 1
+  bool UndoWideVectorShuffleCast(Instruction *inst);
+
+  UniqueVector<Instruction *> potentially_dead_;
+  std::vector<Instruction *> dead_;
+};
+} // namespace
+
+char UndoInstCombinePass::ID = 0;
+INITIALIZE_PASS(UndoInstCombinePass, "UndoInstCombine",
+                "Undo specific harmful instcombine transformations", false,
+                false)
+
+namespace clspv {
+ModulePass *createUndoInstCombinePass() { return new UndoInstCombinePass(); }
+} // namespace clspv
+
+bool UndoInstCombinePass::runOnModule(Module &M) {
+  bool changed = false;
+
+  for (auto &F : M) {
+    changed |= runOnFunction(F);
+  }
+
+  // Cleanup.
+  for (auto inst : dead_)
+    inst->eraseFromParent();
+
+  for (auto inst : potentially_dead_) {
+    if (inst->user_empty())
+      inst->eraseFromParent();
+  }
+
+  return changed;
+}
+
+bool UndoInstCombinePass::runOnFunction(Function &F) {
+  bool changed = false;
+
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      changed |= UndoWideVectorExtractCast(&I);
+      changed |= UndoWideVectorShuffleCast(&I);
+    }
+  }
+
+  return changed;
+}
+
+bool UndoInstCombinePass::UndoWideVectorExtractCast(Instruction *inst) {
+  auto extract = dyn_cast<ExtractElementInst>(inst);
+  if (!extract)
+    return false;
+
+  auto vec_ty = extract->getVectorOperandType();
+  if (vec_ty->getElementCount().Min <= 4)
+    return false;
+
+  // Instcombine only transforms TruncInst (which operates on integers).
+  if (!vec_ty->getVectorElementType()->isIntegerTy())
+    return false;
+
+  auto const_idx = dyn_cast<ConstantInt>(extract->getIndexOperand());
+  if (!const_idx)
+    return false;
+
+  auto cast = dyn_cast<BitCastInst>(extract->getVectorOperand());
+  if (!cast)
+    return false;
+
+  auto src = cast->getOperand(0);
+  auto src_vec_ty = dyn_cast<VectorType>(src->getType());
+  if (!src_vec_ty)
+    return false;
+
+  uint64_t src_elements = src_vec_ty->getElementCount().Min;
+  uint64_t dst_elements = vec_ty->getElementCount().Min;
+
+  if (dst_elements < src_elements)
+    return false;
+
+  uint64_t idx = const_idx->getZExtValue();
+  uint64_t ratio = dst_elements / src_elements;
+  uint64_t new_idx = idx / ratio;
+
+  // Instcombine should never have generated an odd index, so don't handle
+  // right now.
+  if (idx & 0x1)
+    return false;
+
+  // Create a truncate of an extract element.
+  IRBuilder<> builder(inst);
+  auto new_src = builder.CreateExtractElement(src, builder.getInt32(new_idx));
+  auto trunc = builder.CreateTrunc(new_src, extract->getType());
+  extract->replaceAllUsesWith(trunc);
+  dead_.push_back(extract);
+  potentially_dead_.insert(cast);
+
+  return true;
+}
+
+bool UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
+  auto shuffle = dyn_cast<ShuffleVectorInst>(inst);
+  if (!shuffle)
+    return false;
+
+  // Instcombine only transforms TruncInst (which operates on integers).
+  auto vec_ty = cast<VectorType>(shuffle->getType());
+  if (!vec_ty->getVectorElementType()->isIntegerTy())
+    return false;
+
+  auto in1 = shuffle->getOperand(0);
+  auto in1_vec_ty = cast<VectorType>(in1->getType());
+  if (in1_vec_ty->getElementCount().Min <= 4)
+    return false;
+
+  auto in1_cast = dyn_cast<BitCastInst>(in1);
+  if (!in1_cast)
+    return false;
+
+  // Instcombine only produces shuffles with an undef second input, so don't
+  // handle other cases for now.
+  if (!isa<UndefValue>(shuffle->getOperand(1)))
+    return false;
+
+  auto src = in1_cast->getOperand(0);
+  auto src_vec_ty = dyn_cast<VectorType>(src->getType());
+  if (!src_vec_ty)
+    return false;
+
+  uint64_t src_elements = src_vec_ty->getElementCount().Min;
+  uint64_t dst_elements = in1_vec_ty->getElementCount().Min;
+
+  if (dst_elements < src_elements)
+    return false;
+
+  uint64_t ratio = dst_elements / src_elements;
+  auto dst_scalar_type = vec_ty->getVectorElementType();
+
+  SmallVector<int, 16> mask;
+  shuffle->getShuffleMask(mask);
+  for (auto i : mask) {
+    // Instcombine should not have generated odd indices, so don't handle them
+    // for now.
+    if ((i != UndefMaskElem) && (i & 0x1))
+      return false;
+  }
+
+  // For each index, create a truncate of an extract element and insert each
+  // into the result vector.
+  IRBuilder<> builder(inst);
+  Value *insert = nullptr;
+  int i = 0;
+  for (auto idx : mask) {
+    if (idx == UndefMaskElem)
+      continue;
+
+    uint64_t new_idx = idx / ratio;
+    auto extract = builder.CreateExtractElement(src, builder.getInt32(new_idx));
+    auto trunc = builder.CreateTrunc(extract, dst_scalar_type);
+    Value *prev = insert ? insert : Constant::getNullValue(vec_ty);
+    insert = builder.CreateInsertElement(prev, trunc, builder.getInt32(i++));
+  }
+  if (!insert) {
+    insert = Constant::getNullValue(vec_ty);
+  }
+  shuffle->replaceAllUsesWith(insert);
+  dead_.push_back(shuffle);
+  potentially_dead_.insert(in1_cast);
+
+  return true;
+}

--- a/test/UndoInstCombine/undo_extract_cast.cl
+++ b/test/UndoInstCombine/undo_extract_cast.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-NOT: OpTypeVector {{.*}} 16
+
+__kernel void test_r_uint8(read_only image2d_t srcimg, __global unsigned char *dst, sampler_t sampler)
+{
+    int    tid_x = get_global_id(0);
+    int    tid_y = get_global_id(1);
+    int    indx = tid_y * get_image_width(srcimg) + tid_x;
+    uint4    color;
+
+    color = read_imageui(srcimg, sampler, (int2)(tid_x, tid_y));
+    dst[indx] = (unsigned char)(color.x);
+
+}
+

--- a/test/UndoInstCombine/undo_extract_cast_2xi64_to_8xi16.ll
+++ b/test/UndoInstCombine/undo_extract_cast_2xi64_to_8xi16.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt %s -o %t.ll -UndoInstCombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test(<2 x i64> %in, i16 addrspace(1)* %out) {
+entry:
+  ; CHECK-NOT: bitcast
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i64> %in, i32 0
+  ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[ex]] to i16
+  ; CHECK: store i16 [[trunc]]
+  %cast = bitcast <2 x i64> %in to <8 x i16>
+  %conv = extractelement <8 x i16> %cast, i32 0
+  store i16 %conv, i16 addrspace(1)* %out, align 2
+  ret void
+}
+
+

--- a/test/UndoInstCombine/undo_extract_cast_4xi32_to_16xi8.ll
+++ b/test/UndoInstCombine/undo_extract_cast_4xi32_to_16xi8.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt %s -o %t.ll -UndoInstCombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test(<4 x i32> %in, i8 addrspace(1)* %out) {
+entry:
+  ; CHECK-NOT: bitcast
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i32> %in, i32 0
+  ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex]] to i8
+  ; CHECK: store i8 [[trunc]]
+  %cast = bitcast <4 x i32> %in to <16 x i8>
+  %conv = extractelement <16 x i8> %cast, i32 0
+  store i8 %conv, i8 addrspace(1)* %out, align 1
+  ret void
+}
+

--- a/test/UndoInstCombine/undo_shuffle_cast.cl
+++ b/test/UndoInstCombine/undo_shuffle_cast.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-NOT: OpTypeVector {{.*}} 16
+
+__kernel void testReadi(read_only image2d_t srcimg, __global uchar4 *dst)
+{
+    int    tid_x = get_global_id(0);
+    int    tid_y = get_global_id(1);
+    int    indx = tid_y * get_image_width(srcimg) + tid_x;
+    int4    color;
+
+    const sampler_t sampler = CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE;
+    color = read_imagei(srcimg, sampler, (int2)(tid_x, tid_y));
+  uchar4 dst_write;
+     dst_write.x = (uchar)color.x;
+     dst_write.y = (uchar)color.y;
+     dst_write.z = (uchar)color.z;
+     dst_write.w = (uchar)color.w;
+  dst[indx] = dst_write;
+
+}
+

--- a/test/UndoInstCombine/undo_shuffle_cast_2xi64_to_8xi16.ll
+++ b/test/UndoInstCombine/undo_shuffle_cast_2xi64_to_8xi16.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t.ll -UndoInstCombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test(<2 x i64> %in, <2 x i16> addrspace(1)* %out) {
+entry:
+  ; CHECK-NOT: bitcast
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i64> %in, i32 1
+  ; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i64 [[ex0]] to i16
+  ; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertelement <2 x i16> zeroinitializer, i16 [[trunc0]], i32 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i64> %in, i32 2
+  ; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i64 [[ex1]] to i16
+  ; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertelement <2 x i16> [[insert0]], i16 [[trunc1]], i32 1
+  ; CHECK: store <2 x i16> [[insert1]]
+  %cast = bitcast <2 x i64> %in to <8 x i16>
+  %conv = shufflevector <8 x i16> %cast, <8 x i16> undef, <2 x i32> <i32 4, i32 8>
+  store <2 x i16> %conv, <2 x i16> addrspace(1)* %out, align 1
+  ret void
+}
+

--- a/test/UndoInstCombine/undo_shuffle_cast_4xi32_to16xi8.ll
+++ b/test/UndoInstCombine/undo_shuffle_cast_4xi32_to16xi8.ll
@@ -1,0 +1,29 @@
+; RUN: clspv-opt %s -o %t.ll -UndoInstCombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test(<4 x i32> %in, <4 x i8> addrspace(1)* %out) {
+entry:
+  ; CHECK-NOT: bitcast
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <4 x i32> %in, i32 0
+  ; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex0]] to i8
+  ; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> zeroinitializer, i8 [[trunc0]], i32 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <4 x i32> %in, i32 1
+  ; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex1]] to i8
+  ; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert0]], i8 [[trunc1]], i32 1
+  ; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractelement <4 x i32> %in, i32 2
+  ; CHECK: [[trunc2:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex2]] to i8
+  ; CHECK: [[insert2:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert1]], i8 [[trunc2]], i32 2
+  ; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractelement <4 x i32> %in, i32 3
+  ; CHECK: [[trunc3:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex3]] to i8
+  ; CHECK: [[insert3:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert2]], i8 [[trunc3]], i32 3
+  ; CHECK: store <4 x i8> [[insert3]]
+  %cast = bitcast <4 x i32> %in to <16 x i8>
+  %conv = shufflevector <16 x i8> %cast, <16 x i8> undef, <4 x i32> <i32 0, i32 4, i32 8, i32 12>
+  store <4 x i8> %conv, <4 x i8> addrspace(1)* %out, align 1
+  ret void
+}
+
+


### PR DESCRIPTION
Fixes #549

* New pass to undo harmful instcombine transforms
  * Currently handles two cases that produce wide vectors seen in CTS
* Add tests