### PR TITLE
SPIRVProducerPass refactor - phase1

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -104,7 +104,7 @@ enum SPIRVSection {
   kAnnotations,
 
   kTypes,
-  kConstants,
+  kConstants = kTypes,
   kGlobalVariables,
 
   kFunctions,

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3601,7 +3601,6 @@ void SPIRVProducerPass::GenerateModuleInfo(Module &module) {
   EntryPointVecType &EntryPoints = getEntryPointVec();
   ValueMapType &VMap = getValueMap();
   ValueList &EntryPointInterfaces = getEntryPointInterfacesVec();
-  uint32_t &ExtInstImportID = getOpExtInstImportID();
   std::vector<uint32_t> &BuiltinDimVec = getBuiltinDimVec();
 
   SPIRVInstructionList &SPIRVCapabilities = getSPIRVInstList(kCapabilities);
@@ -5574,9 +5573,6 @@ void SPIRVProducerPass::HandleDeferredDecorations(const DataLayout &DL) {
   }
 
   SPIRVInstructionList &SPIRVInstList = getSPIRVInstList(kAnnotations);
-
-  // Find an iterator pointing just past the last decoration.
-  bool seen_decorations = false;
 
   // Insert ArrayStride decorations on pointer types, due to OpPtrAccessChain
   // instructions we generated earlier.

--- a/test/VaryingLocalSizes/one_kernel.cl
+++ b/test/VaryingLocalSizes/one_kernel.cl
@@ -3,10 +3,10 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// CHECK: OpDecorate %[[BUILTIN_ID:[a-zA-Z0-9_]*]] BuiltIn WorkgroupSize
 // CHECK: OpDecorate %[[BUILTIN_X_ID:[a-zA-Z0-9_]*]] SpecId 0
 // CHECK: OpDecorate %[[BUILTIN_Y_ID:[a-zA-Z0-9_]*]] SpecId 1
 // CHECK: OpDecorate %[[BUILTIN_Z_ID:[a-zA-Z0-9_]*]] SpecId 2
-// CHECK: OpDecorate %[[BUILTIN_ID:[a-zA-Z0-9_]*]] BuiltIn WorkgroupSize
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
 // CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -23,10 +23,10 @@ void kernel bar(global uint* a)
 
 // CHECK: OpEntryPoint GLCompute [[_20:%[a-zA-Z0-9_]+]] "foo"
 // CHECK: OpEntryPoint GLCompute [[_32:%[a-zA-Z0-9_]+]] "bar"
+// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
 // CHECK: OpDecorate [[_14:%[a-zA-Z0-9_]+]] SpecId 0
 // CHECK: OpDecorate [[_15:%[a-zA-Z0-9_]+]] SpecId 1
 // CHECK: OpDecorate [[_16:%[a-zA-Z0-9_]+]] SpecId 2
-// CHECK: OpDecorate [[_gl_WorkGroupSize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
 // CHECK-DAG: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
 // CHECK-DAG: [[_uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 1


### PR DESCRIPTION
* Create SPIRV Module Sections for SPIRVInstructions according to 2.4 of the spec.
  * Sections: Capabilities, Extensions, Imports, MemoryModel, EntryPoints, ExecutionModes, Debug, Annotations, Types, Constants, GlobalVariables, Functions
  * This removes the need for looking up where to insert OpDecorates

Phase1 enhancement for issue #545