### PR TITLE
Add generic support to allocate spec ids

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -192,10 +192,18 @@ Consider this example:
 
 It generates the following descriptor map:
 
+    kernel_decl,foo
     kernel,foo,arg,a,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
     kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
     kernel,foo,arg,b,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,buffer
     kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,4
+    spec_constant,workgroup_size_x,spec_id,0
+    spec_constant,workgroup_size_y,spec_id,1
+    spec_constant,workgroup_size_z,spec_id,2
+
+The kernels in the module module are declared as follows:
+- `kernel_decl`
+- kernel name
 
 For kernel arguments of types pointer-to-global, pointer-to-constant, and
 plain-old-data types, the fields are:
@@ -225,15 +233,29 @@ plain-old-data types, the fields are:
 - `argSize`
 - only present for plain-old-data kernel arguments.
 
+Module-wide specialization constants are specified as follows:
+- `spec_constant` to describe the use of a module-wide specialization constant
+- specialization constant type (e.g x dimension of WorkgroupSize)
+- `spec_id`
+- the SpecId value
+
 Consider this example, which uses pointer-to-local arguments:
 
     kernel void foo(local float* L, global float* A, local float4 *L2) {...}
 
 It generates the following descriptor map:
 
+    kernel_decl,foo
     kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
     kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
     kernel,foo,arg,L2,argOrdinal,2,argKind,local,arrayElemSize,16,arrayNumElemSpecId,4
+    spec_constant,workgroup_size_x,spec_id,0
+    spec_constant,workgroup_size_y,spec_id,1
+    spec_constant,workgroup_size_z,spec_id,2
+
+The kernels in the module module are declared as follows:
+- `kernel_decl`
+- kernel name
 
 For kernel arguments of type pointer-to-local, the fields are:
 - `kernel` to indicate a kernel argument
@@ -252,6 +274,12 @@ For kernel arguments of type pointer-to-local, the fields are:
   `SpecId` decoration on the integer constant that specficies the array size.
   (This number is always at least 3 so that specialization IDs 0, 1, and 2 can
   be use for the workgroup size dimensions along `x`, `y`, and `z`.)
+
+Module-wide specialization constants are specified as follows:
+- `spec_constant` to describe the use of a module-wide specialization constant
+- specialization constant type (e.g x dimension of WorkgroupSize)
+- `spec_id`
+- the SpecId value
 
 Notes: Each pointer-to-local argument is assigned its own array type and
 specialization constant to size the array.  Unless you override the
@@ -393,6 +421,14 @@ produces the following descriptor map:
 
 
 TODO(dneto): Give an example using images.
+
+#### Module-wide Specialization Constants
+
+The descriptor map includes entries for specialization constants that are used
+module-wide. The following specialization constants are currently generated:
+- `workgroup\_size\_x`: The x-dimension of workgroup size.
+- `workgroup\_size\_y`: The y-dimension of workgroup size.
+- `workgroup\_size\_z`: The z-dimension of workgroup size.
 
 #### Module scope constants
 

--- a/include/clspv/DescriptorMap.h
+++ b/include/clspv/DescriptorMap.h
@@ -124,9 +124,8 @@ struct DescriptorMapEntry {
         sampler_data(std::move(data)) {}
 
   DescriptorMapEntry(SpecConstantData &&data)
-    : kind(SpecConstant), descriptor_set(-1), binding(-1),
-      spec_constant_data(std::move(data)) {}
-
+      : kind(SpecConstant), descriptor_set(-1), binding(-1),
+        spec_constant_data(std::move(data)) {}
 };
 
 std::ostream &operator<<(std::ostream &str,

--- a/include/clspv/DescriptorMap.h
+++ b/include/clspv/DescriptorMap.h
@@ -20,6 +20,7 @@
 
 #include "clspv/ArgKind.h"
 #include "clspv/PushConstant.h"
+#include "clspv/SpecConstant.h"
 
 namespace clspv {
 namespace version0 {
@@ -50,7 +51,14 @@ const unsigned kSamplerFilterMask = 0x30;
 
 struct DescriptorMapEntry {
   // Type of the entry.
-  enum Kind { Sampler, KernelArg, KernelDecl, Constant, PushConstant } kind;
+  enum Kind {
+    Sampler,
+    KernelArg,
+    KernelDecl,
+    Constant,
+    PushConstant,
+    SpecConstant,
+  } kind;
 
   // Common data.
   uint32_t descriptor_set;
@@ -90,6 +98,11 @@ struct DescriptorMapEntry {
     uint32_t size;
   } push_constant_data;
 
+  struct SpecConstantData {
+    clspv::SpecConstant spec_constant;
+    uint32_t spec_id;
+  } spec_constant_data;
+
   DescriptorMapEntry(PushConstantData &&data)
       : kind(PushConstant), descriptor_set(-1), binding(-1),
         push_constant_data(std::move(data)) {}
@@ -109,6 +122,11 @@ struct DescriptorMapEntry {
   DescriptorMapEntry(SamplerData &&data, uint32_t ds, uint32_t b)
       : kind(Sampler), descriptor_set(ds), binding(b),
         sampler_data(std::move(data)) {}
+
+  DescriptorMapEntry(SpecConstantData &&data)
+    : kind(SpecConstant), descriptor_set(-1), binding(-1),
+      spec_constant_data(std::move(data)) {}
+
 };
 
 std::ostream &operator<<(std::ostream &str,

--- a/include/clspv/SpecConstant.h
+++ b/include/clspv/SpecConstant.h
@@ -1,0 +1,40 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_INCLUDE_CLSPV_SPEC_CONSTANT_H_
+#define CLSPV_INCLUDE_CLSPV_SPEC_CONSTANT_H_
+
+#include <string>
+
+namespace clspv {
+
+enum class SpecConstant : int {
+  // Workgroup size per dimension.
+  kWorkgroupSizeX,
+  kWorkgroupSizeY,
+  kWorkgroupSizeZ,
+  // Local memory array size.
+  kLocalMemorySize,
+};
+
+// Converts an SpecConstant to its string name.
+const char *GetSpecConstantName(SpecConstant);
+
+// Converts a string into its ArgKind.
+SpecConstant GetSpecConstantFromName(const std::string &);
+
+} // namespace clspv
+
+#endif // CLSPV_INCLUDE_CLSPV_SPEC_CONSTANT_H_
+

--- a/include/clspv/SpecConstant.h
+++ b/include/clspv/SpecConstant.h
@@ -37,4 +37,3 @@ SpecConstant GetSpecConstantFromName(const std::string &);
 } // namespace clspv
 
 #endif // CLSPV_INCLUDE_CLSPV_SPEC_CONSTANT_H_
-

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/ShareModuleScopeVariables.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SignedCompareFixupPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SimplifyPointerBitcastPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/SpecConstant.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SpecializeImageTypes.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SplatSelectCondition.cpp

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -46,10 +46,6 @@ inline std::string LiteralSamplerFunction() {
 // Base name for SPIR-V intrinsic functions
 inline std::string SPIRVOpIntrinsicFunction() { return "spirv.op."; }
 
-// The first useable SpecId for pointer-to-local arguments.
-// 0, 1 and 2 are reserved for workgroup size.
-inline int FirstLocalSpecId() { return 3; }
-
 // Name of the literal sampler initializer function.
 inline std::string TranslateSamplerInitializerFunction() {
   return "__translate_sampler_initializer";
@@ -60,6 +56,12 @@ inline std::string PushConstantsVariableName() { return "__push_constants"; }
 
 // Name for module level metadata storing push constant indices.
 inline std::string PushConstantsMetadataName() { return "push_constants"; }
+
+// Name for module level metadata storing next spec constant id.
+inline std::string NextSpecConstantMetadataName() { return "clspv.next_spec_constant_id"; }
+
+// Name for module level metadata store list of allocated spec constants.
+inline std::string SpecConstantMetadataName() { return "clspv.spec_constant_list"; }
 
 } // namespace clspv
 

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -58,10 +58,14 @@ inline std::string PushConstantsVariableName() { return "__push_constants"; }
 inline std::string PushConstantsMetadataName() { return "push_constants"; }
 
 // Name for module level metadata storing next spec constant id.
-inline std::string NextSpecConstantMetadataName() { return "clspv.next_spec_constant_id"; }
+inline std::string NextSpecConstantMetadataName() {
+  return "clspv.next_spec_constant_id";
+}
 
 // Name for module level metadata store list of allocated spec constants.
-inline std::string SpecConstantMetadataName() { return "clspv.spec_constant_list"; }
+inline std::string SpecConstantMetadataName() {
+  return "clspv.spec_constant_list";
+}
 
 } // namespace clspv
 

--- a/lib/DescriptorMap.cpp
+++ b/lib/DescriptorMap.cpp
@@ -40,6 +40,9 @@ std::ostream &operator<<(std::ostream &str,
   case DescriptorMapEntry::Kind::PushConstant:
     str << "pushconstant";
     break;
+  case DescriptorMapEntry::Kind::SpecConstant:
+    str << "spec_constant";
+    break;
   default:
     assert(0 && "Unhandled descriptor map entry kind.");
     break;
@@ -143,6 +146,12 @@ std::ostream &operator<<(std::ostream &str, const DescriptorMapEntry &entry) {
     const auto &data = entry.push_constant_data;
     str << "name," << GetPushConstantName(data.pc) << ",offset," << data.offset
         << ",size," << data.size;
+    break;
+  }
+  case DescriptorMapEntry::Kind::SpecConstant: {
+    const auto &data = entry.spec_constant_data;
+    str << GetSpecConstantName(data.spec_constant) << ",spec_id,"
+        << data.spec_id;
     break;
   }
   default:

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3222,22 +3222,22 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
       // X Dimension
       Ops << MkId(result_type_id) << MkNum(1);
       XDimCstID = nextID++;
-      getSPIRVInstList(kConstants).push_back(
-          new SPIRVInstruction(spv::OpSpecConstant, XDimCstID, Ops));
+      getSPIRVInstList(kConstants)
+          .push_back(new SPIRVInstruction(spv::OpSpecConstant, XDimCstID, Ops));
 
       // Y Dimension
       Ops.clear();
       Ops << MkId(result_type_id) << MkNum(1);
       YDimCstID = nextID++;
-      getSPIRVInstList(kConstants).push_back(
-          new SPIRVInstruction(spv::OpSpecConstant, YDimCstID, Ops));
+      getSPIRVInstList(kConstants)
+          .push_back(new SPIRVInstruction(spv::OpSpecConstant, YDimCstID, Ops));
 
       // Z Dimension
       Ops.clear();
       Ops << MkId(result_type_id) << MkNum(1);
       ZDimCstID = nextID++;
-      getSPIRVInstList(kConstants).push_back(
-          new SPIRVInstruction(spv::OpSpecConstant, ZDimCstID, Ops));
+      getSPIRVInstList(kConstants)
+          .push_back(new SPIRVInstruction(spv::OpSpecConstant, ZDimCstID, Ops));
 
       BuiltinDimVec.push_back(XDimCstID);
       BuiltinDimVec.push_back(YDimCstID);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3180,7 +3180,7 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
 
         auto *Inst =
             new SPIRVInstruction(spv::OpConstantComposite, nextID++, Ops);
-        SPIRVInstList.push_back(Inst);
+        getSPIRVInstList(kConstants).push_back(Inst);
 
         HasMDVec.push_back(true);
       } else {
@@ -3222,21 +3222,21 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
       // X Dimension
       Ops << MkId(result_type_id) << MkNum(1);
       XDimCstID = nextID++;
-      SPIRVInstList.push_back(
+      getSPIRVInstList(kConstants).push_back(
           new SPIRVInstruction(spv::OpSpecConstant, XDimCstID, Ops));
 
       // Y Dimension
       Ops.clear();
       Ops << MkId(result_type_id) << MkNum(1);
       YDimCstID = nextID++;
-      SPIRVInstList.push_back(
+      getSPIRVInstList(kConstants).push_back(
           new SPIRVInstruction(spv::OpSpecConstant, YDimCstID, Ops));
 
       // Z Dimension
       Ops.clear();
       Ops << MkId(result_type_id) << MkNum(1);
       ZDimCstID = nextID++;
-      SPIRVInstList.push_back(
+      getSPIRVInstList(kConstants).push_back(
           new SPIRVInstruction(spv::OpSpecConstant, ZDimCstID, Ops));
 
       BuiltinDimVec.push_back(XDimCstID);
@@ -3258,7 +3258,7 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
 
       auto *Inst =
           new SPIRVInstruction(spv::OpSpecConstantComposite, nextID++, Ops);
-      SPIRVInstList.push_back(Inst);
+      getSPIRVInstList(kConstants).push_back(Inst);
     }
   }
 
@@ -3354,7 +3354,7 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
 }
 
 void SPIRVProducerPass::GenerateWorkgroupVars(Module &M) {
-  SPIRVInstructionList &SPIRVInstList = getSPIRVInstList();
+  SPIRVInstructionList &SPIRVInstList = getSPIRVInstList(kGlobalVariables);
   auto spec_constant_md = M.getNamedMetadata(clspv::SpecConstantMetadataName());
   if (!spec_constant_md)
     return;

--- a/lib/SpecConstant.cpp
+++ b/lib/SpecConstant.cpp
@@ -33,7 +33,8 @@ void InitSpecConstantMetadata(Module *module) {
   auto id_md = MDTuple::get(module->getContext(), {id_const});
   next_spec_id_md->addOperand(id_md);
 
-  auto spec_constant_list_md = module->getOrInsertNamedMetadata(clspv::SpecConstantMetadataName());
+  auto spec_constant_list_md =
+      module->getOrInsertNamedMetadata(clspv::SpecConstantMetadataName());
   spec_constant_list_md->clearOperands();
 }
 
@@ -43,16 +44,17 @@ namespace clspv {
 
 const char *GetSpecConstantName(SpecConstant kind) {
   switch (kind) {
-    case SpecConstant::kWorkgroupSizeX:
-      return "workgroup_size_x";
-    case SpecConstant::kWorkgroupSizeY:
-      return "workgroup_size_y";
-    case SpecConstant::kWorkgroupSizeZ:
-      return "workgroup_size_z";
-    case SpecConstant::kLocalMemorySize:
-      return "local_memory_size";
+  case SpecConstant::kWorkgroupSizeX:
+    return "workgroup_size_x";
+  case SpecConstant::kWorkgroupSizeY:
+    return "workgroup_size_y";
+  case SpecConstant::kWorkgroupSizeZ:
+    return "workgroup_size_z";
+  case SpecConstant::kLocalMemorySize:
+    return "local_memory_size";
   }
-  llvm::errs() << "Unhandled case in clspv::GetSpecConstantName: " << int(kind) << "\n";
+  llvm::errs() << "Unhandled case in clspv::GetSpecConstantName: " << int(kind)
+               << "\n";
   return "";
 }
 
@@ -66,7 +68,8 @@ SpecConstant GetSpecConstantFromName(const std::string &name) {
   else if (name == "local_memory_size")
     return SpecConstant::kLocalMemorySize;
 
-  llvm::errs() << "Unhandled csae in clspv::GetSpecConstantFromName: " << name << "\n";
+  llvm::errs() << "Unhandled csae in clspv::GetSpecConstantFromName: " << name
+               << "\n";
   return SpecConstant::kWorkgroupSizeX;
 }
 
@@ -136,9 +139,11 @@ uint32_t AllocateSpecConstant(Module *module, SpecConstant kind) {
   return next_id;
 }
 
-std::vector<std::pair<SpecConstant, uint32_t>> GetSpecConstants(Module *module) {
+std::vector<std::pair<SpecConstant, uint32_t>>
+GetSpecConstants(Module *module) {
   std::vector<std::pair<SpecConstant, uint32_t>> spec_constants;
-  auto spec_constant_md = module->getNamedMetadata(clspv::SpecConstantMetadataName());
+  auto spec_constant_md =
+      module->getNamedMetadata(clspv::SpecConstantMetadataName());
   if (!spec_constant_md)
     return spec_constants;
 

--- a/lib/SpecConstant.cpp
+++ b/lib/SpecConstant.cpp
@@ -1,0 +1,162 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Constants.h"
+
+#include "Constants.h"
+#include "SpecConstant.h"
+
+using namespace llvm;
+
+namespace {
+
+void InitSpecConstantMetadata(Module *module) {
+  auto next_spec_id_md =
+      module->getOrInsertNamedMetadata(clspv::NextSpecConstantMetadataName());
+  next_spec_id_md->clearOperands();
+
+  // Start at 3 to accommodate workgroup size ids.
+  const uint32_t first_spec_id = 3;
+  auto id_const = ValueAsMetadata::getConstant(ConstantInt::get(
+      IntegerType::get(module->getContext(), 32), first_spec_id));
+  auto id_md = MDTuple::get(module->getContext(), {id_const});
+  next_spec_id_md->addOperand(id_md);
+
+  auto spec_constant_list_md = module->getOrInsertNamedMetadata(clspv::SpecConstantMetadataName());
+  spec_constant_list_md->clearOperands();
+}
+
+} // namespace
+
+namespace clspv {
+
+const char *GetSpecConstantName(SpecConstant kind) {
+  switch (kind) {
+    case SpecConstant::kWorkgroupSizeX:
+      return "workgroup_size_x";
+    case SpecConstant::kWorkgroupSizeY:
+      return "workgroup_size_y";
+    case SpecConstant::kWorkgroupSizeZ:
+      return "workgroup_size_z";
+    case SpecConstant::kLocalMemorySize:
+      return "local_memory_size";
+  }
+  llvm::errs() << "Unhandled case in clspv::GetSpecConstantName: " << int(kind) << "\n";
+  return "";
+}
+
+SpecConstant GetSpecConstantFromName(const std::string &name) {
+  if (name == "workgroup_size_x")
+    return SpecConstant::kWorkgroupSizeX;
+  else if (name == "workgroup_size_y")
+    return SpecConstant::kWorkgroupSizeY;
+  else if (name == "workgroup_size_z")
+    return SpecConstant::kWorkgroupSizeZ;
+  else if (name == "local_memory_size")
+    return SpecConstant::kLocalMemorySize;
+
+  llvm::errs() << "Unhandled csae in clspv::GetSpecConstantFromName: " << name << "\n";
+  return SpecConstant::kWorkgroupSizeX;
+}
+
+void AddWorkgroupSpecConstants(Module *module) {
+  auto spec_constant_list_md =
+      module->getNamedMetadata(SpecConstantMetadataName());
+  if (!spec_constant_list_md) {
+    InitSpecConstantMetadata(module);
+    spec_constant_list_md =
+        module->getNamedMetadata(SpecConstantMetadataName());
+  }
+
+  // Workgroup size spec constants always occupy ids 0, 1 and 2.
+  auto enum_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32),
+                       static_cast<uint64_t>(SpecConstant::kWorkgroupSizeX)));
+  auto id_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32), 0));
+  auto wg_md = MDTuple::get(module->getContext(), {enum_const, id_const});
+  spec_constant_list_md->addOperand(wg_md);
+
+  enum_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32),
+                       static_cast<uint64_t>(SpecConstant::kWorkgroupSizeY)));
+  id_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32), 1));
+  wg_md = MDTuple::get(module->getContext(), {enum_const, id_const});
+  spec_constant_list_md->addOperand(wg_md);
+
+  enum_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32),
+                       static_cast<uint64_t>(SpecConstant::kWorkgroupSizeZ)));
+  id_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32), 2));
+  wg_md = MDTuple::get(module->getContext(), {enum_const, id_const});
+  spec_constant_list_md->addOperand(wg_md);
+}
+
+uint32_t AllocateSpecConstant(Module *module, SpecConstant kind) {
+  auto spec_constant_id_md =
+      module->getNamedMetadata(NextSpecConstantMetadataName());
+  if (!spec_constant_id_md) {
+    InitSpecConstantMetadata(module);
+    spec_constant_id_md =
+        module->getNamedMetadata(NextSpecConstantMetadataName());
+  }
+
+  auto value_md = spec_constant_id_md->getOperand(0);
+  auto value = cast<ConstantInt>(
+      dyn_cast<ValueAsMetadata>(value_md->getOperand(0))->getValue());
+  uint32_t next_id = static_cast<uint32_t>(value->getZExtValue());
+  // Update the next available id.
+  value_md->replaceOperandWith(
+      0, ValueAsMetadata::getConstant(ConstantInt::get(
+             IntegerType::get(module->getContext(), 32), next_id + 1)));
+
+  // Add the allocation to the metadata list.
+  auto spec_constant_list_md =
+      module->getNamedMetadata(SpecConstantMetadataName());
+  auto enum_const = ValueAsMetadata::getConstant(ConstantInt::get(
+      IntegerType::get(module->getContext(), 32), static_cast<uint64_t>(kind)));
+  auto id_const = ValueAsMetadata::getConstant(
+      ConstantInt::get(IntegerType::get(module->getContext(), 32), next_id));
+  auto wg_md = MDTuple::get(module->getContext(), {enum_const, id_const});
+  spec_constant_list_md->addOperand(wg_md);
+
+  return next_id;
+}
+
+std::vector<std::pair<SpecConstant, uint32_t>> GetSpecConstants(Module *module) {
+  std::vector<std::pair<SpecConstant, uint32_t>> spec_constants;
+  auto spec_constant_md = module->getNamedMetadata(clspv::SpecConstantMetadataName());
+  if (!spec_constant_md)
+    return spec_constants;
+
+  for (auto pair : spec_constant_md->operands()) {
+    // Metadata is formatted as pairs of <SpecConstant, id>.
+    auto kind = static_cast<SpecConstant>(
+        cast<ConstantInt>(
+            cast<ValueAsMetadata>(pair->getOperand(0))->getValue())
+            ->getZExtValue());
+
+    uint32_t spec_id = static_cast<uint32_t>(
+        cast<ConstantInt>(
+            cast<ValueAsMetadata>(pair->getOperand(1))->getValue())
+            ->getZExtValue());
+    spec_constants.emplace_back(kind, spec_id);
+  }
+
+  return spec_constants;
+}
+
+} // namespace clspv

--- a/lib/SpecConstant.h
+++ b/lib/SpecConstant.h
@@ -31,7 +31,8 @@ void AddWorkgroupSpecConstants(llvm::Module *module);
 uint32_t AllocateSpecConstant(llvm::Module *module, SpecConstant kind);
 
 // Returns the allocated specializations ids.
-std::vector<std::pair<SpecConstant, uint32_t>> GetSpecConstants(llvm::Module *module);
+std::vector<std::pair<SpecConstant, uint32_t>>
+GetSpecConstants(llvm::Module *module);
 
 } // namespace clspv
 

--- a/lib/SpecConstant.h
+++ b/lib/SpecConstant.h
@@ -1,0 +1,38 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_LIB_SPEC_CONSTANT_H_
+#define CLSPV_LIB_SPEC_CONSTANT_H_
+
+#include <utility>
+#include <vector>
+
+#include "clspv/SpecConstant.h"
+#include "llvm/IR/Module.h"
+
+namespace clspv {
+
+// Record the use of workgroup size spec constants. Always uses 0, 1 and 2 as
+// the spec ids.
+void AddWorkgroupSpecConstants(llvm::Module *module);
+
+// Allocates a specialization id for |kind|.
+uint32_t AllocateSpecConstant(llvm::Module *module, SpecConstant kind);
+
+// Returns the allocated specializations ids.
+std::vector<std::pair<SpecConstant, uint32_t>> GetSpecConstants(llvm::Module *module);
+
+} // namespace clspv
+
+#endif // CLSPV_LIB_SPEC_CONSTANT_H_

--- a/test/workgroup_size_spec_ids.cl
+++ b/test/workgroup_size_spec_ids.cl
@@ -8,10 +8,10 @@ kernel void copy(global int* out, global int* in) {
   *out = *in;
 }
 
+// CHECK: OpDecorate [[wgsize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
 // CHECK: OpDecorate [[wgx:%[a-zA-Z0-9_]+]] SpecId 0
 // CHECK: OpDecorate [[wgy:%[a-zA-Z0-9_]+]] SpecId 1
 // CHECK: OpDecorate [[wgz:%[a-zA-Z0-9_]+]] SpecId 2
-// CHECK: OpDecorate [[wgsize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
 // CHECK: [[wgsize]] = OpSpecConstantComposite {{.*}} [[wgx]] [[wgy]] [[wgz]]
 
 // MAP: spec_constant,workgroup_size_x,spec_id,0

--- a/test/workgroup_size_spec_ids.cl
+++ b/test/workgroup_size_spec_ids.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void copy(global int* out, global int* in) {
+  *out = *in;
+}
+
+// CHECK: OpDecorate [[wgx:%[a-zA-Z0-9_]+]] SpecId 0
+// CHECK: OpDecorate [[wgy:%[a-zA-Z0-9_]+]] SpecId 1
+// CHECK: OpDecorate [[wgz:%[a-zA-Z0-9_]+]] SpecId 2
+// CHECK: OpDecorate [[wgsize:%[a-zA-Z0-9_]+]] BuiltIn WorkgroupSize
+// CHECK: [[wgsize]] = OpSpecConstantComposite {{.*}} [[wgx]] [[wgy]] [[wgz]]
+
+// MAP: spec_constant,workgroup_size_x,spec_id,0
+// MAP: spec_constant,workgroup_size_y,spec_id,1
+// MAP: spec_constant,workgroup_size_z,spec_id,2


### PR DESCRIPTION
* Specializations ids recorded in metadata
  * used to generate new descriptor map entries
* Changed local memory spec ids to use new allocation method
* Added new enum for specialization constants
  * currently only workgroup size is added to the descriptor map

Example:
```
spec_constant,workgroup_size_x,spec_id,0
spec_constant,workgroup_size_y,spec_id,1
spec_constant,workgroup_size_z,spec_id,2
```