### PR TITLE
SPIRVProducerPass refactor - phase2

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2863,10 +2863,10 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
 
       // Allocate spec constants for workgroup size.
       clspv::AddWorkgroupSpecConstants(module);
-      
+
       SPIRVOperandVec Ops;
-      uint32_t result_type_id =
-          getSPIRVType(dyn_cast<VectorType>(Ty->getPointerElementType())->getElementType());
+      uint32_t result_type_id = getSPIRVType(
+          dyn_cast<VectorType>(Ty->getPointerElementType())->getElementType());
 
       // X Dimension
       Ops << MkId(result_type_id) << MkNum(1);
@@ -2913,7 +2913,8 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     // Ops[1] : Default literal value
     InitializerID = nextID++;
 
-    Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32))) << MkNum(3);
+    Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32)))
+        << MkNum(3);
 
     auto *Inst = new SPIRVInstruction(spv::OpSpecConstant, InitializerID, Ops);
     getSPIRVInstList(kConstants).push_back(Inst);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2910,13 +2910,11 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     //
     // Ops[0] : Result Type ID
     // Ops[1] : Default literal value
-    InitializerID = nextID++;
 
     Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32)))
         << MkNum(3);
 
-    auto *Inst = new SPIRVInstruction(spv::OpSpecConstant, InitializerID, Ops);
-    getSPIRVInstList(kConstants).push_back(Inst);
+    InitializerID = addSPIRVInst<kConstants>(spv::OpSpecConstant, Ops);
 
     //
     // Generate SpecId decoration.
@@ -2929,13 +2927,12 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     Ops << MkId(InitializerID) << MkNum(spv::DecorationSpecId)
         << MkNum(spec_id);
 
-    Inst = new SPIRVInstruction(spv::OpDecorate, Ops);
-    getSPIRVInstList(kAnnotations).push_back(Inst);
+    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
   } else if (BuiltinType == spv::BuiltInGlobalOffset) {
     // 1. Generate a spec constant with a default of {0, 0, 0}.
     // 2. Allocate and annotate SpecIds for the constants.
     // 3. Use the spec constant as the initializer for the variable.
-    SPIRVOperandList Ops;
+    SPIRVOperandVec Ops;
 
     //
     // Generate OpSpecConstant for each dimension.
@@ -2943,22 +2940,19 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     // Ops[0] : Result Type ID
     // Ops[1] : Default literal value
     //
-    uint32_t x_id = nextID++;
-    Ops << MkId(lookupType(IntegerType::get(GV.getContext(), 32))) << MkNum(0);
-    auto *Inst = new SPIRVInstruction(spv::OpSpecConstant, x_id, Ops);
-    getSPIRVInstList(kConstants).push_back(Inst);
+    Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32)))
+        << MkNum(0);
+    uint32_t x_id = addSPIRVInst<kConstants>(spv::OpSpecConstant, Ops);
 
-    uint32_t y_id = nextID++;
     Ops.clear();
-    Ops << MkId(lookupType(IntegerType::get(GV.getContext(), 32))) << MkNum(0);
-    Inst = new SPIRVInstruction(spv::OpSpecConstant, y_id, Ops);
-    getSPIRVInstList(kConstants).push_back(Inst);
+    Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32)))
+        << MkNum(0);
+    uint32_t y_id = addSPIRVInst<kConstants>(spv::OpSpecConstant, Ops);
 
-    uint32_t z_id = nextID++;
     Ops.clear();
-    Ops << MkId(lookupType(IntegerType::get(GV.getContext(), 32))) << MkNum(0);
-    Inst = new SPIRVInstruction(spv::OpSpecConstant, z_id, Ops);
-    getSPIRVInstList(kConstants).push_back(Inst);
+    Ops << MkId(getSPIRVType(IntegerType::get(GV.getContext(), 32)))
+        << MkNum(0);
+    uint32_t z_id = addSPIRVInst<kConstants>(spv::OpSpecConstant, Ops);
 
     //
     // Generate SpecId decoration for each dimension.
@@ -2970,20 +2964,17 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     auto spec_id = AllocateSpecConstant(module, SpecConstant::kGlobalOffsetX);
     Ops.clear();
     Ops << MkId(x_id) << MkNum(spv::DecorationSpecId) << MkNum(spec_id);
-    Inst = new SPIRVInstruction(spv::OpDecorate, Ops);
-    getSPIRVInstList(kAnnotations).push_back(Inst);
+    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
 
     spec_id = AllocateSpecConstant(module, SpecConstant::kGlobalOffsetY);
     Ops.clear();
     Ops << MkId(y_id) << MkNum(spv::DecorationSpecId) << MkNum(spec_id);
-    Inst = new SPIRVInstruction(spv::OpDecorate, Ops);
-    getSPIRVInstList(kAnnotations).push_back(Inst);
+    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
 
     spec_id = AllocateSpecConstant(module, SpecConstant::kGlobalOffsetZ);
     Ops.clear();
     Ops << MkId(z_id) << MkNum(spv::DecorationSpecId) << MkNum(spec_id);
-    Inst = new SPIRVInstruction(spv::OpDecorate, Ops);
-    getSPIRVInstList(kAnnotations).push_back(Inst);
+    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
 
     //
     // Generate OpSpecConstantComposite.
@@ -2991,13 +2982,10 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
     // Ops[0] : type id
     // Ops[1..n-1] : elements
     //
-    InitializerID = nextID++;
     Ops.clear();
-    Ops << MkId(lookupType(GV.getType()->getPointerElementType())) << MkId(x_id)
-        << MkId(y_id) << MkId(z_id);
-    Inst =
-        new SPIRVInstruction(spv::OpSpecConstantComposite, InitializerID, Ops);
-    getSPIRVInstList(kConstants).push_back(Inst);
+    Ops << MkId(getSPIRVType(GV.getType()->getPointerElementType()))
+        << MkId(x_id) << MkId(y_id) << MkId(z_id);
+    InitializerID = addSPIRVInst<kConstants>(spv::OpSpecConstantComposite, Ops);
   }
 
   //

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2485,7 +2485,6 @@ SPIRVID SPIRVProducerPass::getSPIRVValue(Value *V) {
   } else {
     llvm_unreachable("Variable not found");
   }
-  return 0;
 }
 
 void SPIRVProducerPass::GenerateSPIRVConstants() {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -188,7 +188,7 @@ struct SPIRVInstruction {
   // Primary constructor must have Opcode, initializes WordCount based on ResID.
   SPIRVInstruction(spv::Op Opc, SPIRVID ResID = 0)
       : Opcode(static_cast<uint16_t>(Opc)) {
-    setResult(Opc, ResID);
+    setResult(ResID);
   }
 
   // Creates an instruction with an opcode and no result ID, and with the given
@@ -213,7 +213,7 @@ struct SPIRVInstruction {
   }
 
 private:
-  void setResult(spv::Op Opc, uint32_t ResID = 0) {
+  void setResult(uint32_t ResID = 0) {
     WordCount = 1 + (ResID != 0 ? 1 : 0);
     ResultID = ResID;
   }

--- a/test/CPlusPlus/generic-addrspace.cl
+++ b/test/CPlusPlus/generic-addrspace.cl
@@ -11,6 +11,9 @@
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK-DAG: %[[__original_id_11:[0-9]+]] = OpTypeFunction %[[void]]
 // CHECK-DAG: %[[_ptr_StorageBuffer_uint:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[uint]]
+// CHECK-DAG: %[[__spc_1:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__spc_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__spc_3:[0-9]+]] = OpSpecConstant %[[uint]] 1
 // CHECK-DAG: %[[__original_id_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
 // CHECK-DAG: %[[_arr_uint_2:[0-9a-zA-Z_]+]] = OpTypeArray %[[uint]] %[[__original_id_2]]
 // CHECK-DAG: %[[_ptr_Workgroup__arr_uint_2:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[_arr_uint_2]]

--- a/test/CPlusPlus/object-and-overload.cl
+++ b/test/CPlusPlus/object-and-overload.cl
@@ -13,6 +13,9 @@
 // CHECK-DAG: %[[_ptr_StorageBuffer__struct_7:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[_struct_7]]
 // CHECK-DAG: %[[_ptr_Workgroup_uint:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[uint]]
 // CHECK-DAG: %[[_ptr_StorageBuffer_uint:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[uint]]
+// CHECK-DAG: %[[__spc_1:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__spc_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__spc_3:[0-9]+]] = OpSpecConstant %[[uint]] 1
 // CHECK-DAG: %[[__original_id_2:[0-9]+]] = OpSpecConstant %[[uint]] 1
 // CHECK-DAG: %[[_arr_uint_2:[0-9a-zA-Z_]+]] = OpTypeArray %[[uint]] %[[__original_id_2]]
 // CHECK-DAG: %[[_ptr_Workgroup__arr_uint_2:[0-9a-zA-Z_]+]] = OpTypePointer Workgroup %[[_arr_uint_2]]

--- a/test/UBO/constant_and_image.cl
+++ b/test/UBO/constant_and_image.cl
@@ -28,6 +28,7 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 // CHECK-DAG: OpDecorate [[data_var]] DescriptorSet 0
 // CHECK: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK: [[image:%[0-9a-zA-Z_]+]] = OpTypeImage [[float]] 2D 0 0 0 1 Unknown
+// CHECK: [[sampled_image:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[image]]
 // CHECK: [[image_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[image]]
 // CHECK: [[sampler:%[0-9a-zA-Z_]+]] = OpTypeSampler
 // CHECK: [[sampler_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[sampler]]
@@ -46,7 +47,6 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 // CHECK: [[ptr_uniform_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v4float]]
 // CHECK: [[ptr_uniform_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v2float]]
 // CHECK: [[ptr_storagebuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[v4float]]
-// CHECK: [[sampled_image:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[image]]
 // CHECK: [[float_zero:%[0-9a-zA-Z_]+]] = OpConstant [[float]] 0
 // CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
 // CHECK: [[image_var]] = OpVariable [[image_ptr]] UniformConstant

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -37,10 +37,10 @@ __kernel void foo(__global data_type* data, __constant data_type* c_arg, __local
 // CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
 // CHECK: [[l_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[int]]
 // CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
 // CHECK: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
 // CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
 // CHECK: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]
-// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
 // CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
 // CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
 // CHECK: [[l_arg:%[0-9a-zA-Z_]+]] = OpVariable [[l_arg_ptr]] Workgroup

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -38,6 +38,9 @@ __kernel void foo(__global data_type* data, __constant data_type* c_arg, __local
 // CHECK: [[l_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[int]]
 // CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
 // CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK: [[size1:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK: [[size2:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK: [[size3:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
 // CHECK: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
 // CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
 // CHECK: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -27,7 +27,6 @@ kernel void foo(local float *L, global float* A, float f, S local* LS, constant 
 // CHECK-DAG:  [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
 // CHECK-DAG:  [[__ptr_Workgroup_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_uint]]
 // CHECK-DAG:  [[__struct_22:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_uint]] [[_uint]]
-// CHECK-DAG:  [[__ptr_Workgroup__struct_22:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__struct_22]]
 // CHECK-DAG:  [[_2]] = OpSpecConstant [[_uint]] 1
 // CHECK-DAG:  [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
 // CHECK-DAG:  [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -34,7 +34,6 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // CHECK-DAG:  [[__ptr_Workgroup_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_uint]]
 // CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
 // CHECK-DAG:  [[__struct_24:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_uint]] [[_uint]]
-// CHECK-DAG:  [[__ptr_Workgroup__struct_24:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__struct_24]]
 // CHECK-DAG:  [[_2]] = OpSpecConstant [[_uint]] 1
 // CHECK-DAG:  [[__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypeArray [[_float]] [[_2]]
 // CHECK-DAG:  [[__ptr_Workgroup__arr_float_2:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr_float_2]]


### PR DESCRIPTION
* addSPIRVInst for creating/inserting new SPIRVInstruction
  * Creates/manages ResultID based on spv::HasResultAndType in one place (almost, nextID still used for second pass)
* Consolidated on SmallVector storage for SPIRVOperandVec (replaces SPIRVOperandList)
* Consolidated Workgroup variable creation

Enhancement for clspv issue #545