### PR TITLE
Remove unused variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ set(CLANG_INCLUDE_DIRS
 
 if(NOT WIN32)
   # Disable RTTI and exceptions (to match LLVM)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -Werror-unused-variable")
 endif()
 
 # Bring in our cmake folder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,9 @@ if(NOT ${SKIP_CLSPV_TOOLS_INSTALL})
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-	# GCC 7.3 complains about LLVM code: RetryAfterSignal in lib/Support/Process.cpp
-	# Silence that warning for now.
-	# TODO(dneto): Upgrade to newer LLVM to avoid this issue.
+  # GCC 7.3 complains about LLVM code: RetryAfterSignal in lib/Support/Process.cpp
+  # Silence that warning for now.
+  # TODO(dneto): Upgrade to newer LLVM to avoid this issue.
   add_compile_options("-Wno-noexcept-type")
 endif()
 
@@ -152,9 +152,6 @@ if(NOT WIN32)
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-	# GCC 7.3 complains about LLVM code: RetryAfterSignal in lib/Support/Process.cpp
-	# Silence that warning for now.
-	# TODO(dneto): Upgrade to newer LLVM to avoid this issue.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-variable")
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror-unused-variable")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 	# GCC 7.3 complains about LLVM code: RetryAfterSignal in lib/Support/Process.cpp
 	# Silence that warning for now.
 	# TODO(dneto): Upgrade to newer LLVM to avoid this issue.
-	add_compile_options("-Wno-noexcept-type")
+  add_compile_options("-Wno-noexcept-type")
 endif()
 
 if (NOT DEFINED SPIRV_HEADERS_SOURCE_DIR)
@@ -148,7 +148,16 @@ set(CLANG_INCLUDE_DIRS
 
 if(NOT WIN32)
   # Disable RTTI and exceptions (to match LLVM)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -Werror-unused-variable")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+	# GCC 7.3 complains about LLVM code: RetryAfterSignal in lib/Support/Process.cpp
+	# Silence that warning for now.
+	# TODO(dneto): Upgrade to newer LLVM to avoid this issue.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-variable")
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror-unused-variable")
 endif()
 
 # Bring in our cmake folder

--- a/kokoro/scripts/linux/build-amber.sh
+++ b/kokoro/scripts/linux/build-amber.sh
@@ -34,7 +34,7 @@ else
   # Specify we want to build with GCC 7 (which supports C++14)
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test
   sudo apt-get update
-  sudo apt-get install -y gcc-7 g++-7
+  sudo aptitude install -y gcc-7 g++-7
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
   sudo update-alternatives --set gcc "/usr/bin/gcc-7"
   CMAKE_C_CXX_COMPILER="-DCMAKE_C_COMPILER=/usr/bin/gcc-7 -DCMAKE_CXX_COMPILER=/usr/bin/g++-7"

--- a/kokoro/scripts/linux/build-clvk.sh
+++ b/kokoro/scripts/linux/build-clvk.sh
@@ -29,7 +29,7 @@ BUILD_TYPE="Debug"
 # We need a newer libstdc++ for clvk
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt update -qq
-sudo apt install -y g++-7
+sudo aptitude install -y g++-7
 
 CMAKE_C_CXX_COMPILER=""
 if [ $COMPILER = "clang" ]; then
@@ -39,7 +39,7 @@ else
   # Specify we want to build with GCC 7 (which supports C++14)
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test
   sudo apt-get update
-  sudo apt-get install -y gcc-7 g++-7
+  sudo aptitude install -y gcc-7 g++-7
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
   sudo update-alternatives --set gcc "/usr/bin/gcc-7"
   CMAKE_C_CXX_COMPILER="-DCMAKE_C_COMPILER=/usr/bin/gcc-7 -DCMAKE_CXX_COMPILER=/usr/bin/g++-7"

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -34,7 +34,7 @@ else
   # Specify we want to build with GCC 7 (which supports C++14)
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test
   sudo apt-get update
-  sudo apt-get install -y gcc-7 g++-7
+  sudo aptitude install -y gcc-7 g++-7
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
   sudo update-alternatives --set gcc "/usr/bin/gcc-7"
   CMAKE_C_CXX_COMPILER="-DCMAKE_C_COMPILER=/usr/bin/gcc-7 -DCMAKE_CXX_COMPILER=/usr/bin/g++-7"

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -79,11 +79,11 @@ private:
   // 0.
   unsigned StartNewDescriptorSet(Module &M) {
     // Allocate the descriptor set we used.
-    unsigned result = descriptor_set_++;
     binding_ = 0;
     const auto set = clspv::TakeDescriptorIndex(&M);
-    assert(set == result);
-    return result;
+    assert(set == descriptor_set_);
+    descriptor_set_++;
+    return set;
   }
 
   // Returns true if |F| or call function |F| calls contains a global barrier.
@@ -851,9 +851,6 @@ bool AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
   // Allocates a SpecId for |type|.
   auto GetSpecId = [&M, &spec_id_types, &function_spec_ids,
                     &function_allocations](Type *type) {
-    const bool always_distinct_sets =
-        clspv::Option::DistinctKernelDescriptorSets();
-
     // Attempt to reuse a SpecId. If the SpecId is associated with the same type
     // in another kernel and not yet assigned to this kernel it can be reused.
     auto where = spec_id_types.find(type);

--- a/lib/ComputeStructuredOrder.cpp
+++ b/lib/ComputeStructuredOrder.cpp
@@ -24,8 +24,6 @@ void clspv::ComputeStructuredOrder(BasicBlock *block, DominatorTree *DT,
   if (!visited->insert(block).second)
     return;
 
-  auto F = block->getParent();
-
   // Identify the merge and continue blocks for special treatment.
   const auto *terminator = block->getTerminator();
   BasicBlock *continue_block = nullptr;

--- a/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
@@ -293,7 +293,7 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
   if (isSupportEnabled) {
     auto Dim = &*F->arg_begin();
     auto InBoundsDim = inBoundsDimensionIndex(Builder, Dim);
-    Value *Indices[] = {Builder.getInt32(0), Dim};
+    Value *Indices[] = {Builder.getInt32(0), InBoundsDim};
     auto GoffPtr =
         GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset);
     auto GoffDimPtr = Builder.CreateInBoundsGEP(GoffPtr, Indices);

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -336,7 +336,6 @@ private:
     const FieldDecl *prev = nullptr;
     for (auto field_decl : RT->getDecl()->fields()) {
       const auto field_type = field_decl->getType();
-      const auto field_alignment = GetAlignment(field_type, layout, context);
       const unsigned field_no = field_decl->getFieldIndex();
       const uint64_t field_offset =
           record_layout.getFieldOffset(field_no) / context.getCharWidth();

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -85,7 +85,7 @@ private:
     auto canonical = QT.getCanonicalType();
     if (auto *PT = dyn_cast<PointerType>(canonical)) {
       return ContainsArrayType(PT->getPointeeType());
-    } else if (auto *AT = dyn_cast<ArrayType>(canonical)) {
+    } else if (isa<ArrayType>(canonical)) {
       return true;
     } else if (auto *RT = dyn_cast<RecordType>(canonical)) {
       for (auto field_decl : RT->getDecl()->fields()) {
@@ -105,7 +105,7 @@ private:
     }
 
     if (auto *PT = dyn_cast<PointerType>(canonical)) {
-      return IsRecursiveType(canonical->getPointeeType(), seen);
+      return IsRecursiveType(PT->getPointeeType(), seen);
     } else if (auto *AT = dyn_cast<ArrayType>(canonical)) {
       return IsRecursiveType(AT->getElementType(), seen);
     } else if (auto *RT = dyn_cast<RecordType>(canonical)) {

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -223,7 +223,7 @@ void MultiVersionUBOFunctionsPass::SpecializeCall(
 
   IRBuilder<> builder(&*where);
   auto new_arg_iter = clone->arg_begin();
-  for (auto &arg : fn->args()) {
+  for (size_t i = 0; i < fn->arg_size(); ++i) {
     ++new_arg_iter;
   }
   for (auto info : resources) {

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -157,8 +157,6 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
       return OutType;
     };
 
-    unsigned *numSrcUnpackings = 0;
-    unsigned *numDstUnpackings = 0;
     while (*SrcElemTy != *DstElemTy) {
       auto SrcElemSize = Layout.getTypeSizeInBits(*SrcElemTy);
       auto DstElemSize = Layout.getTypeSizeInBits(*DstElemTy);
@@ -226,12 +224,15 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
           assert(DstElemTy == SrcElemTy);
 
           auto DstElemSize = Layout.getTypeSizeInBits(DstElemTy) / 8;
+          (void)DstElemSize;
 
           // Check that the size is a multiple of the size of the pointee type.
           assert(Size % DstElemSize == 0);
 
           auto Alignment = cast<MemIntrinsic>(CI)->getDestAlignment();
           auto TypeAlignment = Layout.getABITypeAlignment(DstElemTy);
+          (void)Alignment;
+          (void)TypeAlignment;
 
           // Check that the alignment is at least the alignment of the pointee
           // type.

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -1293,7 +1293,6 @@ bool ReplaceOpenCLBuiltinPass::replaceStep(Function &F, bool is_smooth,
 }
 
 bool ReplaceOpenCLBuiltinPass::replaceSignbit(Function &F, bool is_vec) {
-  Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
     auto Arg = CI->getOperand(0);
     auto Op = is_vec ? Instruction::AShr : Instruction::LShr;
@@ -1307,7 +1306,6 @@ bool ReplaceOpenCLBuiltinPass::replaceSignbit(Function &F, bool is_vec) {
 
 bool ReplaceOpenCLBuiltinPass::replaceMul(Function &F, bool is_float,
                                           bool is_mad) {
-  Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
     // The multiply instruction to use.
     auto MulInst = is_float ? Instruction::FMul : Instruction::Mul;
@@ -1329,7 +1327,6 @@ bool ReplaceOpenCLBuiltinPass::replaceMul(Function &F, bool is_float,
 }
 
 bool ReplaceOpenCLBuiltinPass::replaceVstore(Function &F) {
-  Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
     Value *V = nullptr;
     auto data = CI->getOperand(0);
@@ -1368,7 +1365,6 @@ bool ReplaceOpenCLBuiltinPass::replaceVstore(Function &F) {
 }
 
 bool ReplaceOpenCLBuiltinPass::replaceVload(Function &F) {
-  Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {
     Value *V = nullptr;
     auto ret_type = F.getReturnType();
@@ -2147,8 +2143,6 @@ bool ReplaceOpenCLBuiltinPass::replaceFract(Function &F, int vec_size) {
 
   Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) {
-    auto &Context = M.getContext();
-
     std::string floor_name = "_Z5floor";
     std::string fmin_name = "_Z4fmin";
     std::string clspv_fract_name = "clspv.fract.";

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -446,8 +446,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
               } else {
                 unsigned DstVecTyNumElement =
                     DstVecTy->getNumElements() / NumVector;
-                SmallVector<uint32_t, 4> Idxs;
-                for (unsigned i = 0; i < DstVecTyNumElement; i++) {
+                SmallVector<int32_t, 4> Idxs;
+                for (int i = 0; i < DstVecTyNumElement; i++) {
                   Idxs.push_back(i + (DstVecTyNumElement * VIdx));
                 }
                 Value *UndefVal = UndefValue::get(DstTy);
@@ -468,8 +468,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                 unsigned SrcNumElement = SrcVecTy->getNumElements();
                 unsigned DstNumElement = DstVecTy->getNumElements();
                 for (unsigned i = 0; i < NumElement; i++) {
-                  SmallVector<uint32_t, 4> Idxs;
-                  for (unsigned j = 0; j < SrcNumElement; j++) {
+                  SmallVector<int32_t, 4> Idxs;
+                  for (int j = 0; j < SrcNumElement; j++) {
                     Idxs.push_back(i * SrcNumElement + j);
                   }
 
@@ -717,8 +717,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                 unsigned NumElement = DstTyBitWidth / SrcEleTyBitWidth;
                 Value *Undef = UndefValue::get(SrcTy);
 
-                SmallVector<uint32_t, 4> Idxs;
-                for (unsigned i = 0; i < NumElement; i++) {
+                SmallVector<int32_t, 4> Idxs;
+                for (int i = 0; i < NumElement; i++) {
                   Idxs.push_back(i);
                 }
                 DstVal = Builder.CreateShuffleVector(LDValues[0], Undef, Idxs);
@@ -747,7 +747,6 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                 // ==> if types are same between src and dst, it will be
                 // igonored
                 //
-                unsigned NumElement = SrcTyBitWidth / DstTyBitWidth;
                 unsigned SubNumElement = SrcEleTyBitWidth / DstTyBitWidth;
                 if (SubNumElement != 2 && SubNumElement != 4) {
                   llvm_unreachable("Unsupported SubNumElement");
@@ -830,8 +829,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                   for (unsigned i = 0; i < Values.size(); i++) {
                     Values[i] = Builder.CreateBitCast(Values[i], TmpVecTy);
                   }
-                  SmallVector<uint32_t, 4> Idxs;
-                  for (unsigned i = 0; i < (NumVector * 2); i++) {
+                  SmallVector<int32_t, 4> Idxs;
+                  for (int i = 0; i < (NumVector * 2); i++) {
                     Idxs.push_back(i);
                   }
                   for (unsigned i = 0; i < Values.size(); i = i + 2) {

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -862,8 +862,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
             while (LDValues.size() != 1) {
               SmallVector<Value *, 4> TmpLDValues;
               for (unsigned i = 0; i < LDValues.size(); i = i + 2) {
-                SmallVector<uint32_t, 4> Idxs;
-                for (unsigned j = 0; j < NumElement; j++) {
+                SmallVector<int32_t, 4> Idxs;
+                for (int j = 0; j < NumElement; j++) {
                   Idxs.push_back(j);
                 }
                 Value *TmpVal = Builder.CreateShuffleVector(

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -73,7 +73,8 @@ private:
                                        InsertionVector *chain) {
     auto *structTy = dyn_cast<StructType>(iv->getType());
     assert(structTy);
-    const auto numElems = structTy->getNumElements();
+    if (!structTy)
+      return nullptr;
 
     // Walk backward from the tail to an instruction we don't want to
     // replace.
@@ -85,7 +86,7 @@ private:
         // Try to replace this one.
 
         unsigned index = insertion->getIndices()[0];
-        assert(index < numElems);
+        assert(index < structTy->getNumElements());
         if ((*values)[index] != nullptr) {
           // We already have a value for this slot.  Stop now.
           break;

--- a/lib/SignedCompareFixupPass.cpp
+++ b/lib/SignedCompareFixupPass.cpp
@@ -124,8 +124,6 @@ bool SignedCompareFixupPass::runOnModule(Module &M) {
       llvm_unreachable("Unhandled constant vector type");
     }
     auto *sign_bit = ConstantInt::get(x_type, uint64_t(1) << (bit_width - 1));
-    auto *all_one_bits =
-        ConstantInt::get(x_type, APInt::getMaxValue(bit_width));
 
     Builder.SetInsertPoint(icmp);
     Value *replacement;

--- a/lib/SplatArgPass.cpp
+++ b/lib/SplatArgPass.cpp
@@ -86,7 +86,6 @@ SplatArgPass::getSplatName(const Builtins::FunctionInfo &func_info,
 Function *SplatArgPass::getReplacementFunction(Function &F,
                                                const std::string &NewCallName) {
   Module *M = F.getParent();
-  FunctionType *CalleeTy = F.getFunctionType();
 
   // Create new callee function type with vector type.
   Type *VectorType = F.getArg(0)->getType();

--- a/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
@@ -40,10 +40,11 @@
 // CHECK:     %[[__original_id_26]] = OpFunction %[[uint]] Const %[[__original_id_9]]
 // CHECK:     %[[__original_id_27:[0-9]+]] = OpFunctionParameter %[[uint]]
 // CHECK:     %[[__original_id_28:[0-9]+]] = OpLabel
-// CHECK:     %[[__original_id_29:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_18]] %[[uint_0]] %[[__original_id_27]]
+// CHECK:     %[[less:[a-zA-Z0-9_]+]] = OpULessThan %[[bool]] %[[__original_id_27]] %[[uint_3]]
+// CHECK:     %[[select:[a-zA-Z0-9_]+]] = OpSelect %[[uint]] %[[less]] %[[__original_id_27]] %[[uint_0]]
+// CHECK:     %[[__original_id_29:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_18]] %[[uint_0]] %[[select]]
 // CHECK:     %[[__original_id_30:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_29]]
-// CHECK:     %[[__original_id_31:[0-9]+]] = OpULessThan %[[bool]] %[[__original_id_27]] %[[uint_3]]
-// CHECK:     %[[__original_id_32:[0-9]+]] = OpSelect %[[uint]] %[[__original_id_31]] %[[__original_id_30]] %[[uint_0]]
+// CHECK:     %[[__original_id_32:[0-9]+]] = OpSelect %[[uint]] %[[less]] %[[__original_id_30]] %[[uint_0]]
 // CHECK:     OpReturnValue %[[__original_id_32]]
 // CHECK:     OpFunctionEnd
 


### PR DESCRIPTION
* Add compiler error to clang and gcc for unused variables
* Remove unused variables throughout the code
* Fix a bug in get_global_offset that potentially accessed out-of-bounds
memory
  * updated related test
* Fixed some deprecated uses of CreateShuffleVector