### PR TITLE
Initial support for non-uniform NDRanges

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -516,6 +516,18 @@ Here is a list of the push constants currently supported:
 - `enqueued_local_size`: the 3D local work size returned by
   `get_enqueued_local_size()`. A vector of 3 32-bit integer values. Lower
   dimensions come first in memory.
+- `global_size`: the 3D global size of the NDRange as returned by
+  `get_global_size()`. A vector of 3 32-bit integer values. Lower dimensions
+  come first in memory. Only required when non-uniform NDRanges are supported.
+- `num_workgroups`: the 3D number of work groups in the NDRange as returned by
+  `get_num_groups()`. A vector of 3 32-bit integer values. Lower dimensions come
+  first in memory. Only required when non-uniform NDRanges are supported.
+- `region_offset`: the 3D global ID offset into the NDRange for this uniform
+  region. A vector of 3 32-bit integer values. Lower dimensions come first in
+  memory. Only required when non-uniform NDRanges are supported.
+- `region_group_offset`: the 3D group ID offset into the NDRange for this
+  region. A vector of 3 32-bit integer values. Lower dimensions come first in
+  memory. Only required when non-uniform NDRanges are supported.
 
 ### Attributes
 

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -522,9 +522,10 @@ Here is a list of the push constants currently supported:
 - `num_workgroups`: the 3D number of work groups in the NDRange as returned by
   `get_num_groups()`. A vector of 3 32-bit integer values. Lower dimensions come
   first in memory. Only required when non-uniform NDRanges are supported.
-- `region_offset`: the 3D global ID offset into the NDRange for this uniform
-  region. A vector of 3 32-bit integer values. Lower dimensions come first in
-  memory. Only required when non-uniform NDRanges are supported.
+- `region_offset`: the sum of the global ID offset into the NDRange for this
+  uniform region and the global offset of the NDRange. A vector of 3 32-bit
+  integer values. Lower dimensions come first in memory. Only required when
+  non-uniform NDRanges are supported.
 - `region_group_offset`: the 3D group ID offset into the NDRange for this
   region. A vector of 3 32-bit integer values. Lower dimensions come first in
   memory. Only required when non-uniform NDRanges are supported.

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -159,6 +159,12 @@ bool WorkDim();
 // Returns true when support for global offset is enabled.
 bool GlobalOffset();
 
+// Returns true when support for non uniform NDRanges is enabled.
+static bool NonUniformNDRangeSupported() {
+  return (Language() == SourceLanguage::OpenCL_CPP) ||
+         ((Language() == SourceLanguage::OpenCL_C_20));
+}
+
 } // namespace Option
 } // namespace clspv
 

--- a/include/clspv/PushConstant.h
+++ b/include/clspv/PushConstant.h
@@ -21,6 +21,10 @@ enum class PushConstant : int {
   Dimensions,
   GlobalOffset,
   EnqueuedLocalSize,
+  GlobalSize,
+  RegionOffset,
+  NumWorkgroups,
+  RegionGroupOffset,
 };
 
 } // namespace clspv

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -36,6 +36,14 @@ const char *GetPushConstantName(PushConstant pc) {
     return "global_offset";
   case PushConstant::EnqueuedLocalSize:
     return "enqueued_local_size";
+  case PushConstant::GlobalSize:
+    return "global_size";
+  case PushConstant::RegionOffset:
+    return "region_offset";
+  case PushConstant::NumWorkgroups:
+    return "num_workgroups";
+  case PushConstant::RegionGroupOffset:
+    return "region_group_offset";
   }
   llvm_unreachable("Unknown PushConstant in GetPushConstantName");
   return "";
@@ -49,6 +57,14 @@ Type *GetPushConstantType(Module &M, PushConstant pc) {
   case PushConstant::GlobalOffset:
     return VectorType::get(IntegerType::get(C, 32), 3);
   case PushConstant::EnqueuedLocalSize:
+    return VectorType::get(IntegerType::get(C, 32), 3);
+  case PushConstant::GlobalSize:
+    return VectorType::get(IntegerType::get(C, 32), 3);
+  case PushConstant::RegionOffset:
+    return VectorType::get(IntegerType::get(C, 32), 3);
+  case PushConstant::NumWorkgroups:
+    return VectorType::get(IntegerType::get(C, 32), 3);
+  case PushConstant::RegionGroupOffset:
     return VectorType::get(IntegerType::get(C, 32), 3);
   }
   llvm_unreachable("Unknown PushConstant in GetPushConstantType");

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3210,7 +3210,7 @@ void SPIRVProducerPass::GenerateGlobalVar(GlobalVariable &GV) {
 
     // If all kernels do not have metadata for reqd_work_group_size, generate
     // OpSpecConstants for x/y/z dimension.
-    if (!HasMD) {
+    if (!HasMD || clspv::Option::NonUniformNDRangeSupported()) {
       //
       // Generate OpSpecConstants for x/y/z dimension.
       //
@@ -3853,8 +3853,9 @@ void SPIRVProducerPass::GenerateModuleInfo() {
 
   SPIRVInstructionList &SPIRVExecutionModes = getSPIRVInstList(kExecutionModes);
   for (auto EntryPoint : EntryPoints) {
-    if (const MDNode *MD = dyn_cast<Function>(EntryPoint.first)
-                               ->getMetadata("reqd_work_group_size")) {
+    const MDNode *MD = dyn_cast<Function>(EntryPoint.first)
+                           ->getMetadata("reqd_work_group_size");
+    if ((MD != nullptr) && !clspv::Option::NonUniformNDRangeSupported()) {
 
       if (!BuiltinDimVec.empty()) {
         llvm_unreachable(

--- a/test/WorkItemBuiltins/get_global_id-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_global_id-non-uniform.cl
@@ -6,16 +6,12 @@
 
 // DMAP: pushconstant,name,region_offset,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_12]] Block
 // CHECK:     OpDecorate %[[gl_GlobalInvocationID:[0-9a-zA-Z_]+]] BuiltIn GlobalInvocationId
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
 // CHECK-DAG: %[[_ptr_Input_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[v3uint]]
 // CHECK-DAG: %[[_ptr_Input_uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[uint]]
-// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_12:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_global_id-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_global_id-non-uniform.cl
@@ -1,0 +1,34 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=DMAP %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// DMAP: pushconstant,name,region_offset,offset,0,size,12
+
+// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_3]] Block
+// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_12]] Block
+// CHECK:     OpDecorate %[[gl_GlobalInvocationID:[0-9a-zA-Z_]+]] BuiltIn GlobalInvocationId
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[_ptr_Input_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[v3uint]]
+// CHECK-DAG: %[[_ptr_Input_uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[uint]]
+// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
+// CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[__original_id_16:[0-9]+]] = OpVariable %[[_ptr_PushConstant__struct_12]] PushConstant
+// CHECK-DAG: %[[gl_GlobalInvocationID]] = OpVariable %[[_ptr_Input_v3uint]] Input
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpAccessChain %[[_ptr_Input_uint]] %[[gl_GlobalInvocationID]] %[[uint_0]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_16]] %[[uint_0]] %[[uint_0]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpIAdd %[[uint]] %[[__original_id_25]] %[[__original_id_23]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_global_id(0);
+}
+

--- a/test/WorkItemBuiltins/get_global_size-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_global_size-non-uniform.cl
@@ -6,13 +6,9 @@
 
 // DMAP: pushconstant,name,global_size,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_12]] Block
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
-// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_12:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_global_size-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_global_size-non-uniform.cl
@@ -1,0 +1,27 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=DMAP %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// DMAP: pushconstant,name,global_size,offset,0,size,12
+
+// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_3]] Block
+// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_12]] Block
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
+// CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[__original_id_16:[0-9]+]] = OpVariable %[[_ptr_PushConstant__struct_12]] PushConstant
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_16]] %[[uint_0]] %[[uint_0]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_24]]
+// CHECK:     OpStore {{.*}} %[[__original_id_25]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_global_size(0);
+}
+

--- a/test/WorkItemBuiltins/get_group_id-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_group_id-non-uniform.cl
@@ -1,0 +1,34 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=DMAP %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// DMAP: pushconstant,name,region_group_offset,offset,0,size,12
+
+// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_3]] Block
+// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_12]] Block
+// CHECK:     OpDecorate %[[gl_WorkGroupID:[0-9a-zA-Z_]+]] BuiltIn WorkgroupId
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[_ptr_Input_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[v3uint]]
+// CHECK-DAG: %[[_ptr_Input_uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[uint]]
+// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
+// CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpVariable %[[_ptr_PushConstant__struct_12]] PushConstant
+// CHECK-DAG: %[[gl_WorkGroupID]] = OpVariable %[[_ptr_Input_v3uint]] Input
+// CHECK:     %[[__original_id_30:[0-9]+]] = OpAccessChain %[[_ptr_Input_uint]] %[[gl_WorkGroupID]] %[[uint_0]]
+// CHECK:     %[[__original_id_31:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_30]]
+// CHECK:     %[[__original_id_32:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_18]] %[[uint_0]] %[[uint_0]]
+// CHECK:     %[[__original_id_33:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_32]]
+// CHECK:     %[[__original_id_34:[0-9]+]] = OpIAdd %[[uint]] %[[__original_id_33]] %[[__original_id_31]]
+// CHECK:     OpStore {{.*}} %[[__original_id_34]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_group_id(0);
+}
+

--- a/test/WorkItemBuiltins/get_group_id-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_group_id-non-uniform.cl
@@ -6,16 +6,12 @@
 
 // DMAP: pushconstant,name,region_group_offset,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_12]] Block
 // CHECK:     OpDecorate %[[gl_WorkGroupID:[0-9a-zA-Z_]+]] BuiltIn WorkgroupId
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
 // CHECK-DAG: %[[_ptr_Input_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[v3uint]]
 // CHECK-DAG: %[[_ptr_Input_uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[uint]]
-// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_12:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_num_groups-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_num_groups-non-uniform.cl
@@ -1,0 +1,27 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points -descriptormap=%t.dmap %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=DMAP %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// DMAP: pushconstant,name,num_workgroups,offset,0,size,12
+
+// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_3]] Block
+// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK:     OpDecorate %[[_struct_10]] Block
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[_struct_10]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_ptr_PushConstant__struct_10:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_10]]
+// CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[__original_id_14:[0-9]+]] = OpVariable %[[_ptr_PushConstant__struct_10]] PushConstant
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpAccessChain %[[_ptr_PushConstant_uint]] %[[__original_id_14]] %[[uint_0]] %[[uint_0]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[uint]] %[[__original_id_19]]
+// CHECK:     OpStore {{.*}} %[[__original_id_20]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_num_groups(0);
+}
+

--- a/test/WorkItemBuiltins/get_num_groups-non-uniform.cl
+++ b/test/WorkItemBuiltins/get_num_groups-non-uniform.cl
@@ -6,13 +6,9 @@
 
 // DMAP: pushconstant,name,num_workgroups,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_10]] Block
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
-// CHECK-DAG: %[[_struct_10]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_10:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_10]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/reqd_work_group_size-non-uniform.cl
+++ b/test/reqd_work_group_size-non-uniform.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     OpEntryPoint GLCompute %[[__original_id_16:[0-9]+]] "test"
+// CHECK:     OpDecorate %[[gl_WorkGroupSize:[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
+// CHECK:     OpDecorate %[[__original_id_11:[0-9]+]] SpecId 0
+// CHECK:     OpDecorate %[[__original_id_12:[0-9]+]] SpecId 1
+// CHECK:     OpDecorate %[[__original_id_13:[0-9]+]] SpecId 2
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[__original_id_3:[0-9]+]] = OpTypeFunction %[[void]]
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[_ptr_Private_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Private %[[v3uint]]
+// CHECK-DAG: %[[__original_id_11]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_12]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_13]] = OpSpecConstant %[[uint]] 1
+// CHECK-DAG: %[[gl_WorkGroupSize]] = OpSpecConstantComposite %[[v3uint]] %[[__original_id_11]] %[[__original_id_12]] %[[__original_id_13]]
+// CHECK-DAG: %[[__original_id_15:[0-9]+]] = OpVariable %[[_ptr_Private_v3uint]] Private %[[gl_WorkGroupSize]]
+// CHECK:     %[[__original_id_16]] = OpFunction %[[void]] Const %[[__original_id_3]]
+
+void kernel __attribute__((reqd_work_group_size(1,2,3))) test() {}
+

--- a/test/reqd_work_group_size.cl
+++ b/test/reqd_work_group_size.cl
@@ -1,0 +1,13 @@
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     OpEntryPoint GLCompute %[[__original_id_4:[0-9]+]] "test"
+// CHECK:     OpExecutionMode %[[__original_id_4]] LocalSize 1 2 3
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[__original_id_3:[0-9]+]] = OpTypeFunction %[[void]]
+// CHECK:     %[[__original_id_4]] = OpFunction %[[void]] Const %[[__original_id_3]]
+
+void kernel __attribute__((reqd_work_group_size(1,2,3))) test() {}
+


### PR DESCRIPTION
This implementation uses the approach outlined in #522 and push constants
for all the values that need to be communicated by the application/runtime.
The push constant space required is quite large in the worst case (which is
unlikely to be a common occurrence in typical code). There are definitely
applications where using specialisation constants everywhere would result
in a ridiculous amount of recompilation and likely others where saving some
push constant space would be a win (especially once POD arguments will
use push constants).

The CTS tests require that reqd_work_group_size be treated not as a hard
requirement but more as an upper bound/hint which seems odd. I've created
https://github.com/KhronosGroup/OpenCL-Docs/issues/267 to discuss this.
This change satisfies the CTS and is good enough to pass the entire
non_uniform_work_group CTS suite with the appropriate clvk changes.

Fixes #522.

Signed-off-by: Kévin Petit <kpet@free.fr>