### PR TITLE
Automate pod arg implementation decision

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -408,4 +408,8 @@ llvm::ModulePass *createUndoInstCombinePass();
 /// Removes FreezeInsts from the IR.
 llvm::ModulePass *createStripFreezePass();
 
+/// Annotates kernels with the metadata indicating how the POD args should be
+/// handled.
+llvm::ModulePass *createAutoPodArgsPass();
+
 } // namespace clspv

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -419,7 +419,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
     int arg_index = 0;
     for (Argument &Arg : F.args()) {
       Type *argTy = Arg.getType();
-      const auto arg_kind = clspv::GetArgKindForType(argTy);
+      const auto arg_kind = clspv::GetArgKind(Arg);
 
       int separation_token = 0;
       switch (arg_kind) {
@@ -513,7 +513,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
       for (Argument &Arg : f_ptr->args()) {
         set_and_binding_list.emplace_back(kUnallocated, kUnallocated);
         if (discriminants_list[arg_index].index >= 0) {
-          if (clspv::GetArgKindForType(Arg.getType()) !=
+          if (clspv::GetArgKind(Arg) !=
               clspv::ArgKind::PodPushConstant) {
             // Don't assign a descriptor set to push constants.
             set_and_binding_list.back().first = set;
@@ -541,7 +541,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           unsigned set = kUnallocated;
           unsigned binding = kUnallocated;
           const bool is_push_constant_arg =
-              clspv::GetArgKindForType(f_ptr->getArg(arg_index)->getType()) ==
+              clspv::GetArgKind(*f_ptr->getArg(arg_index)) ==
               clspv::ArgKind::PodPushConstant;
           if (always_single_kernel_descriptor ||
               functions_used_by_discriminant[info.index].size() ==
@@ -640,7 +640,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
                  << " type " << *argTy << "\n";
         }
 
-        const auto arg_kind = clspv::GetArgKindForType(argTy);
+        const auto arg_kind = clspv::GetArgKind(Arg);
 
         Type *resource_type = nullptr;
         unsigned addr_space = kUnallocated;
@@ -886,7 +886,7 @@ bool AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
     int arg_index = 0;
     for (Argument &Arg : F.args()) {
       Type *argTy = Arg.getType();
-      const auto arg_kind = clspv::GetArgKindForType(argTy);
+      const auto arg_kind = clspv::GetArgKind(Arg);
       if (arg_kind == clspv::ArgKind::Local) {
         // Assign a SpecId to this argument.
         int spec_id = GetSpecId(Arg.getType());

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -513,8 +513,7 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
       for (Argument &Arg : f_ptr->args()) {
         set_and_binding_list.emplace_back(kUnallocated, kUnallocated);
         if (discriminants_list[arg_index].index >= 0) {
-          if (clspv::GetArgKind(Arg) !=
-              clspv::ArgKind::PodPushConstant) {
+          if (clspv::GetArgKind(Arg) != clspv::ArgKind::PodPushConstant) {
             // Don't assign a descriptor set to push constants.
             set_and_binding_list.back().first = set;
           }

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -106,13 +106,13 @@ PodArgImpl GetPodArgsImpl(Function &F) {
 ArgKind GetArgKindForPodArgs(Function &F) {
   auto impl = GetPodArgsImpl(F);
   switch (impl) {
-    case kUBO:
-      return ArgKind::PodUBO;
-    case kPushConstant:
-    case kGlobalPushConstant:
-      return ArgKind::PodPushConstant;
-    case kSSBO:
-      return ArgKind::Pod;
+  case kUBO:
+    return ArgKind::PodUBO;
+  case kPushConstant:
+  case kGlobalPushConstant:
+    return ArgKind::PodPushConstant;
+  case kSSBO:
+    return ArgKind::Pod;
   }
 }
 

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -18,6 +18,8 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -26,48 +28,101 @@
 #include "clspv/AddressSpace.h"
 #include "clspv/Option.h"
 
+#include "Constants.h"
 #include "Types.h"
 
 using namespace llvm;
 
-namespace clspv {
+namespace {
 
-ArgKind GetArgKindForType(Type *type) {
+// Maps an LLVM type for a kernel argument to an argument kind.
+clspv::ArgKind GetArgKindForType(Type *type);
+
+// Maps an LLVM type for a kernel argument to an argument
+// kind suitable for a descriptor map.  The result is one of:
+//   buffer     - storage buffer
+//   buffer_ubo - uniform buffer
+//   local      - array in Workgroup storage, number of elements given by
+//                a specialization constant
+//   pod        - plain-old-data
+//   ro_image   - read-only image
+//   wo_image   - write-only image
+//   sampler    - sampler
+inline const char *GetArgKindNameForType(llvm::Type *type) {
+  return GetArgKindName(GetArgKindForType(type));
+}
+
+clspv::ArgKind GetArgKindForType(Type *type) {
   if (type->isPointerTy()) {
-    if (IsSamplerType(type)) {
-      return ArgKind::Sampler;
+    if (clspv::IsSamplerType(type)) {
+      return clspv::ArgKind::Sampler;
     }
     llvm::Type *image_type = nullptr;
-    if (IsImageType(type, &image_type)) {
+    if (clspv::IsImageType(type, &image_type)) {
       StringRef name = dyn_cast<StructType>(image_type)->getName();
       // OpenCL 1.2 only has read-only or write-only images.
-      return name.contains("_ro_t") ? ArgKind::ReadOnlyImage
-                                    : ArgKind::WriteOnlyImage;
+      return name.contains("_ro_t") ? clspv::ArgKind::ReadOnlyImage
+                                    : clspv::ArgKind::WriteOnlyImage;
     }
     switch (type->getPointerAddressSpace()) {
     // Pointer to constant and pointer to global are both in
     // storage buffers.
     case clspv::AddressSpace::Global:
-      return ArgKind::Buffer;
+      return clspv::ArgKind::Buffer;
     case clspv::AddressSpace::Constant:
-      return Option::ConstantArgsInUniformBuffer() ? ArgKind::BufferUBO
-                                                   : ArgKind::Buffer;
+      return clspv::Option::ConstantArgsInUniformBuffer()
+                 ? clspv::ArgKind::BufferUBO
+                 : clspv::ArgKind::Buffer;
     case clspv::AddressSpace::Local:
-      return ArgKind::Local;
+      return clspv::ArgKind::Local;
     default:
       break;
     }
   } else {
     if (clspv::Option::PodArgsInUniformBuffer())
-      return ArgKind::PodUBO;
+      return clspv::ArgKind::PodUBO;
     else if (clspv::Option::PodArgsInPushConstants())
-      return ArgKind::PodPushConstant;
+      return clspv::ArgKind::PodPushConstant;
     else
-      return ArgKind::Pod;
+      return clspv::ArgKind::Pod;
   }
   errs() << "Unhandled case in clspv::GetArgKindNameForType: " << *type << "\n";
   llvm_unreachable("Unhandled case in clspv::GetArgKindNameForType");
-  return ArgKind::Buffer;
+  return clspv::ArgKind::Buffer;
+}
+} // namespace
+
+namespace clspv {
+
+PodArgImpl GetPodArgsImpl(Function &F) {
+  auto md = F.getMetadata(PodArgsImplMetadataName());
+  auto impl = static_cast<PodArgImpl>(
+      cast<ConstantInt>(
+          cast<ConstantAsMetadata>(md->getOperand(0).get())->getValue())
+          ->getZExtValue());
+  return impl;
+}
+
+ArgKind GetArgKindForPodArgs(Function &F) {
+  auto impl = GetPodArgsImpl(F);
+  switch (impl) {
+    case kUBO:
+      return ArgKind::PodUBO;
+    case kPushConstant:
+    case kGlobalPushConstant:
+      return ArgKind::PodPushConstant;
+    case kSSBO:
+      return ArgKind::Pod;
+  }
+}
+
+ArgKind GetArgKind(Argument &Arg) {
+  if (!isa<PointerType>(Arg.getType()) &&
+      Arg.getParent()->getCallingConv() == CallingConv::SPIR_KERNEL) {
+    return GetArgKindForPodArgs(*Arg.getParent());
+  }
+
+  return GetArgKindForType(Arg.getType());
 }
 
 const char *GetArgKindName(ArgKind kind) {

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -24,22 +24,24 @@
 
 namespace clspv {
 
-// Maps an LLVM type for a kernel argument to an argument kind.
-ArgKind GetArgKindForType(llvm::Type *type);
+// Enum for how pod args are implemented. Gets added as metadata to each
+// kernel.
+enum PodArgImpl {
+  kSSBO,
+  kUBO,
+  kPushConstant,
+  // Shared interface across all shaders.
+  kGlobalPushConstant,
+};
 
-// Maps an LLVM type for a kernel argument to an argument
-// kind suitable for a descriptor map.  The result is one of:
-//   buffer     - storage buffer
-//   buffer_ubo - uniform buffer
-//   local      - array in Workgroup storage, number of elements given by
-//                a specialization constant
-//   pod        - plain-old-data
-//   ro_image   - read-only image
-//   wo_image   - write-only image
-//   sampler    - sampler
-inline const char *GetArgKindNameForType(llvm::Type *type) {
-  return GetArgKindName(GetArgKindForType(type));
-}
+// Returns the style of pod args used by |F|. Note that |F| must be a kernel.
+PodArgImpl GetPodArgsImpl(llvm::Function &F);
+
+// Returns the ArgKind for pod args in kernel |F|.
+ArgKind GetArgKindForPodArgs(llvm::Function &F);
+
+// Returns the ArgKind for |Arg|.
+ArgKind GetArgKind(llvm::Argument &Arg);
 
 // Returns true if the given type is a pointer-to-local type.
 bool IsLocalPtr(llvm::Type *type);

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -87,7 +87,7 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
   const auto &DL = M.getDataLayout();
   SmallVector<Type *, 8> pod_types;
   bool satisfies_ubo = true;
-  for (auto &Arg : F) {
+  for (auto &Arg : F.args()) {
     auto arg_type = Arg.getType();
     if (isa<PointerType>(arg_type))
       continue;

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -26,7 +26,7 @@
 #include "Constants.h"
 #include "Layout.h"
 #include "Passes.h"
-#include "PushConstants.h"
+#include "PushConstant.h"
 
 #define DEBUG_TYPE "autopodargs"
 

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -102,11 +102,11 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
     }
   }
 
-  auto pod_struct_ty = StructType::get(M.getContext(), pod_types);
   // Per-kernel push constant interface requires:
   // 1. Clustered pod args.
   // 2. No global push constants.
   // 3. Args must fit in push constant size limit.
+  const auto pod_struct_ty = StructType::get(M.getContext(), pod_types);
   const bool satisfies_push_constant =
       !(!clspv::Option::ClusterPodKernelArgs() || UsesGlobalPushConstant(M) ||
         (DL.getTypeSizeInBits(pod_struct_ty).getFixedSize() / 8) >
@@ -117,13 +117,13 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
   // 2. NYI: global type mangled push constant interface.
   // 3. UBO
   // 4. SSBO
+  clspv::PodArgImpl impl = clspv::PodArgImpl::kSSBO;
   if (satisfies_push_constant) {
-    AddMetadata(F, clspv::PodArgImpl::kPushConstant);
+    impl = clspv::PodArgImpl::kPushConstant;
   } else if (satisfies_ubo) {
-    AddMetadata(F, clspv::PodArgImpl::kUBO);
-  } else {
-    AddMetadata(F, clspv::PodArgImpl::kSSBO);
+    impl = clspv::PodArgImpl::kUBO;
   }
+  AddMetadata(F, impl);
 }
 
 bool AutoPodArgsPass::UsesGlobalPushConstant(Module &M) {

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -1,0 +1,81 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+#include "clspv/Option.h"
+
+#include "ArgKind.h"
+#include "Constants.h"
+#include "Passes.h"
+
+#define DEBUG_TYPE "autopodargs"
+
+using namespace llvm;
+
+namespace {
+class AutoPodArgsPass : public ModulePass {
+public:
+  static char ID;
+  AutoPodArgsPass() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+private:
+  void AnnotateAllKernels(Module &M, clspv::PodArgImpl impl);
+  void AddMetadata(Function &F, clspv::PodArgImpl impl);
+};
+} // namespace
+
+char AutoPodArgsPass::ID = 0;
+INITIALIZE_PASS(AutoPodArgsPass, "AutoPodArgs",
+                "Mark pod arg implementation as metadata on kernels", false, false)
+
+namespace clspv {
+ModulePass *createAutoPodArgsPass() {
+  return new AutoPodArgsPass();
+}
+} // namespace clspv
+
+bool AutoPodArgsPass::runOnModule(Module &M) {
+  if (clspv::Option::PodArgsInUniformBuffer()) {
+    AnnotateAllKernels(M, clspv::PodArgImpl::kUBO);
+  } else if (clspv::Option::PodArgsInPushConstants()) {
+    AnnotateAllKernels(M, clspv::PodArgImpl::kPushConstant);
+  } else {
+    AnnotateAllKernels(M, clspv::PodArgImpl::kSSBO);
+  }
+
+  return true;
+}
+
+void AutoPodArgsPass::AnnotateAllKernels(Module &M, clspv::PodArgImpl impl) {
+  for (auto &F : M) {
+    if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL)
+      continue;
+  
+    AddMetadata(F, impl);
+  }
+}
+
+void AutoPodArgsPass::AddMetadata(Function &F, clspv::PodArgImpl impl) {
+  auto md = MDTuple::get(
+      F.getContext(),
+      ConstantAsMetadata::get(ConstantInt::get(
+          IntegerType::get(F.getContext(), 32), static_cast<uint32_t>(impl))));
+  F.setMetadata(clspv::PodArgsImplMetadataName(), md);
+}

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -39,6 +39,7 @@ public:
   AutoPodArgsPass() : ModulePass(ID) {}
 
   bool runOnModule(Module &M) override;
+
 private:
   // Decides the pod args implementation for each kernel individually.
   void runOnFunction(Function &F);
@@ -53,12 +54,11 @@ private:
 
 char AutoPodArgsPass::ID = 0;
 INITIALIZE_PASS(AutoPodArgsPass, "AutoPodArgs",
-                "Mark pod arg implementation as metadata on kernels", false, false)
+                "Mark pod arg implementation as metadata on kernels", false,
+                false)
 
 namespace clspv {
-ModulePass *createAutoPodArgsPass() {
-  return new AutoPodArgsPass();
-}
+ModulePass *createAutoPodArgsPass() { return new AutoPodArgsPass(); }
 } // namespace clspv
 
 bool AutoPodArgsPass::runOnModule(Module &M) {
@@ -129,7 +129,7 @@ void AutoPodArgsPass::AnnotateAllKernels(Module &M, clspv::PodArgImpl impl) {
   for (auto &F : M) {
     if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
-  
+
     AddMetadata(F, impl);
   }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/AddFunctionAttributesPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/AllocateDescriptorsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/AutoPodArgsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Builtins.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphOrderedFunctions.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ClusterPodKernelArgumentsPass.cpp
@@ -44,6 +45,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerToFunctionArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NormalizeGlobalVariable.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/OpenCLInlinerPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -603,6 +603,7 @@ int PopulatePassManager(
 
   pm->add(clspv::createZeroInitializeAllocasPass());
   pm->add(clspv::createAddFunctionAttributesPass());
+  pm->add(clspv::createAutoPodArgsPass());
   pm->add(clspv::createDeclarePushConstantsPass());
   pm->add(clspv::createDefineOpenCLWorkItemBuiltinsPass());
 

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -67,9 +67,8 @@ inline std::string SpecConstantMetadataName() {
   return "clspv.spec_constant_list";
 }
 
-inline std::string PodArgsImplMetadataName() {
-  return "clspv.pod_args_impl";
-}
+// Pod args implementation metadata name.
+inline std::string PodArgsImplMetadataName() { return "clspv.pod_args_impl"; }
 
 } // namespace clspv
 

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -67,6 +67,10 @@ inline std::string SpecConstantMetadataName() {
   return "clspv.spec_constant_list";
 }
 
+inline std::string PodArgsImplMetadataName() {
+  return "clspv.pod_args_impl";
+}
+
 } // namespace clspv
 
 #endif

--- a/lib/DeclarePushConstantsPass.cpp
+++ b/lib/DeclarePushConstantsPass.cpp
@@ -57,22 +57,6 @@ ModulePass *createDeclarePushConstantsPass() {
 }
 } // namespace clspv
 
-bool DeclarePushConstantsPass::shouldDeclareEnqueuedLocalSize(Module &M) {
-  bool isEnabled = ((clspv::Option::Language() ==
-                     clspv::Option::SourceLanguage::OpenCL_C_20) ||
-                    (clspv::Option::Language() ==
-                     clspv::Option::SourceLanguage::OpenCL_CPP));
-  bool isUsed = M.getFunction("_Z23get_enqueued_local_sizej") != nullptr;
-  return isEnabled && isUsed;
-}
-
-bool DeclarePushConstantsPass::shouldDeclareGlobalOffset(Module &M) {
-  bool isEnabled = clspv::Option::GlobalOffset();
-  bool isUsed = (M.getFunction("_Z17get_global_offsetj") != nullptr) ||
-                (M.getFunction("_Z13get_global_idj") != nullptr);
-  return isEnabled && isUsed;
-}
-
 bool DeclarePushConstantsPass::shouldDeclareGlobalSize(Module &M) {
   bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
   bool isUsed = M.getFunction("_Z15get_global_sizej") != nullptr;
@@ -105,11 +89,11 @@ bool DeclarePushConstantsPass::runOnModule(Module &M) {
 
   auto &C = M.getContext();
 
-  if (shouldDeclareGlobalOffset(M)) {
+  if (clspv::ShouldDeclareGlobalOffset(M)) {
     PushConstants.emplace_back(clspv::PushConstant::GlobalOffset);
   }
 
-  if (shouldDeclareEnqueuedLocalSize(M)) {
+  if (clspv::ShouldDeclareEnqueuedLocalSize(M)) {
     PushConstants.push_back(clspv::PushConstant::EnqueuedLocalSize);
   }
 

--- a/lib/DeclarePushConstantsPass.cpp
+++ b/lib/DeclarePushConstantsPass.cpp
@@ -37,7 +37,6 @@ struct DeclarePushConstantsPass : public ModulePass {
   DeclarePushConstantsPass() : ModulePass(ID) {}
 
   bool shouldDeclareEnqueuedLocalSize(Module &M);
-  bool shouldDeclareGlobalOffset(Module &M);
   bool shouldDeclareGlobalSize(Module &M);
   bool shouldDeclareRegionOffset(Module &M);
   bool shouldDeclareNumWorkgroups(Module &M);
@@ -56,6 +55,12 @@ ModulePass *createDeclarePushConstantsPass() {
   return new DeclarePushConstantsPass();
 }
 } // namespace clspv
+
+bool DeclarePushConstantsPass::shouldDeclareEnqueuedLocalSize(Module &M) {
+  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
+  bool isUsed = M.getFunction("_Z23get_enqueued_local_sizej") != nullptr;
+  return isEnabled && isUsed;
+}
 
 bool DeclarePushConstantsPass::shouldDeclareGlobalSize(Module &M) {
   bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
@@ -93,7 +98,7 @@ bool DeclarePushConstantsPass::runOnModule(Module &M) {
     PushConstants.emplace_back(clspv::PushConstant::GlobalOffset);
   }
 
-  if (clspv::ShouldDeclareEnqueuedLocalSize(M)) {
+  if (shouldDeclareEnqueuedLocalSize(M)) {
     PushConstants.push_back(clspv::PushConstant::EnqueuedLocalSize);
   }
 

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -105,7 +105,7 @@ bool DirectResourceAccessPass::RewriteResourceAccesses(Function *fn) {
   bool Changed = false;
   int arg_index = 0;
   for (Argument &arg : fn->args()) {
-    switch (clspv::GetArgKindForType(arg.getType())) {
+    switch (clspv::GetArgKind(arg)) {
     case clspv::ArgKind::Buffer:
     case clspv::ArgKind::BufferUBO:
     case clspv::ArgKind::ReadOnlyImage:

--- a/lib/Layout.cpp
+++ b/lib/Layout.cpp
@@ -211,4 +211,20 @@ bool isValidExplicitLayout(Module &M, StructType *STy, unsigned Member,
 
   return true;
 }
+
+bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
+                           spv::StorageClass SClass) {
+  auto const &DL = M.getDataLayout();
+  const auto StructLayout = DL.getStructLayout(STy);
+  bool ok = true;
+  auto previous_offset = 0;
+  for (unsigned i = 0; ok && i < STy->getNumElements(); i++) {
+    auto offset = StructLayout->getElementOffset(i);
+    ok &=
+        isValidExplicitLayout(M, STy, i, SClass, offset, previous_offset);
+    previous_offset = offset;
+  }
+
+  return ok;
+}
 } // namespace clspv

--- a/lib/Layout.cpp
+++ b/lib/Layout.cpp
@@ -220,8 +220,7 @@ bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
   auto previous_offset = 0;
   for (unsigned i = 0; ok && i < STy->getNumElements(); i++) {
     auto offset = StructLayout->getElementOffset(i);
-    ok &=
-        isValidExplicitLayout(M, STy, i, SClass, offset, previous_offset);
+    ok &= isValidExplicitLayout(M, STy, i, SClass, offset, previous_offset);
     previous_offset = offset;
   }
 

--- a/lib/Layout.cpp
+++ b/lib/Layout.cpp
@@ -1,0 +1,214 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "clspv/Option.h"
+
+#include "Layout.h"
+
+using namespace llvm;
+
+namespace {
+bool isScalarType(Type *type) {
+  return type->isIntegerTy() || type->isFloatTy();
+}
+
+uint64_t structAlignment(StructType *type,
+                         std::function<uint64_t(Type *)> alignFn) {
+  uint64_t maxAlign = 1;
+  for (unsigned i = 0; i < type->getStructNumElements(); i++) {
+    uint64_t align = alignFn(type->getStructElementType(i));
+    maxAlign = std::max(align, maxAlign);
+  }
+  return maxAlign;
+}
+
+uint64_t scalarAlignment(Type *type) {
+  // A scalar of size N has a scalar alignment of N.
+  if (isScalarType(type)) {
+    return type->getScalarSizeInBits() / 8;
+  }
+
+  // A vector or matrix type has a scalar alignment equal to that of its
+  // component type.
+  if (auto vec_type = dyn_cast<VectorType>(type)) {
+    return scalarAlignment(vec_type->getElementType());
+  }
+
+  // An array type has a scalar alignment equal to that of its element type.
+  if (type->isArrayTy()) {
+    return scalarAlignment(type->getArrayElementType());
+  }
+
+  // A structure has a scalar alignment equal to the largest scalar alignment of
+  // any of its members.
+  if (type->isStructTy()) {
+    return structAlignment(cast<StructType>(type), scalarAlignment);
+  }
+
+  llvm_unreachable("Unsupported type");
+}
+
+uint64_t baseAlignment(Type *type) {
+  // A scalar has a base alignment equal to its scalar alignment.
+  if (isScalarType(type)) {
+    return scalarAlignment(type);
+  }
+
+  if (auto vec_type = dyn_cast<VectorType>(type)) {
+    unsigned numElems = vec_type->getNumElements();
+
+    // A two-component vector has a base alignment equal to twice its scalar
+    // alignment.
+    if (numElems == 2) {
+      return 2 * scalarAlignment(type);
+    }
+    // A three- or four-component vector has a base alignment equal to four
+    // times its scalar alignment.
+    if ((numElems == 3) || (numElems == 4)) {
+      return 4 * scalarAlignment(type);
+    }
+  }
+
+  // An array has a base alignment equal to the base alignment of its element
+  // type.
+  if (type->isArrayTy()) {
+    return baseAlignment(type->getArrayElementType());
+  }
+
+  // A structure has a base alignment equal to the largest base alignment of any
+  // of its members.
+  if (type->isStructTy()) {
+    return structAlignment(cast<StructType>(type), baseAlignment);
+  }
+
+  // TODO A row-major matrix of C columns has a base alignment equal to the base
+  // alignment of a vector of C matrix components.
+  // TODO A column-major matrix has a base alignment equal to the base alignment
+  // of the matrix column type.
+
+  llvm_unreachable("Unsupported type");
+}
+
+uint64_t extendedAlignment(Type *type) {
+  // A scalar, vector or matrix type has an extended alignment equal to its base
+  // alignment.
+  // TODO matrix type
+  if (isScalarType(type) || type->isVectorTy()) {
+    return baseAlignment(type);
+  }
+
+  // An array or structure type has an extended alignment equal to the largest
+  // extended alignment of any of its members, rounded up to a multiple of 16
+  if (type->isStructTy()) {
+    auto salign = structAlignment(cast<StructType>(type), extendedAlignment);
+    return alignTo(salign, 16);
+  }
+
+  if (type->isArrayTy()) {
+    auto salign = extendedAlignment(type->getArrayElementType());
+    return alignTo(salign, 16);
+  }
+
+  llvm_unreachable("Unsupported type");
+}
+
+uint64_t standardAlignment(Type *type, spv::StorageClass sclass) {
+  // If the scalarBlockLayout feature is enabled on the device then every member
+  // must be aligned according to its scalar alignment
+  if (clspv::Option::ScalarBlockLayout()) {
+    return scalarAlignment(type);
+  }
+
+  // All vectors must be aligned according to their scalar alignment
+  if (type->isVectorTy()) {
+    return scalarAlignment(type);
+  }
+
+  // If the uniformBufferStandardLayout feature is not enabled on the device,
+  // then any member of an OpTypeStruct with a storage class of Uniform and a
+  // decoration of Block must be aligned according to its extended alignment.
+  if (!clspv::Option::Std430UniformBufferLayout() &&
+      sclass == spv::StorageClassUniform) {
+    return extendedAlignment(type);
+  }
+
+  // Every other member must be aligned according to its base alignment
+  return baseAlignment(type);
+}
+
+bool improperlyStraddles(const DataLayout &DL, Type *type, unsigned offset) {
+  assert(type->isVectorTy());
+
+  auto size = DL.getTypeStoreSize(type);
+
+  // It is a vector with total size less than or equal to 16 bytes, and has
+  // Offset decorations placing its first byte at F and its last byte at L,
+  // where floor(F / 16) != floor(L / 16).
+  if ((size <= 16) && (offset % 16 + size > 16)) {
+    return true;
+  }
+
+  // It is a vector with total size greater than 16 bytes and has its Offset
+  // decorations placing its first byte at a non-integer multiple of 16
+  if ((size > 16) && (offset % 16 != 0)) {
+    return true;
+  }
+
+  return false;
+}
+} // namespace
+
+namespace clspv {
+
+// See 14.5 Shader Resource Interface in Vulkan spec
+bool isValidExplicitLayout(Module &M, StructType *STy, unsigned Member,
+                           spv::StorageClass SClass, unsigned Offset,
+                           unsigned PreviousMemberOffset) {
+
+  auto MemberType = STy->getElementType(Member);
+  auto Align = standardAlignment(MemberType, SClass);
+  auto &DL = M.getDataLayout();
+
+  // The Offset decoration of any member must be a multiple of its alignment
+  if (Offset % Align != 0) {
+    return false;
+  }
+
+  // TODO Any ArrayStride or MatrixStride decoration must be a multiple of the
+  // alignment of the array or matrix as defined above
+
+  if (!clspv::Option::ScalarBlockLayout()) {
+    // Vectors must not improperly straddle, as defined above
+    if (MemberType->isVectorTy() &&
+        improperlyStraddles(DL, MemberType, Offset)) {
+      return true;
+    }
+
+    // The Offset decoration of a member must not place it between the end
+    // of a structure or an array and the next multiple of the alignment of that
+    // structure or array
+    if (Member > 0) {
+      auto PType = STy->getElementType(Member - 1);
+      if (PType->isStructTy() || PType->isArrayTy()) {
+        auto PAlign = standardAlignment(PType, SClass);
+        if (Offset - PreviousMemberOffset < PAlign) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+} // namespace clspv

--- a/lib/Layout.h
+++ b/lib/Layout.h
@@ -1,0 +1,29 @@
+// Copyright 2020 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Module.h"
+
+#include "spirv/unified1/spirv.hpp"
+
+namespace clspv {
+
+// Returns true if member |Member| is a valid layout in |STy| for storage class
+// |SClass|.
+bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
+                           unsigned Member, spv::StorageClass SClass,
+                           unsigned offset, unsigned PreviousMemberOffset);
+
+} // namespace clspv
+

--- a/lib/Layout.h
+++ b/lib/Layout.h
@@ -30,4 +30,3 @@ bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
                            spv::StorageClass SClass);
 
 } // namespace clspv
-

--- a/lib/Layout.h
+++ b/lib/Layout.h
@@ -25,5 +25,9 @@ bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
                            unsigned Member, spv::StorageClass SClass,
                            unsigned offset, unsigned PreviousMemberOffset);
 
+// Returns true if |STy| is a valid layout for storage class.
+bool isValidExplicitLayout(llvm::Module &M, llvm::StructType *STy,
+                           spv::StorageClass SClass);
+
 } // namespace clspv
 

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -133,7 +133,7 @@ bool MultiVersionUBOFunctionsPass::runOnModule(Module &M) {
 bool MultiVersionUBOFunctionsPass::AnalyzeCall(
     Function *fn, CallInst *user, std::vector<ResourceInfo> *resources) {
   for (auto &arg : fn->args()) {
-    if (clspv::GetArgKindForType(arg.getType()) != clspv::ArgKind::BufferUBO)
+    if (clspv::GetArgKind(arg) != clspv::ArgKind::BufferUBO)
       continue;
 
     Value *arg_operand = user->getOperand(arg.getArgNo());

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -18,6 +18,7 @@ namespace llvm {
 
 void initializeClspvPasses(PassRegistry &r) {
   initializeAddFunctionAttributesPassPass(r);
+  initializeAutoPodArgsPassPass(r);
   initializeAllocateDescriptorsPassPass(r);
   initializeClusterModuleScopeConstantVarsPass(r);
   initializeClusterPodKernelArgumentsPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -21,6 +21,7 @@ class PassRegistry;
 // Individual pass initializers.  See the documentation for
 // initializeClspvPasses() in include/clspv/Passes.h.
 void initializeAddFunctionAttributesPassPass(PassRegistry &);
+void initializeAutoPodArgsPassPass(PassRegistry &);
 void initializeAllocateDescriptorsPassPass(PassRegistry &);
 void initializeClusterModuleScopeConstantVarsPass(PassRegistry &);
 void initializeClusterPodKernelArgumentsPassPass(PassRegistry &);

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -101,4 +101,25 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc) {
   return Builder.CreateInBoundsGEP(GV, Indices);
 }
 
+bool UsesGlobalPushConstants(Module &M) {
+  return clspv::Option::NonUniformNDRangeSupported() ||
+         ShouldDeclareEnqueuedLocalSize(M) || ShouldDeclareGlobalOffset(M);
+}
+
+bool ShouldDeclareEnqueuedLocalSize(Module &M) {
+  bool isEnabled = ((clspv::Option::Language() ==
+                     clspv::Option::SourceLanguage::OpenCL_C_20) ||
+                    (clspv::Option::Language() ==
+                     clspv::Option::SourceLanguage::OpenCL_CPP));
+  bool isUsed = M.getFunction("_Z23get_enqueued_local_sizej") != nullptr;
+  return isEnabled && isUsed;
+}
+
+bool ShouldDeclareGlobalOffset(Module &M) {
+  bool isEnabled = clspv::Option::GlobalOffset();
+  bool isUsed = (M.getFunction("_Z17get_global_offsetj") != nullptr) ||
+                (M.getFunction("_Z13get_global_idj") != nullptr);
+  return isEnabled && isUsed;
+}
+
 } // namespace clspv

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -22,6 +22,8 @@
 #include "llvm/IR/Type.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include "clspv/Option.h"
+
 #include "Constants.h"
 
 using namespace llvm;
@@ -103,16 +105,7 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc) {
 
 bool UsesGlobalPushConstants(Module &M) {
   return clspv::Option::NonUniformNDRangeSupported() ||
-         ShouldDeclareEnqueuedLocalSize(M) || ShouldDeclareGlobalOffset(M);
-}
-
-bool ShouldDeclareEnqueuedLocalSize(Module &M) {
-  bool isEnabled = ((clspv::Option::Language() ==
-                     clspv::Option::SourceLanguage::OpenCL_C_20) ||
-                    (clspv::Option::Language() ==
-                     clspv::Option::SourceLanguage::OpenCL_CPP));
-  bool isUsed = M.getFunction("_Z23get_enqueued_local_sizej") != nullptr;
-  return isEnabled && isUsed;
+         ShouldDeclareGlobalOffset(M);
 }
 
 bool ShouldDeclareGlobalOffset(Module &M) {

--- a/lib/PushConstant.h
+++ b/lib/PushConstant.h
@@ -32,6 +32,14 @@ llvm::Type *GetPushConstantType(llvm::Module &, PushConstant);
 // pointer are appended to the basic block provided.
 llvm::Value *GetPushConstantPointer(llvm::BasicBlock *, PushConstant);
 
+// Returns true if any global push constant is used.
+bool UsesGlobalPushConstants(llvm::Module &);
+
+// Returns true if an implememtation of get_enqueued_local_size() is needed.
+bool ShouldDeclareEnqueuedLocalSize(llvm::Module &);
+
+// Returns true if an implementation of get_global_offset() is needed.
+bool ShouldDeclareGlobalOffset(llvm::Module &);
 } // namespace clspv
 
 #endif // #ifndef CLSPV_LIB_PUSH_CONSTANT_H_

--- a/lib/PushConstant.h
+++ b/lib/PushConstant.h
@@ -35,9 +35,6 @@ llvm::Value *GetPushConstantPointer(llvm::BasicBlock *, PushConstant);
 // Returns true if any global push constant is used.
 bool UsesGlobalPushConstants(llvm::Module &);
 
-// Returns true if an implememtation of get_enqueued_local_size() is needed.
-bool ShouldDeclareEnqueuedLocalSize(llvm::Module &);
-
 // Returns true if an implementation of get_global_offset() is needed.
 bool ShouldDeclareGlobalOffset(llvm::Module &);
 } // namespace clspv

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -57,6 +57,7 @@
 #include "ConstantEmitter.h"
 #include "Constants.h"
 #include "DescriptorCounter.h"
+#include "Layout.h"
 #include "NormalizeGlobalVariable.h"
 #include "Passes.h"
 #include "SpecConstant.h"
@@ -2881,200 +2882,6 @@ void SPIRVProducerPass::GenerateResourceVars() {
   }
 }
 
-namespace {
-
-bool isScalarType(Type *type) {
-  return type->isIntegerTy() || type->isFloatTy();
-}
-
-uint64_t structAlignment(StructType *type,
-                         std::function<uint64_t(Type *)> alignFn) {
-  uint64_t maxAlign = 1;
-  for (unsigned i = 0; i < type->getStructNumElements(); i++) {
-    uint64_t align = alignFn(type->getStructElementType(i));
-    maxAlign = std::max(align, maxAlign);
-  }
-  return maxAlign;
-}
-
-uint64_t scalarAlignment(Type *type) {
-  // A scalar of size N has a scalar alignment of N.
-  if (isScalarType(type)) {
-    return type->getScalarSizeInBits() / 8;
-  }
-
-  // A vector or matrix type has a scalar alignment equal to that of its
-  // component type.
-  if (auto vec_type = dyn_cast<VectorType>(type)) {
-    return scalarAlignment(vec_type->getElementType());
-  }
-
-  // An array type has a scalar alignment equal to that of its element type.
-  if (type->isArrayTy()) {
-    return scalarAlignment(type->getArrayElementType());
-  }
-
-  // A structure has a scalar alignment equal to the largest scalar alignment of
-  // any of its members.
-  if (type->isStructTy()) {
-    return structAlignment(cast<StructType>(type), scalarAlignment);
-  }
-
-  llvm_unreachable("Unsupported type");
-}
-
-uint64_t baseAlignment(Type *type) {
-  // A scalar has a base alignment equal to its scalar alignment.
-  if (isScalarType(type)) {
-    return scalarAlignment(type);
-  }
-
-  if (auto vec_type = dyn_cast<VectorType>(type)) {
-    unsigned numElems = vec_type->getNumElements();
-
-    // A two-component vector has a base alignment equal to twice its scalar
-    // alignment.
-    if (numElems == 2) {
-      return 2 * scalarAlignment(type);
-    }
-    // A three- or four-component vector has a base alignment equal to four
-    // times its scalar alignment.
-    if ((numElems == 3) || (numElems == 4)) {
-      return 4 * scalarAlignment(type);
-    }
-  }
-
-  // An array has a base alignment equal to the base alignment of its element
-  // type.
-  if (type->isArrayTy()) {
-    return baseAlignment(type->getArrayElementType());
-  }
-
-  // A structure has a base alignment equal to the largest base alignment of any
-  // of its members.
-  if (type->isStructTy()) {
-    return structAlignment(cast<StructType>(type), baseAlignment);
-  }
-
-  // TODO A row-major matrix of C columns has a base alignment equal to the base
-  // alignment of a vector of C matrix components.
-  // TODO A column-major matrix has a base alignment equal to the base alignment
-  // of the matrix column type.
-
-  llvm_unreachable("Unsupported type");
-}
-
-uint64_t extendedAlignment(Type *type) {
-  // A scalar, vector or matrix type has an extended alignment equal to its base
-  // alignment.
-  // TODO matrix type
-  if (isScalarType(type) || type->isVectorTy()) {
-    return baseAlignment(type);
-  }
-
-  // An array or structure type has an extended alignment equal to the largest
-  // extended alignment of any of its members, rounded up to a multiple of 16
-  if (type->isStructTy()) {
-    auto salign = structAlignment(cast<StructType>(type), extendedAlignment);
-    return alignTo(salign, 16);
-  }
-
-  if (type->isArrayTy()) {
-    auto salign = extendedAlignment(type->getArrayElementType());
-    return alignTo(salign, 16);
-  }
-
-  llvm_unreachable("Unsupported type");
-}
-
-uint64_t standardAlignment(Type *type, spv::StorageClass sclass) {
-  // If the scalarBlockLayout feature is enabled on the device then every member
-  // must be aligned according to its scalar alignment
-  if (clspv::Option::ScalarBlockLayout()) {
-    return scalarAlignment(type);
-  }
-
-  // All vectors must be aligned according to their scalar alignment
-  if (type->isVectorTy()) {
-    return scalarAlignment(type);
-  }
-
-  // If the uniformBufferStandardLayout feature is not enabled on the device,
-  // then any member of an OpTypeStruct with a storage class of Uniform and a
-  // decoration of Block must be aligned according to its extended alignment.
-  if (!clspv::Option::Std430UniformBufferLayout() &&
-      sclass == spv::StorageClassUniform) {
-    return extendedAlignment(type);
-  }
-
-  // Every other member must be aligned according to its base alignment
-  return baseAlignment(type);
-}
-
-bool improperlyStraddles(const DataLayout &DL, Type *type, unsigned offset) {
-  assert(type->isVectorTy());
-
-  auto size = DL.getTypeStoreSize(type);
-
-  // It is a vector with total size less than or equal to 16 bytes, and has
-  // Offset decorations placing its first byte at F and its last byte at L,
-  // where floor(F / 16) != floor(L / 16).
-  if ((size <= 16) && (offset % 16 + size > 16)) {
-    return true;
-  }
-
-  // It is a vector with total size greater than 16 bytes and has its Offset
-  // decorations placing its first byte at a non-integer multiple of 16
-  if ((size > 16) && (offset % 16 != 0)) {
-    return true;
-  }
-
-  return false;
-}
-
-// See 14.5 Shader Resource Interface in Vulkan spec
-bool isValidExplicitLayout(Module &M, StructType *STy, unsigned Member,
-                           spv::StorageClass SClass, unsigned Offset,
-                           unsigned PreviousMemberOffset) {
-
-  auto MemberType = STy->getElementType(Member);
-  auto Align = standardAlignment(MemberType, SClass);
-  auto &DL = M.getDataLayout();
-
-  // The Offset decoration of any member must be a multiple of its alignment
-  if (Offset % Align != 0) {
-    return false;
-  }
-
-  // TODO Any ArrayStride or MatrixStride decoration must be a multiple of the
-  // alignment of the array or matrix as defined above
-
-  if (!clspv::Option::ScalarBlockLayout()) {
-    // Vectors must not improperly straddle, as defined above
-    if (MemberType->isVectorTy() &&
-        improperlyStraddles(DL, MemberType, Offset)) {
-      return true;
-    }
-
-    // The Offset decoration of a member must not place it between the end
-    // of a structure or an array and the next multiple of the alignment of that
-    // structure or array
-    if (Member > 0) {
-      auto PType = STy->getElementType(Member - 1);
-      if (PType->isStructTy() || PType->isArrayTy()) {
-        auto PAlign = standardAlignment(PType, SClass);
-        if (Offset - PreviousMemberOffset < PAlign) {
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
-
-} // namespace
-
 void SPIRVProducerPass::GeneratePushConstantDescriptorMapEntries() {
 
   if (auto GV = module->getGlobalVariable(clspv::PushConstantsVariableName())) {
@@ -3433,16 +3240,6 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
   // Gather the list of resources that are used by this function's arguments.
   auto &resource_var_at_index = FunctionToResourceVarsMap[&F];
 
-  // TODO(alan-baker): This should become unnecessary by fixing the rest of the
-  // flow to generate pod_ubo arguments earlier.
-  auto remap_arg_kind = [](StringRef argKind) {
-    std::string kind =
-        clspv::Option::PodArgsInUniformBuffer() && argKind.equals("pod")
-            ? "pod_ubo"
-            : argKind.str();
-    return GetArgKindFromName(kind);
-  };
-
   auto *fty = F.getType()->getPointerElementType();
   auto *func_ty = dyn_cast<FunctionType>(fty);
 
@@ -3465,8 +3262,8 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
           dyn_extract<ConstantInt>(arg_node->getOperand(3))->getZExtValue();
       const auto arg_size =
           dyn_extract<ConstantInt>(arg_node->getOperand(4))->getZExtValue();
-      const auto argKind = remap_arg_kind(
-          dyn_cast<MDString>(arg_node->getOperand(5))->getString());
+      const auto argKind = clspv::GetArgKindFromName(
+          dyn_cast<MDString>(arg_node->getOperand(5))->getString().str());
       const auto spec_id =
           dyn_extract<ConstantInt>(arg_node->getOperand(6))->getSExtValue();
 
@@ -3517,7 +3314,7 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
             F.getName().str(),
             arg->getName().str(),
             arg_index,
-            remap_arg_kind(clspv::GetArgKindName(info->arg_kind)),
+            info->arg_kind,
             0,
             0,
             0,

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -135,12 +135,12 @@ bool UBOTypeTransformPass::runOnModule(Module &M) {
     if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
 
+    auto pod_arg_impl = clspv::GetPodArgsImpl(F);
     for (auto &Arg : F.args()) {
       if ((clspv::Option::ConstantArgsInUniformBuffer() &&
-           clspv::GetArgKindForType(Arg.getType()) ==
-               clspv::ArgKind::BufferUBO) ||
+           clspv::GetArgKind(Arg) == clspv::ArgKind::BufferUBO) ||
           (!Arg.getType()->isPointerTy() &&
-           clspv::Option::PodArgsInUniformBuffer())) {
+           pod_arg_impl == clspv::PodArgImpl::kUBO)) {
         // Pre-populate the type mapping for types that must change. This
         // necessary to prevent caching what would appear to be a no-op too
         // early.

--- a/test/AutoPodArgs/cluster_pod_args_preserves_metadata.ll
+++ b/test/AutoPodArgs/cluster_pod_args_preserves_metadata.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt -ClusterPodKernelArgumentsPass %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; The pod args impl metadata needs to be copied onto the wrapper function.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, { i32, i32 } %podargs) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 2}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod1, i32 %pod2) !clspv.pod_args_impl !0 {
+entry:
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  store i32 %pod1, i32 addrspace(1)* %gep0
+  %gep1 = getelementptr i32, i32 addrspace(1)* %out, i32 1
+  store i32 %pod2, i32 addrspace(1)* %gep1
+  ret void
+}
+
+!0 = !{i32 2}

--- a/test/AutoPodArgs/enqueued_local_size_prevents_push_constant.ll
+++ b/test/AutoPodArgs/enqueued_local_size_prevents_push_constant.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt -AutoPodArgs -cl-std=CL2.0 %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; get_enqueued_local_size prevents using push constants.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 1}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) {
+entry:
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  store i32 %pod, i32 addrspace(1)* %gep0
+  %gep1 = getelementptr i32, i32 addrspace(1)* %out, i32 1
+  %enqueued = call i32 @_Z23get_enqueued_local_sizej(i32 0)
+  store i32 %enqueued, i32 addrspace(1)* %gep1
+  ret void
+}
+
+declare i32 @_Z23get_enqueued_local_sizej(i32)

--- a/test/AutoPodArgs/fallback_on_ssbo.ll
+++ b/test/AutoPodArgs/fallback_on_ssbo.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt -AutoPodArgs -cl-std=CL2.0 %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s = type { i8, [2 x i8], i32 }
+
+; get_enqueued_local_size prevents using push constants and the layout of %s
+; prevents UBOs.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, %s %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 0}
+define spir_kernel void @foo(i32 addrspace(1)* %out, %s %pod) {
+entry:
+  %ex = extractvalue %s %pod, 2
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  store i32 %ex, i32 addrspace(1)* %gep0
+  %gep1 = getelementptr i32, i32 addrspace(1)* %out, i32 1
+  %enqueued = call i32 @_Z23get_enqueued_local_sizej(i32 0)
+  store i32 %enqueued, i32 addrspace(1)* %gep1
+  ret void
+}
+
+declare i32 @_Z23get_enqueued_local_sizej(i32)
+

--- a/test/AutoPodArgs/force_pushconstant.ll
+++ b/test/AutoPodArgs/force_pushconstant.ll
@@ -1,0 +1,14 @@
+; RUN: clspv-opt -AutoPodArgs -pod-pushconstant %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 2}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) {
+entry:
+  store i32 %pod, i32 addrspace(1)* %out
+  ret void
+}
+

--- a/test/AutoPodArgs/force_ubo.ll
+++ b/test/AutoPodArgs/force_ubo.ll
@@ -1,0 +1,13 @@
+; RUN: clspv-opt -AutoPodArgs -pod-ubo %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 1}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) {
+entry:
+  store i32 %pod, i32 addrspace(1)* %out
+  ret void
+}

--- a/test/AutoPodArgs/max_size_prevents_push_constants.ll
+++ b/test/AutoPodArgs/max_size_prevents_push_constants.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -AutoPodArgs -max-pushconstant-size=1 %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; max push constant size prevents push constants.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 1}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) {
+entry:
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  store i32 %pod, i32 addrspace(1)* %gep0
+  ret void
+}
+

--- a/test/AutoPodArgs/non_clustered_args_prevents_push_constants.ll
+++ b/test/AutoPodArgs/non_clustered_args_prevents_push_constants.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt -AutoPodArgs -cluster-pod-kernel-args=0 %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; unclustered args size prevents push constants.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod1, i32 %pod2) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 1}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod1, i32 %pod2) {
+entry:
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  store i32 %pod1, i32 addrspace(1)* %gep0
+  %gep1 = getelementptr i32, i32 addrspace(1)* %out, i32 1
+  store i32 %pod2, i32 addrspace(1)* %gep1
+  ret void
+}
+
+

--- a/test/DirectResourceAccess/common_global_into_helper.cl
+++ b/test/DirectResourceAccess/common_global_into_helper.cl
@@ -5,9 +5,9 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 //      MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-//      MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+//      MAP: kernel,foo,arg,n,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 //      MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-//      MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+//      MAP: kernel,bar,arg,m,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NONE: kernel
 
 float core(global float *arr, int n) {

--- a/test/Int8/char_pod_arg.cl
+++ b/test/Int8/char_pod_arg.cl
@@ -9,5 +9,5 @@ kernel void foo(char c) { }
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]]
 // CHECK: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[struct]]
-// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
-// CHECK: OpVariable [[ptr]] StorageBuffer
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[block]]
+// CHECK: OpVariable [[ptr]] PushConstant

--- a/test/PointerAccessChains/pointer_index_in_called_function.cl
+++ b/test/PointerAccessChains/pointer_index_in_called_function.cl
@@ -31,8 +31,6 @@ foo(global Thing* a, global float *b, int n) {
 // CHECK-DAG:  [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[__struct_5]]
 // CHECK-DAG:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr__struct_5]]
 // CHECK-DAG:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
-// CHECK-DAG:  [[__struct_12:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_uint]]
-// CHECK-DAG:  [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
 // CHECK-DAG:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
 // CHECK-DAG:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
 // CHECK-DAG:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
@@ -57,8 +55,6 @@ foo(global Thing* a, global float *b, int n) {
 // NODRA-DAG:  [[__runtimearr__struct_5:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[__struct_5]]
 // NODRA-DAG:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr__struct_5]]
 // NODRA-DAG:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
-// NODRA-DAG:  [[__struct_12:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_uint]]
-// NODRA-DAG:  [[__ptr_StorageBuffer__struct_12:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_12]]
 // NODRA-DAG:  [[__ptr_StorageBuffer__struct_5:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_5]]
 // NODRA-DAG:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
 // NODRA-DAG:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -12,6 +12,4 @@ __constant Foo ppp[3] = {{'a', 0x1234abcd, 1.0}, {'b', 0xffffffff, 1.5}, {0}};
 kernel void foo(global uint* A, uint i) { *A = ppp[i].a; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,61000000cdab34120000803f62000000ffffffff0000c03f000000000000000000000000
-// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
 

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_arr.cl
@@ -9,5 +9,3 @@ __constant uint ppp[2][3] = {{1,2,3}, {5}};
 kernel void foo(global uint* A, uint i) { *A = ppp[i][i]; }
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,010000000200000003000000050000000000000000000000
-// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3.cl
@@ -11,5 +11,3 @@ kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
 
 
 // MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,0100000002000000030000000000000005000000050000000500000000000000
-// MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_no_constants.cl
@@ -7,5 +7,5 @@ kernel void foo(global uint* A, uint i) { A[i] = 0; }
 // MAP-NOT: constant,descriptorSet
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NOT: constant,descriptorSet
-// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,i,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
 // MAP-NOT: constant,descriptorSet

--- a/test/UBO/constant_and_image.cl
+++ b/test/UBO/constant_and_image.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map -cluster-pod-kernel-args=0
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map -cluster-pod-kernel-args=0 -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
@@ -11,7 +11,7 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 //      MAP: kernel,foo,arg,i,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,ro_image
 // MAP-NEXT: kernel,foo,arg,s,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,sampler
 // MAP-NEXT: kernel,foo,arg,offset,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,buffer_ubo
-// MAP-NEXT: kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,8
+// MAP-NEXT: kernel,foo,arg,c,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,pod_ubo,argSize,8
 // MAP-NEXT: kernel,foo,arg,data,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,buffer
 
 // CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
@@ -39,12 +39,12 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 // CHECK: [[offset_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_struct]]
 // CHECK: [[v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 2
 // CHECK: [[struct_v2float:%[0-9a-zA-Z_]+]] = OpTypeStruct [[v2float]]
-// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct_v2float]]
+// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct_v2float]]
 // CHECK: [[runtime]] = OpTypeRuntimeArray [[v4float]]
 // CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 // CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
 // CHECK: [[ptr_uniform_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v4float]]
-// CHECK: [[ptr_storagebuffer_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[v2float]]
+// CHECK: [[ptr_uniform_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v2float]]
 // CHECK: [[ptr_storagebuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[v4float]]
 // CHECK: [[sampled_image:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[image]]
 // CHECK: [[float_zero:%[0-9a-zA-Z_]+]] = OpConstant [[float]] 0
@@ -52,12 +52,12 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 // CHECK: [[image_var]] = OpVariable [[image_ptr]] UniformConstant
 // CHECK: [[sampler_var]] = OpVariable [[sampler_ptr]] UniformConstant
 // CHECK: [[offset_var]] = OpVariable [[offset_ptr]] Uniform
-// CHECK: [[c_var]] = OpVariable [[c_ptr]] StorageBuffer
+// CHECK: [[c_var]] = OpVariable [[c_ptr]] Uniform
 // CHECK: [[data_var]] = OpVariable [[data_ptr]] StorageBuffer
 // CHECK: [[load_image:%[0-9a-zA-Z_]+]] = OpLoad [[image]] [[image_var]]
 // CHECK: [[load_sampler:%[0-9a-zA-Z_]+]] = OpLoad [[sampler]] [[sampler_var]]
 // CHECK: [[offset_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_uniform_v4float]] [[offset_var]] [[zero]] [[zero]]
-// CHECK: [[c_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_storagebuffer_v2float]] [[c_var]] [[zero]]
+// CHECK: [[c_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_uniform_v2float]] [[c_var]] [[zero]]
 // CHECK: [[load_c:%[0-9a-zA-Z_]+]] = OpLoad [[v2float]] [[c_gep]]
 // CHECK: [[data_gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_storagebuffer_v4float]] [[data_var]] [[zero]] [[zero]]
 // CHECK: [[sampled:%[0-9a-zA-Z_]+]] = OpSampledImage [[sampled_image]] [[load_image]] [[load_sampler]]

--- a/test/UBO/test_cluster_pod_args.cl
+++ b/test/UBO/test_cluster_pod_args.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -o %t.spv -descriptormap=%t2.map
+// RUN: clspv -constant-args-ubo -inline-entry-points -cluster-pod-kernel-args %s -o %t.spv -descriptormap=%t2.map -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
@@ -18,5 +18,5 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 
 //      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo
 

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map -int8=0
+// RUN: clspv -constant-args-ubo -inline-entry-points %s -o %t.spv -descriptormap=%t2.map -int8=0 -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
@@ -17,7 +17,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 
 //      MAP: kernel,foo,arg,data,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,c_arg,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo
 
 // CHECK-DAG: OpDecorate [[runtime:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: OpMemberDecorate [[data_type:%[0-9a-zA-Z_]+]] 0 Offset 0

--- a/test/clspv-opt/options.ll
+++ b/test/clspv-opt/options.ll
@@ -6,7 +6,7 @@
 ; RUN: FileCheck %s < %t.ll
 ; CHECK: @__spirv_WorkgroupSize =
 
-define spir_kernel void @foo() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+define spir_kernel void @foo() local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 !clspv.pod_args_impl !4 {
 entry:
   ret void
 }
@@ -20,3 +20,4 @@ attributes #0 = { norecurse nounwind readnone "correctly-rounded-divide-sqrt-fp-
 !0 = !{i32 1, !"wchar_size", i32 4}
 !1 = !{i32 1, i32 2}
 !3 = !{}
+!4 = !{i32 0}

--- a/test/cluster_pod_args_attibutes_on_pod.cl
+++ b/test/cluster_pod_args_attibutes_on_pod.cl
@@ -3,7 +3,7 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // MAP: kernel,test,arg,buf,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP: kernel,test,arg,val,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,1
+// MAP: kernel,test,arg,val,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,1
 
 kernel void test(global char *buf, char val)
 {

--- a/test/cluster_pod_args_attributes.cl
+++ b/test/cluster_pod_args_attributes.cl
@@ -5,8 +5,8 @@
 // MAP: kernel,test_restrict,arg,ptr1,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,test_restrict,arg,ptr2,argOrdinal,3,descriptorSet,0,binding,1,offset,0,argKind,buffer
 // MAP-NEXT: kernel,test_restrict,arg,ptr3,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,buffer
-// MAP-NEXT: kernel,test_restrict,arg,pod1,argOrdinal,1,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,4
-// MAP-NEXT: kernel,test_restrict,arg,pod2,argOrdinal,2,descriptorSet,0,binding,3,offset,4,argKind,pod,argSize,4
+// MAP-NEXT: kernel,test_restrict,arg,pod1,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,test_restrict,arg,pod2,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
 
 kernel void test_restrict(global int* restrict ptr1, int pod1, int pod2, global int* ptr2, global int* restrict ptr3)
 {

--- a/test/cluster_pod_args_globals_scalars.cl
+++ b/test/cluster_pod_args_globals_scalars.cl
@@ -10,17 +10,16 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: OpMemberDecorate [[__struct_7:%[a-zA-Z0-9_]+]] 1 Offset 4
 // CHECK: OpMemberDecorate [[__struct_8:%[a-zA-Z0-9_]+]] 0 Offset 0
 // CHECK: OpDecorate [[__struct_8]] Block
-// CHECK: OpDecorate [[_16:%[a-zA-Z0-9_]+]] Binding 2
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[__ptr_StorageBuffer_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[_float]]
 // CHECK-DAG: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[__struct_7]] = OpTypeStruct [[_float]] [[_uint]]
 // CHECK-DAG: [[__struct_8]] = OpTypeStruct [[__struct_7]]
-// CHECK-DAG: [[__ptr_StorageBuffer__struct_8:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_8]]
-// CHECK-DAG: [[__ptr_StorageBuffer__struct_7:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK-DAG: [[__ptr_PushConstant__struct_8:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[__struct_8]]
+// CHECK-DAG: [[__ptr_PushConstant__struct_7:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[__struct_7]]
 // CHECK-DAG: [[_uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
-// CHECK: [[_16]] = OpVariable [[__ptr_StorageBuffer__struct_8]] StorageBuffer
-// CHECK: [[_19:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_7]] [[_16]] [[_uint_0]]
+// CHECK: [[_16:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_PushConstant__struct_8]] PushConstant
+// CHECK: [[_19:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_PushConstant__struct_7]] [[_16]] [[_uint_0]]
 // CHECK: [[_20:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_7]] [[_19]]
 // CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_20]] 0
 // CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_20]] 1

--- a/test/cluster_pod_args_larger_alignment.cl
+++ b/test/cluster_pod_args_larger_alignment.cl
@@ -6,8 +6,8 @@
 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
-// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+// MAP: kernel,foo,arg,n,argOrdinal,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,offset,16
 
 
 // CHECK: OpMemberDecorate [[first_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
@@ -19,18 +19,16 @@
 
 // CHECK: OpDecorate [[Aarg:%[a-zA-Z0-9_]+]] DescriptorSet 0
 // CHECK: OpDecorate [[Aarg]] Binding 0
-// CHECK: OpDecorate [[podargs:%[a-zA-Z0-9_]+]] DescriptorSet 0
-// CHECK: OpDecorate [[podargs]] Binding 1
 
 // CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]]
 // CHECK-DAG: [[podty]] = OpTypeStruct [[uint]] [[float4]]
 // CHECK-DAG: [[st_podty]] = OpTypeStruct [[podty]]
-// CHECK-DAG: [[sbptr_st_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[st_podty]]
-// CHECK-DAG: [[sbptr_podty:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[podty]]
+// CHECK-DAG: [[sbptr_st_podty:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[st_podty]]
+// CHECK-DAG: [[sbptr_podty:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[podty]]
 
-// CHECK: [[podargs]] = OpVariable [[sbptr_st_podty]] StorageBuffer
+// CHECK: [[podargs:%[a-zA-Z0-9_]+]] = OpVariable [[sbptr_st_podty]] PushConstant
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, uint n, float4 c)
 {

--- a/test/cluster_pod_args_locals_scalars.cl
+++ b/test/cluster_pod_args_locals_scalars.cl
@@ -12,19 +12,18 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,B,argOrdinal,2,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
-// MAP-NEXT: kernel,foo,arg,n,argOrdinal,3,descriptorSet,0,binding,1,offset,4,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,4
+// MAP-NEXT: kernel,foo,arg,n,argOrdinal,3,offset,4,argKind,pod_pushconstant,argSize,4
 // MAP-NOT: kernel
 
 // CHECK: OpDecorate [[_20:%[0-9a-zA-Z_]+]] Binding 0
-// CHECK: OpDecorate [[_21:%[0-9a-zA-Z_]+]] Binding 1
 // CHECK: OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3
 // CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK: [[__struct_12:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]] [[_uint]]
 // CHECK: [[__struct_13:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__struct_12]]
-// CHECK: [[__ptr_StorageBuffer__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_13]]
+// CHECK: [[__ptr_PushConstant__struct_13:%[0-9a-zA-Z_]+]] = OpTypePointer PushConstant [[__struct_13]]
 // CHECK: [[_2]] = OpSpecConstant [[_uint]] 1
 // CHECK: [[_20]] = OpVariable {{.*}} StorageBuffer
-// CHECK: [[_21]] = OpVariable [[__ptr_StorageBuffer__struct_13]] StorageBuffer
+// CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_PushConstant__struct_13]] PushConstant
 // CHECK: OpVariable {{.*}} Workgroup

--- a/test/cluster_pod_args_pod_only.cl
+++ b/test/cluster_pod_args_pod_only.cl
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// MAP: kernel,test,arg,pod,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,pod
+// MAP: kernel,test,arg,pod,argOrdinal,0,offset,0,argKind,pod_pushconstant,argSize,4
 
 kernel void test(int pod)
 {

--- a/test/descriptor_map_argtype.cl
+++ b/test/descriptor_map_argtype.cl
@@ -10,16 +10,16 @@
 // CHECK-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
 // CHECK-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
 // CHECK-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
-// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod,argSize,4
-// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argKind,pod,argSize,4
+// CHECK-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod_ubo,argSize,4
+// CHECK-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,5,offset,0,argKind,pod_ubo,argSize,4
 // CHECK-NOT: foo
 
 // CLUSTER: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // CLUSTER-NEXT: kernel,foo,arg,RO,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,ro_image
 // CLUSTER-NEXT: kernel,foo,arg,WO,argOrdinal,2,descriptorSet,0,binding,2,offset,0,argKind,wo_image
 // CLUSTER-NEXT: kernel,foo,arg,SAM,argOrdinal,3,descriptorSet,0,binding,3,offset,0,argKind,sampler
-// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,descriptorSet,0,binding,4,offset,0,argKind,pod,argSize,4
-// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,descriptorSet,0,binding,4,offset,4,argKind,pod,argSize,4
+// CLUSTER-NEXT: kernel,foo,arg,c,argOrdinal,4,offset,0,argKind,pod_pushconstant,argSize,4
+// CLUSTER-NEXT: kernel,foo,arg,d,argOrdinal,5,offset,4,argKind,pod_pushconstant,argSize,4
 // CLUSTER-NOT: foo
 
 kernel void foo(global int *A, read_only image2d_t RO, write_only image2d_t WO,

--- a/test/descriptor_set_default.cl
+++ b/test/descriptor_set_default.cl
@@ -7,11 +7,11 @@
 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
-// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+// MAP: kernel,foo,arg,n,argOrdinal,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,offset,16
 
 // MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,0,binding,1,offset,0
+// MAP: kernel,bar,arg,m,argOrdinal,1,offset,0
 // MAP-NOT: kernel
 
 

--- a/test/descriptor_set_distinct.cl
+++ b/test/descriptor_set_distinct.cl
@@ -5,11 +5,11 @@
 
 
 // MAP: kernel,foo,arg,A,argOrdinal,0,descriptorSet,0,binding,0,offset,0
-// MAP: kernel,foo,arg,n,argOrdinal,1,descriptorSet,0,binding,1,offset,0
-// MAP: kernel,foo,arg,c,argOrdinal,2,descriptorSet,0,binding,1,offset,16
+// MAP: kernel,foo,arg,n,argOrdinal,1,offset,0
+// MAP: kernel,foo,arg,c,argOrdinal,2,offset,16
 
 // MAP: kernel,bar,arg,B,argOrdinal,0,descriptorSet,1,binding,0,offset,0
-// MAP: kernel,bar,arg,m,argOrdinal,1,descriptorSet,1,binding,1,offset,0
+// MAP: kernel,bar,arg,m,argOrdinal,1,offset,0
 // MAP-NOT: kernel
 
 

--- a/test/one_uint_arg.cl
+++ b/test/one_uint_arg.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args=0
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args=0 -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
@@ -12,9 +12,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(uint a)
 // CHECK:  OpDecorate [[_8]] Binding 0
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK:  [[__struct_2]] = OpTypeStruct [[_uint]]
-// CHECK:  [[__ptr_StorageBuffer__struct_2:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_2]]
-// CHECK:  [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK:  [[__ptr_Uniform__struct_2:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_2]]
+// CHECK:  [[__ptr_Uniform_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[_uint]]
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
-// CHECK:  [[_8]] = OpVariable [[__ptr_StorageBuffer__struct_2]] StorageBuffer
-// CHECK:  [[_11:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_8]] [[_uint_0]]
+// CHECK:  [[_8]] = OpVariable [[__ptr_Uniform__struct_2]] Uniform
+// CHECK:  [[_11:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Uniform_uint]] [[_8]] [[_uint_0]]
 // CHECK:  [[_12:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_11]]

--- a/test/ptr_function_in_callee.cl
+++ b/test/ptr_function_in_callee.cl
@@ -28,16 +28,17 @@ kernel void foo(global int* A, int n) {
 // CHECK: OpDecorate [[_19]] Binding 1
 // CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[__ptr_StorageBuffer_uint:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_uint]]
+// CHECK-DAG: [[__ptr_Uniform_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[_uint]]
 // CHECK-DAG: [[__runtimearr_uint]] = OpTypeRuntimeArray [[_uint]]
 // CHECK-DAG: [[__struct_4]] = OpTypeStruct [[__runtimearr_uint]]
 // CHECK-DAG: [[__ptr_StorageBuffer__struct_4:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_4]]
 // CHECK-DAG: [[__struct_6]] = OpTypeStruct [[_uint]]
-// CHECK-DAG: [[__ptr_StorageBuffer__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_6]]
+// CHECK-DAG: [[__ptr_Uniform__struct_6:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_6]]
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_18]] = OpVariable [[__ptr_StorageBuffer__struct_4]] StorageBuffer
-// CHECK: [[_19]] = OpVariable [[__ptr_StorageBuffer__struct_6]] StorageBuffer
+// CHECK: [[_19]] = OpVariable [[__ptr_Uniform__struct_6]] Uniform
 // CHECK: [[_21:%[0-9a-zA-Z_]+]] = OpLabel
 // CHECK: [[_22:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_18]] [[_uint_0]] [[_uint_0]]
-// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer_uint]] [[_19]] [[_uint_0]]
+// CHECK: [[_23:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Uniform_uint]] [[_19]] [[_uint_0]]
 // CHECK: [[_24:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_23]]
 // CHECK: OpStore [[_22]] [[_24]]

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -13,9 +13,9 @@ kernel void foo(local float *L, global float* A, float f, S local* LS, constant 
 }
 
 //      MAP: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod_ubo,argSize,4
 // MAP-NEXT: kernel,foo,arg,C,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod_ubo,argSize,4
 // MAP-NEXT: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
 // MAP-NEXT: kernel,foo,arg,LS,argOrdinal,3,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NOT: kernel

--- a/test/ptr_local_struct_cluster_pod_args.cl
+++ b/test/ptr_local_struct_cluster_pod_args.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map
+// RUN: clspv %s -o %t.spv -cluster-pod-kernel-args -descriptormap=%t2.map -pod-ubo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck %s < %t2.map -check-prefix=MAP
@@ -16,8 +16,8 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,LS,argOrdinal,2,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NEXT: kernel,foo,arg,C,argOrdinal,3,descriptorSet,0,binding,1,offset,0,argKind,buffer
-// MAP-NEXT: kernel,foo,arg,f,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,pod,argSize,4
-// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,2,offset,4,argKind,pod,argSize,4
+// MAP-NEXT: kernel,foo,arg,f,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,pod_ubo,argSize,4
+// MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,2,offset,4,argKind,pod_ubo,argSize,4
 // MAP-NOT: kernel
 
 // CHECK:      OpDecorate [[_37:%[0-9a-zA-Z_]+]] Binding 2
@@ -26,11 +26,11 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // CHECK-DAG:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG:  [[__struct_15:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]] [[_float]]
 // CHECK-DAG:  [[__struct_16:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__struct_15]]
-// CHECK-DAG:  [[__ptr_StorageBuffer__struct_16:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_16]]
+// CHECK-DAG:  [[__ptr_Uniform__struct_16:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_16]]
 // CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG:  [[__ptr_Workgroup_float:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_float]]
 // CHECK-DAG:  [[__ptr_StorageBuffer_float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[_float]]
-// CHECK-DAG:  [[__ptr_StorageBuffer__struct_15:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_15]]
+// CHECK-DAG:  [[__ptr_Uniform__struct_15:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_15]]
 // CHECK-DAG:  [[__ptr_Workgroup_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[_uint]]
 // CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
 // CHECK-DAG:  [[__struct_24:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_uint]] [[_uint]]
@@ -42,11 +42,11 @@ kernel void foo(local float *L, global float* A, S local* LS, constant float* C,
 // CHECK-DAG:  [[__arr__struct_24_7:%[0-9a-zA-Z_]+]] = OpTypeArray [[__struct_24]] [[_7]]
 // CHECK-DAG:  [[__ptr_Workgroup__arr__struct_24_7:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[__arr__struct_24_7]]
 // CHECK-DAG:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
-// CHECK:      [[_37]] = OpVariable [[__ptr_StorageBuffer__struct_16]] StorageBuffer
+// CHECK:      [[_37]] = OpVariable [[__ptr_Uniform__struct_16]] Uniform
 // CHECK:      [[_1:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr_float_2]] Workgroup
 // CHECK:      [[_6:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Workgroup__arr__struct_24_7]] Workgroup
 // CHECK:      [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Workgroup_float]] [[_1]] [[_uint_0]]
-// CHECK:      [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_StorageBuffer__struct_15]] [[_37]] [[_uint_0]]
+// CHECK:      [[_42:%[0-9a-zA-Z_]+]] = OpAccessChain [[__ptr_Uniform__struct_15]] [[_37]] [[_uint_0]]
 // CHECK:      [[_43:%[0-9a-zA-Z_]+]] = OpLoad [[__struct_15]] [[_42]]
 // CHECK:      [[_44:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_43]] 0
 // CHECK:      [[_45:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]] [[_43]] 1

--- a/test/reuse_kernel_arg_var.cl
+++ b/test/reuse_kernel_arg_var.cl
@@ -59,15 +59,15 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 // CHECK:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_uint]]
 // CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
 // CHECK:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_9]]
+// CHECK:  [[__ptr_Uniform__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_9]]
 // CHECK:  [[A_R]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[B_S]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[C]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CHECK:  [[D]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
-// CHECK:  [[f_y]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
-// CHECK:  [[g]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK:  [[f_y]] = OpVariable [[__ptr_Uniform__struct_9]] Uniform
+// CHECK:  [[g]] = OpVariable [[__ptr_Uniform__struct_9]] Uniform
 // CHECK:  [[T]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
-// CHECK:  [[x]] = OpVariable [[__ptr_StorageBuffer__struct_9]] StorageBuffer
+// CHECK:  [[x]] = OpVariable [[__ptr_Uniform__struct_9]] Uniform
 // CHECK:  [[foo]] = OpFunction
 // CHECK:  OpAccessChain {{.*}} [[A_R]]
 // CHECK:  OpAccessChain {{.*}} [[B_S]]
@@ -88,9 +88,7 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 // CLUSTER:  OpDecorate [[B_S:%[0-9a-zA-Z_]+]] Binding 1
 // CLUSTER:  OpDecorate [[C:%[0-9a-zA-Z_]+]] Binding 2
 // CLUSTER:  OpDecorate [[D:%[0-9a-zA-Z_]+]] Binding 3
-// CLUSTER:  OpDecorate [[fg:%[0-9a-zA-Z_]+]] Binding 4
 // CLUSTER:  OpDecorate [[T:%[0-9a-zA-Z_]+]] Binding 2
-// CLUSTER:  OpDecorate [[xy:%[0-9a-zA-Z_]+]] Binding 3
 // CLUSTER:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CLUSTER:  [[__runtimearr_float:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_float]]
 // CLUSTER:  [[__struct_3:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_float]]
@@ -101,14 +99,14 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 // CLUSTER:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
 // CLUSTER:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]] [[_float]]
 // CLUSTER:  [[__struct_10:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__struct_9]]
-// CLUSTER:  [[__ptr_StorageBuffer__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_10]]
+// CLUSTER:  [[__ptr_PushConstant__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer PushConstant [[__struct_10]]
 // CLUSTER:  [[A_R]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CLUSTER:  [[B_S]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CLUSTER:  [[C]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
 // CLUSTER:  [[D]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
-// CLUSTER:  [[fg]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CLUSTER:  [[fg:%[a-zA-Z0-9_.]+]] = OpVariable [[__ptr_PushConstant__struct_10]] PushConstant
 // CLUSTER:  [[T]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
-// CLUSTER:  [[xy]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
+// CLUSTER:  [[xy:%[a-zA-Z0-9_.]+]] = OpVariable [[__ptr_PushConstant__struct_10]] PushConstant
 // CLUSTER:  [[foo]] = OpFunction
 // CLUSTER:  OpAccessChain {{.*}} [[A_R]]
 // CLUSTER:  OpAccessChain {{.*}} [[B_S]]


### PR DESCRIPTION
Contributes to #529 

Add a new pass to decide on a per kernel basis how pod args should be implemented. Currently handles three possibilities: ssbo, ubo and per-kernel push constant. Soon I want to support a type-mangled global push constant interface. The pass attempts to use push constants if possible, then UBOs and finally falls back on SSBOs.

Changes:
 * new pass
   * automated choice can be overridden by command line options
 * updated cluster pod args to copy metadata
 * refactored ArgKind utilities to use the actual argument everywhere
   * new utility looks at the kernel's pod arg implementation to decide
   * old utility based on type is used for pointer args
 * refactored some push constant related helper methods into PushConstant.cpp/h
 * refactored layout checks into separate files
   * added a new version to check a whole struct at once
 * updated many tests to account for different pod arg choices
    * picked a spread of implementations