### PR TITLE
Add ability to generate global offset as spec constant

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -624,7 +624,7 @@ The OpenCL C work-item functions map to Vulkan SPIR-V as follows:
   `get_local_size()` by the result from `get_num_groups()`.
 - `get_global_id()` is mapped to a SPIR-V variable decorated with
   `GlobalInvocationId`. The global offset is added to that variable when
-   `-global-offset` is enabled.
+   `-global-offset` or `-global-offset-push-constant` is enabled.
 - `get_local_size()` is mapped to a SPIR-V variable decorated with
   `WorkgroupSize`.
 - `get_local_id()` is mapped to a SPIR-V variable decorated with
@@ -634,9 +634,10 @@ The OpenCL C work-item functions map to Vulkan SPIR-V as follows:
 - `get_group_id()` is mapped to a SPIR-V variable decorated with
   `WorkgroupId`.
 - `get_global_offset()` is mapped to the `global_offset` spec constant or push
-  constant when `-global-offset` is enabled, otherwise it always returns 0.
-  Spec constants are used unless `-global-offset-push-constant` is specified or
-  the language is set to OpenCL C++ or OpenCL 2.0.
+  constant when `-global-offset` or `-global-offset-push-constant` is enabled,
+  otherwise it always returns 0.  Spec constants are used unless
+  `-global-offset-push-constant` is specified or the language is set to OpenCL
+  C++ or OpenCL 2.0.
 
 ## OpenCL C Restrictions
 

--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -430,6 +430,9 @@ module-wide. The following specialization constants are currently generated:
 - `workgroup\_size\_y`: The y-dimension of workgroup size.
 - `workgroup\_size\_z`: The z-dimension of workgroup size.
 - `work_dim`: The work dimensions.
+- `global\_offset\_x`: The x-dimension of global offset.
+- `global\_offset\_y`: The y-dimension of global offset.
+- `global\_offset\_z`: The z-dimension of global offset.
 
 #### Module scope constants
 
@@ -630,8 +633,10 @@ The OpenCL C work-item functions map to Vulkan SPIR-V as follows:
   `NumWorkgroups`.
 - `get_group_id()` is mapped to a SPIR-V variable decorated with
   `WorkgroupId`.
-- `get_global_offset()` is mapped to the `global_offset` push constant when
-  `-global-offset` is enabled, otherwise it always returns 0.
+- `get_global_offset()` is mapped to the `global_offset` spec constant or push
+  constant when `-global-offset` is enabled, otherwise it always returns 0.
+  Spec constants are used unless `-global-offset-push-constant` is specified or
+  the language is set to OpenCL C++ or OpenCL 2.0.
 
 ## OpenCL C Restrictions
 

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -159,6 +159,9 @@ bool WorkDim();
 // Returns true when support for global offset is enabled.
 bool GlobalOffset();
 
+// Returns true when support for global offset is enabled using push constants.
+bool GlobalOffsetPushConstant();
+
 // Returns true when support for non uniform NDRanges is enabled.
 static bool NonUniformNDRangeSupported() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||

--- a/include/clspv/SpecConstant.h
+++ b/include/clspv/SpecConstant.h
@@ -28,6 +28,10 @@ enum class SpecConstant : int {
   kLocalMemorySize,
   // Work dimensions.
   kWorkDim,
+  // Global offset per dimension.
+  kGlobalOffsetX,
+  kGlobalOffsetY,
+  kGlobalOffsetZ,
 };
 
 // Converts an SpecConstant to its string name.

--- a/lib/DeclarePushConstantsPass.cpp
+++ b/lib/DeclarePushConstantsPass.cpp
@@ -94,7 +94,7 @@ bool DeclarePushConstantsPass::runOnModule(Module &M) {
 
   auto &C = M.getContext();
 
-  if (clspv::ShouldDeclareGlobalOffset(M)) {
+  if (clspv::ShouldDeclareGlobalOffsetPushConstant(M)) {
     PushConstants.emplace_back(clspv::PushConstant::GlobalOffset);
   }
 

--- a/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
@@ -385,7 +385,8 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
     auto InBoundsDim = inBoundsDimensionIndex(Builder, Dim);
     Value *Indices[] = {Builder.getInt32(0), InBoundsDim};
     Value *gep = nullptr;
-    const bool uses_push_constant = clspv::ShouldDeclareGlobalOffset(M);
+    const bool uses_push_constant =
+        clspv::ShouldDeclareGlobalOffsetPushConstant(M);
     if (uses_push_constant) {
       auto GoffPtr =
           GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset);

--- a/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
@@ -199,7 +199,8 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalIDBuiltin(Module &M) {
     Ret = Builder.CreateAdd(Ret, RegOff);
   } else {
     // If we have a global offset we need to add it
-    if (clspv::Option::GlobalOffset()) {
+    if (clspv::Option::GlobalOffset() ||
+        clspv::Option::GlobalOffsetPushConstant()) {
       auto Goff =
           Builder.CreateCall(M.getFunction("_Z17get_global_offsetj"), Dim);
       Goff->setCallingConv(CallingConv::SPIR_FUNC);
@@ -353,7 +354,8 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGroupIDBuiltin(Module &M) {
 
 bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
   Function *F = M.getFunction("_Z17get_global_offsetj");
-  bool isSupportEnabled = clspv::Option::GlobalOffset();
+  bool isSupportEnabled = clspv::Option::GlobalOffset() ||
+                          clspv::Option::GlobalOffsetPushConstant();
   bool isUsedDirectly = F != nullptr;
   bool isUsedIndirectly =
       isSupportEnabled && M.getFunction("_Z13get_global_idj") != nullptr;
@@ -367,9 +369,9 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
 
   // If get_global_offset isn't used but get_global_id is then we need to
   // declare it ourselves.
+  auto &C = M.getContext();
+  auto Int32Ty = IntegerType::get(C, 32);
   if (isUsedIndirectly && !isUsedDirectly) {
-    auto &C = M.getContext();
-    auto Int32Ty = IntegerType::get(C, 32);
     auto FType = FunctionType::get(Int32Ty, Int32Ty, false);
     F = cast<Function>(
         M.getOrInsertFunction("_Z17get_global_offsetj", FType).getCallee());
@@ -382,11 +384,21 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
     auto Dim = &*F->arg_begin();
     auto InBoundsDim = inBoundsDimensionIndex(Builder, Dim);
     Value *Indices[] = {Builder.getInt32(0), InBoundsDim};
-    auto GoffPtr =
-        GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset);
-    auto GoffDimPtr = Builder.CreateInBoundsGEP(GoffPtr, Indices);
-    auto GoffDim = Builder.CreateLoad(GoffDimPtr);
-    auto Ret = inBoundsDimensionOrDefaultValue(Builder, Dim, GoffDim, 0);
+    Value *gep = nullptr;
+    const bool uses_push_constant = clspv::ShouldDeclareGlobalOffset(M);
+    if (uses_push_constant) {
+      auto GoffPtr =
+          GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset);
+      gep = Builder.CreateInBoundsGEP(GoffPtr, Indices);
+    } else {
+      auto VecTy = VectorType::get(Int32Ty, 3);
+      StringRef name = "__spirv_GlobalOffset";
+      auto offset_var = createGlobalVariable(M, name, VecTy,
+                                             AddressSpace::ModuleScopePrivate);
+      gep = Builder.CreateInBoundsGEP(offset_var, Indices);
+    }
+    auto load = Builder.CreateLoad(gep);
+    auto Ret = inBoundsDimensionOrDefaultValue(Builder, Dim, load, 0);
     Builder.CreateRet(Ret);
   } else {
     // Get global offset is easy for us as it only returns 0.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -190,6 +190,10 @@ static llvm::cl::opt<bool>
     global_offset("global-offset", llvm::cl::init(false),
                   llvm::cl::desc("Enable support for global offsets"));
 
+static llvm::cl::opt<bool> global_offset_push_constant(
+    "global-offset-push-constant", llvm::cl::init(false),
+    llvm::cl::desc("Enable support for global offsets in push constants"));
+
 static bool use_sampler_map = false;
 
 static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
@@ -239,6 +243,7 @@ SourceLanguage Language() { return cl_std; }
 bool ScalarBlockLayout() { return scalar_block_layout; }
 bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
+bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 
 } // namespace Option

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -105,10 +105,10 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc) {
 
 bool UsesGlobalPushConstants(Module &M) {
   return clspv::Option::NonUniformNDRangeSupported() ||
-         ShouldDeclareGlobalOffset(M);
+         ShouldDeclareGlobalOffsetPushConstant(M);
 }
 
-bool ShouldDeclareGlobalOffset(Module &M) {
+bool ShouldDeclareGlobalOffsetPushConstant(Module &M) {
   bool isEnabled = (clspv::Option::GlobalOffset() &&
                     clspv::Option::NonUniformNDRangeSupported()) ||
                    clspv::Option::GlobalOffsetPushConstant();

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -109,7 +109,9 @@ bool UsesGlobalPushConstants(Module &M) {
 }
 
 bool ShouldDeclareGlobalOffset(Module &M) {
-  bool isEnabled = clspv::Option::GlobalOffset();
+  bool isEnabled = (clspv::Option::GlobalOffset() &&
+                    clspv::Option::NonUniformNDRangeSupported()) ||
+                   clspv::Option::GlobalOffsetPushConstant();
   bool isUsed = (M.getFunction("_Z17get_global_offsetj") != nullptr) ||
                 (M.getFunction("_Z13get_global_idj") != nullptr);
   return isEnabled && isUsed;

--- a/lib/PushConstant.h
+++ b/lib/PushConstant.h
@@ -36,7 +36,7 @@ llvm::Value *GetPushConstantPointer(llvm::BasicBlock *, PushConstant);
 bool UsesGlobalPushConstants(llvm::Module &);
 
 // Returns true if an implementation of get_global_offset() is needed.
-bool ShouldDeclareGlobalOffset(llvm::Module &);
+bool ShouldDeclareGlobalOffsetPushConstant(llvm::Module &);
 } // namespace clspv
 
 #endif // #ifndef CLSPV_LIB_PUSH_CONSTANT_H_

--- a/lib/SpecConstant.cpp
+++ b/lib/SpecConstant.cpp
@@ -54,6 +54,12 @@ const char *GetSpecConstantName(SpecConstant kind) {
     return "local_memory_size";
   case SpecConstant::kWorkDim:
     return "work_dim";
+  case SpecConstant::kGlobalOffsetX:
+    return "global_offset_x";
+  case SpecConstant::kGlobalOffsetY:
+    return "global_offset_y";
+  case SpecConstant::kGlobalOffsetZ:
+    return "global_offset_z";
   }
   llvm::errs() << "Unhandled case in clspv::GetSpecConstantName: " << int(kind)
                << "\n";
@@ -71,6 +77,12 @@ SpecConstant GetSpecConstantFromName(const std::string &name) {
     return SpecConstant::kLocalMemorySize;
   else if (name == "work_dim")
     return SpecConstant::kWorkDim;
+  else if (name == "global_offset_x")
+    return SpecConstant::kGlobalOffsetX;
+  else if (name == "global_offset_y")
+    return SpecConstant::kGlobalOffsetY;
+  else if (name == "global_offset_z")
+    return SpecConstant::kGlobalOffsetZ;
 
   llvm::errs() << "Unhandled csae in clspv::GetSpecConstantFromName: " << name
                << "\n";

--- a/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
+++ b/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset %s -o %t.spv
+// RUN: clspv -global-offset-push-constant %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_id-with-global-offset-spec-constant.cl
+++ b/test/WorkItemBuiltins/get_global_id-with-global-offset-spec-constant.cl
@@ -1,0 +1,32 @@
+// RUN: clspv -global-offset %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     OpDecorate [[spec_id_x:%[a-zA-Z0-9_]+]] SpecId 3
+// CHECK:     OpDecorate [[spec_id_y:%[a-zA-Z0-9_]+]] SpecId 4
+// CHECK:     OpDecorate [[spec_id_z:%[a-zA-Z0-9_]+]] SpecId 5
+// CHECK:     OpDecorate [[gid:%[0-9a-zA-Z_]+]] BuiltIn GlobalInvocationId
+// CHECK-DAG: [[uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[uint]] 3
+// CHECK-DAG: [[_ptr_Input_v3uint:%[0-9a-zA-Z_]+]] = OpTypePointer Input [[v3uint]]
+// CHECK-DAG: [[_ptr_Input_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Input [[uint]]
+// CHECK-DAG: [[spec_id_x]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[spec_id_y]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[spec_id_z]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[const:%[a-zA-Z0-9_]+]] = OpSpecConstantComposite [[v3uint]] [[spec_id_x]] [[spec_id_y]] [[spec_id_z]]
+// CHECK-DAG: [[offset_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[v3uint]]
+// CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[uint]]
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[gid]] = OpVariable [[_ptr_Input_v3uint]] Input
+// CHECK-DAG: [[offset:%[a-zA-Z0-9_]+]] = OpVariable [[offset_ptr]] Private
+// CHECK:     [[__original_id_22:%[0-9]+]] = OpAccessChain [[_ptr_Input_uint]] [[gid]] [[uint_0]]
+// CHECK:     [[__original_id_23:%[0-9]+]] = OpLoad [[uint]] [[__original_id_22]]
+// CHECK:     [[offset_gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[offset]] [[uint_0]]
+// CHECK:     [[offset_load:%[a-zA-Z0-9_]+]] = OpLoad [[uint]] [[offset_gep]]
+// CHECK:     OpIAdd [[uint]] [[offset_load]] [[__original_id_23]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_global_id(0);
+}
+

--- a/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset %s -o %t.spv
+// RUN: clspv -global-offset-push-constant %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_offset-push-constant.cl
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset -descriptormap=%t.dmap %s -o %t.spv
+// RUN: clspv -global-offset-push-constant -descriptormap=%t.dmap %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: FileCheck --check-prefix=DMAP %s < %t.dmap

--- a/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.cl
+++ b/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.cl
@@ -1,0 +1,33 @@
+// RUN: clspv -global-offset %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpDecorate [[spec_id_x:%[a-zA-Z0-9_]+]] SpecId 3
+// CHECK: OpDecorate [[spec_id_y:%[a-zA-Z0-9_]+]] SpecId 4
+// CHECK: OpDecorate [[spec_id_z:%[a-zA-Z0-9_]+]] SpecId 5
+// CHECK-DAG: [[uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[uint]] 3
+// CHECK-DAG: [[bool:%[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[spec_id_x]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[spec_id_y]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[spec_id_z]] = OpSpecConstant [[uint]] 0
+// CHECK-DAG: [[const:%[a-zA-Z0-9_]+]] = OpSpecConstantComposite [[v3uint]] [[spec_id_x]] [[spec_id_y]] [[spec_id_z]]
+// CHECK-DAG: [[var_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[v3uint]]
+// CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Private [[uint]]
+// CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[var_ptr]] Private
+// CHECK: [[param:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[uint]]
+// CHECK: [[less:%[a-zA-Z0-9_]+]] = OpULessThan [[bool]] [[param]] [[uint_3]]
+// CHECK: [[select:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[less]] [[param]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[select]]
+// CHECK: [[load:%[a-zA-Z0-9_]+]] = OpLoad [[uint]] [[gep]]
+// CHECK: [[select2:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[less]] [[load]] [[uint_0]]
+// CHECK: OpReturnValue [[select2]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_global_offset(out[1]);
+}
+

--- a/test/WorkItemBuiltins/get_global_offset-spec-constant.cl
+++ b/test/WorkItemBuiltins/get_global_offset-spec-constant.cl
@@ -1,0 +1,31 @@
+// RUN: clspv -global-offset -descriptormap=%t.dmap %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=DMAP %s < %t.dmap
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// DMAP: spec_constant,global_offset_x,spec_id,3
+// DMAP: spec_constant,global_offset_y,spec_id,4
+// DMAP: spec_constant,global_offset_z,spec_id,5
+
+// CHECK: OpDecorate %[[spec_id_x:[a-zA-Z0-9_]+]] SpecId 3
+// CHECK: OpDecorate %[[spec_id_y:[a-zA-Z0-9_]+]] SpecId 4
+// CHECK: OpDecorate %[[spec_id_z:[a-zA-Z0-9_]+]] SpecId 5
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[spec_id_x]] = OpSpecConstant %[[uint]] 0
+// CHECK-DAG: %[[spec_id_y]] = OpSpecConstant %[[uint]] 0
+// CHECK-DAG: %[[spec_id_z]] = OpSpecConstant %[[uint]] 0
+// CHECK-DAG: %[[spec_const:[a-zA-Z0-9_]+]] = OpSpecConstantComposite %[[v3uint]] %[[spec_id_x]] %[[spec_id_y]] %[[spec_id_z]]
+// CHECK-DAG: %[[var_ptr:[a-zA-Z0-9_]+]] = OpTypePointer Private %[[v3uint]]
+// CHECK-DAG: %[[ptr:[a-zA-Z0-9_]+]] = OpTypePointer Private %[[uint]]
+// CHECK: %[[var:[a-zA-Z0-9_]+]] = OpVariable %[[var_ptr]] Private
+// CHECK: %[[gep:[a-zA-Z0-9_]+]] = OpAccessChain %[[ptr]] %[[var]] %[[uint_0]]
+// CHECK: %[[load:[a-zA-Z0-9_]+]] = OpLoad %[[uint]] %[[gep]]
+// CHECK: OpStore {{.*}} %[[load]]
+
+void kernel __attribute__((reqd_work_group_size(1,1,1))) test(global int *out) {
+    out[0] = get_global_offset(0);
+}
+


### PR DESCRIPTION
Contributes to #529

* -global-offset will now generate either a spec constant or push
constant
  * push constant is used for OpenCL 2.0 and OpenCL C++
  * push constant can be forced with -global-offset-push-constant
* global offset as a spec constant generates a private variable with
spec constant initializer
  * new SpecConstant enum values for x, y and z dimensions of global
  offset
* refactored some logic for push constants
* updated docs
* new tests