### PR TITLE
Fix local arg spec id assignment

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -856,6 +856,10 @@ bool AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
     if (where != spec_id_types.end()) {
       for (auto id : where->second) {
         if (!function_spec_ids.count(id)) {
+          // Reuse |id| for |type| in this kernel. Record the use of |id| in
+          // this kernel.
+          function_allocations.emplace_back(type, id);
+          function_spec_ids.insert(id);
           return id;
         }
       }

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -181,22 +181,4 @@ bool IsLocalPtr(llvm::Type *type) {
          type->getPointerAddressSpace() == clspv::AddressSpace::Local;
 }
 
-ArgIdMapType AllocateArgSpecIds(Module &M) {
-  ArgIdMapType result;
-
-  int next_spec_id = 3; // Reserve space for workgroup size spec ids.
-  for (Function &F : M) {
-    if (F.isDeclaration() || F.getCallingConv() != CallingConv::SPIR_KERNEL) {
-      continue;
-    }
-    for (const auto &Arg : F.args()) {
-      if (IsLocalPtr(Arg.getType())) {
-        result[&Arg] = next_spec_id++;
-      }
-    }
-  }
-
-  return result;
-}
-
 } // namespace clspv

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -46,22 +46,6 @@ ArgKind GetArgKind(llvm::Argument &Arg);
 // Returns true if the given type is a pointer-to-local type.
 bool IsLocalPtr(llvm::Type *type);
 
-using ArgIdMapType = llvm::DenseMap<const llvm::Argument *, int>;
-
-// Returns a mapping from pointer-to-local Argument to a specialization constant
-// ID for that argument's array size.  The lowest value allocated is 3.
-//
-// The mapping is as follows:
-// - The first index used is 3.
-// - There are no gaps in the list of used indices.
-// - Arguments from earlier kernel bodies have lower indices than arguments from
-//   later kernel bodies.
-// - Lower-numbered arguments have lower indices than higher-numbered arguments
-//   in the same function.
-// Note that this mapping is stable as long as the order of kernel bodies is
-// retained, and the number and order of pointer-to-local arguments is retained.
-ArgIdMapType AllocateArgSpecIds(llvm::Module &M);
-
 } // namespace clspv
 
 #endif

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -128,8 +128,8 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
       if (isa<PointerType>(ArgTy)) {
         PtrArgTys.push_back(ArgTy);
         const auto kind = clspv::GetArgKind(Arg);
-        RemapInfo.push_back({std::string(Arg.getName()), arg_index, new_index++,
-                             0u, 0u, kind});
+        RemapInfo.push_back(
+            {std::string(Arg.getName()), arg_index, new_index++, 0u, 0u, kind});
       } else {
         PodIndexMap[&Arg] = pod_index++;
         PodArgTys.push_back(ArgTy);
@@ -291,9 +291,9 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
             ConstantAsMetadata::get(Builder.getInt32(arg_mapping.arg_size));
         auto argKindName = GetArgKindName(arg_mapping.arg_kind);
         auto *argtype_md = MDString::get(Context, argKindName);
-        auto *arg_md = MDNode::get(
-            Context, {name_md, old_index_md, new_index_md, offset_md,
-                      arg_size_md, argtype_md});
+        auto *arg_md =
+            MDNode::get(Context, {name_md, old_index_md, new_index_md,
+                                  offset_md, arg_size_md, argtype_md});
         mappings.push_back(arg_md);
       }
 

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -70,6 +70,9 @@ inline std::string SpecConstantMetadataName() {
 // Pod args implementation metadata name.
 inline std::string PodArgsImplMetadataName() { return "clspv.pod_args_impl"; }
 
+// Clustered arguments mapping metadata name.
+inline std::string KernelArgMapMetadataName() { return "kernel_arg_map"; }
+
 } // namespace clspv
 
 #endif

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3243,12 +3243,12 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
   auto *fty = F.getType()->getPointerElementType();
   auto *func_ty = dyn_cast<FunctionType>(fty);
 
-
   // If we've clustered POD arguments, then argument details are in metadata.
   // If an argument maps to a resource variable, then get descriptor set and
   // binding from the resoure variable.  Other info comes from the metadata.
   const auto *arg_map = F.getMetadata(clspv::KernelArgMapMetadataName());
-  auto local_spec_id_md = module->getNamedMetadata(clspv::LocalSpecIdMetadataName());
+  auto local_spec_id_md =
+      module->getNamedMetadata(clspv::LocalSpecIdMetadataName());
   if (arg_map) {
     for (const auto &arg : arg_map->operands()) {
       const MDNode *arg_node = dyn_cast<MDNode>(arg.get());
@@ -3267,12 +3267,14 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
       const auto argKind = clspv::GetArgKindFromName(
           dyn_cast<MDString>(arg_node->getOperand(5))->getString().str());
 
-      // If this is a local memory argument, find the right spec id for this argument.
+      // If this is a local memory argument, find the right spec id for this
+      // argument.
       int64_t spec_id = -1;
       if (argKind == clspv::ArgKind::Local) {
         for (auto spec_id_arg : local_spec_id_md->operands()) {
-          if ((&F == dyn_cast<Function>(dyn_cast<ValueAsMetadata>(
-                         spec_id_arg->getOperand(0))->getValue())) &&
+          if ((&F == dyn_cast<Function>(
+                         dyn_cast<ValueAsMetadata>(spec_id_arg->getOperand(0))
+                             ->getValue())) &&
               (new_index ==
                mdconst::extract<ConstantInt>(spec_id_arg->getOperand(1))
                    ->getZExtValue())) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3252,7 +3252,7 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
   if (arg_map) {
     for (const auto &arg : arg_map->operands()) {
       const MDNode *arg_node = dyn_cast<MDNode>(arg.get());
-      assert(arg_node->getNumOperands() == 7);
+      assert(arg_node->getNumOperands() == 6);
       const auto name =
           dyn_cast<MDString>(arg_node->getOperand(0))->getString();
       const auto old_index =

--- a/test/multiple_local_ptr_args.cl
+++ b/test/multiple_local_ptr_args.cl
@@ -1,0 +1,40 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -cluster-pod-kernel-args
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck  %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+//
+// RUN: clspv %s -o %t2.spv -descriptormap=%t2.map -cluster-pod-kernel-args=0
+// RUN: spirv-dis %t2.spv -o %t2.spvasm
+// RUN: FileCheck  %s < %t2.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t2.map
+// RUN: spirv-val --target-env vulkan1.0 %t2.spv
+
+kernel void foo(global int* out, local int* l1, int a, int b, local int* l2) {
+  *out = *l1 + a + b + *l2;
+}
+
+kernel void bar(global int* out, local int* l1, int a, int b, local int* l2) {
+  *out = *l1 - a - b - *l2;
+}
+
+// MAP: kernel,foo,arg,l1,argOrdinal,1,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+// MAP: kernel,foo,arg,l2,argOrdinal,4,argKind,local,arrayElemSize,4,arrayNumElemSpecId,4
+
+// CHECK: OpDecorate [[spec_id_3:%[a-zA-Z0-9_]+]] SpecId 3
+// CHECK: OpDecorate [[spec_id_4:%[a-zA-Z0-9_]+]] SpecId 4
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[spec_id_3]] = OpSpecConstant [[uint]] 1
+// CHECK-DAG: [[array_3:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[spec_id_3]]
+// CHECK-DAG: [[ptr_id_3:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[array_3]]
+// CHECK-DAG: [[spec_id_4]] = OpSpecConstant [[uint]] 1
+// CHECK-DAG: [[array_4:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[spec_id_4]]
+// CHECK-DAG: [[ptr_id_4:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[array_4]]
+// CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK-DAG: [[var_3:%[a-zA-Z0-9_]+]] = OpVariable [[ptr_id_3]] Workgroup
+// CHECK-DAG: [[var_4:%[a-zA-Z0-9_]+]] = OpVariable [[ptr_id_4]] Workgroup
+// CHECK: [[gep_3:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var_3]] [[uint_0]]
+// CHECK: [[gep_4:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var_4]] [[uint_0]]
+// CHECK: OpLoad [[uint]] [[gep_3]]
+// CHECK: OpLoad [[uint]] [[gep_4]]


### PR DESCRIPTION
Fixes #577

* Only assign spec ids in AllocateDescriptorMap
* Remove spec ids from the kernel arg map
* when setting up the descriptor map with the kernel arg map use the
module metadata created in AllocateDescriptorMap
* test