### PR TITLE
Add fine-grained storage restrictions

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -75,6 +75,27 @@ language must conform to the following the rules:
     _"VK\_KHR\_storage\_buffer\_storage\_class"_ and
     _"VK\_KHR\_variable\_pointers"_ **must** succeed.
 
+### Storage Capabilities
+
+In order to pass 8- or 16-bit types in the shader interface, Vulkan requires
+the appropriate bits are set in VkPhysicalDevice8BitStorageFeaturesKHR for
+8-bit types or VkPhysicalDevice16BitStorageFeaturesKHR (or the appropriate
+Vulkan 1.1 or 1.2 feature structs). By default clspv assumes all feature bits
+are enabled, but provides options to disallow 8- or 16-bit interfaces.
+-no-8bit-storage reflects 8-bit storage features and -no-16bit-storage reflects
+16-bit storage features. Each option can take the following values (can be
+specified in a comma-separated list or multiple times):
+
+- `ssbo`: Represents the storage buffer feature bit.
+- `ubo`: Represents the uniform and storage buffer feature bit.
+- `pushconstant`: Represents the push constant feature bit.
+
+For example, if your device only supports storageBuffer16BitAccess (and no
+8-bit interfaces), pass the following on the command line:
+```
+-no-16bit-storage=ubo,pushconstant -no-8bit-storage=ssbo,ubo,pushconstant
+```
+
 ### Descriptor Type Mappings
 
 OpenCL C kernel argument types are mapped to Vulkan descriptor types in the

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -20,9 +20,6 @@
 namespace clspv {
 namespace Option {
 
-// Returns true if code generation can use SPV_KHR_16bit_storage.
-bool F16BitStorage();
-
 // Returns true if each kernel must use its own descriptor set for all
 // arguments.
 bool DistinctKernelDescriptorSets();
@@ -167,6 +164,18 @@ static bool NonUniformNDRangeSupported() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||
          ((Language() == SourceLanguage::OpenCL_C_20));
 }
+
+enum class StorageClass : int {
+  kSSBO = 0,
+  kUBO,
+  kPushConstant
+};
+
+// Returns true if |sc| supports 16-bit storage.
+bool Supports16BitStorageClass(StorageClass sc);
+
+// Returns true if |sc| supports 8-bit storage.
+bool Supports8BitStorageClass(StorageClass sc);
 
 } // namespace Option
 } // namespace clspv

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -168,7 +168,7 @@ static bool NonUniformNDRangeSupported() {
 enum class StorageClass : int {
   kSSBO = 0,
   kUBO,
-  kPushConstant
+  kPushConstant,
 };
 
 // Returns true if |sc| supports 16-bit storage.

--- a/kokoro/check-format/build.sh
+++ b/kokoro/check-format/build.sh
@@ -21,11 +21,11 @@ set -x
 BUILD_ROOT=$PWD
 SRC=$PWD/github/clspv
 
-# Get clang-format-5.0.0.
+# Get clang-format-8.0.0.
 # Once kokoro upgrades the Ubuntu VMs, we can use 'apt-get install clang-format'
-curl -L http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
+curl -L http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
 tar xf clang-llvm.tar.xz
-export PATH=$PWD/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+export PATH=$PWD/clang+llvm-8.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
 
 cd $SRC
 curl -L http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py -o utils/clang-format-diff.py;

--- a/kokoro/check-format/build.sh
+++ b/kokoro/check-format/build.sh
@@ -21,11 +21,11 @@ set -x
 BUILD_ROOT=$PWD
 SRC=$PWD/github/clspv
 
-# Get clang-format-8.0.0.
+# Get clang-format-5.0.0.
 # Once kokoro upgrades the Ubuntu VMs, we can use 'apt-get install clang-format'
-curl -L http://releases.llvm.org/8.0.0/clang+llvm-8.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
+curl -L http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
 tar xf clang-llvm.tar.xz
-export PATH=$PWD/clang+llvm-8.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+export PATH=$PWD/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
 
 cd $SRC
 curl -L http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py -o utils/clang-format-diff.py;

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -132,7 +132,7 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
                                    clspv::Option::StorageClass::kPushConstant);
   const bool fits_push_constant =
       DL.getTypeSizeInBits(pod_struct_ty).getFixedSize() / 8 <=
-      clspv::Option::MaxPushConstantSize();
+      clspv::Option::MaxPushConstantsSize();
   const bool satisfies_push_constant =
       clspv::Option::ClusterPodKernelArgs() && support_16bit_pc &&
       support_8bit_pc && fits_push_constant &&

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -54,8 +54,8 @@ private:
   // since we are dealing with pod args.
   bool ContainsArrayType(Type *type) const;
 
-  // Returns true if |type| contains a 16-bit integer or floating-point type.
-  // Does not look through pointer since we are dealing with pod args.
+  // Returns true if |type| contains a |width|-bit integer or floating-point
+  // type. Does not look through pointer since we are dealing with pod args.
   bool ContainsSizedType(Type *type, uint32_t width) const;
 };
 } // namespace

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -69,15 +69,15 @@ private:
 
   clspv::Option::StorageClass ConvertToStorageClass(clang::LangAS aspace) {
     switch (aspace) {
-      case LangAS::opencl_constant:
-        if (clspv::Option::ConstantArgsInUniformBuffer()) {
-          return clspv::Option::StorageClass::kUBO;
-        } else {
-          return clspv::Option::StorageClass::kSSBO;
-        }
-      case LangAS::opencl_global:
-      default:
+    case LangAS::opencl_constant:
+      if (clspv::Option::ConstantArgsInUniformBuffer()) {
+        return clspv::Option::StorageClass::kUBO;
+      } else {
         return clspv::Option::StorageClass::kSSBO;
+      }
+    case LangAS::opencl_global:
+    default:
+      return clspv::Option::StorageClass::kSSBO;
     }
   }
 
@@ -85,18 +85,18 @@ private:
     auto canonical = QT.getCanonicalType();
     if (auto *BT = dyn_cast<BuiltinType>(canonical)) {
       switch (BT->getKind()) {
-        case BuiltinType::UShort:
-        case BuiltinType::Short:
-        case BuiltinType::Half:
-        case BuiltinType::Float16:
-          return width == 16;
-        case BuiltinType::UChar:
-        case BuiltinType::Char_U:
-        case BuiltinType::SChar:
-        case BuiltinType::Char_S:
-          return width == 8;
-        default:
-          return false;
+      case BuiltinType::UShort:
+      case BuiltinType::Short:
+      case BuiltinType::Half:
+      case BuiltinType::Float16:
+        return width == 16;
+      case BuiltinType::UChar:
+      case BuiltinType::Char_U:
+      case BuiltinType::SChar:
+      case BuiltinType::Char_S:
+        return width == 8;
+      default:
+        return false;
       }
     } else if (auto *PT = dyn_cast<PointerType>(canonical)) {
       return ContainsSizedType(PT->getPointeeType(), width);

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -61,9 +61,58 @@ private:
     CustomDiagnosticRecursiveStruct = 18,
     CustomDiagnosticPushConstantSizeExceeded = 19,
     CustomDiagnosticPushConstantContainsArray = 20,
+    CustomDiagnosticUnsupported16BitStorage = 21,
+    CustomDiagnosticUnsupported8BitStorage = 22,
     CustomDiagnosticTotal
   };
   std::vector<unsigned> CustomDiagnosticsIDMap;
+
+  clspv::Option::StorageClass ConvertToStorageClass(clang::LangAS aspace) {
+    switch (aspace) {
+      case LangAS::opencl_constant:
+        if (clspv::Option::ConstantArgsInUniformBuffer()) {
+          return clspv::Option::StorageClass::kUBO;
+        } else {
+          return clspv::Option::StorageClass::kSSBO;
+        }
+      case LangAS::opencl_global:
+      default:
+        return clspv::Option::StorageClass::kSSBO;
+    }
+  }
+
+  bool ContainsSizedType(QualType QT, uint32_t width) {
+    auto canonical = QT.getCanonicalType();
+    if (auto *BT = dyn_cast<BuiltinType>(canonical)) {
+      switch (BT->getKind()) {
+        case BuiltinType::UShort:
+        case BuiltinType::Short:
+        case BuiltinType::Half:
+        case BuiltinType::Float16:
+          return width == 16;
+        case BuiltinType::UChar:
+        case BuiltinType::Char_U:
+        case BuiltinType::SChar:
+        case BuiltinType::Char_S:
+          return width == 8;
+        default:
+          return false;
+      }
+    } else if (auto *PT = dyn_cast<PointerType>(canonical)) {
+      return ContainsSizedType(PT->getPointeeType(), width);
+    } else if (auto *AT = dyn_cast<ArrayType>(canonical)) {
+      return ContainsSizedType(AT->getElementType(), width);
+    } else if (auto *VT = dyn_cast<VectorType>(canonical)) {
+      return ContainsSizedType(VT->getElementType(), width);
+    } else if (auto *RT = dyn_cast<RecordType>(canonical)) {
+      for (auto field_decl : RT->getDecl()->fields()) {
+        if (ContainsSizedType(field_decl->getType(), width))
+          return true;
+      }
+    }
+
+    return false;
+  }
 
   bool ContainsPointerType(QualType QT) {
     auto canonical = QT.getCanonicalType();
@@ -491,6 +540,14 @@ public:
         DE.getCustomDiagID(
             DiagnosticsEngine::Error,
             "arrays are not supported in push constants currently");
+    CustomDiagnosticsIDMap[CustomDiagnosticUnsupported16BitStorage] =
+        DE.getCustomDiagID(DiagnosticsEngine::Error,
+                           "16-bit storage is not supported for "
+                           "%select{SSBOs|UBOs|push constants}0");
+    CustomDiagnosticsIDMap[CustomDiagnosticUnsupported8BitStorage] =
+        DE.getCustomDiagID(DiagnosticsEngine::Error,
+                           "8-bit storage is not supported for "
+                           "%select{SSBOs|UBOs|push constants}0");
   }
 
   virtual bool HandleTopLevelDecl(DeclGroupRef DG) override {
@@ -555,6 +612,39 @@ public:
                                      P->getSourceRange(),
                                      P->getSourceRange())) {
                 return false;
+              }
+            }
+
+            // Check if storage capabilities are supported.
+            if (is_opencl_kernel) {
+              bool contains_16bit =
+                  ContainsSizedType(type.getCanonicalType(), 16);
+              bool contains_8bit =
+                  ContainsSizedType(type.getCanonicalType(), 8);
+              auto sc = clspv::Option::StorageClass::kSSBO;
+              if (type->isPointerType()) {
+                sc = ConvertToStorageClass(
+                    type->getPointeeType().getAddressSpace());
+              } else if (clspv::Option::PodArgsInUniformBuffer()) {
+                sc = clspv::Option::StorageClass::kUBO;
+              } else if (clspv::Option::PodArgsInPushConstants()) {
+                sc = clspv::Option::StorageClass::kPushConstant;
+              }
+              if (contains_16bit &&
+                  !clspv::Option::Supports16BitStorageClass(sc)) {
+                Instance.getDiagnostics().Report(
+                    P->getSourceRange().getBegin(),
+                    CustomDiagnosticsIDMap
+                        [CustomDiagnosticUnsupported16BitStorage])
+                    << static_cast<int>(sc);
+              }
+              if (contains_8bit &&
+                  !clspv::Option::Supports8BitStorageClass(sc)) {
+                Instance.getDiagnostics().Report(
+                    P->getSourceRange().getBegin(),
+                    CustomDiagnosticsIDMap
+                        [CustomDiagnosticUnsupported8BitStorage])
+                    << static_cast<int>(sc);
               }
             }
 

--- a/lib/Layout.cpp
+++ b/lib/Layout.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 
 namespace {
 bool isScalarType(Type *type) {
-  return type->isIntegerTy() || type->isFloatTy();
+  return type->isIntegerTy() || type->isFloatingPointTy();
 }
 
 uint64_t structAlignment(StructType *type,

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -195,25 +195,27 @@ static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
 
 static llvm::cl::list<clspv::Option::StorageClass> no_16bit_storage(
     "no-16bit-storage",
-    llvm::cl::desc("Specify fine-grained 16-bit storage capabilities. SSBO "
-                   "support is assumed."),
+    llvm::cl::desc("Disable fine-grained 16-bit storage capabilities."),
     llvm::cl::Prefix, llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
     llvm::cl::values(
-        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo", "ssbo"),
-        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo", "ubo"),
+        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo",
+                   "Disallow 16-bit types in SSBO interfaces"),
+        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo",
+                   "Disallow 16-bit types in UBO interfaces"),
         clEnumValN(clspv::Option::StorageClass::kPushConstant, "pushconstant",
-                   "push constant")));
+                   "Disallow 16-bit types in push constant interfaces")));
 
 static llvm::cl::list<clspv::Option::StorageClass> no_8bit_storage(
     "no-8bit-storage",
-    llvm::cl::desc("Specify fine-grained 8-bit storage capabilities. SSBO "
-                   "support is assumed."),
+    llvm::cl::desc("Disable fine-grained 8-bit storage capabilities."),
     llvm::cl::Prefix, llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
     llvm::cl::values(
-        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo", "ssbo"),
-        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo", "ubo"),
+        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo",
+                   "Disallow 8-bit types in SSBO interfaces"),
+        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo",
+                   "Disallow 8-bit types in UBO interfaces"),
         clEnumValN(clspv::Option::StorageClass::kPushConstant, "pushconstant",
-                   "push constant")));
+                   "Disallow 8-bit types in push constant interfaces")));
 
 } // namespace
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -52,16 +52,6 @@ llvm::cl::opt<bool> distinct_kernel_descriptor_sets(
     llvm::cl::desc("Each kernel uses its own descriptor set for its arguments. "
                    "Turns off direct-resource-access optimizations."));
 
-// TODO(dneto): As per Neil Henning suggestion, might not need this if
-// you can trace the pointer back far enough to see that it's 32-bit
-// aligned.  However, even in the vstore_half case, you'll probably get
-// better performance if you can rely on SPV_KHR_16bit_storage since in
-// the alternate case you're using a (relaxed) atomic, and therefore
-// have to write through to the cache.
-llvm::cl::opt<bool> f16bit_storage(
-    "f16bit_storage", llvm::cl::init(false),
-    llvm::cl::desc("Assume the target supports SPV_KHR_16bit_storage"));
-
 llvm::cl::opt<bool> hack_initializers(
     "hack-initializers", llvm::cl::init(false),
     llvm::cl::desc(
@@ -203,6 +193,28 @@ static llvm::cl::opt<bool> cluster_non_pointer_kernel_args(
                    "other arguments. Use this to reduce storage buffer "
                    "descriptors."));
 
+static llvm::cl::list<clspv::Option::StorageClass> no_16bit_storage(
+    "no-16bit-storage",
+    llvm::cl::desc("Specify fine-grained 16-bit storage capabilities. SSBO "
+                   "support is assumed."),
+    llvm::cl::Prefix, llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
+    llvm::cl::values(
+        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo", "ssbo"),
+        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo", "ubo"),
+        clEnumValN(clspv::Option::StorageClass::kPushConstant, "pushconstant",
+                   "push constant")));
+
+static llvm::cl::list<clspv::Option::StorageClass> no_8bit_storage(
+    "no-8bit-storage",
+    llvm::cl::desc("Specify fine-grained 8-bit storage capabilities. SSBO "
+                   "support is assumed."),
+    llvm::cl::Prefix, llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
+    llvm::cl::values(
+        clEnumValN(clspv::Option::StorageClass::kSSBO, "ssbo", "ssbo"),
+        clEnumValN(clspv::Option::StorageClass::kUBO, "ubo", "ubo"),
+        clEnumValN(clspv::Option::StorageClass::kPushConstant, "pushconstant",
+                   "push constant")));
+
 } // namespace
 
 namespace clspv {
@@ -215,7 +227,6 @@ bool DirectResourceAccess() {
 }
 bool ShareModuleScopeVariables() { return !no_share_module_scope_variables; }
 bool DistinctKernelDescriptorSets() { return distinct_kernel_descriptor_sets; }
-bool F16BitStorage() { return f16bit_storage; }
 bool HackDistinctImageSampler() { return hack_dis; }
 bool HackInitializers() { return hack_initializers; }
 bool HackInserts() { return hack_inserts; }
@@ -245,6 +256,26 @@ bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
+
+bool Supports16BitStorageClass(StorageClass sc) {
+  // -no-16bit-storage removes storage capabilities.
+  for (auto storage_class : no_16bit_storage) {
+    if (storage_class == sc)
+      return false;
+  }
+
+  return true;
+}
+
+bool Supports8BitStorageClass(StorageClass sc) {
+  // -no-8bit-storage removes storage capabilities.
+  for (auto storage_class : no_8bit_storage) {
+    if (storage_class == sc)
+      return false;
+  }
+
+  return true;
+}
 
 } // namespace Option
 } // namespace clspv

--- a/test/AutoPodArgs/array_prevents_push_constants.ll
+++ b/test/AutoPodArgs/array_prevents_push_constants.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt -AutoPodArgs %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; The array in the struct prevents use of push constants.
+
+%struct = type { [4 x i32] }
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, %struct %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 1}
+define spir_kernel void @foo(i32 addrspace(1)* %out, %struct %pod) {
+entry:
+  %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0
+  %ex = extractvalue %struct %pod, 0, 1
+  store i32 %ex, i32 addrspace(1)* %gep0
+  ret void
+}
+

--- a/test/AutoPodArgs/no_16bit_push_constant.ll
+++ b/test/AutoPodArgs/no_16bit_push_constant.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -AutoPodArgs %s -o %t.ll -no-16bit-storage=pushconstant
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s1 = type { i16 }
+%s2 = type { <4 x half> }
+
+; CHECK: define spir_kernel void @foo(i16 addrspace(1)* %out, i16 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @foo(i16 addrspace(1)* %out, i16 %pod) {
+entry:
+  %gep0 = getelementptr i16, i16 addrspace(1)* %out, i32 0
+  store i16 %pod, i16 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @bar(i16 addrspace(1)* %out, %s1 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @bar(i16 addrspace(1)* %out, %s1 %pod) {
+entry:
+  %gep0 = getelementptr i16, i16 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s1 %pod, 0
+  store i16 %ex, i16 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @baz(half addrspace(1)* %out, %s2 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @baz(half addrspace(1)* %out, %s2 %pod) {
+entry:
+  %gep0 = getelementptr half, half addrspace(1)* %out, i32 0
+  %ex = extractvalue %s2 %pod, 0
+  %ex2 = extractelement <4 x half> %ex, i32 3
+  store half %ex2, half addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: [[MD]] = !{i32 1}

--- a/test/AutoPodArgs/no_16bit_ubo_pushconstant.ll
+++ b/test/AutoPodArgs/no_16bit_ubo_pushconstant.ll
@@ -1,0 +1,38 @@
+; RUN: clspv-opt -AutoPodArgs %s -o %t.ll -no-16bit-storage=pushconstant,ubo
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s1 = type { i16 }
+%s2 = type { <4 x half> }
+
+; CHECK: define spir_kernel void @foo(i16 addrspace(1)* %out, i16 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @foo(i16 addrspace(1)* %out, i16 %pod) {
+entry:
+  %gep0 = getelementptr i16, i16 addrspace(1)* %out, i32 0
+  store i16 %pod, i16 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @bar(i16 addrspace(1)* %out, %s1 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @bar(i16 addrspace(1)* %out, %s1 %pod) {
+entry:
+  %gep0 = getelementptr i16, i16 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s1 %pod, 0
+  store i16 %ex, i16 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @baz(half addrspace(1)* %out, %s2 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @baz(half addrspace(1)* %out, %s2 %pod) {
+entry:
+  %gep0 = getelementptr half, half addrspace(1)* %out, i32 0
+  %ex = extractvalue %s2 %pod, 0
+  %ex2 = extractelement <4 x half> %ex, i32 3
+  store half %ex2, half addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: [[MD]] = !{i32 0}
+

--- a/test/AutoPodArgs/no_8bit_push_constant.ll
+++ b/test/AutoPodArgs/no_8bit_push_constant.ll
@@ -1,0 +1,39 @@
+; RUN: clspv-opt -AutoPodArgs %s -o %t.ll -no-8bit-storage=pushconstant
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s1 = type { i8 }
+%s2 = type { <4 x i8> }
+
+; CHECK: define spir_kernel void @foo(i8 addrspace(1)* %out, i8 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @foo(i8 addrspace(1)* %out, i8 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  store i8 %pod, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @bar(i8 addrspace(1)* %out, %s1 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @bar(i8 addrspace(1)* %out, %s1 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s1 %pod, 0
+  store i8 %ex, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @baz(i8 addrspace(1)* %out, %s2 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @baz(i8 addrspace(1)* %out, %s2 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s2 %pod, 0
+  %ex2 = extractelement <4 x i8> %ex, i32 3
+  store i8 %ex2, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: [[MD]] = !{i32 1}
+
+

--- a/test/AutoPodArgs/no_8bit_ubo_pushconstant.ll
+++ b/test/AutoPodArgs/no_8bit_ubo_pushconstant.ll
@@ -1,0 +1,39 @@
+; RUN: clspv-opt -AutoPodArgs %s -o %t.ll -no-8bit-storage=pushconstant,ubo
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s1 = type { i8 }
+%s2 = type { <4 x i8> }
+
+; CHECK: define spir_kernel void @foo(i8 addrspace(1)* %out, i8 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @foo(i8 addrspace(1)* %out, i8 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  store i8 %pod, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @bar(i8 addrspace(1)* %out, %s1 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @bar(i8 addrspace(1)* %out, %s1 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s1 %pod, 0
+  store i8 %ex, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: define spir_kernel void @baz(i8 addrspace(1)* %out, %s2 %pod) !clspv.pod_args_impl [[MD]]
+define spir_kernel void @baz(i8 addrspace(1)* %out, %s2 %pod) {
+entry:
+  %gep0 = getelementptr i8, i8 addrspace(1)* %out, i32 0
+  %ex = extractvalue %s2 %pod, 0
+  %ex2 = extractelement <4 x i8> %ex, i32 3
+  store i8 %ex2, i8 addrspace(1)* %gep0
+  ret void
+}
+
+; CHECK: [[MD]] = !{i32 0}
+
+

--- a/test/Diagnostics/no-pushconstant-16bit.cl
+++ b/test/Diagnostics/no-pushconstant-16bit.cl
@@ -1,0 +1,9 @@
+// RUN: clspv -verify %s -no-16bit-storage=pushconstant -w -pod-pushconstant
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(short a) { } //expected-error{{16-bit storage is not supported for push constants}}
+
+kernel void bar(half a) { } //expected-error{{16-bit storage is not supported for push constants}}
+
+kernel void baz(ushort a) { } //expected-error{{16-bit storage is not supported for push constants}}

--- a/test/Diagnostics/no-pushconstant-8bit.cl
+++ b/test/Diagnostics/no-pushconstant-8bit.cl
@@ -1,0 +1,6 @@
+// RUN: clspv -verify %s -no-8bit-storage=pushconstant -w -pod-pushconstant
+
+kernel void bar(char a) { } //expected-error{{8-bit storage is not supported for push constants}}
+
+kernel void baz(uchar a) { } //expected-error{{8-bit storage is not supported for push constants}}
+

--- a/test/Diagnostics/no-ssbo-16bit.cl
+++ b/test/Diagnostics/no-ssbo-16bit.cl
@@ -1,0 +1,17 @@
+// RUN: clspv -verify %s -no-16bit-storage=ssbo -w
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+struct A {
+  half4 x;
+};
+
+struct B {
+  struct A a[2];
+};
+
+kernel void foo(global short* a) { } //expected-error{{16-bit storage is not supported for SSBOs}}
+
+kernel void bar(constant struct B* a) { } //expected-error{{16-bit storage is not supported for SSBOs}}
+
+kernel void baz(ushort a) { } //expected-error{{16-bit storage is not supported for SSBOs}}

--- a/test/Diagnostics/no-ssbo-8bit.cl
+++ b/test/Diagnostics/no-ssbo-8bit.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -verify %s -no-8bit-storage=ssbo -w
+
+kernel void foo(global char* a) { } //expected-error{{8-bit storage is not supported for SSBOs}}
+
+kernel void bar(constant char* a) { } //expected-error{{8-bit storage is not supported for SSBOs}}
+
+kernel void baz(uchar a) { } //expected-error{{8-bit storage is not supported for SSBOs}}
+

--- a/test/Diagnostics/no-ubo-16bit.cl
+++ b/test/Diagnostics/no-ubo-16bit.cl
@@ -1,0 +1,10 @@
+// RUN: clspv -verify %s -no-16bit-storage=ubo -w -pod-ubo -constant-args-ubo -std430-ubo-layout
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(constant half* a) { } //expected-error{{16-bit storage is not supported for UBOs}}
+
+kernel void bar(ushort a) { } //expected-error{{16-bit storage is not supported for UBOs}}
+
+kernel void baz(short a) { } //expected-error{{16-bit storage is not supported for UBOs}}
+

--- a/test/Diagnostics/no-ubo-8bit.cl
+++ b/test/Diagnostics/no-ubo-8bit.cl
@@ -1,0 +1,8 @@
+// RUN: clspv -verify %s -no-8bit-storage=ubo -w -pod-ubo -constant-args-ubo -std430-ubo-layout
+
+kernel void foo(constant char* a) { } //expected-error{{8-bit storage is not supported for UBOs}}
+
+kernel void bar(uchar a) { } //expected-error{{8-bit storage is not supported for UBOs}}
+
+kernel void baz(char a) { } //expected-error{{8-bit storage is not supported for UBOs}}
+

--- a/test/HalfStorage/vload_half_pointer_cast_from_short.cl
+++ b/test/HalfStorage/vload_half_pointer_cast_from_short.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -f16bit_storage
+// RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
+++ b/test/HalfStorage/vstore_half_pointer_cast_to_short.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -f16bit_storage
+// RUN: clspv %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
+++ b/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -no-16bit-storage=ssbo
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
@@ -33,6 +33,5 @@
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global float* b, int n)
 {
-  global half* a_half = (global half*) a;
   vstore_half(*b, n, (global half *)a);
 }


### PR DESCRIPTION
Contributes to #529

* Remove -f16bit_storage in favour of new options
  * updated uses
* New options to restrict which storage classes support 8- and 16-bit
types
  * -no-storage-16bit and -no-storage-8bit
  * Default behaviour assumes support for all storage classes
* Added frontend diagnostics to check 8- and 16-bit storage support of
kernel arguments
* Modified pod arg determination to check storage class support
* Added a restriction to not generate push constant pod args if pod args
contain an array
* Added tests