### PR TITLE
Fix check for module-scope push constants

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -789,7 +789,7 @@ int ParseOptions(const int argc, const char *const argv[]) {
     }
 
     // Conservatively error if a module scope push constant could be used.
-    if (clspv::Option::GlobalOffset() ||
+    if (clspv::Option::GlobalOffsetPushConstant() ||
         clspv::Option::Language() ==
             clspv::Option::SourceLanguage::OpenCL_C_20 ||
         clspv::Option::Language() ==

--- a/test/PushConstant/pod_vs_module_scope.cl
+++ b/test/PushConstant/pod_vs_module_scope.cl
@@ -1,0 +1,9 @@
+// Valid combinations
+// RUN: clspv %s -pod-pushconstant -global-offset 2>&1
+// RUN: clspv %s -pod-ubo -global-offset-push-constant 2>&1
+// RUN: clspv %s -pod-ubo -cl-std=CL2.0 -inline-entry-points 2>&1
+
+// POD args cannot be push constants if there are module scope push constants
+// RUN: not clspv %s -pod-pushconstant -global-offset-push-constant 2>&1 | FileCheck %s
+// RUN: not clspv %s -pod-pushconstant -cl-std=CL2.0 -inline-entry-points 2>&1 | FileCheck %s
+// CHECK: POD arguments as push constants are not compatible with module scope push constants


### PR DESCRIPTION
This check was not updated when global offsets were moved to spec constants.