### PR TITLE
Fix trunc removal in UndoTruncatedSwitchCondition

### DIFF
--- a/test/widen_switch_condition_binary_ops.ll
+++ b/test/widen_switch_condition_binary_ops.ll
@@ -7,9 +7,9 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @subf(i32 %x, i32 %y) {
 entry:
   ; CHECK-LABEL subf
-  ; CHECK: [[sub:%[a-zA-Z0-9_]+]] = sub i32 4, %mul
-  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_]+]] = and i32 [[sub]], 7
-  ; CHECK-NEXT: switch i32 [[and]], label %default [
+  ; CHECK: [[and:%[a-zA-Z0-9_]+]] = and i32 %mul, 7
+  ; CHECK-NEXT: [[sub:%[a-zA-Z0-9_]+]] = sub i32 4, [[and]]
+  ; CHECK-NEXT: switch i32 [[sub]], label %default [
   ; CHECK-NEXT:   i32 1, label %one_label
   ; CHECK-NEXT:   i32 2, label %two_label
   ; CHECK-NEXT:   i32 3, label %three_label
@@ -46,9 +46,9 @@ exit:
 define spir_kernel void @addf(i32 %x, i32 %y) {
 entry:
   ; CHECK-LABEL addf
-  ; CHECK: [[add:%[a-zA-Z0-9_]+]] = add i32 16, %mul
-  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_]+]] = and i32 [[sub]], 31
-  ; CHECK-NEXT: switch i32 [[and]], label %default [
+  ; CHECK: [[and:%[a-zA-Z0-9_]+]] = and i32 %mul, 31
+  ; CHECK-NEXT: [[add:%[a-zA-Z0-9_]+]] = add i32 16, [[and]]
+  ; CHECK-NEXT: switch i32 [[add]], label %default [
   ; CHECK-NEXT:   i32 1, label %one_label
   ; CHECK-NEXT:   i32 2, label %two_label
   ; CHECK-NEXT:   i32 3, label %three_label

--- a/test/widen_switch_condition_trunc.ll
+++ b/test/widen_switch_condition_trunc.ll
@@ -1,0 +1,41 @@
+; RUN: clspv-opt -UndoTruncatedSwitchCondition %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @truncf(i32 %x) {
+entry:
+  ; CHECK-LABEL trunc
+  ; CHECK: [[and:%[a-zA-Z0-9_]+]] = and i32 %x, 7
+  ; CHECK-NEXT: switch i32 [[and]], label %default [
+  ; CHECK-NEXT:   i32 1, label %one_label
+  ; CHECK-NEXT:   i32 2, label %two_label
+  ; CHECK-NEXT:   i32 3, label %three_label
+  ; CHECK-NEXT:   i32 4, label %four_label
+  %trunc = trunc i32 %x to i3
+  switch i3 %trunc, label %default [
+    i3 1, label %one_label
+    i3 2, label %two_label
+    i3 3, label %three_label
+    i3 -4, label %four_label
+  ]
+
+default:
+  br label %exit
+
+one_label:
+  br label %exit
+
+two_label:
+  br label %exit
+
+three_label:
+  br label %exit
+
+four_label:
+  br label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
We were previously inserting a mask only after binary operations,
instead of after every trunc instruction.