### PR TITLE
Expand functionality to catch odd truncates

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -259,17 +259,17 @@ llvm::ModulePass *createUndoSRetPass();
 /// optimizations on a function that would help here.
 llvm::ModulePass *createUndoTranslateSamplerFoldPass();
 
-/// Undo LLVM optimizing switch instruction conditions by truncating them.
+/// Undo LLVM optimizing a mask to a small integer size.
 /// @return An LLVM module pass.
 ///
-/// LLVM will optimize switch instructions conditions such that it will
-/// sometimes produce invalid integer types. LLVM backends can handle this, but
-/// since this backend does not conform to the normal process, we undo this
-/// optimization here instead.
+/// LLVM will optimize masks to smaller integers that get used in switches and
+/// comparisons. These integer sizes may be invalid types. LLVM backends can
+/// handle this, but since this backend does not conform to the normal process,
+/// we undo this optimization here instead.
 ///
 /// If we could add a flag to our LLVM target to indiciate "please do not create
 /// malformed types" that would make this pass redundant.
-llvm::ModulePass *createUndoTruncatedSwitchConditionPass();
+llvm::ModulePass *createUndoTruncateToOddIntegerPass();
 
 /// Cluster module-scope __constant variables.
 /// @return An LLVM module pass.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -77,7 +77,7 @@ add_library(clspv_passes
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoInstCombinePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoSRetPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UndoTranslateSamplerFoldPass.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/UndoTruncatedSwitchConditionPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/UndoTruncateToOddIntegerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ZeroInitializeAllocasPass.cpp
 )
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -684,7 +684,7 @@ int PopulatePassManager(
   pm->add(clspv::createFunctionInternalizerPass());
   pm->add(clspv::createReplaceLLVMIntrinsicsPass());
   pm->add(clspv::createUndoBoolPass());
-  pm->add(clspv::createUndoTruncatedSwitchConditionPass());
+  pm->add(clspv::createUndoTruncateToOddIntegerPass());
   pm->add(llvm::createStructurizeCFGPass(false));
   // Must be run after structurize cfg.
   pm->add(clspv::createFixupStructuredCFGPass());

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -55,7 +55,7 @@ void initializeClspvPasses(PassRegistry &r) {
   initializeUndoInstCombinePassPass(r);
   initializeUndoSRetPassPass(r);
   initializeUndoTranslateSamplerFoldPassPass(r);
-  initializeUndoTruncatedSwitchConditionPassPass(r);
+  initializeUndoTruncateToOddIntegerPassPass(r);
   initializeZeroInitializeAllocasPassPass(r);
 }
 

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -58,7 +58,7 @@ void initializeUndoGetElementPtrConstantExprPassPass(PassRegistry &);
 void initializeUndoInstCombinePassPass(PassRegistry &);
 void initializeUndoSRetPassPass(PassRegistry &);
 void initializeUndoTranslateSamplerFoldPassPass(PassRegistry &);
-void initializeUndoTruncatedSwitchConditionPassPass(PassRegistry &);
+void initializeUndoTruncateToOddIntegerPassPass(PassRegistry &);
 void initializeZeroInitializeAllocasPassPass(PassRegistry &);
 } // namespace llvm
 

--- a/lib/UndoTruncateToOddIntegerPass.cpp
+++ b/lib/UndoTruncateToOddIntegerPass.cpp
@@ -44,7 +44,6 @@ private:
   // values are created.
   // TODO(dneto): Handle 64 bit case as well, but separately.
   Value *ZeroExtend(Value *v, uint32_t desired_bit_width) {
-    //outs() << "Zero extend to " << desired_bit_width << " bits: " << *v << "\n";
     auto bit_width = 0;
     if (v->getType()->isIntegerTy())
       bit_width = v->getType()->getIntegerBitWidth();
@@ -249,8 +248,6 @@ bool UndoTruncateToOddIntegerPass::runOnModule(Module &M) {
     if (!zombie->hasNUsesOrMore(1))
       zombie->eraseFromParent();
   }
-
-  //outs() << M << "\n";
 
   return Changed;
 }

--- a/lib/UndoTruncateToOddIntegerPass.cpp
+++ b/lib/UndoTruncateToOddIntegerPass.cpp
@@ -222,33 +222,12 @@ bool UndoTruncateToOddIntegerPass::runOnModule(Module &M) {
     }
   }
 
-  // Remove the zombies if we can.  We expect to. Generally this can be done in
-  // 1 or 2 passes.
-  SmallVector<Instruction *, 8> extra;
-  for (auto *zombie : zombies_) {
-    if (!zombie->hasNUsesOrMore(1)) {
+  // Remove the zombies if we can.  We expect to. We've ordered zombies in
+  // reverse.
+  for (int i = zombies_.size(); i >= 1; --i) {
+    auto zombie = zombies_[i];
+    if (!zombie->hasNUsesOrMore(1))
       zombie->eraseFromParent();
-    } else {
-      extra.push_back(zombie);
-    }
-  }
-
-  // This is not ideal, but the way we identify instructions doesn't lend
-  // itself to a single pass well.
-  bool updated = true;
-  while (updated) {
-    updated = false;
-    SmallVector<Instruction *, 8> new_extra;
-    for (auto *zombie : extra) {
-      if (!zombie->hasNUsesOrMore(1)) {
-        updated = true;
-        zombie->eraseFromParent();
-      } else {
-        new_extra.push_back(zombie);
-      }
-    }
-
-    extra.swap(new_extra);
   }
 
   return Changed;

--- a/lib/UndoTruncateToOddIntegerPass.cpp
+++ b/lib/UndoTruncateToOddIntegerPass.cpp
@@ -23,12 +23,12 @@
 
 using namespace llvm;
 
-#define DEBUG_TYPE "UndoTruncatedSwitchCondition"
+#define DEBUG_TYPE "UndoTruncateToOddInteger"
 
 namespace {
-struct UndoTruncatedSwitchConditionPass : public ModulePass {
+struct UndoTruncateToOddIntegerPass : public ModulePass {
   static char ID;
-  UndoTruncatedSwitchConditionPass() : ModulePass(ID) {}
+  UndoTruncateToOddIntegerPass() : ModulePass(ID) {}
 
   bool runOnModule(Module &M) override;
 
@@ -167,18 +167,17 @@ private:
 };
 } // namespace
 
-char UndoTruncatedSwitchConditionPass::ID = 0;
-INITIALIZE_PASS(UndoTruncatedSwitchConditionPass,
-                "UndoTruncatedSwitchCondition",
+char UndoTruncateToOddIntegerPass::ID = 0;
+INITIALIZE_PASS(UndoTruncateToOddIntegerPass, "UndoTruncateToOddInteger",
                 "Undo Truncated Switch Condition Pass", false, false)
 
 namespace clspv {
-ModulePass *createUndoTruncatedSwitchConditionPass() {
-  return new UndoTruncatedSwitchConditionPass();
+ModulePass *createUndoTruncateToOddIntegerPass() {
+  return new UndoTruncateToOddIntegerPass();
 }
 } // namespace clspv
 
-bool UndoTruncatedSwitchConditionPass::runOnModule(Module &M) {
+bool UndoTruncateToOddIntegerPass::runOnModule(Module &M) {
   bool Changed = false;
 
   SmallVector<Instruction *, 8> WorkList;
@@ -192,6 +191,7 @@ bool UndoTruncatedSwitchConditionPass::runOnModule(Module &M) {
           default:
             WorkList.push_back(trunc);
             break;
+          case 1: // i1 is a bool.
           case 8:
           case 16:
           case 32:

--- a/test/clspv-opt/options.ll
+++ b/test/clspv-opt/options.ll
@@ -2,7 +2,7 @@
 ; check any specific transformation.  It just makes sure that the options
 ; are accepted.
 
-; RUN: clspv-opt %s -o %t.ll -AllocateDescriptorsPass -ClusterModuleScopeConstantVars -ClusterPodKernelArgumentsPass -DefineOpenCLWorkItemBuiltins -DirectResourceAccessPass -FunctionInternalizer -HideConstantLoads -InlineEntryPointsPass -InlineFuncWithPointerBitCastArg -InlineFuncWithPointerToFunctionArgPass -InlineFuncWithSingleCallSite -OpenCLInliner -RemoveUnusedArguments -ReorderBasicBlocks -ReplaceLLVMIntrinsics -ReplaceOpenCLBuiltin -ReplacePointerBitcast -RewriteInserts -Scalarize -ShareModuleScopeVariablesPass -SignedCompareFixupPass -SimplifyPointerBitcast -SplatArg -SplatSelectCond -UBOTypeTransformPass -UndoBool -UndoByval -UndoGetElementPtrConstantExpr -UndoSRet -UndoTranslateSamplerFold -UndoTruncatedSwitchCondition -UnhideConstantLoads -ZeroInitializeAllocasPass
+; RUN: clspv-opt %s -o %t.ll -AllocateDescriptorsPass -ClusterModuleScopeConstantVars -ClusterPodKernelArgumentsPass -DefineOpenCLWorkItemBuiltins -DirectResourceAccessPass -FunctionInternalizer -HideConstantLoads -InlineEntryPointsPass -InlineFuncWithPointerBitCastArg -InlineFuncWithPointerToFunctionArgPass -InlineFuncWithSingleCallSite -OpenCLInliner -RemoveUnusedArguments -ReorderBasicBlocks -ReplaceLLVMIntrinsics -ReplaceOpenCLBuiltin -ReplacePointerBitcast -RewriteInserts -Scalarize -ShareModuleScopeVariablesPass -SignedCompareFixupPass -SimplifyPointerBitcast -SplatArg -SplatSelectCond -UBOTypeTransformPass -UndoBool -UndoByval -UndoGetElementPtrConstantExpr -UndoSRet -UndoTranslateSamplerFold -UndoTruncateToOddInteger -UnhideConstantLoads -ZeroInitializeAllocasPass
 ; RUN: FileCheck %s < %t.ll
 ; CHECK: @__spirv_WorkgroupSize =
 

--- a/test/widen_mixed_truncate.ll
+++ b/test/widen_mixed_truncate.ll
@@ -1,0 +1,72 @@
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @ret_i32a(i32 %a, i8 %b) {
+entry:
+  ; CHECK-LABEL ret_i32a
+  ; CHECK: [[trunc_a:%[a-zA-Z0-9_.]+]] = trunc i32 %a to i8
+  ; CHECK-NEXT: [[and_a:%[a-zA-Z0-9_.]+]] = and i8 [[trunc_a]], 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i8 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i8 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i8 [[mul]], 3
+  ; CHECK-NEXT: [[zext:%[a-zA-Z0-9_.]+]] = zext i8 [[and]] to i32
+  ; CHECK-NEXT: ret i32 [[zext]]
+  %trunc_a = trunc i32 %a to i2
+  %trunc_b = trunc i8 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i32
+  ret i32 %zext
+}
+
+define i8 @ret_i8a(i32 %a, i8 %b) {
+entry:
+  ; CHECK-LABEL ret_i8a
+  ; CHECK: [[trunc_a:%[a-zA-Z0-9_.]+]] = trunc i32 %a to i8
+  ; CHECK-NEXT: [[and_a:%[a-zA-Z0-9_.]+]] = and i8 [[trunc_a]], 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i8 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i8 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i8 [[mul]], 3
+  ; CHECK-NEXT: ret i8 [[and]]
+  %trunc_a = trunc i32 %a to i2
+  %trunc_b = trunc i8 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i8
+  ret i8 %zext
+}
+
+define i32 @ret_i32b(i8 %a, i32 %b) {
+entry:
+  ; CHECK-LABEL ret_i32b
+  ; CHECK: [[zext_a:%[a-zA-Z0-9_.]+]] = zext i8 %a to i32
+  ; CHECK-NEXT: [[and_a:%[a-zA-Z0-9_.]+]] = and i32 [[zext_a]], 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i32 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i32 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[mul]], 3
+  ; CHECK-NEXT: ret i32 [[and]]
+  %trunc_a = trunc i8 %a to i2
+  %trunc_b = trunc i32 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i32
+  ret i32 %zext
+}
+
+define i8 @ret_i8b(i8 %a, i32 %b) {
+entry:
+  ; CHECK-LABEL ret_i8a
+  ; CHECK: [[zext_a:%[a-zA-Z0-9_.]+]] = zext i8 %a to i32
+  ; CHECK-NEXT: [[and_a:%[a-zA-Z0-9_.]+]] = and i32 [[trunc_a]], 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i32 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i32 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[mul]], 3
+  ; CHECK-NEXT: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[and]] to i8
+  ; CHECK-NEXT: ret i8 [[trunc]]
+  %trunc_a = trunc i8 %a to i2
+  %trunc_b = trunc i32 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i8
+  ret i8 %zext
+}
+

--- a/test/widen_switch_condition_binary_ops.ll
+++ b/test/widen_switch_condition_binary_ops.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -UndoTruncatedSwitchCondition %s -o %t
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
 ; RUN: FileCheck %s < %t
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/widen_switch_condition_binary_ops.ll
+++ b/test/widen_switch_condition_binary_ops.ll
@@ -9,7 +9,8 @@ entry:
   ; CHECK-LABEL subf
   ; CHECK: [[and:%[a-zA-Z0-9_]+]] = and i32 %mul, 7
   ; CHECK-NEXT: [[sub:%[a-zA-Z0-9_]+]] = sub i32 4, [[and]]
-  ; CHECK-NEXT: switch i32 [[sub]], label %default [
+  ; CHECK-NEXT: [[sub_mask:%[a-zA-Z0-9_]+]] = and i32 [[sub]], 7
+  ; CHECK-NEXT: switch i32 [[sub_mask]], label %default [
   ; CHECK-NEXT:   i32 1, label %one_label
   ; CHECK-NEXT:   i32 2, label %two_label
   ; CHECK-NEXT:   i32 3, label %three_label
@@ -48,7 +49,8 @@ entry:
   ; CHECK-LABEL addf
   ; CHECK: [[and:%[a-zA-Z0-9_]+]] = and i32 %mul, 31
   ; CHECK-NEXT: [[add:%[a-zA-Z0-9_]+]] = add i32 16, [[and]]
-  ; CHECK-NEXT: switch i32 [[add]], label %default [
+  ; CHECK-NEXT: [[add_mask:%[a-zA-Z0-9_]+]] = and i32 [[add]], 31
+  ; CHECK-NEXT: switch i32 [[add_mask]], label %default [
   ; CHECK-NEXT:   i32 1, label %one_label
   ; CHECK-NEXT:   i32 2, label %two_label
   ; CHECK-NEXT:   i32 3, label %three_label

--- a/test/widen_switch_condition_trunc.ll
+++ b/test/widen_switch_condition_trunc.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -UndoTruncatedSwitchCondition %s -o %t
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
 ; RUN: FileCheck %s < %t
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/widen_truncate.ll
+++ b/test/widen_truncate.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -UndoTruncatedSwitchCondition %s -o %t
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
 ; RUN: FileCheck %s < %t
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/widen_truncate.ll
+++ b/test/widen_truncate.ll
@@ -1,0 +1,24 @@
+; RUN: clspv-opt -UndoTruncatedSwitchCondition %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo(float addrspace(1)* nocapture %output, i32 %arg) {
+entry:
+  ; CHECK-LABEL foo
+  ; CHECK: [[and:%[a-zA-Z0-9_.]+]] = and i32 %arg, 3
+  ; CHECK-NEXT: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq i32 [[and]], 2
+  ; CHECK-NEXT: [[sel1:%[a-zA-Z0-9_.]+]] = select i1 [[cmp]],
+  ; CHECK-NEXT: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq i32 [[and]], 1
+  ; CHECK-NEXT: [[sel:%[a-zA-Z0-9_.]+]] = select i1 [[cmp]],
+  %trunc = trunc i32 %arg to i2
+  %switch.selectcmp = icmp eq i2 %trunc, -2
+  %switch.select = select i1 %switch.selectcmp, float 4.000000e+00, float 0.000000e+00
+  %switch.selectcmp2 = icmp eq i2 %trunc, 1
+  %switch.select3 = select i1 %switch.selectcmp2, float 2.000000e+00, float %switch.select
+  %arrayidx = getelementptr inbounds float, float addrspace(1)* %output, i32 %arg
+  store float %switch.select3, float addrspace(1)* %arrayidx, align 4
+  ret void
+}
+

--- a/test/widen_truncate_to_i32.ll
+++ b/test/widen_truncate_to_i32.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @multiple_trunc(i32 %a, i32 %b) {
+entry:
+  ; CHECK-LABEL multiple_trunc
+  ; CHECK: [[and_a:%[a-zA-Z0-9_.]+]] = and i32 %a, 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i32 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i32 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[mul]], 3
+  ; CHECK-NEXT: ret i32 [[and]]
+  %trunc_a = trunc i32 %a to i2
+  %trunc_b = trunc i32 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i32
+  ret i32 %zext
+}

--- a/test/widen_truncate_to_i8.ll
+++ b/test/widen_truncate_to_i8.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt -UndoTruncateToOddInteger %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i8 @multiple_trunc(i8 %a, i8 %b) {
+entry:
+  ; CHECK-LABEL multiple_trunc
+  ; CHECK: [[and_a:%[a-zA-Z0-9_.]+]] = and i8 %a, 3
+  ; CHECK-NEXT: [[and_b:%[a-zA-Z0-9_.]+]] = and i8 %b, 3
+  ; CHECK-NEXT: [[mul:%[a-zA-Z0-9_.]+]] = mul i8 [[and_a]], [[and_b]]
+  ; CHECK-NEXT: [[and:%[a-zA-Z0-9_.]+]] = and i8 [[mul]], 3
+  ; CHECK-NEXT: ret i8 [[and]]
+  %trunc_a = trunc i8 %a to i2
+  %trunc_b = trunc i8 %b to i2
+  %mul = mul i2 %trunc_a, %trunc_b
+  %zext = zext i2 %mul to i8
+  ret i8 %zext
+}
+


### PR DESCRIPTION
Fixes #583

* Changes UndoTruncatedSwitchPass to look for truncates to look for
truncates to non-power-of-2 integer sizes instead of switches on odd
sizes
  * rename pass
  * new logic to update instructions that aren't full rewritten
  * new tests

The first commit has the heart of the changes. The second commit just renames things.