### PR TITLE
Support global type-mangled pod args in push constants

### DIFF
--- a/include/clspv/PushConstant.h
+++ b/include/clspv/PushConstant.h
@@ -25,6 +25,7 @@ enum class PushConstant : int {
   RegionOffset,
   NumWorkgroups,
   RegionGroupOffset,
+  KernelArgument,
 };
 
 } // namespace clspv

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -149,7 +149,7 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
   const auto global_size = clspv::GlobalPushConstantsSize(M) + pod_struct_size;
   const auto fits_global_size =
       global_size <= clspv::Option::MaxPushConstantsSize();
-  // Leave some extra room.
+  // Leave some extra room for other push constants.
   const uint64_t max_struct_members = 0x3fff - 64;
   const auto enough_members = (global_size / 4) < max_struct_members;
   const bool satisfies_global_push_constant =

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -136,9 +136,9 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
   const bool support_8bit_pc = !ContainsSizedType(pod_struct_ty, 8) ||
                                clspv::Option::Supports8BitStorageClass(
                                    clspv::Option::StorageClass::kPushConstant);
-  // Align to 16 to use <4 x i32> storage.
+  // Align to 4 to use i32s.
   const uint64_t pod_struct_size =
-      alignTo(DL.getTypeStoreSize(pod_struct_ty).getKnownMinSize(), 16);
+      alignTo(DL.getTypeStoreSize(pod_struct_ty).getKnownMinSize(), 4);
   const bool fits_push_constant =
       pod_struct_size <= clspv::Option::MaxPushConstantsSize();
   const bool satisfies_push_constant =

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -96,6 +96,11 @@ void AutoPodArgsPass::runOnFunction(Function &F) {
   bool satisfies_ubo = true;
   for (auto &Arg : F.args()) {
     auto arg_type = Arg.getType();
+    if (Arg.hasByValAttr()) {
+      // Byval arguments end up as POD arguments.
+      arg_type = arg_type->getPointerElementType();
+    }
+
     if (isa<PointerType>(arg_type))
       continue;
 

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -531,6 +531,14 @@ Value *ClusterPodKernelArgumentsPass::ConvertToType(Module &M,
   const auto ele_start_index = ele_offset / kIntBytes; // round down
   const auto ele_end_index = (ele_offset + ele_size + kIntBytes - 1) / kIntBytes; // round up
 
+  //outs() << "Pod struct: " << *pod_struct << "\n";
+  //outs() << " index: " << index << "\n";
+  //outs() << " ele: " << *ele_ty << "\n";
+  //outs() << " size: " << ele_size << "\n";
+  //outs() << " offset: " << ele_offset << "\n";
+  //outs() << " start: " << ele_start_index << "\n";
+  //outs() << " end: " << ele_end_index << "\n";
+
   // Load the right number of ints. We'll load at least one, but may load
   // ele_size / 4 + 1 integers depending on the offset.
   std::vector<Value *> int_elements;

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -531,14 +531,6 @@ Value *ClusterPodKernelArgumentsPass::ConvertToType(Module &M,
   const auto ele_start_index = ele_offset / kIntBytes; // round down
   const auto ele_end_index = (ele_offset + ele_size + kIntBytes - 1) / kIntBytes; // round up
 
-  //outs() << "Pod struct: " << *pod_struct << "\n";
-  //outs() << " index: " << index << "\n";
-  //outs() << " ele: " << *ele_ty << "\n";
-  //outs() << " size: " << ele_size << "\n";
-  //outs() << " offset: " << ele_offset << "\n";
-  //outs() << " start: " << ele_start_index << "\n";
-  //outs() << " end: " << ele_end_index << "\n";
-
   // Load the right number of ints. We'll load at least one, but may load
   // ele_size / 4 + 1 integers depending on the offset.
   std::vector<Value *> int_elements;

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -607,11 +607,11 @@ Value *ClusterPodKernelArgumentsPass::BuildFromElements(
       dst = builder.CreateShuffleVector(casts[0], casts[1], indices);
     } else {
       // General case, break into elements and construct the composite type.
+      auto ele_ty = dst_vec_ty ? dst_vec_ty->getElementType()
+                               : dst_array_ty->getElementType();
       assert((DL.getTypeStoreSize(ele_ty).getKnonwnMinSize()() < kIntBytes ||
               base_offset == 0) &&
              "Unexpected packed data format");
-      auto ele_ty = dst_vec_ty ? dst_vec_ty->getElementType()
-                               : dst_array_ty->getElementType();
       uint64_t ele_size = DL.getTypeStoreSize(ele_ty);
       uint32_t num_elements = dst_vec_ty ? dst_vec_ty->getElementCount().Min
                                          : dst_array_ty->getNumElements();

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -620,7 +620,8 @@ Value *ClusterPodKernelArgumentsPass::BuildFromElements(
       uint64_t bytes_consumed = 0;
       for (uint32_t i = 0; i < num_elements; ++i) {
         uint64_t ele_offset = (base_offset + bytes_consumed) % kIntBytes;
-        uint64_t ele_index = base_index + (base_offset + bytes_consumed) / kIntBytes;
+        uint64_t ele_index =
+            base_index + (base_offset + bytes_consumed) / kIntBytes;
         // Convert the element.
         auto tmp = BuildFromElements(M, builder, ele_ty, ele_offset, ele_index,
                                      elements);

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -609,7 +609,7 @@ Value *ClusterPodKernelArgumentsPass::BuildFromElements(
       // General case, break into elements and construct the composite type.
       auto ele_ty = dst_vec_ty ? dst_vec_ty->getElementType()
                                : dst_array_ty->getElementType();
-      assert((DL.getTypeStoreSize(ele_ty).getKnonwnMinSize()() < kIntBytes ||
+      assert((DL.getTypeStoreSize(ele_ty).getKnownMinSize() < kIntBytes ||
               base_offset == 0) &&
              "Unexpected packed data format");
       uint64_t ele_size = DL.getTypeStoreSize(ele_ty);

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -616,13 +616,11 @@ Value *ClusterPodKernelArgumentsPass::BuildFromElements(
       uint32_t num_elements = dst_vec_ty ? dst_vec_ty->getElementCount().Min
                                          : dst_array_ty->getNumElements();
 
+      // Arrays of shorts/halfs could be offset from the start of an int.
       uint64_t bytes_consumed = 0;
-      assert(((ele_size >= kIntBytes) ||
-              (base_offset + num_elements * ele_size) <= kIntBytes) &&
-             "Unexpected packed data format");
       for (uint32_t i = 0; i < num_elements; ++i) {
         uint64_t ele_offset = (base_offset + bytes_consumed) % kIntBytes;
-        uint64_t ele_index = base_index + (bytes_consumed / kIntBytes);
+        uint64_t ele_index = base_index + (base_offset + bytes_consumed) / kIntBytes;
         // Convert the element.
         auto tmp = BuildFromElements(M, builder, ele_ty, ele_offset, ele_index,
                                      elements);

--- a/lib/DeclarePushConstantsPass.cpp
+++ b/lib/DeclarePushConstantsPass.cpp
@@ -36,12 +36,6 @@ struct DeclarePushConstantsPass : public ModulePass {
   static char ID;
   DeclarePushConstantsPass() : ModulePass(ID) {}
 
-  bool shouldDeclareEnqueuedLocalSize(Module &M);
-  bool shouldDeclareGlobalSize(Module &M);
-  bool shouldDeclareRegionOffset(Module &M);
-  bool shouldDeclareNumWorkgroups(Module &M);
-  bool shouldDeclareRegionGroupOffset(Module &M);
-
   bool runOnModule(Module &M) override;
 };
 } // namespace
@@ -56,36 +50,6 @@ ModulePass *createDeclarePushConstantsPass() {
 }
 } // namespace clspv
 
-bool DeclarePushConstantsPass::shouldDeclareEnqueuedLocalSize(Module &M) {
-  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
-  bool isUsed = M.getFunction("_Z23get_enqueued_local_sizej") != nullptr;
-  return isEnabled && isUsed;
-}
-
-bool DeclarePushConstantsPass::shouldDeclareGlobalSize(Module &M) {
-  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
-  bool isUsed = M.getFunction("_Z15get_global_sizej") != nullptr;
-  return isEnabled && isUsed;
-}
-
-bool DeclarePushConstantsPass::shouldDeclareRegionOffset(Module &M) {
-  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
-  bool isUsed = M.getFunction("_Z13get_global_idj") != nullptr;
-  return isEnabled && isUsed;
-}
-
-bool DeclarePushConstantsPass::shouldDeclareNumWorkgroups(Module &M) {
-  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
-  bool isUsed = M.getFunction("_Z14get_num_groupsj") != nullptr;
-  return isEnabled && isUsed;
-}
-
-bool DeclarePushConstantsPass::shouldDeclareRegionGroupOffset(Module &M) {
-  bool isEnabled = clspv::Option::NonUniformNDRangeSupported();
-  bool isUsed = M.getFunction("_Z12get_group_idj") != nullptr;
-  return isEnabled && isUsed;
-}
-
 bool DeclarePushConstantsPass::runOnModule(Module &M) {
 
   bool changed = false;
@@ -98,23 +62,23 @@ bool DeclarePushConstantsPass::runOnModule(Module &M) {
     PushConstants.emplace_back(clspv::PushConstant::GlobalOffset);
   }
 
-  if (shouldDeclareEnqueuedLocalSize(M)) {
+  if (clspv::ShouldDeclareEnqueuedLocalSizePushConstant(M)) {
     PushConstants.push_back(clspv::PushConstant::EnqueuedLocalSize);
   }
 
-  if (shouldDeclareGlobalSize(M)) {
+  if (clspv::ShouldDeclareGlobalSizePushConstant(M)) {
     PushConstants.push_back(clspv::PushConstant::GlobalSize);
   }
 
-  if (shouldDeclareRegionOffset(M)) {
+  if (clspv::ShouldDeclareRegionOffsetPushConstant(M)) {
     PushConstants.push_back(clspv::PushConstant::RegionOffset);
   }
 
-  if (shouldDeclareNumWorkgroups(M)) {
+  if (clspv::ShouldDeclareNumWorkgroupsPushConstant(M)) {
     PushConstants.push_back(clspv::PushConstant::NumWorkgroups);
   }
 
-  if (shouldDeclareRegionGroupOffset(M)) {
+  if (clspv::ShouldDeclareRegionGroupOffsetPushConstant(M)) {
     PushConstants.push_back(clspv::PushConstant::RegionGroupOffset);
   }
 

--- a/lib/HideConstantLoadsPass.cpp
+++ b/lib/HideConstantLoadsPass.cpp
@@ -65,7 +65,8 @@ private:
 
 char HideConstantLoadsPass::ID = 0;
 INITIALIZE_PASS(HideConstantLoadsPass, "HideConstantLoads",
-                "Hide loads from __constant memory", false, false)
+                "Hide loads from __constant and push constant memory", false,
+                false)
 
 namespace clspv {
 llvm::ModulePass *createHideConstantLoadsPass() {
@@ -81,7 +82,9 @@ bool HideConstantLoadsPass::runOnModule(Module &M) {
     for (BasicBlock &BB : F) {
       for (Instruction &I : BB) {
         if (LoadInst *load = dyn_cast<LoadInst>(&I)) {
-          if (clspv::AddressSpace::Constant == load->getPointerAddressSpace()) {
+          if (clspv::AddressSpace::Constant == load->getPointerAddressSpace() ||
+              clspv::AddressSpace::PushConstant ==
+                  load->getPointerAddressSpace()) {
             WorkList.push_back(load);
           }
         }
@@ -148,7 +151,8 @@ private:
 
 char UnhideConstantLoadsPass::ID = 0;
 INITIALIZE_PASS(UnhideConstantLoadsPass, "UnhideConstantLoads",
-                "Unhide loads from __constant memory", false, false)
+                "Unhide loads from __constant and push constant memory", false,
+                false)
 
 namespace clspv {
 llvm::ModulePass *createUnhideConstantLoadsPass() {

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -113,8 +113,12 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc,
 }
 
 bool UsesGlobalPushConstants(Module &M) {
-  return clspv::Option::NonUniformNDRangeSupported() ||
-         ShouldDeclareGlobalOffsetPushConstant(M);
+  return ShouldDeclareGlobalOffsetPushConstant(M) ||
+         ShouldDeclareEnqueuedLocalSizePushConstant(M) ||
+         ShouldDeclareGlobalSizePushConstant(M) ||
+         ShouldDeclareRegionOffsetPushConstant(M) ||
+         ShouldDeclareNumWorkgroupsPushConstant(M) ||
+         ShouldDeclareRegionGroupOffsetPushConstant(M);
 }
 
 bool ShouldDeclareGlobalOffsetPushConstant(Module &M) {

--- a/lib/PushConstant.h
+++ b/lib/PushConstant.h
@@ -17,6 +17,7 @@
 
 #include "clspv/PushConstant.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Value.h"
 
@@ -30,13 +31,32 @@ llvm::Type *GetPushConstantType(llvm::Module &, PushConstant);
 
 // Returns a pointer to the push constant passed. Instructions to create the
 // pointer are appended to the basic block provided.
-llvm::Value *GetPushConstantPointer(llvm::BasicBlock *, PushConstant);
+llvm::Value *GetPushConstantPointer(llvm::BasicBlock *, PushConstant,
+                                    const llvm::ArrayRef<llvm::Value *> & = {});
 
 // Returns true if any global push constant is used.
 bool UsesGlobalPushConstants(llvm::Module &);
 
 // Returns true if an implementation of get_global_offset() is needed.
 bool ShouldDeclareGlobalOffsetPushConstant(llvm::Module &);
+
+// Returns true if an implementation of get_enqueued_local_size() is needed.
+bool ShouldDeclareEnqueuedLocalSizePushConstant(llvm::Module &);
+
+// Returns true if non-uniform NDRange get_global_size() is needed.
+bool ShouldDeclareGlobalSizePushConstant(llvm::Module &);
+
+// Returns true if non-uniform NDRange region offset is needed.
+bool ShouldDeclareRegionOffsetPushConstant(llvm::Module &);
+
+// Returns true if non-uniform NDRange get_num_groups() is needed.
+bool ShouldDeclareNumWorkgroupsPushConstant(llvm::Module &);
+
+// Returns true if non-uniform NDRange region group offset is needed.
+bool ShouldDeclareRegionGroupOffsetPushConstant(llvm::Module &);
+
+// Returns the size of global push constants.
+uint64_t GlobalPushConstantsSize(llvm::Module &);
 } // namespace clspv
 
 #endif // #ifndef CLSPV_LIB_PUSH_CONSTANT_H_

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2738,18 +2738,22 @@ void SPIRVProducerPass::GeneratePushConstantDescriptorMapEntries() {
     for (unsigned i = 0; i < STy->getNumElements(); i++) {
       auto pc = static_cast<clspv::PushConstant>(
           mdconst::extract<ConstantInt>(MD->getOperand(i))->getZExtValue());
-      auto memberType = STy->getElementType(i);
-      auto offset = GetExplicitLayoutStructMemberOffset(STy, i, DL);
-      unsigned previousOffset = 0;
-      if (i > 0) {
-        previousOffset = GetExplicitLayoutStructMemberOffset(STy, i - 1, DL);
+      if (pc != clspv::PushConstant::KernelArgument) {
+        auto memberType = STy->getElementType(i);
+        auto offset = GetExplicitLayoutStructMemberOffset(STy, i, DL);
+        unsigned previousOffset = 0;
+        if (i > 0) {
+          previousOffset = GetExplicitLayoutStructMemberOffset(STy, i - 1, DL);
+        }
+        auto size =
+            static_cast<uint32_t>(GetTypeSizeInBits(memberType, DL)) / 8;
+        assert(isValidExplicitLayout(*module, STy, i,
+                                     spv::StorageClassPushConstant, offset,
+                                     previousOffset));
+        version0::DescriptorMapEntry::PushConstantData data = {pc, offset,
+                                                               size};
+        descriptorMapEntries->emplace_back(std::move(data));
       }
-      auto size = static_cast<uint32_t>(GetTypeSizeInBits(memberType, DL)) / 8;
-      assert(isValidExplicitLayout(*module, STy, i,
-                                   spv::StorageClassPushConstant, offset,
-                                   previousOffset));
-      version0::DescriptorMapEntry::PushConstantData data = {pc, offset, size};
-      descriptorMapEntries->emplace_back(std::move(data));
     }
   }
 }
@@ -3118,8 +3122,8 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
       const auto old_index =
           dyn_extract<ConstantInt>(arg_node->getOperand(1))->getZExtValue();
       // Remapped argument index
-      const size_t new_index = static_cast<size_t>(
-          dyn_extract<ConstantInt>(arg_node->getOperand(2))->getZExtValue());
+      const int new_index = static_cast<int>(
+          dyn_extract<ConstantInt>(arg_node->getOperand(2))->getSExtValue());
       const auto offset =
           dyn_extract<ConstantInt>(arg_node->getOperand(3))->getZExtValue();
       const auto arg_size =
@@ -3135,7 +3139,7 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
           if ((&F == dyn_cast<Function>(
                          dyn_cast<ValueAsMetadata>(spec_id_arg->getOperand(0))
                              ->getValue())) &&
-              (new_index ==
+              (static_cast<uint64_t>(new_index) ==
                mdconst::extract<ConstantInt>(spec_id_arg->getOperand(1))
                    ->getZExtValue())) {
             spec_id = mdconst::extract<ConstantInt>(spec_id_arg->getOperand(2))
@@ -3155,7 +3159,7 @@ void SPIRVProducerPass::GenerateDescriptorMapInfo(Function &F) {
         kernel_data.local_element_size = static_cast<uint32_t>(GetTypeAllocSize(
             func_ty->getParamType(unsigned(new_index))->getPointerElementType(),
             DL));
-      } else {
+      } else if (new_index >= 0) {
         auto *info = resource_var_at_index[new_index];
         assert(info);
         descriptor_set = info->descriptor_set;

--- a/test/AutoPodArgs/array_prevents_push_constants.ll
+++ b/test/AutoPodArgs/array_prevents_push_constants.ll
@@ -9,7 +9,7 @@ target triple = "spir-unknown-unknown"
 %struct = type { [4 x i32] }
 
 ; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, %struct %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
-; CHECK: [[MD]] = !{i32 1}
+; CHECK: [[MD]] = !{i32 {{[013]}}}
 define spir_kernel void @foo(i32 addrspace(1)* %out, %struct %pod) {
 entry:
   %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0

--- a/test/AutoPodArgs/enqueued_local_size_prevents_push_constant.ll
+++ b/test/AutoPodArgs/enqueued_local_size_prevents_push_constant.ll
@@ -7,7 +7,7 @@ target triple = "spir-unknown-unknown"
 ; get_enqueued_local_size prevents using push constants.
 
 ; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
-; CHECK: [[MD]] = !{i32 1}
+; CHECK: [[MD]] = !{i32 {{[013]}}}
 define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %pod) {
 entry:
   %gep0 = getelementptr i32, i32 addrspace(1)* %out, i32 0

--- a/test/AutoPodArgs/fallback_on_ssbo.ll
+++ b/test/AutoPodArgs/fallback_on_ssbo.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -AutoPodArgs -cl-std=CL2.0 %s -o %t.ll
+; RUN: clspv-opt -AutoPodArgs -cl-std=CL2.0 %s -o %t.ll -max-pushconstant-size=4
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -6,8 +6,7 @@ target triple = "spir-unknown-unknown"
 
 %s = type { i8, [2 x i8], i32 }
 
-; get_enqueued_local_size prevents using push constants and the layout of %s
-; prevents UBOs.
+; Max push constant size prevents push constants and layout prevents UBOs.
 
 ; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, %s %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
 ; CHECK: [[MD]] = !{i32 0}

--- a/test/AutoPodArgs/no_16bit_push_constant.ll
+++ b/test/AutoPodArgs/no_16bit_push_constant.ll
@@ -34,4 +34,4 @@ entry:
   ret void
 }
 
-; CHECK: [[MD]] = !{i32 1}
+; CHECK: [[MD]] = !{i32 {{[013]}}}

--- a/test/AutoPodArgs/no_16bit_ubo_pushconstant.ll
+++ b/test/AutoPodArgs/no_16bit_ubo_pushconstant.ll
@@ -34,5 +34,5 @@ entry:
   ret void
 }
 
-; CHECK: [[MD]] = !{i32 0}
+; CHECK: [[MD]] = !{i32 {{[[03]}}}
 

--- a/test/AutoPodArgs/no_8bit_push_constant.ll
+++ b/test/AutoPodArgs/no_8bit_push_constant.ll
@@ -34,6 +34,6 @@ entry:
   ret void
 }
 
-; CHECK: [[MD]] = !{i32 1}
+; CHECK: [[MD]] = !{i32 {{[[013]}}}
 
 

--- a/test/AutoPodArgs/no_8bit_ubo_pushconstant.ll
+++ b/test/AutoPodArgs/no_8bit_ubo_pushconstant.ll
@@ -34,6 +34,6 @@ entry:
   ret void
 }
 
-; CHECK: [[MD]] = !{i32 0}
+; CHECK: [[MD]] = !{i32 {{[03]}}}
 
 

--- a/test/AutoPodArgs/other_push_constants_prevent_global_push_constants.ll
+++ b/test/AutoPodArgs/other_push_constants_prevent_global_push_constants.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt -AutoPodArgs -no-16bit-storage=pushconstant -max-pushconstant-size=32 -global-offset -cl-std=CL2.0 %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Storage restrictions prevent per-kernel push constants and the use of other
+; push constants prevents global push constants.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i16 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+; CHECK: [[MD]] = !{i32 {{[01]}}}
+define spir_kernel void @foo(i32 addrspace(1)* %out, i16 %pod) {
+entry:
+  %ext = zext i16 %pod to i32
+  %gid = call i32 @_Z13get_global_idj(i32 0)
+  %add = add i32 %ext, %gid
+  store i32 %add, i32 addrspace(1)* %out
+  ret void
+}
+
+declare i32 @_Z13get_global_idj(i32)
+

--- a/test/AutoPodArgs/use_global_push_constant.ll
+++ b/test/AutoPodArgs/use_global_push_constant.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt -AutoPodArgs -no-16bit-storage=pushconstant -no-8bit-storage=pushconstant %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Type-mangled arguments don't need to worry about 8- or 16-bit storage restrictions.
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out, i16 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @foo(i32 addrspace(1)* %out, i16 %pod) {
+entry:
+  %ext = zext i16 %pod to i32
+  store i32 %ext, i32 addrspace(1)* %out
+  ret void
+}
+
+; CHECK: define spir_kernel void @bar(i32 addrspace(1)* %out, i8 %pod) !clspv.pod_args_impl [[MD:![0-9]+]]
+define spir_kernel void @bar(i32 addrspace(1)* %out, i8 %pod) {
+entry:
+  %ext = zext i8 %pod to i32
+  store i32 %ext, i32 addrspace(1)* %out
+  ret void
+}
+
+; CHECK: [[MD]] = !{i32 3}
+

--- a/test/PushConstant/cluster_global_pod_args-arrays.ll
+++ b/test/PushConstant/cluster_global_pod_args-arrays.ll
@@ -1,0 +1,216 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { [[inner:%[a-zA-Z0-9_.]+]] }
+; CHECK: [[inner]] = type { i32, i32, i32, i32 }
+
+; CHECK: @__push_constants = addrspace(9) global [[outer]] zeroinitializer, !push_constants [[pc_md:![0-9]+]]
+
+define spir_kernel void @i8x16([16 x i8] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @i8x16() !clspv.pod_args_impl [[pod_args_md:![0-9]+]] !kernel_arg_map [[map_md:![0-9]+]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld0]] to i8
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] undef, i8 [[cast]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 1
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in0]], i8 [[ex]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 2
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in1]], i8 [[ex]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 3
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in2]], i8 [[ex]], 3
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld1]] to i8
+  ; CHECK: [[in4:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in3]], i8 [[cast]], 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 1
+  ; CHECK: [[in5:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in4]], i8 [[ex]], 5
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 2
+  ; CHECK: [[in6:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in5]], i8 [[ex]], 6
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 3
+  ; CHECK: [[in7:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in6]], i8 [[ex]], 7
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld2]] to i8
+  ; CHECK: [[in8:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in7]], i8 [[cast]], 8
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 1
+  ; CHECK: [[in9:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in8]], i8 [[ex]], 9
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 2
+  ; CHECK: [[in10:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in9]], i8 [[ex]], 10
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 3
+  ; CHECK: [[in11:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in10]], i8 [[ex]], 11
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld3]] to i8
+  ; CHECK: [[in12:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in11]], i8 [[cast]], 12
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 1
+  ; CHECK: [[in13:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in12]], i8 [[ex]], 13
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 2
+  ; CHECK: [[in14:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in13]], i8 [[ex]], 14
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 3
+  ; CHECK: [[in15:%[a-zA-Z0-9_.]+]] = insertvalue [16 x i8] [[in14]], i8 [[ex]], 15
+  ret void
+}
+
+define spir_kernel void @i16x8([8 x i16] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @i16x8() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld0]] to i16
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] undef, i16 [[cast]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in0]], i16 [[ex]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld1]] to i16
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in1]], i16 [[cast]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in2]], i16 [[ex]], 3
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld2]] to i16
+  ; CHECK: [[in4:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in3]], i16 [[cast]], 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in5:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in4]], i16 [[ex]], 5
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld3]] to i16
+  ; CHECK: [[in6:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in5]], i16 [[cast]], 6
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in7:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in6]], i16 [[ex]], 7
+  ret void
+}
+
+define spir_kernel void @i32x4([4 x i32] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @i32x4() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i32] undef, i32 [[ld0]], 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i32] [[in0]], i32 [[ld1]], 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i32] [[in1]], i32 [[ld2]], 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i32] [[in2]], i32 [[ld3]], 3
+  ret void
+}
+
+define spir_kernel void @i64x2([2 x i64] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @i64x2() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[ex1]], 32
+  ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[ex0]], [[shl]]
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i64] undef, i64 [[or]], 0
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[ex1]], 32
+  ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[ex0]], [[shl]]
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i64] [[in0]], i64 [[or]], 1
+  ret void
+}
+
+define spir_kernel void @halfx8([8 x half] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @halfx8() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 0
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] undef, half [[ex]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 1
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in0]], half [[ex]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 0
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in1]], half [[ex]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 1
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in2]], half [[ex]], 3
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 0
+  ; CHECK: [[in4:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in3]], half [[ex]], 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 1
+  ; CHECK: [[in5:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in4]], half [[ex]], 5
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 0
+  ; CHECK: [[in6:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in5]], half [[ex]], 6
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <2 x half>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x half> [[cast]], i64 1
+  ; CHECK: [[in7:%[a-zA-Z0-9_.]+]] = insertvalue [8 x half] [[in6]], half [[ex]], 7
+  ret void
+}
+
+define spir_kernel void @floatx4([4 x float] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @floatx4() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to float
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [4 x float] undef, float [[cast]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to float
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [4 x float] [[in0]], float [[cast]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to float
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [4 x float] [[in1]], float [[cast]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to float
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [4 x float] [[in2]], float [[cast]], 3
+  ret void
+}
+
+define spir_kernel void @doublex2([2 x double] %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @doublex2() !clspv.pod_args_impl [[pod_args_md]] !kernel_arg_map [[map_md]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[ex1]], 32
+  ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[ex0]], [[shl]]
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or]] to double
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [2 x double] undef, double [[cast]], 0
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[ex1]], 32
+  ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[ex0]], [[shl]]
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or]] to double
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [2 x double] [[in0]], double [[cast]], 1
+  ret void
+}
+
+; CHECK: [[pc_md]] = !{i32 7}
+; CHECK: [[pod_args_md]] = !{i32 3}
+; CHECK: [[map_md]] = !{[[arg_md:![0-9]+]]}
+; CHECK: [[arg_md]] = !{!"arg", i32 0, i32 -1, i32 0, i32 16, !"pod_pushconstant"}
+
+!0 = !{i32 3}

--- a/test/PushConstant/cluster_global_pod_args-int.ll
+++ b/test/PushConstant/cluster_global_pod_args-int.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { <3 x i32>, <3 x i32>, [[inner:%[a-zA-Z0-9_.]+]] }
+; CHECK: [[inner]] = type { i32 }
+; CHECK: @__push_constants = addrspace(9) global [[outer]] zeroinitializer, !push_constants [[pc_md:![0-9]+]]
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out) !clspv.pod_args_impl [[pod_args_md:![0-9]+]] !kernel_arg_map [[arg_map_md:![0-9]+]]
+; CHECK: load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+
+; CHECK: [[pc_md]] = !{i32 1, i32 4, i32 7}
+; CHECK: [[pod_args_md]] = !{i32 3}
+; CHECK: [[arg_map_md]] = !{[[out_md:![0-9]+]], [[int_arg_md:![0-9]+]]}
+; CHECK: [[out_md]] = !{!"out", i32 0, i32 0
+; CHECK: [[int_arg_md]] = !{!"int_arg", i32 1, i32 -1, i32 32, i32 4, !"pod_pushconstant"}
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32> }
+
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define spir_kernel void @foo(i32 addrspace(1)* %out, i32 %int_arg) !clspv.pod_args_impl !1 {
+entry:
+  ret void
+}
+
+!0 = !{i32 1, i32 4}
+!1 = !{i32 3}
+

--- a/test/PushConstant/cluster_global_pod_args-scalars.ll
+++ b/test/PushConstant/cluster_global_pod_args-scalars.ll
@@ -10,8 +10,8 @@
 ; CHECK: trunc i32 [[ld]] to i8
 
 ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
-; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[ld]], 16
-; CHECK: trunc i32 [[shr]] to i16
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <2 x i16>
+; CHECK: extractelement <2 x i16> [[cast]], i64 1
 
 ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
 
@@ -26,8 +26,8 @@
 ; CHECK: bitcast i32 [[ld]] to float
 
 ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
-; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld]] to i16
-; CHECK: bitcast i16 [[trunc]] to half
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <2 x half>
+; CHECK: extractelement <2 x half> [[cast]], i64 0
 
 ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 6), align 4
 ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 7), align 4

--- a/test/PushConstant/cluster_global_pod_args-scalars.ll
+++ b/test/PushConstant/cluster_global_pod_args-scalars.ll
@@ -1,0 +1,66 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { <3 x i32>, <3 x i32>, [[inner:%[a-zA-Z0-9_.]+]] }
+; CHECK: [[inner]] = type { i32, i32, i32, i32, i32, i32, i32, i32 }
+; CHECK: @__push_constants = addrspace(9) global [[outer]] zeroinitializer, !push_constants [[pc_md:![0-9]+]]
+
+; CHECK: define spir_kernel void @foo(i32 addrspace(1)* %out) !clspv.pod_args_impl [[pod_args_md:![0-9]+]] !kernel_arg_map [[arg_map_md:![0-9]+]]
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+; CHECK: trunc i32 [[ld]] to i8
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[ld]], 16
+; CHECK: trunc i32 [[shr]] to i16
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+
+; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 3), align 4
+; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+; CHECK: or i64 [[zext0]], [[shl]]
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 4), align 4
+; CHECK: bitcast i32 [[ld]] to float
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld]] to i16
+; CHECK: bitcast i16 [[trunc]] to half
+
+; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 6), align 4
+; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 7), align 4
+; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl]]
+; CHECK: bitcast i64 [[or]] to double
+
+; CHECK: [[pc_md]] = !{i32 1, i32 4, i32 7}
+; CHECK: [[pod_args_md]] = !{i32 3}
+; CHECK: [[arg_map_md]] = !{[[out_md:![0-9]+]], [[char_arg_md:![0-9]+]], [[short_arg_md:![0-9]+]], [[int_arg_md:![0-9]+]], [[long_arg_md:![0-9]+]], [[float_arg_md:![0-9]+]], [[half_arg_md:![0-9]+]], [[double_arg_md:![0-9]+]]}
+; CHECK: [[out_md]] = !{!"out", i32 0, i32 0
+; CHECK: [[char_arg_md]] = !{!"char_arg", i32 1, i32 -1, i32 32, i32 1, !"pod_pushconstant"}
+; CHECK: [[short_arg_md]] = !{!"short_arg", i32 2, i32 -1, i32 34, i32 2, !"pod_pushconstant"}
+; CHECK: [[int_arg_md]] = !{!"int_arg", i32 3, i32 -1, i32 36, i32 4, !"pod_pushconstant"}
+; CHECK: [[long_arg_md]] = !{!"long_arg", i32 4, i32 -1, i32 40, i32 8, !"pod_pushconstant"}
+; CHECK: [[float_arg_md]] = !{!"float_arg", i32 5, i32 -1, i32 48, i32 4, !"pod_pushconstant"}
+; CHECK: [[half_arg_md]] = !{!"half_arg", i32 6, i32 -1, i32 52, i32 2, !"pod_pushconstant"}
+; CHECK: [[double_arg_md]] = !{!"double_arg", i32 7, i32 -1, i32 56, i32 8, !"pod_pushconstant"}
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32> }
+
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define spir_kernel void @foo(i32 addrspace(1)* %out, i8 %char_arg, i16 %short_arg, i32 %int_arg, i64 %long_arg, float %float_arg, half %half_arg, double %double_arg) !clspv.pod_args_impl !1 {
+entry:
+  ret void
+}
+
+!0 = !{i32 1, i32 4}
+!1 = !{i32 3}
+

--- a/test/PushConstant/cluster_global_pod_args-short_array.ll
+++ b/test/PushConstant/cluster_global_pod_args-short_array.ll
@@ -1,0 +1,49 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%original = type { i8, [8 x i16] }
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { [[inner:%[a-zA-Z0-9_.]+]] }
+; CHECK: [[inner]] = type { i32, i32, i32, i32, i32 }
+
+; CHECK: @__push_constants = addrspace(9) global [[outer]] zeroinitializer, !push_constants [[pc_md:![0-9]+]]
+
+define spir_kernel void @i8x16(%original %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 4), align 4
+
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld0]] to i8
+  ; CHECK: [[s_in0:%[a-zA-Z0-9_.]+]] = insertvalue %original undef, i8 [[cast]], 0
+
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] undef, i16 [[ex]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld1]] to i16
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in0]], i16 [[cast]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in1]], i16 [[ex]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld2]] to i16
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in2]], i16 [[cast]], 3
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in4:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in3]], i16 [[ex]], 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld3]] to i16
+  ; CHECK: [[in5:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in4]], i16 [[cast]], 5
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to <2 x i16>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
+  ; CHECK: [[in6:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in5]], i16 [[ex]], 6
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld4]] to i16
+  ; CHECK: [[in7:%[a-zA-Z0-9_.]+]] = insertvalue [8 x i16] [[in6]], i16 [[cast]], 7
+  ; CHECK: [[s_in1:%[a-zA-Z0-9_.]+]] = insertvalue %original [[s_in0]], [8 x i16] [[in7]], 1
+  ret void
+}
+
+!0 = !{i32 3}

--- a/test/PushConstant/cluster_global_pod_args-structs.ll
+++ b/test/PushConstant/cluster_global_pod_args-structs.ll
@@ -1,0 +1,74 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { i8 }
+%1 = type { %0, %0, %0, %0 }
+%2 = type { i8, i64 }
+%3 = type { i8, %2 }
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { [[inner:%[a-zA-Z0-9_.]+]] }
+; CHECK: [[inner:%[a-zA-Z0-9_.]+]] = type { i32, i32, i32, i32, i32, i32 }
+; CHECK-DAG: [[s0:%[a-zA-Z0-9_.]+]] = type { i8 }
+; CHECK-DAG: [[s1:%[a-zA-Z0-9_.]+]] = type { [[s0]], [[s0]], [[s0]], [[s0]] }
+; CHECK-DAG: [[s2:%[a-zA-Z0-9_.]+]] = type { i8, i64 }
+; CHECK-DAG: [[s3:%[a-zA-Z0-9_.]+]] = type { i8, [[s2]] }
+
+; CHECK: @__push_constants = addrspace(9) global [[outer]] zeroinitializer, !push_constants [[pc_md:![0-9]+]]
+
+define spir_kernel void @chars(%1 %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @chars() !clspv.pod_args_impl [[pod_arg_md:![0-9]+]] !kernel_arg_map [[chars_map:![0-9]+]]
+
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld]] to i8
+  ; CHECK: [[in:%[a-zA-Z0-9_.]+]] = insertvalue [[s0]] undef, i8 [[cast]], 0
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [[s1]] undef, %3 [[in]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 1
+  ; CHECK: [[in:%[a-zA-Z0-9_.]+]] = insertvalue [[s0]] undef, i8 [[ex]], 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [[s1]] [[in0]], %3 [[in]], 1
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 2
+  ; CHECK: [[in:%[a-zA-Z0-9_.]+]] = insertvalue [[s0]] undef, i8 [[ex]], 0
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertvalue [[s1]] [[in1]], %3 [[in]], 2
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <4 x i8>
+  ; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[cast]], i64 3
+  ; CHECK: [[in:%[a-zA-Z0-9_.]+]] = insertvalue [[s0]] undef, i8 [[ex]], 0
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertvalue [[s1]] [[in2]], %3 [[in]], 3
+  ret void
+}
+
+define spir_kernel void @aligns(%3 %arg) !clspv.pod_args_impl !0 {
+entry:
+  ; CHECK: define spir_kernel void @aligns() !clspv.pod_args_impl [[pod_arg_md]] !kernel_arg_map [[aligns_map:![0-9]+]]
+
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 3), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 4), align 4
+  ; CHECK: [[ld5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds (%0, %0 addrspace(9)* @__push_constants, i32 0, i32 0, i32 5), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld0]] to i8
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertvalue [[s3]] undef, i8 [[cast]], 0
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = trunc i32 [[ld2]] to i8
+  ; CHECK: [[in00:%[a-zA-Z0-9_.]+]] = insertvalue [[s2]] undef, i8 [[cast]], 0
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld4]] to i64
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld5]] to i64
+  ; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[ex1]], 32
+  ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[ex0]], [[shl]]
+  ; CHECK: [[in01:%[a-zA-Z0-9_.]+]] = insertvalue [[s2]] [[in00]], i64 [[or]], 1
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertvalue [[s3]] [[in0]], [[s2]] [[in01]], 1
+  ret void
+}
+
+; CHECK: [[pc_md]] = !{i32 7}
+; CHECK: [[pod_arg_md]] = !{i32 3}
+; CHECK: [[chars_map]] = !{[[arg_md:![0-9]+]]}
+; CHECK: [[arg_md]] = !{!"arg", i32 0, i32 -1, i32 0, i32 4, !"pod_pushconstant"}
+; CHECK: [[aligns_map]] = !{[[arg_md:![0-9]+]]}
+; CHECK: [[arg_md]] = !{!"arg", i32 0, i32 -1, i32 0, i32 24, !"pod_pushconstant"}
+
+!0 = !{i32 3}

--- a/test/PushConstant/cluster_global_pod_args-vectors.ll
+++ b/test/PushConstant/cluster_global_pod_args-vectors.ll
@@ -1,0 +1,330 @@
+; RUN: clspv-opt %s -o %t.ll -ClusterPodKernelArgumentsPass
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32> }
+
+; CHECK: [[outer:%[a-zA-Z0-9_.]+]] = type { <3 x i32>, <3 x i32>, [[inner:%[a-zA-Z0-9_.]+]] }
+; @longs and @doubles need 24 i32s.
+; CHECK: [[inner]] = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }
+
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define spir_kernel void @chars(<2 x i8> %v2, <3 x i8> %v3, <4 x i8> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @chars() !clspv.pod_args_impl !1 !kernel_arg_map [[char_args:![0-9]+]]
+
+  ; <2 x i8>
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <4 x i8>
+  ; CHECK: shufflevector <4 x i8> [[cast]], <4 x i8> undef, <2 x i32> <i32 0, i32 1>
+
+  ; <3 x i8>
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+  ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld]] to <4 x i8>
+  ; CHECK: shufflevector <4 x i8> [[cast]], <4 x i8> undef, <3 x i32> <i32 0, i32 1, i32 2>
+
+  ; <4 x i8>
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+  ; CHECK: bitcast i32 [[ld]] to <4 x i8>
+  ret void
+}
+
+define spir_kernel void @shorts(<2 x i16> %v2, <3 x i16> %v3, <4 x i16> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @shorts() !clspv.pod_args_impl !1 !kernel_arg_map [[short_args:![0-9]+]]
+
+  ; <2 x i16>
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: bitcast i32 [[ld]] to <2 x i16>
+
+  ; <3 x i16>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 3), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x i16>
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x i16>
+  ; CHECK: shufflevector <2 x i16> [[cast0]], <2 x i16> [[cast1]], <3 x i32> <i32 0, i32 1, i32 2>
+
+  ; <4 x i16>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 4), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x i16>
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x i16>
+  ; CHECK: shufflevector <2 x i16> [[cast0]], <2 x i16> [[cast1]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret void
+}
+
+define spir_kernel void @ints(<2 x i32> %v2, <3 x i32> %v3, <4 x i32> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @ints() !clspv.pod_args_impl !1 !kernel_arg_map [[int_args:![0-9]+]]
+
+  ; <2 x i32>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x i32> undef, i32 [[ld0]], i64 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x i32> [[in0]], i32 [[ld1]], i64 1
+  
+  ; <3 x i32>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 4), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 6), align 4
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x i32> undef, i32 [[ld0]], i64 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <3 x i32> [[in0]], i32 [[ld1]], i64 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <3 x i32> [[in1]], i32 [[ld2]], i64 2
+  
+  ; <4 x i32>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 8), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 9), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 10), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 11), align 4
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x i32> undef, i32 [[ld0]], i64 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x i32> [[in0]], i32 [[ld1]], i64 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x i32> [[in1]], i32 [[ld2]], i64 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x i32> [[in2]], i32 [[ld3]], i64 3
+  ret void
+}
+
+define spir_kernel void @longs(<2 x i64> %v2, <3 x i64> %v3, <4 x i64> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @longs() !clspv.pod_args_impl !1 !kernel_arg_map [[long_args:![0-9]+]]
+
+  ; <2 x i64>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 3), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x i64> undef, i64 [[or1]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x i64> [[in0]], i64 [[or3]], i64 1
+
+  ; <3 x i64>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 8), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 9), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 10), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 11), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 12), align 4
+  ; CHECK: [[ld5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 13), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x i64> undef, i64 [[or1]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <3 x i64> [[in0]], i64 [[or3]], i64 1
+  ; CHECK: [[zext4:%[a-zA-Z0-9_.]+]] = zext i32 [[ld4]] to i64
+  ; CHECK: [[zext5:%[a-zA-Z0-9_.]+]] = zext i32 [[ld5]] to i64
+  ; CHECK: [[shl5:%[a-zA-Z0-9_.]+]] = shl i64 [[zext5]], 32
+  ; CHECK: [[or5:%[a-zA-Z0-9_.]+]] = or i64 [[zext4]], [[shl5]]
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <3 x i64> [[in1]], i64 [[or5]], i64 2
+
+  ; <4 x i64>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 16), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 17), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 18), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 19), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 20), align 4
+  ; CHECK: [[ld5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 21), align 4
+  ; CHECK: [[ld6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 22), align 4
+  ; CHECK: [[ld7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 23), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x i64> undef, i64 [[or1]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x i64> [[in0]], i64 [[or3]], i64 1
+  ; CHECK: [[zext4:%[a-zA-Z0-9_.]+]] = zext i32 [[ld4]] to i64
+  ; CHECK: [[zext5:%[a-zA-Z0-9_.]+]] = zext i32 [[ld5]] to i64
+  ; CHECK: [[shl5:%[a-zA-Z0-9_.]+]] = shl i64 [[zext5]], 32
+  ; CHECK: [[or5:%[a-zA-Z0-9_.]+]] = or i64 [[zext4]], [[shl5]]
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x i64> [[in1]], i64 [[or5]], i64 2
+  ; CHECK: [[zext6:%[a-zA-Z0-9_.]+]] = zext i32 [[ld6]] to i64
+  ; CHECK: [[zext7:%[a-zA-Z0-9_.]+]] = zext i32 [[ld7]] to i64
+  ; CHECK: [[shl7:%[a-zA-Z0-9_.]+]] = shl i64 [[zext7]], 32
+  ; CHECK: [[or7:%[a-zA-Z0-9_.]+]] = or i64 [[zext6]], [[shl7]]
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x i64> [[in2]], i64 [[or7]], i64 3
+  ret void
+}
+
+define spir_kernel void @halfs(<2 x half> %v2, <3 x half> %v3, <4 x half> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @halfs() !clspv.pod_args_impl !1 !kernel_arg_map [[short_args]]
+
+  ; <2 x half>
+  ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: bitcast i32 [[ld]] to <2 x half>
+
+  ; <3 x half>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 3), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x half>
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x half>
+  ; CHECK: shufflevector <2 x half> [[cast0]], <2 x half> [[cast1]], <3 x i32> <i32 0, i32 1, i32 2>
+
+  ; <4 x half>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 4), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to <2 x half>
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to <2 x half>
+  ; CHECK: shufflevector <2 x half> [[cast0]], <2 x half> [[cast1]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret void
+}
+
+define spir_kernel void @floats(<2 x float> %v2, <3 x float> %v3, <4 x float> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @floats() !clspv.pod_args_impl !1 !kernel_arg_map [[int_args]]
+
+  ; <2 x float>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to float
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> undef, float [[cast0]], i64 0
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to float
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> [[in0]], float [[cast1]], i64 1
+  
+  ; <3 x float>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 4), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 5), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 6), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to float
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x float> undef, float [[cast0]], i64 0
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to float
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <3 x float> [[in0]], float [[cast1]], i64 1
+  ; CHECK: [[cast2:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to float
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <3 x float> [[in1]], float [[cast2]], i64 2
+  
+  ; <4 x float>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 8), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 9), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 10), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 11), align 4
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld0]] to float
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[cast0]], i64 0
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld1]] to float
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in0]], float [[cast1]], i64 1
+  ; CHECK: [[cast2:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld2]] to float
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in1]], float [[cast2]], i64 2
+  ; CHECK: [[cast3:%[a-zA-Z0-9_.]+]] = bitcast i32 [[ld3]] to float
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in2]], float [[cast3]], i64 3
+  ret void
+}
+
+define spir_kernel void @doubles(<2 x double> %v2, <3 x double> %v3, <4 x double> %v4) !clspv.pod_args_impl !1 {
+entry:
+  ; CHECK: define spir_kernel void @doubles() !clspv.pod_args_impl !1 !kernel_arg_map [[long_args]]
+
+  ; <2 x double>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 0), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 1), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 2), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 3), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or1]] to double
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x double> undef, double [[cast0]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or3]] to double
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x double> [[in0]], double [[cast1]], i64 1
+
+  ; <3 x double>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 8), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 9), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 10), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 11), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 12), align 4
+  ; CHECK: [[ld5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 13), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or1]] to double
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x double> undef, double [[cast0]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or3]] to double
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <3 x double> [[in0]], double [[cast1]], i64 1
+  ; CHECK: [[zext4:%[a-zA-Z0-9_.]+]] = zext i32 [[ld4]] to i64
+  ; CHECK: [[zext5:%[a-zA-Z0-9_.]+]] = zext i32 [[ld5]] to i64
+  ; CHECK: [[shl5:%[a-zA-Z0-9_.]+]] = shl i64 [[zext5]], 32
+  ; CHECK: [[or5:%[a-zA-Z0-9_.]+]] = or i64 [[zext4]], [[shl5]]
+  ; CHECK: [[cast2:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or5]] to double
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <3 x double> [[in1]], double [[cast2]], i64 2
+
+  ; <4 x double>
+  ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 16), align 4
+  ; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 17), align 4
+  ; CHECK: [[ld2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 18), align 4
+  ; CHECK: [[ld3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 19), align 4
+  ; CHECK: [[ld4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 20), align 4
+  ; CHECK: [[ld5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 21), align 4
+  ; CHECK: [[ld6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 22), align 4
+  ; CHECK: [[ld7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(9)* getelementptr inbounds ([[outer]], [[outer]] addrspace(9)* @__push_constants, i32 0, i32 2, i32 23), align 4
+  ; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ld0]] to i64
+  ; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ld1]] to i64
+  ; CHECK: [[shl1:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+  ; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl1]]
+  ; CHECK: [[cast0:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or1]] to double
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x double> undef, double [[cast0]], i64 0
+  ; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i32 [[ld2]] to i64
+  ; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i32 [[ld3]] to i64
+  ; CHECK: [[shl3:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 32
+  ; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[zext2]], [[shl3]]
+  ; CHECK: [[cast1:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or3]] to double
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x double> [[in0]], double [[cast1]], i64 1
+  ; CHECK: [[zext4:%[a-zA-Z0-9_.]+]] = zext i32 [[ld4]] to i64
+  ; CHECK: [[zext5:%[a-zA-Z0-9_.]+]] = zext i32 [[ld5]] to i64
+  ; CHECK: [[shl5:%[a-zA-Z0-9_.]+]] = shl i64 [[zext5]], 32
+  ; CHECK: [[or5:%[a-zA-Z0-9_.]+]] = or i64 [[zext4]], [[shl5]]
+  ; CHECK: [[cast2:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or5]] to double
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x double> [[in1]], double [[cast2]], i64 2
+  ; CHECK: [[zext6:%[a-zA-Z0-9_.]+]] = zext i32 [[ld6]] to i64
+  ; CHECK: [[zext7:%[a-zA-Z0-9_.]+]] = zext i32 [[ld7]] to i64
+  ; CHECK: [[shl7:%[a-zA-Z0-9_.]+]] = shl i64 [[zext7]], 32
+  ; CHECK: [[or7:%[a-zA-Z0-9_.]+]] = or i64 [[zext6]], [[shl7]]
+  ; CHECK: [[cast3:%[a-zA-Z0-9_.]+]] = bitcast i64 [[or7]] to double
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x double> [[in2]], double [[cast3]], i64 3
+  ret void
+}
+
+; CHECK: [[char_args]] = !{[[v2:![0-9]+]], [[v3:![0-9]+]], [[v4:![0-9]+]]}
+; CHECK: [[v2]] = !{!"v2", i32 0, i32 -1, i32 32, i32 2, !"pod_pushconstant"}
+; CHECK: [[v3]] = !{!"v3", i32 1, i32 -1, i32 36, i32 3, !"pod_pushconstant"}
+; CHECK: [[v4]] = !{!"v4", i32 2, i32 -1, i32 40, i32 4, !"pod_pushconstant"}
+; CHECK: [[short_args]] = !{[[v2:![0-9]+]], [[v3:![0-9]+]], [[v4:![0-9]+]]}
+; CHECK: [[v2]] = !{!"v2", i32 0, i32 -1, i32 32, i32 4, !"pod_pushconstant"}
+; CHECK: [[v3]] = !{!"v3", i32 1, i32 -1, i32 40, i32 6, !"pod_pushconstant"}
+; CHECK: [[v4]] = !{!"v4", i32 2, i32 -1, i32 48, i32 8, !"pod_pushconstant"}
+; CHECK: [[int_args]] = !{[[v2:![0-9]+]], [[v3:![0-9]+]], [[v4:![0-9]+]]}
+; CHECK: [[v2]] = !{!"v2", i32 0, i32 -1, i32 32, i32 8, !"pod_pushconstant"}
+; CHECK: [[v3]] = !{!"v3", i32 1, i32 -1, i32 48, i32 12, !"pod_pushconstant"}
+; CHECK: [[v4]] = !{!"v4", i32 2, i32 -1, i32 64, i32 16, !"pod_pushconstant"}
+; CHECK: [[long_args]] = !{[[v2:![0-9]+]], [[v3:![0-9]+]], [[v4:![0-9]+]]}
+; CHECK: [[v2]] = !{!"v2", i32 0, i32 -1, i32 32, i32 16, !"pod_pushconstant"}
+; CHECK: [[v3]] = !{!"v3", i32 1, i32 -1, i32 64, i32 24, !"pod_pushconstant"}
+; CHECK: [[v4]] = !{!"v4", i32 2, i32 -1, i32 96, i32 32, !"pod_pushconstant"}
+
+!0 = !{i32 1, i32 4}
+!1 = !{i32 3}
+

--- a/test/PushConstant/global_push_constant_pod_args-halfs.cl
+++ b/test/PushConstant/global_push_constant_pod_args-halfs.cl
@@ -51,5 +51,4 @@ kernel void foo(global half *out, half s, half2 v2, half3 v3, half4 v4) {
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
 // CHECK: [[cast_v4:%[a-zA-Z0-9_]+]] = OpBitcast [[half2]] [[ld]]
 
-// CHECK: [[ex:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[half]] [[cast_v3]] 1
-// CHECK: [[ex:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[half]] [[cast_v4]] 0
+// Uses of the casts aren't checked because LLVM optimizes them to vector additions.

--- a/test/PushConstant/global_push_constant_pod_args-halfs.cl
+++ b/test/PushConstant/global_push_constant_pod_args-halfs.cl
@@ -1,0 +1,55 @@
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -inline-entry-points -cl-std=CL2.0
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half *out, half s, half2 v2, half3 v3, half4 v4) {
+  *out = s + v2[0] + v3[1] + v4[2];
+}
+
+// MAP: kernel,foo,arg,out,argOrdinal,0
+// MAP: kernel,foo,arg,s,argOrdinal,1,offset,0,argKind,pod_pushconstant,argSize,2
+// MAP: kernel,foo,arg,v2,argOrdinal,2,offset,4,argKind,pod_pushconstant,argSize,4
+// MAP: kernel,foo,arg,v3,argOrdinal,3,offset,8,argKind,pod_pushconstant,argSize,6
+// MAP: kernel,foo,arg,v4,argOrdinal,4,offset,16,argKind,pod_pushconstant,argSize,8
+
+// CHECK-DAG: OpMemberDecorate [[inner:%[a-zA-Z0-9_]+]] 5 Offset 20
+// CHECK-DAG: OpMemberDecorate [[inner]] 4 Offset 16
+// CHECK-DAG: OpMemberDecorate [[inner]] 3 Offset 12
+// CHECK-DAG: OpMemberDecorate [[inner]] 2 Offset 8
+// CHECK-DAG: OpMemberDecorate [[inner]] 1 Offset 4
+// CHECK-DAG: OpMemberDecorate [[inner]] 0 Offset 0
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[int_2:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2
+// CHECK-DAG: [[int_5:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 5
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half2:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 2
+// CHECK-DAG: [[inner]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]] [[int]] [[int]]
+// CHECK-DAG: [[outer:%[a-zA-Z0-9_]+]] = OpTypeStruct [[inner]]
+// CHECK-DAG: [[outer_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[outer]]
+// CHECK-DAG: [[int_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[int]]
+// CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[outer_ptr]] PushConstant
+
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[var]] [[int_0]] [[int_0]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[half2]] [[ld]]
+
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[var]] [[int_0]] [[int_1]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[half2]] [[ld]]
+
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[var]] [[int_0]] [[int_2]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[cast_v3:%[a-zA-Z0-9_]+]] = OpBitcast [[half2]] [[ld]]
+
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[var]] [[int_0]] [[int_5]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[cast_v4:%[a-zA-Z0-9_]+]] = OpBitcast [[half2]] [[ld]]
+
+// CHECK: [[ex:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[half]] [[cast_v3]] 1
+// CHECK: [[ex:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[half]] [[cast_v4]] 0

--- a/test/PushConstant/global_push_constant_pod_args-halfs.cl
+++ b/test/PushConstant/global_push_constant_pod_args-halfs.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -descriptormap=%t.map -inline-entry-points -cl-std=CL2.0
+// RUN: clspv %s -o %t.spv -descriptormap=%t.map -inline-entry-points -cl-std=CL2.0 -no-16bit-storage=pushconstant
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 // RUN: FileCheck --check-prefix=MAP %s < %t.map

--- a/test/PushConstant/global_push_constant_pod_args-scalars.cl
+++ b/test/PushConstant/global_push_constant_pod_args-scalars.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -global-offset -inline-entry-points -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global int* out, char c, short s, int i, long l, float f, half h, double d) {
+  *out = i + get_global_id(0);
+}
+
+// CHECK: pushconstant,name,global_offset,offset,0,size,12
+// CHECK: pushconstant,name,region_offset,offset,16,size,12
+// CHECK: kernel,foo,arg,out,argOrdinal,0
+// CHECK: kernel,foo,arg,c,argOrdinal,1,offset,32,argKind,pod_pushconstant,argSize,1
+// CHECK: kernel,foo,arg,s,argOrdinal,2,offset,34,argKind,pod_pushconstant,argSize,2
+// CHECK: kernel,foo,arg,i,argOrdinal,3,offset,36,argKind,pod_pushconstant,argSize,4
+// CHECK: kernel,foo,arg,l,argOrdinal,4,offset,40,argKind,pod_pushconstant,argSize,8
+// CHECK: kernel,foo,arg,f,argOrdinal,5,offset,48,argKind,pod_pushconstant,argSize,4
+// CHECK: kernel,foo,arg,h,argOrdinal,6,offset,52,argKind,pod_pushconstant,argSize,2
+// CHECK: kernel,foo,arg,d,argOrdinal,7,offset,56,argKind,pod_pushconstant,argSize,8

--- a/test/PushConstant/global_push_constant_pod_args.cl
+++ b/test/PushConstant/global_push_constant_pod_args.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -global-offset -inline-entry-points -descriptormap=%t.map
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: FileCheck --check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out, int a) {
+  *out = a + get_global_id(0);
+}
+
+// MAP: pushconstant,name,global_offset,offset,0,size,12
+// MAP: pushconstant,name,region_offset,offset,16,size,12
+// MAP: kernel,foo,arg,out,argOrdinal,0
+// MAP: kernel,foo,arg,a,argOrdinal,1,offset,32,argKind,pod_pushconstant,argSize,4
+
+// CHECK-DAG: OpMemberDecorate [[pc_block:%[a-zA-Z0-9_]+]] 1 Offset 16
+// CHECK-DAG: OpMemberDecorate [[pc_block]] 2 Offset 32
+// CHECK-DAG: OpMemberDecorate [[pc_block]] 0 Offset 0
+//     CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
+// CHECK-DAG: [[pod_arg_struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int]]
+// CHECK-DAG: [[pc_block]] = OpTypeStruct [[int3]] [[int3]] [[pod_arg_struct]]
+// CHECK-DAG: [[pc_block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[pc_block]]
+// CHECK-DAG: [[int_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant [[int]]
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[int_2:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2
+// CHECK: [[pc_var:%[a-zA-Z0-9_]+]] = OpVariable [[pc_block_ptr]] PushConstant
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[pc_var]] [[int_2]] [[int_0]]
+// CHECK: [[ld_arg:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[int_ptr]] [[pc_var]] [[int_1]] [[int_0]]
+// CHECK: [[ld_offset:%[a-zA-Z0-9_]+]] = OpLoad [[int]] [[gep]]
+// CHECK: [[add1:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] {{.*}} [[ld_arg]]
+// CHECK: [[add2:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[add1]] [[ld_offset]]

--- a/tools/clspv-opt/main.cpp
+++ b/tools/clspv-opt/main.cpp
@@ -29,6 +29,8 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
+// Necessary to initialize options and passes.
+#include "clspv/Option.h"
 #include "clspv/Passes.h"
 
 using namespace llvm;


### PR DESCRIPTION
Contributes to #529 

* AutoPodArgsPass can now decide to put pod kernel arguments into a type mangled structure shared by all kernels with that style of pod arg implementation
* The heavy lifting is in ClusterPodKernelArgumentsPass
  * for this style pod args are removed from the kernel, but still appear in the kernel arg map
  * instead the pod args are implemented as a struct of integers in the same variable that holds the other global push constants (e.g. region offset)
  * only considers unpacked struct sizes right now
  * offsets account for global push constants also being present
  * When generating the wrapper function, the pass converts an appropriate number of integers back into the appropriate type
    * the type conversion does a pretty good job of generating a minimal number of instructions
    * though the type conversion results in more instructions it can also workaround the storage restrictions since only i32s are loaded from the push constant variable
* FIxed a bug in AutoPodArgsPass where byval pod args were not properly considered for size restrictions
* Push constant loads are now hidden and unhidden the same as __constant loads
  * this prevents generating some awkward nested constant expressions
* updated the spirv producer to handle the new style
* bunch of new tests