### PR TITLE
Relax frontend 8- and 16-bit type check

### DIFF
--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -630,21 +630,27 @@ public:
               } else if (clspv::Option::PodArgsInPushConstants()) {
                 sc = clspv::Option::StorageClass::kPushConstant;
               }
-              if (contains_16bit &&
-                  !clspv::Option::Supports16BitStorageClass(sc)) {
-                Instance.getDiagnostics().Report(
-                    P->getSourceRange().getBegin(),
-                    CustomDiagnosticsIDMap
-                        [CustomDiagnosticUnsupported16BitStorage])
-                    << static_cast<int>(sc);
-              }
-              if (contains_8bit &&
-                  !clspv::Option::Supports8BitStorageClass(sc)) {
-                Instance.getDiagnostics().Report(
-                    P->getSourceRange().getBegin(),
-                    CustomDiagnosticsIDMap
-                        [CustomDiagnosticUnsupported8BitStorage])
-                    << static_cast<int>(sc);
+
+              if (type->isPointerType() ||
+                  sc != clspv::Option::StorageClass::kSSBO ||
+                  !clspv::Option::ClusterPodKernelArgs()) {
+                // For clustered pod args, assume we can fall back on type-mangling.
+                if (contains_16bit &&
+                    !clspv::Option::Supports16BitStorageClass(sc)) {
+                  Instance.getDiagnostics().Report(
+                      P->getSourceRange().getBegin(),
+                      CustomDiagnosticsIDMap
+                          [CustomDiagnosticUnsupported16BitStorage])
+                      << static_cast<int>(sc);
+                }
+                if (contains_8bit &&
+                    !clspv::Option::Supports8BitStorageClass(sc)) {
+                  Instance.getDiagnostics().Report(
+                      P->getSourceRange().getBegin(),
+                      CustomDiagnosticsIDMap
+                          [CustomDiagnosticUnsupported8BitStorage])
+                      << static_cast<int>(sc);
+                }
               }
             }
 

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -634,7 +634,8 @@ public:
               if (type->isPointerType() ||
                   sc != clspv::Option::StorageClass::kSSBO ||
                   !clspv::Option::ClusterPodKernelArgs()) {
-                // For clustered pod args, assume we can fall back on type-mangling.
+                // For clustered pod args, assume we can fall back on
+                // type-mangling.
                 if (contains_16bit &&
                     !clspv::Option::Supports16BitStorageClass(sc)) {
                   Instance.getDiagnostics().Report(

--- a/test/Diagnostics/no-ssbo-16bit.cl
+++ b/test/Diagnostics/no-ssbo-16bit.cl
@@ -13,5 +13,3 @@ struct B {
 kernel void foo(global short* a) { } //expected-error{{16-bit storage is not supported for SSBOs}}
 
 kernel void bar(constant struct B* a) { } //expected-error{{16-bit storage is not supported for SSBOs}}
-
-kernel void baz(ushort a) { } //expected-error{{16-bit storage is not supported for SSBOs}}

--- a/test/Diagnostics/no-ssbo-8bit.cl
+++ b/test/Diagnostics/no-ssbo-8bit.cl
@@ -4,5 +4,3 @@ kernel void foo(global char* a) { } //expected-error{{8-bit storage is not suppo
 
 kernel void bar(constant char* a) { } //expected-error{{8-bit storage is not supported for SSBOs}}
 
-kernel void baz(uchar a) { } //expected-error{{8-bit storage is not supported for SSBOs}}
-

--- a/test/Diagnostics/relax_16bit_pod_arg_check.cl
+++ b/test/Diagnostics/relax_16bit_pod_arg_check.cl
@@ -1,0 +1,4 @@
+// RUN: clspv %s -verify -no-16bit-storage=ssbo -w
+
+// Lack of ssbo support for 16-bit values shouldn't prohibit this kernel.
+kernel void foo(short x) {} //expected-no-diagnostics


### PR DESCRIPTION
* Allow clustered pod args in ssbo to work despite contradictory command
line options assuming type mangled push constants will succeed
* fix tests