### PR TITLE
Disable PRE in GVN

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -757,10 +757,13 @@ int ParseOptions(const int argc, const char *const argv[]) {
   const std::string pre = "-enable-pre";
   const std::string load_pre = "-enable-load-pre";
   for (int i = 1; i < argc; ++i) {
-    if (strncmp(argv[i], load_pre.c_str(), load_pre.size()) == 0) {
-      has_load_pre = true;
-    } else if (strncmp(argv[i], pre.c_str(), pre.size()) == 0) {
+    std::string option(argv[i]);
+    auto pre_pos = option.find(pre);
+    auto load_pos = option.find(load_pre);
+    if (pre_pos == 0 || (pre_pos == 1 && option[0] == '-')) {
       has_pre = true;
+    } else if (load_pos == 0 || (load_pos == 1 && option[0] == '-')) {
+      has_load_pre = true;
     }
   }
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -750,13 +750,30 @@ int PopulatePassManager(
 }
 
 int ParseOptions(const int argc, const char *const argv[]) {
-  // We need to change how one of the called passes works by spoofing
-  // ParseCommandLineOptions with the specific option.
-  const int llvmArgc = 2;
-  const char *llvmArgv[llvmArgc] = {
-      argv[0],
-      "-simplifycfg-sink-common=false",
-  };
+  // We need to change how some of the called passes works by spoofing
+  // ParseCommandLineOptions with the specific options.
+  bool has_pre = false;
+  bool has_load_pre = false;
+  const std::string pre = "-enable-pre";
+  const std::string load_pre = "-enable-load-pre";
+  for (int i = 1; i < argc; ++i) {
+    if (strncmp(argv[i], load_pre.c_str(), load_pre.size()) == 0) {
+      has_load_pre = true;
+    } else if (strncmp(argv[i], pre.c_str(), pre.size()) == 0) {
+      has_pre = true;
+    }
+  }
+
+  int llvmArgc = 2;
+  const char *llvmArgv[4];
+  llvmArgv[0] = argv[0];
+  llvmArgv[1] = "-simplifycfg-sink-common=false";
+  if (!has_pre) {
+    llvmArgv[llvmArgc++] = "-enable-pre=0";
+  }
+  if (!has_load_pre) {
+    llvmArgv[llvmArgc++] = "-enable-load-pre=0";
+  }
 
   llvm::cl::ResetAllOptionOccurrences();
   llvm::cl::ParseCommandLineOptions(llvmArgc, llvmArgv);

--- a/test/global-variable-no-undef-initializer.cl
+++ b/test/global-variable-no-undef-initializer.cl
@@ -1,4 +1,4 @@
-// RUN: clspv  %s -o %t.spv
+// RUN: clspv  %s -o %t.spv -enable-pre=1 -enable-load-pre=1
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/loop_continue_no_selection_merge.cl
+++ b/test/loop_continue_no_selection_merge.cl
@@ -1,4 +1,4 @@
-// RUN: clspv  %s -o %t.spv -enable-pre=1 -enable-load-pre=1
+// RUN: clspv  %s -o %t.spv --enable-pre=1 --enable-load-pre=1
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/loop_continue_no_selection_merge.cl
+++ b/test/loop_continue_no_selection_merge.cl
@@ -1,4 +1,4 @@
-// RUN: clspv  %s -o %t.spv
+// RUN: clspv  %s -o %t.spv -enable-pre=1 -enable-load-pre=1
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/no_pre_sampler.cl
+++ b/test/no_pre_sampler.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+// CHECK-NOT: OpPhi [[sampler]]
+
+static const sampler_t sampler =
+  CLK_NORMALIZED_COORDS_FALSE |
+  CLK_ADDRESS_CLAMP_TO_EDGE |
+  CLK_FILTER_NEAREST;
+
+kernel void foo(read_only image2d_t imageA, int itrs) {
+  int x = (int)get_global_id(0);
+  int y = (int)get_global_id(1);
+  for (int i = 0; i < itrs; ++i) {
+    int2 coords = (int2)(x, y);
+    float4 valueA = read_imagef(imageA, sampler, coords);
+  }
+  float4 valueB = read_imagef(imageA, sampler, (int2)(0, 0));
+}


### PR DESCRIPTION
Fixes #594

* Disable PRE in GVN
* add a test

I think this is good generally. PRE might be beneficial in some circumstances, but it seems like that decision should be made by the driver. 

I have previously given some guidance to disable it to some users which is why I attempt to detect if they have been added to the command line (multiple occurrences cause an error).