### PR TITLE
Handle smax, smin and sclamp in -hack-scf

### DIFF
--- a/amber/hack_scf/sclamp.amber
+++ b/amber/hack_scf/sclamp.amber
@@ -1,0 +1,49 @@
+#!amber
+
+SHADER compute sclamp_shader OPENCL-C
+kernel void foo(global int* out, global int* a, global int* b, global int* c) {
+  int gid = get_global_id(0);
+  out[gid] = clamp(a[gid], b[gid], c[gid]);
+}
+END
+
+BUFFER a DATA_TYPE int32 DATA
+-10 42 0 -1 5
+END
+BUFFER b DATA_TYPE int32 DATA
+42 -10 0 -3 3
+END
+BUFFER c DATA_TYPE int32 DATA
+48 -1 1 1 6
+END
+BUFFER expect DATA_TYPE int32 DATA
+42 -1 0 -1 5
+END
+BUFFER out1 DATA_TYPE int32 SIZE 5 FILL 13
+BUFFER out2 DATA_TYPE int32 SIZE 5 FILL 13
+
+PIPELINE compute sclamp_pipeline
+  ATTACH sclamp_shader ENTRY_POINT foo \
+    SPECIALIZE 0 AS uint32 5 \
+    SPECIALIZE 1 AS uint32 1 \
+    SPECIALIZE 2 AS uint32 1
+
+  BIND BUFFER out1 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER a AS storage DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER b AS storage DESCRIPTOR_SET 0 BINDING 2
+  BIND BUFFER c AS storage DESCRIPTOR_SET 0 BINDING 3
+END
+
+DERIVE_PIPELINE scf_pipeline FROM sclamp_pipeline
+  BIND BUFFER out2 AS storage DESCRIPTOR_SET 0 BINDING 0
+  COMPILE_OPTIONS sclamp_shader
+    -hack-scf
+  END
+END
+
+RUN sclamp_pipeline 1 1 1
+RUN scf_pipeline 1 1 1
+
+EXPECT out1 EQ_BUFFER expect
+EXPECT out2 EQ_BUFFER expect
+

--- a/amber/hack_scf/smax.amber
+++ b/amber/hack_scf/smax.amber
@@ -1,0 +1,44 @@
+#!amber
+
+SHADER compute smax_shader OPENCL-C
+kernel void foo(global int* out, global int* a, global int* b) {
+  int gid = get_global_id(0);
+  out[gid] = max(a[gid], b[gid]);
+}
+END
+
+BUFFER a DATA_TYPE int32 DATA
+-10 42 0 -1 5
+END
+BUFFER b DATA_TYPE int32 DATA
+42 -10 0 -3 3
+END
+BUFFER expect DATA_TYPE int32 DATA
+42 42 0 -1 5
+END
+BUFFER out1 DATA_TYPE int32 SIZE 5 FILL 13
+BUFFER out2 DATA_TYPE int32 SIZE 5 FILL 13
+
+PIPELINE compute smax_pipeline
+  ATTACH smax_shader ENTRY_POINT foo \
+    SPECIALIZE 0 AS uint32 5 \
+    SPECIALIZE 1 AS uint32 1 \
+    SPECIALIZE 2 AS uint32 1
+
+  BIND BUFFER out1 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER a AS storage DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER b AS storage DESCRIPTOR_SET 0 BINDING 2
+END
+
+DERIVE_PIPELINE scf_pipeline FROM smax_pipeline
+  BIND BUFFER out2 AS storage DESCRIPTOR_SET 0 BINDING 0
+  COMPILE_OPTIONS smax_shader
+    -hack-scf
+  END
+END
+
+RUN smax_pipeline 1 1 1
+RUN scf_pipeline 1 1 1
+
+EXPECT out1 EQ_BUFFER expect
+EXPECT out2 EQ_BUFFER expect

--- a/amber/hack_scf/smax_vector.amber
+++ b/amber/hack_scf/smax_vector.amber
@@ -1,0 +1,45 @@
+#!amber
+
+SHADER compute smax_shader OPENCL-C
+kernel void foo(global int2 *out, global int2 *a, global int2 *b) {
+  int gid = get_global_id(0);
+  out[gid] = max(a[gid], b[gid]);
+}
+END
+
+BUFFER a DATA_TYPE int32 DATA
+-10 -10 42 42 0 1 -1 5
+END
+BUFFER b DATA_TYPE int32 DATA
+42 42 -10 -10  0 -1 -3 3
+END
+BUFFER expect DATA_TYPE int32 DATA
+42 42 42 42 0 1 -1 5
+END
+BUFFER out1 DATA_TYPE int32 SIZE 8 FILL 13
+BUFFER out2 DATA_TYPE int32 SIZE 8 FILL 13
+
+PIPELINE compute smax_pipeline
+  ATTACH smax_shader ENTRY_POINT foo \
+    SPECIALIZE 0 AS uint32 4 \
+    SPECIALIZE 1 AS uint32 1 \
+    SPECIALIZE 2 AS uint32 1
+
+  BIND BUFFER out1 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER a AS storage DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER b AS storage DESCRIPTOR_SET 0 BINDING 2
+END
+
+DERIVE_PIPELINE scf_pipeline FROM smax_pipeline
+  BIND BUFFER out2 AS storage DESCRIPTOR_SET 0 BINDING 0
+  COMPILE_OPTIONS smax_shader
+    -hack-scf
+  END
+END
+
+RUN smax_pipeline 1 1 1
+RUN scf_pipeline 1 1 1
+
+EXPECT out1 EQ_BUFFER expect
+EXPECT out2 EQ_BUFFER expect
+

--- a/amber/hack_scf/smin.amber
+++ b/amber/hack_scf/smin.amber
@@ -1,0 +1,45 @@
+#!amber
+
+SHADER compute smin_shader OPENCL-C
+kernel void foo(global int* out, global int* a, global int* b) {
+  int gid = get_global_id(0);
+  out[gid] = min(a[gid], b[gid]);
+}
+END
+
+BUFFER a DATA_TYPE int32 DATA
+-10 42 0 -1 5
+END
+BUFFER b DATA_TYPE int32 DATA
+42 -10 0 -3 3
+END
+BUFFER expect DATA_TYPE int32 DATA
+-10 -10 0 -3 3
+END
+BUFFER out1 DATA_TYPE int32 SIZE 5 FILL 13
+BUFFER out2 DATA_TYPE int32 SIZE 5 FILL 13
+
+PIPELINE compute smin_pipeline
+  ATTACH smin_shader ENTRY_POINT foo \
+    SPECIALIZE 0 AS uint32 5 \
+    SPECIALIZE 1 AS uint32 1 \
+    SPECIALIZE 2 AS uint32 1
+
+  BIND BUFFER out1 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER a AS storage DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER b AS storage DESCRIPTOR_SET 0 BINDING 2
+END
+
+DERIVE_PIPELINE scf_pipeline FROM smin_pipeline
+  BIND BUFFER out2 AS storage DESCRIPTOR_SET 0 BINDING 0
+  COMPILE_OPTIONS smin_shader
+    -hack-scf
+  END
+END
+
+RUN smin_pipeline 1 1 1
+RUN scf_pipeline 1 1 1
+
+EXPECT out1 EQ_BUFFER expect
+EXPECT out2 EQ_BUFFER expect
+

--- a/lib/SignedCompareFixupPass.cpp
+++ b/lib/SignedCompareFixupPass.cpp
@@ -27,8 +27,10 @@
 
 #include "clspv/Option.h"
 
+#include "Builtins.h"
 #include "Passes.h"
 
+using namespace clspv;
 using namespace llvm;
 
 #define DEBUG_TYPE "signedcomparefixup"
@@ -60,6 +62,11 @@ private:
     }
     return false;
   }
+
+  // Replaces |call| which is a smin, smax or sclamp call with an equivalent
+  // instruction stream. Also adds the comparisons introduced to |work_list|.
+  void ReplaceBuiltin(CallInst *call, Builtins::BuiltinType type,
+                      SmallVectorImpl<ICmpInst *> *work_list);
 };
 } // namespace
 
@@ -80,6 +87,7 @@ bool SignedCompareFixupPass::runOnModule(Module &M) {
     return Changed;
   }
 
+  SmallVector<Instruction *, 16> to_remove;
   SmallVector<ICmpInst *, 16> work_list;
   for (auto &F : M) {
     for (auto &BB : F) {
@@ -87,6 +95,30 @@ bool SignedCompareFixupPass::runOnModule(Module &M) {
         if (auto *icmp = dyn_cast<ICmpInst>(&inst)) {
           if (IsSignedRelational(icmp->getPredicate())) {
             work_list.push_back(icmp);
+          }
+        } else if (auto call = dyn_cast<CallInst>(&inst)) {
+          // Same bug exists for smin, smax and sclamp. Break those calls down
+          // and then replace the resulting comparisons too.
+          auto &info = Builtins::Lookup(call->getCalledFunction());
+          switch (info.getType()) {
+          case Builtins::kMax:
+          case Builtins::kMin:
+          case Builtins::kClamp: {
+            auto param_info = info.getParameter(0);
+            // Note that this also covers vector operands.
+            if (param_info.is_signed &&
+                param_info.type_id == llvm::Type::IntegerTyID) {
+              if (ShowSCF) {
+                outs() << "SCF: Replace " << *call << "\n";
+              }
+              ReplaceBuiltin(call, info.getType(), &work_list);
+              Changed = true;
+              to_remove.push_back(call);
+            }
+            break;
+          }
+          default:
+            break;
           }
         }
       }
@@ -189,6 +221,9 @@ bool SignedCompareFixupPass::runOnModule(Module &M) {
     icmp->replaceAllUsesWith(replacement);
   }
 
+  for (auto *inst : to_remove) {
+    inst->eraseFromParent();
+  }
   for (auto *inst : work_list) {
     inst->eraseFromParent();
   }
@@ -199,4 +234,41 @@ bool SignedCompareFixupPass::runOnModule(Module &M) {
 
   return Changed;
 }
+
+void SignedCompareFixupPass::ReplaceBuiltin(
+    CallInst *call, Builtins::BuiltinType type,
+    SmallVectorImpl<ICmpInst *> *work_list) {
+  // The returns from CreateICmpSLT are tested because they may have been
+  // folded to a constant.
+  IRBuilder<> builder(call->getContext());
+  builder.SetInsertPoint(call);
+  Value *out = nullptr;
+  if (type == Builtins::kClamp) {
+    // clamp(a,b,c) is min(max(x, b), c). Results are undefined if b > c, so
+    // both comparisons can be made against x.
+    auto x = call->getOperand(0);
+    auto min = call->getOperand(1);
+    auto max = call->getOperand(2);
+    auto cmp1 = builder.CreateICmpSLT(x, min);
+    auto sel = builder.CreateSelect(cmp1, min, x);
+    auto cmp2 = builder.CreateICmpSLT(max, x);
+    out = builder.CreateSelect(cmp2, max, sel);
+    if (auto icmp = dyn_cast<ICmpInst>(cmp1))
+      work_list->push_back(icmp);
+    if (auto icmp = dyn_cast<ICmpInst>(cmp2))
+      work_list->push_back(icmp);
+  } else {
+    bool is_min = type == Builtins::kMin;
+    auto lhs = call->getOperand(0);
+    auto rhs = call->getOperand(1);
+    if (is_min)
+      std::swap(lhs, rhs);
+    auto cmp = builder.CreateICmpSLT(lhs, rhs);
+    out = builder.CreateSelect(cmp, call->getOperand(1), call->getOperand(0));
+    if (auto icmp = dyn_cast<ICmpInst>(cmp))
+      work_list->push_back(icmp);
+  }
+  call->replaceAllUsesWith(out);
+}
+
 } // namespace

--- a/lib/SignedCompareFixupPass.cpp
+++ b/lib/SignedCompareFixupPass.cpp
@@ -244,7 +244,7 @@ void SignedCompareFixupPass::ReplaceBuiltin(
   builder.SetInsertPoint(call);
   Value *out = nullptr;
   if (type == Builtins::kClamp) {
-    // clamp(a,b,c) is min(max(x, b), c). Results are undefined if b > c, so
+    // clamp(x,b,c) is min(max(x, b), c). Results are undefined if b > c, so
     // both comparisons can be made against x.
     auto x = call->getOperand(0);
     auto min = call->getOperand(1);

--- a/test/hack_scf/sclamp.ll
+++ b/test/hack_scf/sclamp.ll
@@ -1,0 +1,47 @@
+; RUN: clspv-opt -hack-scf -SignedCompareFixupPass %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LABEL: sclamp
+; CHECK: [[b_m_a:%[0-9]+]] = sub i32 %b, %a
+; CHECK: [[m_1:%[0-9]+]] = sub i32 [[b_m_a]], 1
+; CHECK: [[and:%[0-9]+]] = and i32 [[m_1]], -2147483648
+; CHECK: [[cmp:%[0-9]+]] = icmp eq i32 [[and]], 0
+; CHECK: [[sel:%[0-9]+]] = select i1 [[cmp]], i32 %b, i32 %a
+; CHECK: [[a_m_c:%[0-9]+]] = sub i32 %a, %c
+; CHECK: [[m_1:%[0-9]+]] = sub i32 [[a_m_c]], 1
+; CHECK: [[and:%[0-9]+]] = and i32 [[m_1]], -2147483648
+; CHECK: [[cmp:%[0-9]+]] = icmp eq i32 [[and]], 0
+; CHECK: [[sel2:%[0-9]+]] = select i1 [[cmp]], i32 %c, i32 [[sel]]
+; CHECK: ret i32 [[sel2]]
+
+define i32 @sclamp(i32 %a, i32 %b, i32 %c) {
+entry:
+  %clamp = call spir_func i32 @_Z5clampiii(i32 %a, i32 %b, i32 %c)
+  ret i32 %clamp
+}
+
+declare spir_func i32 @_Z5clampiii(i32, i32, i32)
+
+; CHECK-LABEL: sclamp4
+; CHECK: [[b_m_a:%[0-9]+]] = sub <4 x i32> %b, %a
+; CHECK: [[m_1:%[0-9]+]] = sub <4 x i32> [[b_m_a]], <i32 1, i32 1, i32 1, i32 1>
+; CHECK: [[and:%[0-9]+]] = and <4 x i32> [[m_1]], <i32 -2147483648, i32 -2147483648, i32 -2147483648, i32 -2147483648>
+; CHECK: [[cmp:%[0-9]+]] = icmp eq <4 x i32> [[and]], zeroinitializer
+; CHECK: [[sel:%[0-9]+]] = select <4 x i1> [[cmp]], <4 x i32> %b, <4 x i32> %a
+; CHECK: [[a_m_c:%[0-9]+]] = sub <4 x i32> %a, %c
+; CHECK: [[m_1:%[0-9]+]] = sub <4 x i32> [[a_m_c]], <i32 1, i32 1, i32 1, i32 1>
+; CHECK: [[and:%[0-9]+]] = and <4 x i32> [[m_1]], <i32 -2147483648, i32 -2147483648, i32 -2147483648, i32 -2147483648>
+; CHECK: [[cmp:%[0-9]+]] = icmp eq <4 x i32> [[and]], zeroinitializer
+; CHECK: [[sel2:%[0-9]+]] = select <4 x i1> [[cmp]], <4 x i32> %c, <4 x i32> [[sel]]
+; CHECK: ret <4 x i32> [[sel2]]
+
+define <4 x i32> @sclamp4(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c) {
+entry:
+  %clamp4 = call spir_func <4 x i32> @_Z5clampDv4_iS_S_(<4 x i32> %a, <4 x i32> %b, <4 x i32> %c)
+  ret <4 x i32> %clamp4
+}
+
+declare spir_func <4 x i32> @_Z5clampDv4_iS_S_(<4 x i32>, <4 x i32>, <4 x i32>)

--- a/test/hack_scf/smax.ll
+++ b/test/hack_scf/smax.ll
@@ -1,0 +1,38 @@
+; RUN: clspv-opt -hack-scf -SignedCompareFixupPass %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-LABEL: smax
+; CHECK: [[b_m_a:%[0-9]+]] = sub i32 %b, %a
+; CHECK: [[m_1:%[0-9]+]] = sub i32 [[b_m_a]], 1
+; CHECK: [[and:%[0-9]+]] = and i32 [[m_1]], -2147483648
+; CHECK: [[cmp:%[0-9]+]] = icmp eq i32 [[and]], 0
+; CHECK: [[sel:%[0-9]+]] = select i1 [[cmp]], i32 %b, i32 %a
+; CHECK: ret i32 [[sel]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @smax(i32 %a, i32 %b) {
+entry:
+  %max = call spir_func i32 @_Z3maxii(i32 %a, i32 %b)
+  ret i32 %max
+}
+
+declare spir_func i32 @_Z3maxii(i32, i32)
+
+; CHECK-LABEL: smax3
+; CHECK: [[b_m_a:%[0-9]+]] = sub <3 x i32> %b, %a
+; CHECK: [[m_1:%[0-9]+]] = sub <3 x i32> [[b_m_a]], <i32 1, i32 1, i32 1>
+; CHECK: [[and:%[0-9]+]] = and <3 x i32> [[m_1]], <i32 -2147483648, i32 -2147483648, i32 -2147483648>
+; CHECK: [[cmp:%[0-9]+]] = icmp eq <3 x i32> [[and]], zeroinitializer
+; CHECK: [[sel:%[0-9]+]] = select <3 x i1> [[cmp]], <3 x i32> %b, <3 x i32> %a
+; CHECK: ret <3 x i32> [[sel]]
+
+define <3 x i32> @smax3(<3 x i32> %a, <3 x i32> %b) {
+entry:
+  %max3 = call spir_func <3 x i32> @_Z3maxDv3_iS_(<3 x i32> %a, <3 x i32> %b)
+  ret <3 x i32> %max3
+}
+
+declare spir_func <3 x i32> @_Z3maxDv3_iS_(<3 x i32>, <3 x i32>)
+

--- a/test/hack_scf/smin.ll
+++ b/test/hack_scf/smin.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -hack-scf -SignedCompareFixupPass %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-LABEL: smin
+; CHECK: [[a_m_b:%[0-9]+]] = sub i32 %a, %b
+; CHECK: [[m_1:%[0-9]+]] = sub i32 [[a_m_b]], 1
+; CHECK: [[and:%[0-9]+]] = and i32 [[m_1]], -2147483648
+; CHECK: [[cmp:%[0-9]+]] = icmp eq i32 [[and]], 0
+; CHECK: [[sel:%[0-9]+]] = select i1 [[cmp]], i32 %b, i32 %a
+; CHECK: ret i32 [[sel]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @smin(i32 %a, i32 %b) {
+entry:
+  %min = call spir_func i32 @_Z3minii(i32 %a, i32 %b)
+  ret i32 %min
+}
+
+declare spir_func i32 @_Z3minii(i32, i32)
+
+; CHECK-LABEL: smin2
+; CHECK: [[a_m_b:%[0-9]+]] = sub <2 x i32> %a, %b
+; CHECK: [[m_1:%[0-9]+]] = sub <2 x i32> [[a_m_b]], <i32 1, i32 1>
+; CHECK: [[and:%[0-9]+]] = and <2 x i32> [[m_1]], <i32 -2147483648, i32 -2147483648>
+; CHECK: [[cmp:%[0-9]+]] = icmp eq <2 x i32> [[and]], zeroinitializer
+; CHECK: [[sel:%[0-9]+]] = select <2 x i1> [[cmp]], <2 x i32> %b, <2 x i32> %a
+; CHECK: ret <2 x i32> [[sel]]
+
+define <2 x i32> @smin2(<2 x i32> %a, <2 x i32> %b) {
+entry:
+  %min2 = call spir_func <2 x i32> @_Z3minDv2_iS_(<2 x i32> %a, <2 x i32> %b)
+  ret <2 x i32> %min2
+}
+
+declare spir_func <2 x i32> @_Z3minDv2_iS_(<2 x i32>, <2 x i32>)


### PR DESCRIPTION
Fixes #593

* smax, smin and sclamp now get replaced when -hack-scf is specified
  * they are broken down to compare and select operations
  * the compare is then replaced like the other comparisons
* new tests