### PR TITLE
Update msvc 2017

### DIFF
--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -19,12 +19,6 @@ set SRC=%cd%\github\clspv
 set BUILD_TYPE=%1
 set VS_VERSION=%2
 
-choco install cmake --pre --yes --no-progress
-choco upgrade cmake --pre --yes --no-progress
-
-:: Force usage of python 3.6 and add cmake to the path.
-set PATH=C:\python36;"C:\Program Files\CMake\bin";%PATH%
-
 cd %SRC%
 python utils/fetch_sources.py
 

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -19,6 +19,9 @@ set SRC=%cd%\github\clspv
 set BUILD_TYPE=%1
 set VS_VERSION=%2
 
+:: Force usage of python 3.6.
+set PATH=C:\python36;%PATH%
+
 cd %SRC%
 python utils/fetch_sources.py
 

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -25,7 +25,10 @@ python utils/fetch_sources.py
 :: #########################################
 :: set up msvc build env
 :: #########################################
-if %VS_VERSION% == 2017 (
+if %VS_VERSION% == 2019 (
+  set GENERATOR="Visual Studio 16 2019"
+  echo "Using VS 2019..."
+) else if %VS_VERSION% == 2017 (
   set GENERATOR="Visual Studio 15 2017 Win64"
   echo "Using VS 2017..."
 ) else if %VS_VERSION% == 2015 (

--- a/kokoro/windows-msvc-2019-release/build.bat
+++ b/kokoro/windows-msvc-2019-release/build.bat
@@ -1,0 +1,22 @@
+:: Copyright 2020 The Clspv Authors. All rights reserved.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+@echo on
+
+:: Find out the directory of the common build script.
+set SCRIPT_DIR=%~dp0
+
+:: Call with correct parameter
+call %SCRIPT_DIR%\..\scripts\windows\build.bat Release 2019
+

--- a/kokoro/windows-msvc-2019-release/continuous.cfg
+++ b/kokoro/windows-msvc-2019-release/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2020 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "clspv/kokoro/windows-msvc-2019-release/build.bat"

--- a/kokoro/windows-msvc-2019-release/presubmit.cfg
+++ b/kokoro/windows-msvc-2019-release/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2020 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "clspv/kokoro/windows-msvc-2019-release/build.bat"

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1952,7 +1952,7 @@ SPIRVID SPIRVProducerPass::getSPIRVConstant(Constant *Cst) {
       Opcode = spv::OpConstantNull;
     }
   } else if (const ConstantInt *CI = dyn_cast<ConstantInt>(Cst)) {
-    unsigned bit_width = CI->getbit_width();
+    unsigned bit_width = CI->getBitWidth();
     if (bit_width == 1) {
       // If the bitwidth of constant is 1, generate OpConstantTrue or
       // OpConstantFalse.

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1952,8 +1952,8 @@ SPIRVID SPIRVProducerPass::getSPIRVConstant(Constant *Cst) {
       Opcode = spv::OpConstantNull;
     }
   } else if (const ConstantInt *CI = dyn_cast<ConstantInt>(Cst)) {
-    unsigned BitWidth = CI->getBitWidth();
-    if (BitWidth == 1) {
+    unsigned bit_width = CI->getbit_width();
+    if (bit_width == 1) {
       // If the bitwidth of constant is 1, generate OpConstantTrue or
       // OpConstantFalse.
       if (CI->getZExtValue()) {
@@ -1967,7 +1967,7 @@ SPIRVID SPIRVProducerPass::getSPIRVConstant(Constant *Cst) {
       auto V = CI->getZExtValue();
       LiteralNum.push_back(V & 0xFFFFFFFF);
 
-      if (BitWidth > 32) {
+      if (bit_width > 32) {
         LiteralNum.push_back(V >> 32);
       }
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1757,25 +1757,25 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
     break;
   }
   case Type::IntegerTyID: {
-    uint32_t BitWidth = static_cast<uint32_t>(Ty->getPrimitiveSizeInBits());
+    uint32_t bit_width = static_cast<uint32_t>(Ty->getPrimitiveSizeInBits());
 
-    if (clspv::Option::Int8Support() && BitWidth == 8) {
+    if (clspv::Option::Int8Support() && bit_width == 8) {
       addCapability(spv::CapabilityInt8);
-    } else if (BitWidth == 16) {
+    } else if (bit_width == 16) {
       addCapability(spv::CapabilityInt16);
-    } else if (BitWidth == 64) {
+    } else if (bit_width == 64) {
       addCapability(spv::CapabilityInt64);
     }
 
-    if (BitWidth == 1) {
+    if (bit_width == 1) {
       RID = addSPIRVInst<kTypes>(spv::OpTypeBool);
     } else {
-      if (!clspv::Option::Int8Support() && BitWidth == 8) {
+      if (!clspv::Option::Int8Support() && bit_width == 8) {
         // i8 is added to TypeMap as i32.
         RID = getSPIRVType(Type::getIntNTy(Ty->getContext(), 32));
       } else {
         SPIRVOperandVec Ops;
-        Ops << BitWidth << 0 /* not signed */;
+        Ops << bit_width << 0 /* not signed */;
         RID = addSPIRVInst<kTypes>(spv::OpTypeInt, Ops);
       }
     }
@@ -1784,15 +1784,15 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
   case Type::HalfTyID:
   case Type::FloatTyID:
   case Type::DoubleTyID: {
-    uint32_t BitWidth = static_cast<uint32_t>(Ty->getPrimitiveSizeInBits());
-    if (BitWidth == 16) {
+    uint32_t bit_width = static_cast<uint32_t>(Ty->getPrimitiveSizeInBits());
+    if (bit_width == 16) {
       addCapability(spv::CapabilityFloat16);
-    } else if (BitWidth == 64) {
+    } else if (bit_width == 64) {
       addCapability(spv::CapabilityFloat64);
     }
 
     SPIRVOperandVec Ops;
-    Ops << BitWidth;
+    Ops << bit_width;
 
     RID = addSPIRVInst<kTypes>(spv::OpTypeFloat, Ops);
     break;


### PR DESCRIPTION
Update windows build scripts to utilize the new VM image differences. Add scripts for MSVC 2019 (not currently enabled).