### PR TITLE
Fix missing link reference to build clspv-opt

### DIFF
--- a/tools/clspv-opt/CMakeLists.txt
+++ b/tools/clspv-opt/CMakeLists.txt
@@ -19,8 +19,12 @@ endif()
 add_executable(clspv-opt ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 set(CLSPV_LLVM_COMPONENTS
+  LLVMAnalysis
   LLVMCore
+  LLVMIRReader
   LLVMPasses
+  LLVMScalarOpts
+  LLVMSupport
 )
 
 add_dependencies(clspv-opt intrinsics_gen)


### PR DESCRIPTION
Link against LLVMSupport to fix this issue:

    clspv-opt.dir/main.cpp.o: undefined reference to symbol '_ZTVN4llvm2cl11OptionValueINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEE'
    libLLVMSupport.so.11git: error adding symbols: DSO missing from command line

This only affects shared library builds.

Add transitive dependencies as well to ensure check-spirv works out of
the box with shared library build.