### PR TITLE
Use NMax/NMin for fmax/fmin (#506)

### DIFF
--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -2163,7 +2163,7 @@ bool ReplaceOpenCLBuiltinPass::replaceFract(Function &F, int vec_size) {
   //    OpStore %ptr %floor_result
   //    %fract_intermediate = OpExtInst %float %glsl_ext Fract %x
   //    %fract_result = OpExtInst %float
-  //       %glsl_ext Fmin %fract_intermediate %just_under_1
+  //       %glsl_ext Nmin %fract_intermediate %just_under_1
 
   using std::string;
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4869,9 +4869,9 @@ SPIRVProducerPass::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
   case Builtins::kAbs:
     return glsl::ExtInst::ExtInstSAbs;
   case Builtins::kFmax:
-    return glsl::ExtInst::ExtInstFMax;
+    return glsl::ExtInst::ExtInstNMax;
   case Builtins::kFmin:
-    return glsl::ExtInst::ExtInstFMin;
+    return glsl::ExtInst::ExtInstNMin;
   case Builtins::kDegrees:
     return glsl::ExtInst::ExtInstDegrees;
   case Builtins::kRadians:

--- a/test/CommonBuiltins/max/half2_fmax.cl
+++ b/test/CommonBuiltins/max/half2_fmax.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half2:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 2
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
-// CHECK: OpExtInst [[half2]] [[EXT]] FMax [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half2]] [[EXT]] NMax [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/max/half3_fmax.cl
+++ b/test/CommonBuiltins/max/half3_fmax.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half3:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 3
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half3]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half3]]
-// CHECK: OpExtInst [[half3]] [[EXT]] FMax [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half3]] [[EXT]] NMax [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/max/half4_fmax.cl
+++ b/test/CommonBuiltins/max/half4_fmax.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
-// CHECK: OpExtInst [[half4]] [[EXT]] FMax [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half4]] [[EXT]] NMax [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/max/half_fmax.cl
+++ b/test/CommonBuiltins/max/half_fmax.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half2:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 2
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
-// CHECK: OpExtInst [[half2]] [[EXT]] FMax [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half2]] [[EXT]] NMax [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/min/half2_fmin.cl
+++ b/test/CommonBuiltins/min/half2_fmin.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half2:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 2
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half2]]
-// CHECK: OpExtInst [[half2]] [[EXT]] FMin [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half2]] [[EXT]] NMin [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/min/half3_fmin.cl
+++ b/test/CommonBuiltins/min/half3_fmin.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half3:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 3
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half3]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half3]]
-// CHECK: OpExtInst [[half3]] [[EXT]] FMin [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half3]] [[EXT]] NMin [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/min/half4_fmin.cl
+++ b/test/CommonBuiltins/min/half4_fmin.cl
@@ -8,7 +8,7 @@
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
-// CHECK: OpExtInst [[half4]] [[EXT]] FMin [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half4]] [[EXT]] NMin [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/CommonBuiltins/min/half_fmin.cl
+++ b/test/CommonBuiltins/min/half_fmin.cl
@@ -7,7 +7,7 @@
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
 // CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
-// CHECK: OpExtInst [[half]] [[EXT]] FMin [[ld0]] [[ld1]]
+// CHECK: OpExtInst [[half]] [[EXT]] NMin [[ld0]] [[ld1]]
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/MathBuiltins/fmax/float2_fmax.cl
+++ b/test/MathBuiltins/fmax/float2_fmax.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)

--- a/test/MathBuiltins/fmax/float3_fmax.cl
+++ b/test/MathBuiltins/fmax/float3_fmax.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/MathBuiltins/fmax/float4_fmax.cl
+++ b/test/MathBuiltins/fmax/float4_fmax.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)

--- a/test/MathBuiltins/fmax/float_fmax.cl
+++ b/test/MathBuiltins/fmax/float_fmax.cl
@@ -7,7 +7,7 @@
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[LOADB_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)

--- a/test/MathBuiltins/fmin/float2_fmin.cl
+++ b/test/MathBuiltins/fmin/float2_fmin.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)

--- a/test/MathBuiltins/fmin/float3_fmin.cl
+++ b/test/MathBuiltins/fmin/float3_fmin.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/MathBuiltins/fmin/float4_fmin.cl
+++ b/test/MathBuiltins/fmin/float4_fmin.cl
@@ -9,7 +9,7 @@
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)

--- a/test/MathBuiltins/fmin/float_fmin.cl
+++ b/test/MathBuiltins/fmin/float_fmin.cl
@@ -7,7 +7,7 @@
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[LOADB_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB_ID]] %[[CONSTANT_FLOAT_1_ID]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)

--- a/test/MathBuiltins/fract/float2_fract_private.cl
+++ b/test/MathBuiltins/fract/float2_fract_private.cl
@@ -17,6 +17,6 @@ void kernel foo(global float2* A, global float2* B, float2 x)
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Floor [[_31]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Fract [[_31]]
-// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] FMin [[_33]] [[_17]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore {{.*}} [[_34]]
 // CHECK: OpStore {{.*}} [[_32]]

--- a/test/MathBuiltins/fract/float3_fract_private.cl
+++ b/test/MathBuiltins/fract/float3_fract_private.cl
@@ -19,6 +19,6 @@ void kernel foo(global float3* A, global float3* B, float3 x)
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Floor [[_31]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Fract [[_31]]
-// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] FMin [[_33]] [[_17]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore [[_28]] [[_34]]
 // CHECK: OpStore [[_29]] [[_32]]

--- a/test/MathBuiltins/fract/float4_fract_private.cl
+++ b/test/MathBuiltins/fract/float4_fract_private.cl
@@ -17,6 +17,6 @@ void kernel foo(global float4* A, global float4* B, float4 x)
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_31]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Fract [[_31]]
-// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] FMin [[_33]] [[_17]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore {{.*}} [[_34]]
 // CHECK: OpStore {{.*}} [[_32]]

--- a/test/MathBuiltins/fract/float_fract_private.cl
+++ b/test/MathBuiltins/fract/float_fract_private.cl
@@ -15,6 +15,6 @@ void kernel foo(global float* A, global float* B, float x)
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
 // CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Floor [[_29]]
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Fract [[_29]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] FMin [[_31]] [[_float_1]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] NMin [[_31]] [[_float_1]]
 // CHECK: OpStore {{.*}} [[_32]]
 // CHECK: OpStore {{.*}} [[_30]]


### PR DESCRIPTION
OpenCL C fmax/fmin maps to GLSL SPIR-V instruction NMax/NMin due to the
behaviour requirement on NaN inputs.

Applies by transitivity to OpenCL C fract.