### PR TITLE
Fix barrier and mem_fence scopes

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -850,6 +850,9 @@ constants as follows:
   for Signed-Integer types, `OpGroupNonUniformUMax` operation for 
   Unsigned-Integer types and `OpGroupNonUniformFMax` operation for Float types.
   Requires `CapabilityGroupNonUniformArithmetic` capability.
+- `sub_group_barrier()` is mapped to OpControlBarrier with an execution scope of
+  `Subgroup`. If no memory scope is specified, `Subgroup` is used. The memory
+  semantics depend on the flags on the barrier.
 
 The `group_op` qualifier translates as follows:
 
@@ -861,7 +864,6 @@ These extension built-in functions are not supported:
 
 - `get_max_sub_group_size()` requires CapabilityKernel (incompatible with Shader)
 - `get_enqueued_num_sub_groups()` requires CapabilityKernel (incompatible with Shader)
-- `sub_group_barrier()`
 - `sub_group_reserve_read_pipe()`
 - `sub_group_reserve_write_pipe()`
 - `sub_group_commit_read_pipe()`

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_both.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// SequentiallyConsistent | StorageBufferMemory | WorkgroupMemory
-// CHECK-DAG: %[[CONSTANT_0x150_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 336
+// AcquireRelease | StorageBufferMemory | WorkgroupMemory
+// CHECK-DAG: %[[CONSTANT_328_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 328
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x150_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_328_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_global.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// SequentiallyConsistent | StorageBufferMemory
-// CHECK-DAG: %[[CONSTANT_0x050_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 80
+// AcquireRelease | StorageBufferMemory
+// CHECK-DAG: %[[CONSTANT_72_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x050_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_72_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/mem_fence_local.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// SequentiallyConsistent | WorkgroupMemory
-// CHECK-DAG: %[[CONSTANT_0x110_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 272
+// AcquireRelease | WorkgroupMemory
+// CHECK-DAG: %[[CONSTANT_264_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 264
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x110_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_264_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_both.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Acquire | StorageBufferMemory | WorkgroupMemory
 // CHECK-DAG: %[[CONSTANT_0x142_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 322
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x142_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x142_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_global.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Acquire | StorageBufferMemory
 // CHECK-DAG: %[[CONSTANT_0x042_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 66
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x042_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x042_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/read_mem_fence_local.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Acquire | WorkgroupMemory
 // CHECK-DAG: %[[CONSTANT_0x102_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 258
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x102_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x102_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_both.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Release | StorageBufferMemory | WorkgroupMemory
 // CHECK-DAG: %[[CONSTANT_0x144_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 324
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x144_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x144_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_global.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Release | StorageBufferMemory
 // CHECK-DAG: %[[CONSTANT_0x044_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 68
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x044_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x044_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
+++ b/test/ExplicitMemoryFenceBuiltins/write_mem_fence_local.cl
@@ -7,14 +7,14 @@
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// Workgroup
+// CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
 // Release | WorkgroupMemory
 // CHECK-DAG: %[[CONSTANT_0x104_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 260
 
 // CHECK: %[[FOO_ID]] = OpFunction
-// CHECK: OpMemoryBarrier %[[CONSTANT_1_ID]] %[[CONSTANT_0x104_ID]]
+// CHECK: OpMemoryBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_0x104_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/SynchronizationBuiltins/barrier_both.cl
+++ b/test/SynchronizationBuiltins/barrier_both.cl
@@ -8,13 +8,10 @@
 // Workgroup
 // CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// AcquireRelease | StorageBufferMemory | WorkgroupMemory
+// CHECK-DAG: %[[CONSTANT_328_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 328
 
-// SequentiallyConsistent | StorageBufferMemory | WorkgroupMemory
-// CHECK-DAG: %[[CONSTANT_0x150_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 336
-
-// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_0x150_ID]]
+// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_2_ID]] %[[CONSTANT_328_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/SynchronizationBuiltins/barrier_global.cl
+++ b/test/SynchronizationBuiltins/barrier_global.cl
@@ -8,13 +8,10 @@
 // Workgroup
 // CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// Device
-// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// AcquireRelease | StorageBufferMemory
+// CHECK-DAG: %[[CONSTANT_72_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
 
-// SequentiallyConsistent | StorageBufferMemory
-// CHECK-DAG: %[[CONSTANT_0x050_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 80
-
-// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_0x050_ID]]
+// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_2_ID]] %[[CONSTANT_72_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/SynchronizationBuiltins/barrier_local.cl
+++ b/test/SynchronizationBuiltins/barrier_local.cl
@@ -8,10 +8,10 @@
 // Workgroup
 // CHECK-DAG: %[[CONSTANT_2_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2
 
-// SequentiallyConsistent | WorkgroupMemory
-// CHECK-DAG: %[[CONSTANT_0x110_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 272
+// AcquireRelease | WorkgroupMemory
+// CHECK-DAG: %[[CONSTANT_264_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 264
 
-// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_2_ID]] %[[CONSTANT_0x110_ID]]
+// CHECK: OpControlBarrier %[[CONSTANT_2_ID]] %[[CONSTANT_2_ID]] %[[CONSTANT_264_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo()
 {

--- a/test/SynchronizationBuiltins/sub_group_barrier.cl
+++ b/test/SynchronizationBuiltins/sub_group_barrier.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points --spv-version=1.3
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.1 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+
+// CHECK: [[uint:%[a-zA-Z0-9_.]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_264:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 264
+// CHECK: OpControlBarrier [[uint_3]] [[uint_3]] [[uint_264]]
+kernel void foo() {
+  sub_group_barrier(CLK_LOCAL_MEM_FENCE);
+}
+

--- a/test/SynchronizationBuiltins/sub_group_barrier_scope.cl
+++ b/test/SynchronizationBuiltins/sub_group_barrier_scope.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points --spv-version=1.3
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.1 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+
+// CHECK: [[uint:%[a-zA-Z0-9_.]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_264:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 264
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 1
+// CHECK: OpControlBarrier [[uint_3]] [[uint_1]] [[uint_264]]
+// CHECK: OpControlBarrier [[uint_3]] [[uint_2]] [[uint_264]]
+// CHECK: OpControlBarrier [[uint_3]] [[uint_3]] [[uint_264]]
+kernel void foo() {
+  sub_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_device);
+  sub_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_work_group);
+  sub_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_sub_group);
+}
+

--- a/test/SynchronizationBuiltins/work_group_barrier.cl
+++ b/test/SynchronizationBuiltins/work_group_barrier.cl
@@ -13,5 +13,5 @@ kernel void foo(global int* in, global int* out) {
 
 //     CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
-// CHECK-DAG: [[uint_272:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 272
-//     CHECK: OpControlBarrier [[uint_2]] [[uint_2]] [[uint_272]]
+// CHECK-DAG: [[uint_264:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 264
+//     CHECK: OpControlBarrier [[uint_2]] [[uint_2]] [[uint_264]]

--- a/test/SynchronizationBuiltins/work_group_barrier_scope.cl
+++ b/test/SynchronizationBuiltins/work_group_barrier_scope.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points --spv-version=1.3
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.1 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+
+// CHECK: [[uint:%[a-zA-Z0-9_.]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_264:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 264
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_.]+]] = OpConstant [[uint]] 1
+// CHECK: OpControlBarrier [[uint_2]] [[uint_1]] [[uint_264]]
+// CHECK: OpControlBarrier [[uint_2]] [[uint_2]] [[uint_264]]
+// CHECK: OpControlBarrier [[uint_2]] [[uint_3]] [[uint_264]]
+kernel void foo() {
+  work_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_device);
+  work_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_work_group);
+  work_group_barrier(CLK_LOCAL_MEM_FENCE, memory_scope_sub_group);
+}


### PR DESCRIPTION
Fixes #604

* barrier, work_group_barrier and mem_fence should default to workgroup
  memory scope
* support CL 2.0 explicit memory scope barriers
* support sub_group_barrier
* use AcquireRelease semantics instead of SequentiallyConsistent