### PR TITLE
Add missing break

### DIFF
--- a/tools/reflection/ReflectionParser.cpp
+++ b/tools/reflection/ReflectionParser.cpp
@@ -318,6 +318,7 @@ ReflectionParser::ParseInstruction(const spv_parsed_instruction_t *inst) {
       }
       break;
     }
+    break;
   default:
     break;
   }


### PR DESCRIPTION
Prevents warning and errors about implicit fall throughs 