### PR TITLE
Replace pointer bitcasts should handle array sources better

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -673,6 +673,8 @@ int PopulatePassManager(
   pm->add(clspv::createUndoInstCombinePass());
   pm->add(clspv::createFunctionInternalizerPass());
   pm->add(clspv::createReplaceLLVMIntrinsicsPass());
+  // Replace LLVM intrinsics can leave dead code around.
+  pm->add(llvm::createDeadCodeEliminationPass());
   pm->add(clspv::createUndoBoolPass());
   pm->add(clspv::createUndoTruncateToOddIntegerPass());
   pm->add(llvm::createStructurizeCFGPass(false));

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -287,6 +287,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
 
   const DataLayout &DL = M.getDataLayout();
 
+  SmallVector<Instruction *, 16> ToBeDeleted;
   SmallVector<Instruction *, 16> VectorWorkList;
   SmallVector<Instruction *, 16> ScalarWorkList;
   SmallVector<User *, 16> UserWorkList;
@@ -325,15 +326,46 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
               continue;
             }
 
+            auto inst = &I;
             Type *SrcEleTy =
-                I.getOperand(0)->getType()->getPointerElementType();
-            Type *DstEleTy = I.getType()->getPointerElementType();
+                inst->getOperand(0)->getType()->getPointerElementType();
+
+            // De-"canonicalize" the input pointer.
+            // If Src is an array, LLVM has likely canonicalized all GEPs to
+            // the first element away as the following addresses are all
+            // equivalent:
+            // * %in = alloca [4 x [4 x float]]
+            // * %gep0 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in
+            // * %gep1 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0
+            // * %gep2 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0, i32 0
+            // * %gep3 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0, i32 0, i32 0
+            // Note: count initialized to 1 to account for the first gep index.
+            uint32_t count = 1;
+            while (auto ArrayTy = dyn_cast<ArrayType>(SrcEleTy)) {
+              ++count;
+              SrcEleTy = ArrayTy->getElementType();
+            }
+
+            if (count > 1) {
+              // Create a cast of the pointer. Replace the original cast with
+              // it and mark the original cast for deletion.
+              SmallVector<Value *, 4> indices(
+                  count,
+                  ConstantInt::get(IntegerType::get(M.getContext(), 32), 0));
+              auto gep = GetElementPtrInst::CreateInBounds(inst->getOperand(0), indices, "", inst);
+              ToBeDeleted.push_back(&I);
+              auto cast = new BitCastInst(gep, inst->getType(), "", inst);
+              inst->replaceAllUsesWith(cast);
+              inst = cast;
+            }
+
+            Type *DstEleTy = inst->getType()->getPointerElementType();
             if (SrcEleTy->isVectorTy() || DstEleTy->isVectorTy()) {
               // Handle case either operand is vector type like char4* -> int4*.
-              VectorWorkList.push_back(&I);
+              VectorWorkList.push_back(inst);
             } else {
               // Handle case all operands are scalar type like char* -> int*.
-              ScalarWorkList.push_back(&I);
+              ScalarWorkList.push_back(inst);
             }
 
             Changed = true;
@@ -345,7 +377,6 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
     }
   }
 
-  SmallVector<Instruction *, 16> ToBeDeleted;
   for (Instruction *Inst : VectorWorkList) {
     Value *Src = Inst->getOperand(0);
     Type *SrcTy = Src->getType()->getPointerElementType();
@@ -355,7 +386,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
     Type *SrcEleTy = SrcTy->isVectorTy() ? SrcVecTy->getElementType() : SrcTy;
     Type *DstEleTy = DstTy->isVectorTy() ? DstVecTy->getElementType() : DstTy;
     // These are bit widths of the source and destination types, even
-    // if they are vector types.  E.g. bit width of float4 is 64.
+    // if they are vector types.  E.g. bit width of float4 is 128.
     unsigned SrcTyBitWidth = DL.getTypeStoreSizeInBits(SrcTy);
     unsigned DstTyBitWidth = DL.getTypeStoreSizeInBits(DstTy);
     unsigned SrcEleTyBitWidth = DL.getTypeStoreSizeInBits(SrcEleTy);

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -335,10 +335,15 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
             // the first element away as the following addresses are all
             // equivalent:
             // * %in = alloca [4 x [4 x float]]
-            // * %gep0 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in
-            // * %gep1 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0
-            // * %gep2 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0, i32 0
-            // * %gep3 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]* %in, i32 0, i32 0, i32 0
+            // * %gep0 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]*
+            //   %in
+            // * %gep1 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]*
+            //   %in, i32 0
+            // * %gep2 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]*
+            //   %in, i32 0, i32 0
+            // * %gep3 = getelementptr [4 x [4 x float]]*, [4 x [4 x [float]]*
+            //   %in, i32 0, i32 0, i32 0
+            //
             // Note: count initialized to 1 to account for the first gep index.
             uint32_t count = 1;
             while (auto ArrayTy = dyn_cast<ArrayType>(SrcEleTy)) {
@@ -352,7 +357,8 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
               SmallVector<Value *, 4> indices(
                   count,
                   ConstantInt::get(IntegerType::get(M.getContext(), 32), 0));
-              auto gep = GetElementPtrInst::CreateInBounds(inst->getOperand(0), indices, "", inst);
+              auto gep = GetElementPtrInst::CreateInBounds(inst->getOperand(0),
+                                                           indices, "", inst);
               ToBeDeleted.push_back(&I);
               auto cast = new BitCastInst(gep, inst->getType(), "", inst);
               inst->replaceAllUsesWith(cast);

--- a/test/PointerCasts/canonical_pointer.ll
+++ b/test/PointerCasts/canonical_pointer.ll
@@ -1,0 +1,76 @@
+; RUN: clspv-opt %s -o %t.ll -ReplacePointerBitcast
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(float addrspace(1)* nocapture readonly %input, <4 x float> addrspace(1)* nocapture %output)  {
+entry:
+  %in = alloca [4 x [4 x float]], align 16
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [4 x [4 x float]], [4 x [4 x float]]* %in, i32 0, i32 0, i32 0
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 0
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 1
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 2
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 3
+  ; CHECK: load float, float* [[gep]]
+  %bc0 = bitcast [4 x [4 x float]]* %in to <4 x float>*
+  %ld0 = load <4 x float>, <4 x float>* %bc0
+
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [4 x [4 x float]], [4 x [4 x float]]* %gep1, i32 0, i32 0, i32 0
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 0
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 1
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 2
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 3
+  ; CHECK: load float, float* [[gep]]
+  %gep1 = getelementptr [4 x [4 x float]], [4 x [4 x float]]* %in
+  %bc1 = bitcast [4 x [4 x float]]* %gep1 to <4 x float>*
+  %ld1 = load <4 x float>, <4 x float>* %bc1
+
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [4 x [4 x float]], [4 x [4 x float]]* %gep2, i32 0, i32 0, i32 0
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 0
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 1
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 2
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 3
+  ; CHECK: load float, float* [[gep]]
+  %gep2 = getelementptr [4 x [4 x float]], [4 x [4 x float]]* %in, i32 0
+  %bc2 = bitcast [4 x [4 x float]]* %gep2 to <4 x float>*
+  %ld2 = load <4 x float>, <4 x float>* %bc2
+
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [4 x float], [4 x float]* %gep3, i32 0, i32 0
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 0
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 1
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 2
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* [[base]], i32 3
+  ; CHECK: load float, float* [[gep]]
+  %gep3 = getelementptr [4 x [4 x float]], [4 x [4 x float]]* %in, i32 0, i32 0
+  %bc3 = bitcast [4 x float]* %gep3 to <4 x float>*
+  %ld3 = load <4 x float>, <4 x float>* %bc3
+
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* %gep4, i32 0
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* %gep4, i32 1
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* %gep4, i32 2
+  ; CHECK: load float, float* [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, float* %gep4, i32 3
+  ; CHECK: load float, float* [[gep]]
+  %gep4 = getelementptr [4 x [4 x float]], [4 x [4 x float]]* %in, i32 0, i32 0, i32 0
+  %bc4 = bitcast float* %gep4 to <4 x float>*
+  %ld4 = load <4 x float>, <4 x float>* %bc4
+  ret void
+}
+


### PR DESCRIPTION
Fixes #619

* When a pointer to the first element of an array is the source of a
  bitcast, generate a gep to unwrap the arrays and generate a new
  bitcast for handling
  * Added a test
* Added an extra pass of DCE since ReplaceLLVMIntrinsics leaves dead
  code around