### PR TITLE
Various improvements to the compilation process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13.4)
 
 if(NOT COMMAND find_host_package)
   macro(find_host_package)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -96,7 +96,7 @@ foreach(clspv_lib clspv_core clspv_passes)
 
 endforeach(clspv_lib)
 
-set(CLSPV_LLVM_COMPONENTS clangCodeGen LLVMAnalysis LLVMScalarOpts LLVMCore)
+set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore)
 
 if(${EXTERNAL_LLVM} EQUAL 1)
   include(${CLSPV_LLVM_BINARY_DIR}/lib/cmake/llvm/LLVMConfig.cmake)
@@ -107,11 +107,13 @@ if(${EXTERNAL_LLVM} EQUAL 1)
 endif()
 
 # clspv_c_strings, clspv_glsl, and clspv_reflection are used by SPIRVProducerPass.cpp.
-add_dependencies(clspv_passes clspv_c_strings clspv_glsl clspv_reflection ${CLSPV_LLVM_COMPONENTS})
+add_dependencies(clspv_passes clspv_c_strings clspv_glsl clspv_reflection)
+target_link_libraries(clspv_passes PRIVATE ${CLSPV_LLVM_COMPONENTS})
 
 # clspv_baked_opencl_header is used by Compiler.cpp.
 add_dependencies(clspv_core clspv_baked_opencl_header)
-target_link_libraries(clspv_core PRIVATE clspv_passes ${CLSPV_LLVM_COMPONENTS})
+target_link_libraries(clspv_core PUBLIC clspv_passes)
+target_link_libraries(clspv_core PRIVATE clangCodeGen)
 
 if (MSVC)
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/SPIRVProducerPass.cpp"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(clspv_core
 # Pass library.  Transformation passes and pass-specific support are
 # defined here.  This must be loadable by LLVM opt for testing individual
 # passes.
-add_library(clspv_passes
+add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/AddFunctionAttributesPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/AllocateDescriptorsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
@@ -96,7 +96,7 @@ foreach(clspv_lib clspv_core clspv_passes)
 
 endforeach(clspv_lib)
 
-set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore)
+set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore LLVMTransformUtils)
 
 if(${EXTERNAL_LLVM} EQUAL 1)
   include(${CLSPV_LLVM_BINARY_DIR}/lib/cmake/llvm/LLVMConfig.cmake)

--- a/test/clspv-opt/options.ll
+++ b/test/clspv-opt/options.ll
@@ -2,7 +2,7 @@
 ; check any specific transformation.  It just makes sure that the options
 ; are accepted.
 
-; RUN: clspv-opt %s -o %t.ll -AllocateDescriptorsPass -ClusterModuleScopeConstantVars -ClusterPodKernelArgumentsPass -DefineOpenCLWorkItemBuiltins -DirectResourceAccessPass -FunctionInternalizer -HideConstantLoads -InlineEntryPointsPass -InlineFuncWithPointerBitCastArg -InlineFuncWithPointerToFunctionArgPass -InlineFuncWithSingleCallSite -OpenCLInliner -RemoveUnusedArguments -ReorderBasicBlocks -ReplaceLLVMIntrinsics -ReplaceOpenCLBuiltin -ReplacePointerBitcast -RewriteInserts -Scalarize -ShareModuleScopeVariablesPass -SignedCompareFixupPass -SimplifyPointerBitcast -SplatArg -SplatSelectCond -UBOTypeTransformPass -UndoBool -UndoByval -UndoGetElementPtrConstantExpr -UndoSRet -UndoTranslateSamplerFold -UndoTruncateToOddInteger -UnhideConstantLoads -ZeroInitializeAllocasPass
+; RUN: clspv-opt %s -o %t.ll -AllocateDescriptorsPass -ClusterModuleScopeConstantVars -ClusterPodKernelArgumentsPass -DefineOpenCLWorkItemBuiltins -DirectResourceAccessPass -FunctionInternalizer -HideConstantLoads -InlineEntryPointsPass -InlineFuncWithPointerBitCastArg -InlineFuncWithPointerToFunctionArgPass -InlineFuncWithSingleCallSite -MultiVersionUBOFunctionsPass -OpenCLInliner -RemoveUnusedArguments -ReorderBasicBlocks -ReplaceLLVMIntrinsics -ReplaceOpenCLBuiltin -ReplacePointerBitcast -RewriteInserts -Scalarize -ShareModuleScopeVariablesPass -SignedCompareFixupPass -SimplifyPointerBitcast -SplatArg -SplatSelectCond -UBOTypeTransformPass -UndoBool -UndoByval -UndoGetElementPtrConstantExpr -UndoSRet -UndoTranslateSamplerFold -UndoTruncateToOddInteger -UnhideConstantLoads -ZeroInitializeAllocasPass
 ; RUN: FileCheck %s < %t.ll
 ; CHECK: @__spirv_WorkgroupSize =
 

--- a/tools/clspv-opt/CMakeLists.txt
+++ b/tools/clspv-opt/CMakeLists.txt
@@ -19,10 +19,8 @@ endif()
 add_executable(clspv-opt ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 set(CLSPV_LLVM_COMPONENTS
-  LLVMAnalysis
   LLVMCore
   LLVMIRReader
-  LLVMPasses
   LLVMScalarOpts
   LLVMSupport
 )

--- a/tools/reflection/CMakeLists.txt
+++ b/tools/reflection/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(clspv-reflection PRIVATE
   ${SPIRV_HEADERS_INCLUDE_DIRS}
   ${SPIRV_TOOLS_SOURCE_DIR}/include)
 
-target_link_libraries(clspv-reflection PRIVATE clspv_core SPIRV-Tools)
+target_link_libraries(clspv-reflection PRIVATE clspv_core SPIRV-Tools-static)
 
 set_target_properties(clspv-reflection PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CLSPV_BINARY_DIR}/bin)
 


### PR DESCRIPTION
I've noticed some issues with the build process. Namely, the available options were not the same for a static build than for a shared build. For example, the `--MultiVersionUBOFunctions` option of `clspv-opt` wasn't available in a static build. I had exactly the same issue for the pass I want to introduce for #613 so here is a general fix.

I also had to fix compilation for shared build. I tested this using `cmake --target check-spirv` with the four {Debug,Release} x {shared,static} configurations on Linux.

Below are the commit messages for the two commits in this PR.

---

1. Improve support for shared build

Fix compilation for clspv-reflection when doing a shared-library build.
 - Add clspv_passes to the public list of dependencies of clspv_core so
   that clspv-opt, clspv-reflection and any other target depending on
   clspv_core don't have to link against the dependencies of
   clspv_passes.
 - Remove unnecessary dependencies of clspv-opt now that they are
   transitively added thanks to the previous point.
 - Move clangCodeGen dependency to clspv_core because it isn't used by
   clsvp_passes.
 - Because SPIRV-Tools-shared has hidden symbol visibility, some symbols
   are undefined when linking against SPIRV-Tools (which is an alias for
   SPIRV-Tools-shared or SPIRV-Tools-static based on build options).
   This is worked around by always linking against SPIRV-Tools-static,
   regardless of the build options.
 - Don't explicitly list LLVM components as dependencies as this is
   resolved automatically by CMake.

2. Improve support for static build

Use OBJECT library for clspv_passes to ensure all the symbols for global
static variables are present in clspv-opt, ensuring passes using a
static RegisterPass<> object are registered. This is effectively
equivalent to using the linker option --whole-archive for static build,
but in a more portable way as not all toolchains support this option.

Previously, the output of `clspv-opt --help-hidden` and `clspv --help-hidden`
would differ from a shared library build to a static
library build. There are still some differences but they seem to be
unrelated to clspv passes but rather related to LLVM passes.

The MultiVersionUBOFunctionsPass pass is using such a global static
object. Update existing test to cover this pass.

Bump required CMake version. Chose 3.13.4 as it is required by the
latest LLVM and it supports linking against OBJECT libraries.

Add a missing dependency of clspv_passes that was identified by using
OBJECT library when using a shared build.