### PR TITLE
Improve SimplifyPointerBitcastPass

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -216,8 +216,9 @@ bool SimplifyPointerBitcastPass::runOnBitcastFromBitcast(Module &M) const {
       Bitcast->replaceAllUsesWith(OtherBitcast);
     } else {
       // Create a new bitcast from the other bitcasts argument to our type.
-      auto NewBitcast = CastInst::CreatePointerCast(
-          OtherBitcast->getOperand(0), Bitcast->getType(), "", Bitcast);
+      auto NewBitcast =
+          CastInst::Create(Instruction::BitCast, OtherBitcast->getOperand(0),
+                           Bitcast->getType(), "", Bitcast);
 
       // And replace the original bitcast with our replacement bitcast.
       Bitcast->replaceAllUsesWith(NewBitcast);

--- a/test/PointerCasts/non_pointer_cast.ll
+++ b/test/PointerCasts/non_pointer_cast.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt --SimplifyPointerBitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; Ensure the pass doesn't crash on this input and properly simplifies the cast.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test(float %x) {
+entry:
+  %y = bitcast float %x to i32
+  %z = bitcast i32 %y to <2 x i16>
+  ret void
+}
+
+; CHECK-LABEL: @test
+; CHECK-SAME: (float [[X:%[^ ]+]])
+; CHECK: [[Y:%[^ ]+]] = bitcast float [[X]] to <2 x i16>
+; CHECK-NOT: bitcast


### PR DESCRIPTION
Ignore non-trivial casts on non-pointer types.
Add test covering this.

Developed independently of #624 but seems to address the issue as well.