### PR TITLE
Enable CompileFromSourceString to return a build log

### DIFF
--- a/include/clspv/Compiler.h
+++ b/include/clspv/Compiler.h
@@ -31,7 +31,8 @@ int Compile(const int argc, const char *const argv[]);
 int CompileFromSourceString(const std::string &program,
                             const std::string &sampler_map,
                             const std::string &options,
-                            std::vector<uint32_t> *output_binary);
+                            std::vector<uint32_t> *output_binary,
+                            std::string *output_log = nullptr);
 } // namespace clspv
 
 #endif // CLSPV_INCLUDE_CLSPV_COMPILER_H_

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -952,7 +952,8 @@ int Compile(const int argc, const char *const argv[]) {
 int CompileFromSourceString(const std::string &program,
                             const std::string &sampler_map,
                             const std::string &options,
-                            std::vector<uint32_t> *output_binary) {
+                            std::vector<uint32_t> *output_binary,
+                            std::string *output_log) {
 
   llvm::SmallVector<const char *, 20> argv;
   llvm::BumpPtrAllocator A;
@@ -998,9 +999,12 @@ int CompileFromSourceString(const std::string &program,
       instance.getDiagnostics().getClient();
   consumer->finish();
 
+  if (output_log != nullptr) {
+    *output_log = log;
+  }
+
   auto num_errors = consumer->getNumErrors();
   if (result || num_errors > 0) {
-    llvm::errs() << log << "\n";
     return -1;
   }
 


### PR DESCRIPTION
Also stop printing the log to stderr.

Signed-off-by: Kévin Petit <kpet@free.fr>