### PR TITLE
Map llvm.unreachable to OpUnreachable

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3833,6 +3833,8 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
 
       Ops << I.getType() << I.getOperand(0);
       RID = addSPIRVInst(spv::OpFNegate, Ops);
+    } else if (I.getOpcode() == Instruction::Unreachable) {
+      RID = addSPIRVInst(spv::OpUnreachable);
     } else {
       I.print(errs());
       llvm_unreachable("Unsupported instruction???");
@@ -4919,6 +4921,7 @@ void SPIRVProducerPass::WriteSPIRVBinary(SPIRVInstructionList &SPIRVInstList) {
       llvm_unreachable("Unsupported SPIRV instruction");
       break;
     }
+    case spv::OpUnreachable:
     case spv::OpCapability:
     case spv::OpExtension:
     case spv::OpMemoryModel:

--- a/test/LLVMIntrinsics/unreachable.ll
+++ b/test/LLVMIntrinsics/unreachable.ll
@@ -1,0 +1,16 @@
+; RUN: clspv -x ir %s -o %t.spv
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+; RUN: spirv-dis %t.spv -o - | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test() {
+entry:
+  unreachable
+}
+
+; CHECK: OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpUnreachable
+; CHECK-NEXT: OpFunctionEnd


### PR DESCRIPTION
This is quiet handy to have, especially when using `bugpoint` and `clspv-opt` to reduce some LLVM IR module when working on a pass.