### PR TITLE
Lower BinaryOperator instructions on long-vector

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -12,12 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Debug.h"
 
 #include "clspv/Passes.h"
 
 #include "Passes.h"
+
+#include <functional>
 
 using namespace llvm;
 
@@ -34,13 +41,206 @@ public:
 
   /// Lower the content of the given module @p M.
   bool runOnModule(Module &M) override;
+
+private:
+  /// Higher-level dispatcher.
+  /// Returns nullptr if no lowering is required.
+  Value *visit(Value *V);
+
+private:
+  // Helpers for lowering types.
+
+  /// Get a struct equivalent for this type, if it uses a long vector.
+  /// Returns nullptr if no lowering is required.
+  Type *getEquivalentType(Type *Ty);
+
+private:
+  // Hight-level implementation details of runOnModule.
+
+  /// Lower the given function.
+  bool runOnFunction(Function &F);
 };
 
 char LongVectorLoweringPass::ID = 0;
 
-bool LongVectorLoweringPass::runOnModule(Module &) {
-  // TODO implement long-vector lowering.
+/// Convert the given value @p V to a value of the given @p EquivalentTy.
+///
+/// @return @p V when @p V's type is @p newType.
+/// @return an equivalent vector when @p V is an aggregate.
+/// @return an equivalent aggregate when @p V is a vector.
+Value *convertEquivalentValue(IRBuilder<> &B, Value *V, Type *EquivalentTy) {
+  if (V->getType() == EquivalentTy) {
+    return V;
+  }
+
+  // TODO Support pointer types.
+  assert(EquivalentTy->isVectorTy() || EquivalentTy->isStructTy());
+
+  Value *NewValue = UndefValue::get(EquivalentTy);
+
+  if (EquivalentTy->isVectorTy()) {
+    assert(V->getType()->isStructTy());
+
+    unsigned Arity = V->getType()->getNumContainedTypes();
+    for (unsigned i = 0; i < Arity; ++i) {
+      Value *Scalar = B.CreateExtractValue(V, i);
+      NewValue = B.CreateInsertElement(NewValue, Scalar, i);
+    }
+  } else {
+    assert(EquivalentTy->isStructTy());
+    assert(V->getType()->isVectorTy());
+
+    unsigned Arity = EquivalentTy->getNumContainedTypes();
+    for (unsigned i = 0; i < Arity; ++i) {
+      Value *Scalar = B.CreateExtractElement(V, i);
+      NewValue = B.CreateInsertValue(NewValue, Scalar, i);
+    }
+  }
+
+  return NewValue;
+}
+
+using ScalarOperationFactory =
+    std::function<Value *(IRBuilder<> & /* B */, ArrayRef<Value *> /* Args */)>;
+
+/// Scalarise a vector instruction element-wise by invoking the operation
+/// @p ScalarOperation.
+Value *convertVectorOperation(IRBuilder<> &B, Type *EquivalentReturnTy,
+                              ArrayRef<Value *> EquivalentArgs,
+                              ScalarOperationFactory ScalarOperation) {
+  assert(EquivalentReturnTy != nullptr);
+  assert(EquivalentReturnTy->isStructTy());
+
+  Value *ReturnValue = UndefValue::get(EquivalentReturnTy);
+  unsigned Arity = EquivalentReturnTy->getNumContainedTypes();
+
+  // Invoke the scalar operation once for each vector element.
+  for (unsigned i = 0; i < Arity; ++i) {
+    SmallVector<Value *, 16> Args;
+    Args.resize(EquivalentArgs.size());
+
+    for (unsigned j = 0; j < Args.size(); ++j) {
+      assert(EquivalentArgs[j]->getType()->isStructTy());
+      Args[j] = B.CreateExtractValue(EquivalentArgs[j], i);
+    }
+
+    Value *Scalar = ScalarOperation(B, Args);
+    ReturnValue = B.CreateInsertValue(ReturnValue, Scalar, i);
+  }
+
+  return ReturnValue;
+}
+
+bool LongVectorLoweringPass::runOnModule(Module &M) {
   bool Modified = false;
+
+  for (auto &F : M.functions()) {
+    Modified |= runOnFunction(F);
+  }
+
+  return Modified;
+}
+
+Value *LongVectorLoweringPass::visit(Value *V) {
+  if (auto *BinOp = dyn_cast<BinaryOperator>(V)) {
+    if (auto *EquivalentType = getEquivalentType(BinOp->getType())) {
+      IRBuilder<> B(BinOp);
+
+      SmallVector<Value *, 16> EquivalentArgs;
+      for (auto &Operand : BinOp->operands()) {
+        auto *Arg = Operand.get();
+        // TODO Visit argument to lower it.
+        // Instead, for now, we create an equivalent aggregate.
+        auto *EquivalentArgTy = getEquivalentType(Arg->getType());
+        auto *EquivalentArg = convertEquivalentValue(B, Arg, EquivalentArgTy);
+        EquivalentArgs.push_back(EquivalentArg);
+      }
+
+      auto ScalarFactory = [Opcode = BinOp->getOpcode()](auto &B, auto Args) {
+        return B.CreateNAryOp(Opcode, Args);
+      };
+      Value *EquivalentValue = convertVectorOperation(
+          B, EquivalentType, EquivalentArgs, ScalarFactory);
+
+      // TODO Implement support for additional instructions.
+      // Because support is very limited, as an initial step we convert the
+      // aggregate back to a vector to generate a valid module.
+      auto *ReplacementValue =
+          convertEquivalentValue(B, EquivalentValue, BinOp->getType());
+      BinOp->replaceAllUsesWith(ReplacementValue);
+
+      return ReplacementValue;
+    }
+  }
+
+#ifndef NDEBUG
+  dbgs() << "Value not handled: " << *V << '\n';
+#endif
+  // TODO Once additional features are implemented, turn this into an error by
+  // uncommenting the next line.
+  // llvm_unreachable("Kind of value not handled yet.");
+  return nullptr;
+}
+
+Type *LongVectorLoweringPass::getEquivalentType(Type *Ty) {
+  if (Ty->isIntegerTy() || Ty->isFloatingPointTy() || Ty->isVoidTy() ||
+      Ty->isLabelTy()) {
+    // No lowering required.
+    return nullptr;
+  }
+
+  if (auto *VectorTy = dyn_cast<VectorType>(Ty)) {
+    unsigned Arity = VectorTy->getElementCount().getKnownMinValue();
+    bool RequireLowering = (Arity >= 8);
+
+    if (RequireLowering) {
+      assert(!VectorTy->getElementCount().isScalable() &&
+             "Unsupported scalable vector");
+
+      // This assumes that the element type of the vector is a primitive scalar.
+      // That is, no vectors of pointers for example.
+      Type *ScalarTy = VectorTy->getElementType();
+      assert((ScalarTy->isFloatingPointTy() || ScalarTy->isIntegerTy()) &&
+             "Unsupported scalar type");
+
+      SmallVector<Type *, 16> AggregateBody(Arity, ScalarTy);
+      auto &C = Ty->getContext();
+      return StructType::get(C, AggregateBody);
+    }
+
+    return nullptr;
+  }
+
+#ifndef NDEBUG
+  dbgs() << "Unsupported type: " << *Ty << '\n';
+#endif
+  // TODO Once additional features are implemented, turn this into an error by
+  // uncommenting the next line.
+  // llvm_unreachable("Unsupported kind of Type.");
+  return nullptr;
+}
+
+bool LongVectorLoweringPass::runOnFunction(Function &F) {
+  LLVM_DEBUG(dbgs() << "Processing " << F.getName() << '\n');
+
+  // Skip declarations.
+  if (F.isDeclaration()) {
+    return false;
+  }
+
+  // TODO Support long-vector types as parameters of non-kernel functions.
+  Function *FunctionToVisit = &F;
+
+  bool Modified = (FunctionToVisit != &F);
+  for (Instruction &I : instructions(FunctionToVisit)) {
+    Modified |= (visit(&I) != nullptr);
+  }
+
+  // TODO Clean dead instructions.
+
+  LLVM_DEBUG(dbgs() << "Final version for " << F.getName() << '\n');
+  LLVM_DEBUG(dbgs() << *FunctionToVisit << '\n');
+
   return Modified;
 }
 

--- a/test/LongVectorLowering/add.ll
+++ b/test/LongVectorLowering/add.ll
@@ -1,0 +1,97 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test8(<4 x i32> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr, align 16
+  %ptr1 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 1
+  %x1 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr1, align 16
+  %a = shufflevector <4 x i32> %x0, <4 x i32> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 2
+  %x2 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr2, align 16
+  %ptr3 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 3
+  %x3 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr3, align 16
+  %b = shufflevector <4 x i32> %x2, <4 x i32> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %add = add <8 x i32> %a, %b
+
+  %c = shufflevector <8 x i32> %add, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 4
+  store <4 x i32> %c, <4 x i32> addrspace(1)* %ptr4, align 16
+
+  %d = shufflevector <8 x i32> %add, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 5
+  store <4 x i32> %d, <4 x i32> addrspace(1)* %ptr5, align 16
+
+  ret void
+}
+
+; CHECK-LABEL: @test8
+; TODO Once dead instructions are removed, add CHECK-NOT: add <8 x i32>
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+
+define spir_func void @test16(<4 x i32> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr, align 16
+  %ptr1 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 1
+  %x1 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr1, align 16
+  %a = shufflevector <4 x i32> %x0, <4 x i32> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 2
+  %x2 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr2, align 16
+  %ptr3 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 3
+  %x3 = load <4 x i32>, <4 x i32> addrspace(1)* %ptr3, align 16
+  %b = shufflevector <4 x i32> %x2, <4 x i32> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %c = shufflevector <8 x i32> %a, <8 x i32> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  %add = add <16 x i32> %c, <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  %d = shufflevector <16 x i32> %add, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 4
+  store <4 x i32> %d, <4 x i32> addrspace(1)* %ptr4, align 16
+
+  %e = shufflevector <16 x i32> %add, <16 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 5
+  store <4 x i32> %e, <4 x i32> addrspace(1)* %ptr5, align 16
+
+  %f = shufflevector <16 x i32> %add, <16 x i32> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %ptr6 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 6
+  store <4 x i32> %f, <4 x i32> addrspace(1)* %ptr6, align 16
+
+  %g = shufflevector <16 x i32> %add, <16 x i32> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %ptr7 = getelementptr <4 x i32>, <4 x i32> addrspace(1)* %ptr, i32 7
+  store <4 x i32> %g, <4 x i32> addrspace(1)* %ptr7, align 16
+
+  ret void
+}
+
+; CHECK-LABEL: @test16
+; TODO Once dead instructions are removed, add CHECK-NOT: add <16 x i32>
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32
+; CHECK: add i32

--- a/test/LongVectorLowering/add.ll
+++ b/test/LongVectorLowering/add.ll
@@ -31,7 +31,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test8
-; TODO Once dead instructions are removed, add CHECK-NOT: add <8 x i32>
+; CHECK-NOT: add <8 x i32>
 ; CHECK: add i32
 ; CHECK: add i32
 ; CHECK: add i32
@@ -40,6 +40,7 @@ entry:
 ; CHECK: add i32
 ; CHECK: add i32
 ; CHECK: add i32
+; CHECK-NOT: add <8 x i32>
 
 define spir_func void @test16(<4 x i32> addrspace(1)* %ptr) {
 entry:
@@ -78,7 +79,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test16
-; TODO Once dead instructions are removed, add CHECK-NOT: add <16 x i32>
+; CHECK-NOT: add <16 x i32>
 ; CHECK: add i32
 ; CHECK: add i32
 ; CHECK: add i32
@@ -95,3 +96,4 @@ entry:
 ; CHECK: add i32
 ; CHECK: add i32
 ; CHECK: add i32
+; CHECK-NOT: add <16 x i32>

--- a/test/LongVectorLowering/and.ll
+++ b/test/LongVectorLowering/and.ll
@@ -1,0 +1,97 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test8(<4 x i64> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr, align 32
+  %ptr1 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 1
+  %x1 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr1, align 32
+  %a = shufflevector <4 x i64> %x0, <4 x i64> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 2
+  %x2 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr2, align 32
+  %ptr3 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 3
+  %x3 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr3, align 32
+  %b = shufflevector <4 x i64> %x2, <4 x i64> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %and = and <8 x i64> %a, %b
+
+  %c = shufflevector <8 x i64> %and, <8 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 4
+  store <4 x i64> %c, <4 x i64> addrspace(1)* %ptr4, align 32
+
+  %d = shufflevector <8 x i64> %and, <8 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 5
+  store <4 x i64> %d, <4 x i64> addrspace(1)* %ptr5, align 32
+
+  ret void
+}
+
+; CHECK-LABEL: @test8
+; TODO Once dead instructions are removed, add CHECK-NOT: and <8 x i64>
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+
+define spir_func void @test16(<4 x i64> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr, align 32
+  %ptr1 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 1
+  %x1 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr1, align 32
+  %a = shufflevector <4 x i64> %x0, <4 x i64> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 2
+  %x2 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr2, align 32
+  %ptr3 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 3
+  %x3 = load <4 x i64>, <4 x i64> addrspace(1)* %ptr3, align 32
+  %b = shufflevector <4 x i64> %x2, <4 x i64> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %c = shufflevector <8 x i64> %a, <8 x i64> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  %and = and <16 x i64> %c, <i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8, i64 9, i64 10, i64 11, i64 12, i64 13, i64 14, i64 15>
+
+  %d = shufflevector <16 x i64> %and, <16 x i64> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 4
+  store <4 x i64> %d, <4 x i64> addrspace(1)* %ptr4, align 32
+
+  %e = shufflevector <16 x i64> %and, <16 x i64> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 5
+  store <4 x i64> %e, <4 x i64> addrspace(1)* %ptr5, align 32
+
+  %f = shufflevector <16 x i64> %and, <16 x i64> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %ptr6 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 6
+  store <4 x i64> %f, <4 x i64> addrspace(1)* %ptr6, align 32
+
+  %g = shufflevector <16 x i64> %and, <16 x i64> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %ptr7 = getelementptr <4 x i64>, <4 x i64> addrspace(1)* %ptr, i64 7
+  store <4 x i64> %g, <4 x i64> addrspace(1)* %ptr7, align 32
+
+  ret void
+}
+
+; CHECK-LABEL: @test16
+; TODO Once dead instructions are removed, add CHECK-NOT: and <16 x i64>
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64
+; CHECK: and i64

--- a/test/LongVectorLowering/and.ll
+++ b/test/LongVectorLowering/and.ll
@@ -31,7 +31,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test8
-; TODO Once dead instructions are removed, add CHECK-NOT: and <8 x i64>
+; CHECK-NOT: and <8 x i64>
 ; CHECK: and i64
 ; CHECK: and i64
 ; CHECK: and i64
@@ -40,6 +40,7 @@ entry:
 ; CHECK: and i64
 ; CHECK: and i64
 ; CHECK: and i64
+; CHECK-NOT: and <8 x i64>
 
 define spir_func void @test16(<4 x i64> addrspace(1)* %ptr) {
 entry:
@@ -78,7 +79,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test16
-; TODO Once dead instructions are removed, add CHECK-NOT: and <16 x i64>
+; CHECK-NOT: and <16 x i64>
 ; CHECK: and i64
 ; CHECK: and i64
 ; CHECK: and i64
@@ -95,3 +96,4 @@ entry:
 ; CHECK: and i64
 ; CHECK: and i64
 ; CHECK: and i64
+; CHECK-NOT: and <16 x i64>

--- a/test/LongVectorLowering/frem.ll
+++ b/test/LongVectorLowering/frem.ll
@@ -1,0 +1,97 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test8(<4 x float> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x float>, <4 x float> addrspace(1)* %ptr, align 16
+  %ptr1 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 1
+  %x1 = load <4 x float>, <4 x float> addrspace(1)* %ptr1, align 16
+  %a = shufflevector <4 x float> %x0, <4 x float> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 2
+  %x2 = load <4 x float>, <4 x float> addrspace(1)* %ptr2, align 16
+  %ptr3 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 3
+  %x3 = load <4 x float>, <4 x float> addrspace(1)* %ptr3, align 16
+  %b = shufflevector <4 x float> %x2, <4 x float> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %frem = frem <8 x float> %a, %b
+
+  %c = shufflevector <8 x float> %frem, <8 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 4
+  store <4 x float> %c, <4 x float> addrspace(1)* %ptr4, align 16
+
+  %d = shufflevector <8 x float> %frem, <8 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 5
+  store <4 x float> %d, <4 x float> addrspace(1)* %ptr5, align 16
+
+  ret void
+}
+
+; CHECK-LABEL: @test8
+; TODO Once dead instructions are removed, add CHECK-NOT: frem <8 x float>
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+
+define spir_func void @test16(<4 x float> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x float>, <4 x float> addrspace(1)* %ptr, align 16
+  %ptr1 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 1
+  %x1 = load <4 x float>, <4 x float> addrspace(1)* %ptr1, align 16
+  %a = shufflevector <4 x float> %x0, <4 x float> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 2
+  %x2 = load <4 x float>, <4 x float> addrspace(1)* %ptr2, align 16
+  %ptr3 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 3
+  %x3 = load <4 x float>, <4 x float> addrspace(1)* %ptr3, align 16
+  %b = shufflevector <4 x float> %x2, <4 x float> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %c = shufflevector <8 x float> %a, <8 x float> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  %frem = frem <16 x float> %c, <float 0.0, float 1.0, float 2.0, float 3.0, float 4.0, float 5.0, float 6.0, float 7.0, float 8.0, float 9.0, float 10.0, float 11.0, float 12.0, float 13.0, float 14.0, float 15.0>
+
+  %d = shufflevector <16 x float> %frem, <16 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 4
+  store <4 x float> %d, <4 x float> addrspace(1)* %ptr4, align 16
+
+  %e = shufflevector <16 x float> %frem, <16 x float> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 5
+  store <4 x float> %e, <4 x float> addrspace(1)* %ptr5, align 16
+
+  %f = shufflevector <16 x float> %frem, <16 x float> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %ptr6 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 6
+  store <4 x float> %f, <4 x float> addrspace(1)* %ptr6, align 16
+
+  %g = shufflevector <16 x float> %frem, <16 x float> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %ptr7 = getelementptr <4 x float>, <4 x float> addrspace(1)* %ptr, i32 7
+  store <4 x float> %g, <4 x float> addrspace(1)* %ptr7, align 16
+
+  ret void
+}
+
+; CHECK-LABEL: @test16
+; TODO Once dead instructions are removed, add CHECK-NOT: frem <16 x float>
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float
+; CHECK: frem float

--- a/test/LongVectorLowering/frem.ll
+++ b/test/LongVectorLowering/frem.ll
@@ -31,7 +31,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test8
-; TODO Once dead instructions are removed, add CHECK-NOT: frem <8 x float>
+; CHECK-NOT: frem <8 x float>
 ; CHECK: frem float
 ; CHECK: frem float
 ; CHECK: frem float
@@ -40,6 +40,7 @@ entry:
 ; CHECK: frem float
 ; CHECK: frem float
 ; CHECK: frem float
+; CHECK-NOT: frem <8 x float>
 
 define spir_func void @test16(<4 x float> addrspace(1)* %ptr) {
 entry:
@@ -78,7 +79,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test16
-; TODO Once dead instructions are removed, add CHECK-NOT: frem <16 x float>
+; CHECK-NOT: frem <16 x float>
 ; CHECK: frem float
 ; CHECK: frem float
 ; CHECK: frem float
@@ -95,3 +96,4 @@ entry:
 ; CHECK: frem float
 ; CHECK: frem float
 ; CHECK: frem float
+; CHECK-NOT: frem <16 x float>

--- a/test/LongVectorLowering/lshr.ll
+++ b/test/LongVectorLowering/lshr.ll
@@ -1,0 +1,97 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test8(<4 x i16> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr, align 8
+  %ptr1 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 1
+  %x1 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr1, align 8
+  %a = shufflevector <4 x i16> %x0, <4 x i16> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 2
+  %x2 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr2, align 8
+  %ptr3 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 3
+  %x3 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr3, align 8
+  %b = shufflevector <4 x i16> %x2, <4 x i16> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %lshr = lshr <8 x i16> %a, %b
+
+  %c = shufflevector <8 x i16> %lshr, <8 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 4
+  store <4 x i16> %c, <4 x i16> addrspace(1)* %ptr4, align 8
+
+  %d = shufflevector <8 x i16> %lshr, <8 x i16> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 5
+  store <4 x i16> %d, <4 x i16> addrspace(1)* %ptr5, align 8
+
+  ret void
+}
+
+; CHECK-LABEL: @test8
+; TODO Once dead instructions are removed, add CHECK-NOT: lshr <8 x i16>
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+
+define spir_func void @test16(<4 x i16> addrspace(1)* %ptr) {
+entry:
+  %x0 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr, align 8
+  %ptr1 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 1
+  %x1 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr1, align 8
+  %a = shufflevector <4 x i16> %x0, <4 x i16> %x1, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %ptr2 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 2
+  %x2 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr2, align 8
+  %ptr3 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 3
+  %x3 = load <4 x i16>, <4 x i16> addrspace(1)* %ptr3, align 8
+  %b = shufflevector <4 x i16> %x2, <4 x i16> %x3, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+
+  %c = shufflevector <8 x i16> %a, <8 x i16> %b, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  %lshr = lshr <16 x i16> %c, <i16 0, i16 1, i16 2, i16 3, i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15>
+
+  %d = shufflevector <16 x i16> %lshr, <16 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %ptr4 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 4
+  store <4 x i16> %d, <4 x i16> addrspace(1)* %ptr4, align 8
+
+  %e = shufflevector <16 x i16> %lshr, <16 x i16> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %ptr5 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 5
+  store <4 x i16> %e, <4 x i16> addrspace(1)* %ptr5, align 8
+
+  %f = shufflevector <16 x i16> %lshr, <16 x i16> undef, <4 x i32> <i32 8, i32 9, i32 10, i32 11>
+  %ptr6 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 6
+  store <4 x i16> %f, <4 x i16> addrspace(1)* %ptr6, align 8
+
+  %g = shufflevector <16 x i16> %lshr, <16 x i16> undef, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
+  %ptr7 = getelementptr <4 x i16>, <4 x i16> addrspace(1)* %ptr, i16 7
+  store <4 x i16> %g, <4 x i16> addrspace(1)* %ptr7, align 8
+
+  ret void
+}
+
+; CHECK-LABEL: @test16
+; TODO Once dead instructions are removed, add CHECK-NOT: lshr <16 x i16>
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16
+; CHECK: lshr i16

--- a/test/LongVectorLowering/lshr.ll
+++ b/test/LongVectorLowering/lshr.ll
@@ -31,7 +31,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test8
-; TODO Once dead instructions are removed, add CHECK-NOT: lshr <8 x i16>
+; CHECK-NOT: lshr <8 x i16>
 ; CHECK: lshr i16
 ; CHECK: lshr i16
 ; CHECK: lshr i16
@@ -40,6 +40,7 @@ entry:
 ; CHECK: lshr i16
 ; CHECK: lshr i16
 ; CHECK: lshr i16
+; CHECK-NOT: lshr <8 x i16>
 
 define spir_func void @test16(<4 x i16> addrspace(1)* %ptr) {
 entry:
@@ -78,7 +79,7 @@ entry:
 }
 
 ; CHECK-LABEL: @test16
-; TODO Once dead instructions are removed, add CHECK-NOT: lshr <16 x i16>
+; CHECK-NOT: lshr <16 x i16>
 ; CHECK: lshr i16
 ; CHECK: lshr i16
 ; CHECK: lshr i16
@@ -95,3 +96,4 @@ entry:
 ; CHECK: lshr i16
 ; CHECK: lshr i16
 ; CHECK: lshr i16
+; CHECK-NOT: lshr <16 x i16>


### PR DESCRIPTION
This PR continues adding support for lowering long-vectors (#613) with three commits: 1) lower `BinaryOperator`, 2) cache lowering results, 3) remove dead instructions (i.e. instruction that were lowered and therefore cached).

Later commits will bring support for many additional instructions using `InstVisitor`. This is left out for now to make this patch smaller and easier to review.

Because only `BinaryOperator`s are lowered, their operand are still long-vector. Hence, temporary instructions are generated to read those vectors and create equivalent aggregates, and vice-versa for the value generated by the binary operator. This is done in order to keep generating valid LLVM modules and won't be necessary in the future when operands are recursively visited and more kinds of instructions can be lowered.