### PR TITLE
Read write images

### DIFF
--- a/include/clspv/ArgKind.h
+++ b/include/clspv/ArgKind.h
@@ -26,8 +26,8 @@ enum class ArgKind : int {
   Pod,
   PodUBO,
   PodPushConstant,
-  ReadOnlyImage,
-  WriteOnlyImage,
+  SampledImage,
+  StorageImage,
   Sampler,
 };
 

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -426,8 +426,8 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
 
       int separation_token = 0;
       switch (arg_kind) {
-      case clspv::ArgKind::ReadOnlyImage:
-      case clspv::ArgKind::WriteOnlyImage:
+      case clspv::ArgKind::SampledImage:
+      case clspv::ArgKind::StorageImage:
       case clspv::ArgKind::Sampler:
         if (always_distinct_image_sampler) {
           separation_token = num_image_sampler_arguments;
@@ -736,8 +736,8 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           break;
         }
         case clspv::ArgKind::Sampler:
-        case clspv::ArgKind::ReadOnlyImage:
-        case clspv::ArgKind::WriteOnlyImage:
+        case clspv::ArgKind::SampledImage:
+        case clspv::ArgKind::StorageImage:
           // We won't be translating the value here.  Keep the type the same.
           // since calls using these values need to keep the same type.
           resource_type = argTy->getPointerElementType();
@@ -802,8 +802,8 @@ bool AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           auto *gep = Builder.CreateGEP(call, {zero, zero});
           replacement = Builder.CreateLoad(gep);
         } break;
-        case clspv::ArgKind::ReadOnlyImage:
-        case clspv::ArgKind::WriteOnlyImage:
+        case clspv::ArgKind::SampledImage:
+        case clspv::ArgKind::StorageImage:
         case clspv::ArgKind::Sampler: {
           // The call returns a pointer to an opaque type.  Eventually the
           // SPIR-V will need to load the variable, so the natural thing would

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -61,6 +61,7 @@ clspv::ArgKind GetArgKindForType(Type *type) {
     if (clspv::IsImageType(type, &image_type)) {
       StringRef name = dyn_cast<StructType>(image_type)->getName();
       // OpenCL 1.2 only has read-only or write-only images.
+      // Treat OpenCL 2.0 read_write images as write-only images.
       return name.contains("_ro_t") ? clspv::ArgKind::ReadOnlyImage
                                     : clspv::ArgKind::WriteOnlyImage;
     }

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -45,8 +45,8 @@ clspv::ArgKind GetArgKindForType(Type *type);
 //   local      - array in Workgroup storage, number of elements given by
 //                a specialization constant
 //   pod        - plain-old-data
-//   ro_image   - read-only image
-//   wo_image   - write-only image
+//   ro_image   - sampled image
+//   wo_image   - storage image
 //   sampler    - sampler
 inline const char *GetArgKindNameForType(llvm::Type *type) {
   return GetArgKindName(GetArgKindForType(type));
@@ -60,10 +60,12 @@ clspv::ArgKind GetArgKindForType(Type *type) {
     llvm::Type *image_type = nullptr;
     if (clspv::IsImageType(type, &image_type)) {
       StringRef name = dyn_cast<StructType>(image_type)->getName();
-      // OpenCL 1.2 only has read-only or write-only images.
-      // Treat OpenCL 2.0 read_write images as write-only images.
-      return name.contains("_ro_t") ? clspv::ArgKind::ReadOnlyImage
-                                    : clspv::ArgKind::WriteOnlyImage;
+      // OpenCL 1.2 only has read-only and write-only images.
+      // OpenCL 2.0 (and later) also has read-write images.
+      // Read-only images are translated to sampled images, while write-only
+      // and read-write images are translated as storage images.
+      return name.contains("_ro_t") ? clspv::ArgKind::SampledImage
+                                    : clspv::ArgKind::StorageImage;
     }
     switch (type->getPointerAddressSpace()) {
     // Pointer to constant and pointer to global are both in
@@ -140,9 +142,11 @@ const char *GetArgKindName(ArgKind kind) {
     return "pod_ubo";
   case ArgKind::PodPushConstant:
     return "pod_pushconstant";
-  case ArgKind::ReadOnlyImage:
+  case ArgKind::SampledImage:
+    // For historical purposes this string still refers to read-only images.
     return "ro_image";
-  case ArgKind::WriteOnlyImage:
+  case ArgKind::StorageImage:
+    // For historical purposes this string still refers to write-only images.
     return "wo_image";
   case ArgKind::Sampler:
     return "sampler";
@@ -166,9 +170,9 @@ ArgKind GetArgKindFromName(const std::string &name) {
   } else if (name == "pod_pushconstant") {
     return ArgKind::PodPushConstant;
   } else if (name == "ro_image") {
-    return ArgKind::ReadOnlyImage;
+    return ArgKind::SampledImage;
   } else if (name == "wo_image") {
-    return ArgKind::WriteOnlyImage;
+    return ArgKind::StorageImage;
   } else if (name == "sampler") {
     return ArgKind::Sampler;
   }

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -109,8 +109,8 @@ bool DirectResourceAccessPass::RewriteResourceAccesses(Function *fn) {
     switch (clspv::GetArgKind(arg)) {
     case clspv::ArgKind::Buffer:
     case clspv::ArgKind::BufferUBO:
-    case clspv::ArgKind::ReadOnlyImage:
-    case clspv::ArgKind::WriteOnlyImage:
+    case clspv::ArgKind::SampledImage:
+    case clspv::ArgKind::StorageImage:
     case clspv::ArgKind::Sampler:
     case clspv::ArgKind::Local:
       Changed |= RewriteAccessesForArg(fn, arg_index, arg);

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -651,9 +651,8 @@ bool ReplaceOpenCLBuiltinPass::replaceBarrier(Function &F, bool subgroup) {
     auto MemorySemantics1 =
         BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
                                ConstantAcquireRelease, "", CI);
-    auto MemorySemantics2 =
-        BinaryOperator::Create(Instruction::Or, MemorySemanticsUniform,
-                               MemorySemanticsImage, "", CI);
+    auto MemorySemantics2 = BinaryOperator::Create(
+        Instruction::Or, MemorySemanticsUniform, MemorySemanticsImage, "", CI);
     auto MemorySemantics = BinaryOperator::Create(
         Instruction::Or, MemorySemantics1, MemorySemantics2, "", CI);
 
@@ -752,9 +751,8 @@ bool ReplaceOpenCLBuiltinPass::replaceMemFence(Function &F,
     auto MemorySemantics1 =
         BinaryOperator::Create(Instruction::Or, MemorySemanticsWorkgroup,
                                ConstantMemorySemantics, "", CI);
-    auto MemorySemantics2 =
-        BinaryOperator::Create(Instruction::Or, MemorySemanticsUniform,
-                               MemorySemanticsImage, "", CI);
+    auto MemorySemantics2 = BinaryOperator::Create(
+        Instruction::Or, MemorySemanticsUniform, MemorySemanticsImage, "", CI);
     auto MemorySemantics = BinaryOperator::Create(
         Instruction::Or, MemorySemantics1, MemorySemantics2, "", CI);
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1760,14 +1760,15 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
 
         // TODO: Set up Image Format.
         Ops << spv::ImageFormatUnknown;
-
         RID = addSPIRVInst<kTypes>(spv::OpTypeImage, Ops);
 
-        Ops.clear();
-        Ops << RID;
-
-        getImageTypeMap()[Ty] =
-            addSPIRVInst<kTypes>(spv::OpTypeSampledImage, Ops);
+        // Only need a sampled version of the type if it is used with a sampler.
+        if (Sampled == 1) {
+          Ops.clear();
+          Ops << RID;
+          getImageTypeMap()[Ty] =
+              addSPIRVInst<kTypes>(spv::OpTypeSampledImage, Ops);
+        }
         break;
       }
     }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2356,6 +2356,8 @@ void SPIRVProducerPass::GenerateResourceVars() {
     case clspv::ArgKind::StorageImage: {
       auto *type = info->var_fn->getReturnType();
       auto *struct_ty = cast<StructType>(type->getPointerElementType());
+      // TODO(alan-baker): This is conservative. If compiling for OpenCL 2.0 or
+      // above, the compiler treats all write_only images as read_write images.
       if (struct_ty->getName().contains("_wo_t")) {
         Ops.clear();
         Ops << info->var_id << spv::DecorationNonReadable;

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -187,7 +187,8 @@ Type *SpecializeImageTypesPass::RemapUse(Value *value, unsigned operand_no) {
                      clspv::Option::SourceLanguage::OpenCL_C_20 &&
                  pos != std::string::npos) {
         // In OpenCL 2.0 (or later), treat write_only images as read_write
-        // images.
+        // images. This prevents the compiler from generating duplicate image
+        // types (invalid SPIR-V).
         name = name.substr(0, pos) + "_rw_t" + name.substr(pos + 5);
       }
 

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -178,16 +178,9 @@ Type *SpecializeImageTypesPass::RemapUse(Value *value, unsigned operand_no) {
         break;
       }
 
-      // Both sampled and unsampled reads generate an OpTypeImage with Sampled
-      // operand of 1.
-      switch (func_info.getType()) {
-      case Builtins::kReadImagef:
-      case Builtins::kReadImagei:
-      case Builtins::kReadImageui:
+      // Read only images are translated as sampled images.
+      if (!IsStorageImageType(imageTy)) {
         name += ".sampled";
-        break;
-      default:
-        break;
       }
 
       StructType *new_struct =

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -22,11 +22,11 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "clspv/Option.h"
 #include "Builtins.h"
 #include "Constants.h"
 #include "Passes.h"
 #include "Types.h"
+#include "clspv/Option.h"
 
 using namespace clspv;
 using namespace clspv::Builtins;

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -42,14 +42,19 @@ bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
     if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
       if (STy->isOpaque()) {
         if (STy->getName().startswith("opencl.image1d_ro_t") ||
+            STy->getName().startswith("opencl.image1d_rw_t") ||
             STy->getName().startswith("opencl.image1d_wo_t") ||
             STy->getName().startswith("opencl.image1d_array_ro_t") ||
+            STy->getName().startswith("opencl.image1d_array_rw_t") ||
             STy->getName().startswith("opencl.image1d_array_wo_t") ||
             STy->getName().startswith("opencl.image2d_ro_t") ||
+            STy->getName().startswith("opencl.image2d_rw_t") ||
             STy->getName().startswith("opencl.image2d_wo_t") ||
             STy->getName().startswith("opencl.image2d_array_ro_t") ||
+            STy->getName().startswith("opencl.image2d_array_rw_t") ||
             STy->getName().startswith("opencl.image2d_array_wo_t") ||
             STy->getName().startswith("opencl.image3d_ro_t") ||
+            STy->getName().startswith("opencl.image3d_rw_t") ||
             STy->getName().startswith("opencl.image3d_wo_t")) {
           isImageType = true;
           if (struct_type_ptr)
@@ -100,6 +105,20 @@ bool clspv::IsSampledImageType(Type *type) {
     if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
       if (struct_ty->getName().contains(".sampled"))
         return true;
+    }
+  }
+
+  return false;
+}
+
+bool clspv::IsStorageImageType(Type *type) {
+  Type *ty = nullptr;
+  if (IsImageType(type, &ty)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
+      if (struct_ty->getName().contains("_wo_t") ||
+          struct_ty->getName().contains("_rw_t")) {
+        return true;
+      }
     }
   }
 

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -38,6 +38,10 @@ bool IsArrayImageType(llvm::Type *type);
 // after image specialization.
 bool IsSampledImageType(llvm::Type *type);
 
+// Returns true if the given type is a storage image type. This is the case
+// for read_write and write_only images.
+bool IsStorageImageType(llvm::Type *type);
+
 // Returns true if the given type is a float image type.
 // Before image specialization, all images are considered float images.
 bool IsFloatImageType(llvm::Type *type);

--- a/test/ImageBuiltins/get_image_depth_image3d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_depth_image3d_readwrite.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_write image3d_t im)
+{
+  *out = get_image_depth(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 2
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_dim_image2d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_dim_image2d_readwrite.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int2* out, read_write image2d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: OpStore {{.*}} [[_19]]
+

--- a/test/ImageBuiltins/get_image_dim_image3d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_dim_image3d_readwrite.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int4* out, read_write image3d_t im)
+{
+  *out = get_image_dim(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeConstruct [[_v4uint]] [[_19]] [[uint_0]]
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_height_image2d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_height_image2d_readwrite.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_write image2d_t im)
+{
+  *out = get_image_height(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 1
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_height_image3d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_height_image3d_readwrite.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_write image3d_t im)
+{
+  *out = get_image_height(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 1
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_width_image1d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_width_image1d_readwrite.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, write_only image1d_t im)
+{
+  *out = get_image_width(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 1D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_uint]] [[_18]]
+// CHECK: OpStore {{.*}} [[_19]]
+

--- a/test/ImageBuiltins/get_image_width_image2d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_width_image2d_readwrite.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_write image2d_t im)
+{
+  *out = get_image_width(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 2D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v2uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 0
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/get_image_width_image3d_readwrite.cl
+++ b/test/ImageBuiltins/get_image_width_image3d_readwrite.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1)))
+foo(global int* out, read_write image3d_t im)
+{
+  *out = get_image_width(im);
+}
+// CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] 3D 0 0 0 2 Unknown
+// CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
+// CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_v3uint]] [[_18]]
+// CHECK: [[_20:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_19]] 0
+// CHECK: OpStore {{.*}} [[_20]]
+

--- a/test/ImageBuiltins/readwrite_imagef_int.cl
+++ b/test/ImageBuiltins/readwrite_imagef_int.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image1d_t im) {
+  float4 x = read_imagef(im, 0);
+  write_imagef(im, 0, x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 1D 0 0 0 2 Unknown
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[float4]] [[ld]] [[int_0]]
+// CHECK: OpImageWrite [[ld]] [[int_0]] [[x]]

--- a/test/ImageBuiltins/readwrite_imagef_int2.cl
+++ b/test/ImageBuiltins/readwrite_imagef_int2.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image2d_t im) {
+  float4 x = read_imagef(im, (int2)(0, 0));
+  write_imagef(im, (int2)(0, 0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 2D 0 0 0 2 Unknown
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[int2]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[float4]] [[ld]] [[coord]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[x]]

--- a/test/ImageBuiltins/readwrite_imagef_int4.cl
+++ b/test/ImageBuiltins/readwrite_imagef_int4.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image3d_t im) {
+  float4 x = read_imagef(im, (int4)(0,0,0,0));
+  write_imagef(im, (int4)(0,0,0,0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 3D 0 0 0 2 Unknown
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[int4]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[float4]] [[ld]] [[coord]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[x]]
+

--- a/test/ImageBuiltins/readwrite_imagei_int.cl
+++ b/test/ImageBuiltins/readwrite_imagei_int.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image1d_t im) {
+  int4 x = read_imagei(im, 0);
+  write_imagei(im, 0, x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint4:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 4
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 1
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 1D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[coord]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[uint4]] [[x]]
+// CHECK: [[cast2:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]] [[cast]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[cast2]]
+

--- a/test/ImageBuiltins/readwrite_imagei_int2.cl
+++ b/test/ImageBuiltins/readwrite_imagei_int2.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image2d_t im) {
+  int4 x = read_imagei(im, (int2)(0,0));
+  write_imagei(im, (int2)(0,0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint2:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[uint4:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 4
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 1
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[uint2]]
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 2D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[coord]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[uint4]] [[x]]
+// CHECK: [[cast2:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]] [[cast]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[cast2]]
+

--- a/test/ImageBuiltins/readwrite_imagei_int4.cl
+++ b/test/ImageBuiltins/readwrite_imagei_int4.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image3d_t im) {
+  int4 x = read_imagei(im, (int4)(0,0,0,0));
+  write_imagei(im, (int4)(0,0,0,0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint4:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 4
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 1
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[uint4]]
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 3D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[coord]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[uint4]] [[x]]
+// CHECK: [[cast2:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]] [[cast]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[cast2]]
+

--- a/test/ImageBuiltins/readwrite_imageui_int.cl
+++ b/test/ImageBuiltins/readwrite_imageui_int.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image1d_t im) {
+  uint4 x = read_imageui(im, 0);
+  write_imageui(im, 0, x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 1D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[int_0]]
+// CHECK: OpImageWrite [[ld]] [[int_0]] [[x]]
+

--- a/test/ImageBuiltins/readwrite_imageui_int2.cl
+++ b/test/ImageBuiltins/readwrite_imageui_int2.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image2d_t im) {
+  uint4 x = read_imageui(im, (int2)(0,0));
+  write_imageui(im, (int2)(0,0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[int2]]
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 2D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[coord]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[x]]
+

--- a/test/ImageBuiltins/readwrite_imageui_int4.cl
+++ b/test/ImageBuiltins/readwrite_imageui_int4.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image3d_t im) {
+  uint4 x = read_imageui(im, (int4)(0,0,0,0));
+  write_imageui(im, (int4)(0,0,0,0), x);
+}
+
+// CHECK-DAG: OpCapability StorageImageReadWithoutFormat
+// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[coord:%[a-zA-Z0-9_]+]] = OpConstantNull [[int4]]
+// CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] 3D 0 0 0 2 Unknown
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[image]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[ld]] [[coord]]
+// CHECK: OpImageWrite [[ld]] [[coord]] [[x]]
+

--- a/test/Reflection/readwrite_image_argument.cl
+++ b/test/Reflection/readwrite_image_argument.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+kernel void foo(read_write image2d_t im) { }
+
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.1"
+// CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
+// CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
+// CHECK-DAG: [[im_name:%[a-zA-Z0-9_]+]] = OpString "im"
+// CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK: [[kernel:%[a-zA-Z0-9_]+]] = OpExtInst [[void]] [[import]] Kernel [[foo]] [[foo_name]]
+// CHECK: [[info:%[a-zA-Z0-9_]+]] = OpExtInst [[void]] [[import]] ArgumentInfo [[im_name]]
+// CHECK: [[arg:%[a-zA-Z0-9_]+]] = OpExtInst [[void]] [[import]] ArgumentStorageImage [[kernel]] [[int_0]] [[int_0]] [[int_0]] [[info]]

--- a/test/SpecializeImageTypes/readwrite_image2d_read_float.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_read_float.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t -cl-std=CL2.0
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.float]] = type opaque
+; CHECK: declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_float
+; CHECK: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @read_float(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord) #3
+  store <4 x float> %call, <4 x float> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }

--- a/test/SpecializeImageTypes/readwrite_image2d_read_int.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_read_int.ll
@@ -1,0 +1,28 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t -cl-std=CL2.0
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.int]] = type opaque
+; CHECK: declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_int
+; CHECK: call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @read_int(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord) #3
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/readwrite_image2d_read_uint.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_read_uint.ll
@@ -1,0 +1,28 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t -cl-std=CL2.0
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.uint]] = type opaque
+; CHECK: declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @read_uint
+; CHECK: call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @read_uint(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord) #3
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %data, align 16
+  ret void
+}
+
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/readwrite_image2d_write_float.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_write_float.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.float]] = type opaque
+; CHECK: declare spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>, <4 x float>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @write_float
+; CHECK: call spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @write_float(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x float>, <4 x float> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x float> %ld) #2
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>, <4 x float>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/readwrite_image2d_write_int.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_write_int.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.int]] = type opaque
+; CHECK: declare spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>, <4 x i32>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @write_int
+; CHECK: call spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @write_int(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x i32>, <4 x i32> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> %ld) #2
+  ret void
+}
+
+declare spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>, <4 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/readwrite_image2d_write_uint.ll
+++ b/test/SpecializeImageTypes/readwrite_image2d_write_uint.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.uint]] = type opaque
+; CHECK: declare spir_func void @_Z13write_imageui14ocl_image2d_rwDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>, <4 x i32>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @write_uint
+; CHECK: call spir_func void @_Z13write_imageui14ocl_image2d_rwDv2_iDv4_i.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t = type opaque
+
+define spir_kernel void @write_uint(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x i32>, <4 x i32> addrspace(1)* %data, align 16
+  call spir_func void @_Z13write_imageui14ocl_image2d_rwDv2_iDv4_i(%opencl.image2d_rw_t addrspace(1)* %image, <2 x i32> %coord, <4 x i32> %ld) #2
+  ret void
+}
+
+declare spir_func void @_Z13write_imageui14ocl_image2d_rwDv2_iDv4_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>, <4 x i32>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/SpecializeImageTypes/write_only_image_as_read_write_image_in_cl20.ll
+++ b/test/SpecializeImageTypes/write_only_image_as_read_write_image_in_cl20.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t --cl-std=CL2.0
+; RUN: FileCheck %s < %t
+
+; CHECK: %[[IMAGE:opencl.image2d_rw_t.float]] = type opaque
+; CHECK: declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)*, <2 x i32>, <4 x float>) [[ATTRS:#[0-9]+]]
+; CHECK: define spir_kernel void @write_float
+; CHECK: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image
+; CHECK: attributes [[ATTRS]] = { convergent nounwind }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_wo_t = type opaque
+
+define spir_kernel void @write_float(%opencl.image2d_wo_t addrspace(1)* %image, <2 x i32> %coord, <4 x float> addrspace(1)* nocapture %data) local_unnamed_addr #0 {
+entry:
+  %ld = load <4 x float>, <4 x float> addrspace(1)* %data, align 16
+  call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)* %image, <2 x i32> %coord, <4 x float> %ld) #2
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)*, <2 x i32>, <4 x float>) local_unnamed_addr #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nounwind }
+attributes #2 = { convergent nobuiltin nounwind readonly }
+

--- a/test/image2d_write.cl
+++ b/test/image2d_write.cl
@@ -14,4 +14,5 @@
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2d_t b)
 {
+  write_imagef(b, (int2)(0, 0), (float4)(0,0,0,0));
 }

--- a/test/image3d.cl
+++ b/test/image3d.cl
@@ -4,7 +4,6 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-NOT OpCapability StorageImageReadWithoutFormat
-// CHECK-DAG: OpCapability StorageImageWriteWithoutFormat
 // CHECK: OpDecorate %[[ARG0_ID:[a-zA-Z0-9_]*]] DescriptorSet 0
 // CHECK: OpDecorate %[[ARG0_ID]] Binding 0
 // CHECK: OpDecorate %[[ARG1_ID:[a-zA-Z0-9_]*]] DescriptorSet 0

--- a/test/image3d_write.cl
+++ b/test/image3d_write.cl
@@ -16,4 +16,5 @@
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image3d_t b)
 {
+  write_imagef(b, (int4)(0,0,0,0), (float4)(0,0,0,0));
 }

--- a/tools/reflection/ReflectionParser.cpp
+++ b/tools/reflection/ReflectionParser.cpp
@@ -79,9 +79,9 @@ clspv::ArgKind ReflectionParser::GetArgKindFromExtInst(uint32_t value) {
   case clspv::reflection::ExtInstArgumentPodPushConstant:
     return clspv::ArgKind::PodPushConstant;
   case clspv::reflection::ExtInstArgumentSampledImage:
-    return clspv::ArgKind::ReadOnlyImage;
+    return clspv::ArgKind::SampledImage;
   case clspv::reflection::ExtInstArgumentStorageImage:
-    return clspv::ArgKind::WriteOnlyImage;
+    return clspv::ArgKind::StorageImage;
   case clspv::reflection::ExtInstArgumentSampler:
     return clspv::ArgKind::Sampler;
   case clspv::reflection::ExtInstArgumentWorkgroup:


### PR DESCRIPTION
Support read-write images.

* When targeting OpenCL 2.0 or later, treat write-only images as read-write images to prevent duplicate types
* Read-write images are translated as storage images (same as write-only images)
* Add support for CLK_IMAGE_MEM_FENCE for mem fence and barriers
* rename ArgKind::ReadOnlyImage and ArgKind::WriteOnlyImage to ArgKind::SampledImage and ArgKind::StorageImage respectively
* tests