### PR TITLE
Lower function parameters and return type

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -21,6 +21,7 @@
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/Local.h"
 
 #include "clspv/Passes.h"
@@ -69,11 +70,22 @@ private:
   /// Implementation details of getEquivalentType.
   Type *getEquivalentTypeImpl(Type *Ty) const;
 
+  /// Return the equivalent type for @p Ty or @p Ty if no lowering is needed.
+  Type *getEquivalentTypeOrSelf(Type *Ty) {
+    auto *EquivalentTy = getEquivalentType(Ty);
+    return EquivalentTy ? EquivalentTy : Ty;
+  }
+
 private:
   // Hight-level implementation details of runOnModule.
 
   /// Lower the given function.
   bool runOnFunction(Function &F);
+
+  /// Create an alternative version of @p F that doesn't have long vectors as
+  /// parameter or return types.
+  /// Returns nullptr if no lowering is required.
+  Function *convertUserDefinedFunction(Function &F);
 
   /// Clears the dead instructions and others that might be rendered dead
   /// by their removal.
@@ -91,6 +103,12 @@ private:
   /// and transformed. Instructions are not removed from the function as they
   /// are visited because this would invalidate iterators.
   DenseMap<Value *, Value *> InstructionMap;
+
+  /// A map between functions and their replacement.
+  ///
+  /// The keys in this mapping should be deleted when finishing processing the
+  /// module.
+  DenseMap<Function *, Function *> FunctionMap;
 };
 
 char LongVectorLoweringPass::ID = 0;
@@ -183,6 +201,72 @@ Value *convertVectorOperation(IRBuilder<> &B, Type *EquivalentReturnTy,
   }
 
   return ReturnValue;
+}
+
+/// Map the arguments of the wrapper function (which are either not long-vectors
+/// or aggregates of scalars) to the original arguments of the user-defined
+/// function (which can be long-vectors).
+SmallVector<Value *, 16> mapWrapperArgsToWrappeeArgs(IRBuilder<> &B,
+                                                     Function &Wrappee,
+                                                     Function &Wrapper) {
+  SmallVector<Value *, 16> Args;
+
+  std::size_t ArgumentCount = Wrapper.arg_size();
+  Args.reserve(ArgumentCount);
+
+  for (std::size_t i = 0; i < ArgumentCount; ++i) {
+    auto *NewArg = Wrapper.getArg(i);
+    auto *OldArgTy = Wrappee.getFunctionType()->getParamType(i);
+    auto *EquivalentArg = convertEquivalentValue(B, NewArg, OldArgTy);
+    Args.push_back(EquivalentArg);
+  }
+
+  return Args;
+}
+
+/// Create a new, equivalent function with no long-vector types.
+///
+/// This is achieved by creating a new function (the "wrapper") which inlines
+/// the given function (the "wrappee"). Only the parameters and return types are
+/// mapped. The function body still needs to be lowered.
+Function *createFunctionWithMappedTypes(Function &F, Type *EquivalentReturnTy,
+                                        ArrayRef<Type *> EquivalentParamTys) {
+  assert(!F.isVarArg() && "varargs not supported");
+
+  auto *Wrapper = Function::Create(
+      FunctionType::get(EquivalentReturnTy, EquivalentParamTys, false),
+      F.getLinkage());
+  Wrapper->takeName(&F);
+  Wrapper->setCallingConv(F.getCallingConv());
+  Wrapper->copyAttributesFrom(&F);
+  Wrapper->copyMetadata(&F, /* offset */ 0);
+
+  BasicBlock::Create(F.getContext(), "", Wrapper);
+  IRBuilder<> B(&Wrapper->getEntryBlock());
+
+  // Fill in the body of the wrapper function.
+  auto WrappeeArgs = mapWrapperArgsToWrappeeArgs(B, F, *Wrapper);
+  CallInst *Call = B.CreateCall(&F, WrappeeArgs);
+  if (Call->getType()->isVoidTy()) {
+    B.CreateRetVoid();
+  } else {
+    Value *ReturnValue = convertEquivalentValue(B, Call, EquivalentReturnTy);
+    B.CreateRet(ReturnValue);
+  }
+
+  // Ensure wrapper has a parent or InlineFunction will crash.
+  F.getParent()->getFunctionList().push_front(Wrapper);
+
+  // Inline the original function.
+  InlineFunctionInfo Info;
+  auto Result = InlineFunction(*Call, Info);
+  if (!Result.isSuccess()) {
+    LLVM_DEBUG(dbgs() << "Failed to inline " << F.getName() << '\n');
+    LLVM_DEBUG(dbgs() << "Reason: " << Result.getFailureReason() << '\n');
+    llvm_unreachable("Unexpected failure when inlining function.");
+  }
+
+  return Wrapper;
 }
 
 bool LongVectorLoweringPass::runOnModule(Module &M) {
@@ -327,8 +411,13 @@ bool LongVectorLoweringPass::runOnFunction(Function &F) {
     return false;
   }
 
-  // TODO Support long-vector types as parameters of non-kernel functions.
-  Function *FunctionToVisit = &F;
+  // Lower the function parameters and return type if needed.
+  Function *FunctionToVisit = convertUserDefinedFunction(F);
+  if (FunctionToVisit == nullptr) {
+    // The parameters don't rely on long vectors, but maybe some instructions in
+    // the function body do.
+    FunctionToVisit = &F;
+  }
 
   bool Modified = (FunctionToVisit != &F);
   for (Instruction &I : instructions(FunctionToVisit)) {
@@ -341,6 +430,54 @@ bool LongVectorLoweringPass::runOnFunction(Function &F) {
   LLVM_DEBUG(dbgs() << *FunctionToVisit << '\n');
 
   return Modified;
+}
+
+Function *LongVectorLoweringPass::convertUserDefinedFunction(Function &F) {
+  auto it = FunctionMap.find(&F);
+  if (it != FunctionMap.end()) {
+    return it->second;
+  }
+
+  LLVM_DEBUG(dbgs() << "Handling of user defined function:\n");
+  LLVM_DEBUG(dbgs() << F << '\n');
+
+  auto *FunctionTy = F.getFunctionType();
+  assert(!FunctionTy->isVarArg() && "VarArgs not supported");
+
+  bool RequireLowering = false;
+
+  // Convert parameter types.
+  SmallVector<Type *, 16> EquivalentParamTys;
+  EquivalentParamTys.reserve(FunctionTy->getNumParams());
+  for (auto *ParamTy : FunctionTy->params()) {
+    auto *EquivalentParamTy = getEquivalentTypeOrSelf(ParamTy);
+    EquivalentParamTys.push_back(EquivalentParamTy);
+    RequireLowering |= (EquivalentParamTy != ParamTy);
+  }
+
+  // Convert return type.
+  auto *ReturnTy = FunctionTy->getReturnType();
+  auto *EquivalentReturnTy = getEquivalentTypeOrSelf(ReturnTy);
+  RequireLowering |= (EquivalentReturnTy != ReturnTy);
+
+  // If no work is needed, mark it as so for future reference and bail out.
+  if (!RequireLowering) {
+    LLVM_DEBUG(dbgs() << "No need of wrapper function\n");
+    FunctionMap.insert({&F, nullptr});
+    return nullptr;
+  }
+
+  Function *EquivalentFunction =
+      createFunctionWithMappedTypes(F, EquivalentReturnTy, EquivalentParamTys);
+
+  LLVM_DEBUG(dbgs() << "Wrapper function:\n" << *EquivalentFunction << "\n");
+
+  // The body of the new function is intentionally not visited right now because
+  // we could be currently visiting a call instruction. Instead, it is being
+  // visited in runOnFunction. This is to ensure the state of the lowering pass
+  // remains valid.
+  FunctionMap.insert({&F, EquivalentFunction});
+  return EquivalentFunction;
 }
 
 void LongVectorLoweringPass::cleanDeadInstructions() {

--- a/test/LongVectorLowering/fadd.ll
+++ b/test/LongVectorLowering/fadd.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x float> @test(<8 x float> %a, <8 x float> %b) {
+entry:
+  %add = fadd <8 x float> %a, %b
+  ret <8 x float> %add
+}
+
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd
+; CHECK: fadd

--- a/test/LongVectorLowering/fdiv.ll
+++ b/test/LongVectorLowering/fdiv.ll
@@ -1,0 +1,28 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <16 x float> @test(<16 x float> %a, <16 x float> %b) {
+entry:
+  %add = fdiv <16 x float> %a, %b
+  ret <16 x float> %add
+}
+
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv
+; CHECK: fdiv

--- a/test/LongVectorLowering/function.ll
+++ b/test/LongVectorLowering/function.ll
@@ -1,0 +1,25 @@
+; RUN: clspv-opt --LongVectorLowering --early-cse --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+
+; Test that function arguments and return types can be lowered.
+; Rely on CSE and InstCombine to simplify the generated IR.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x float> @test(<8 x float> %x) !info !0 {
+  ret <8 x float> %x
+}
+
+!0 = !{!"some metadata"}
+
+; TODO Once dead functions are removed, add CHECK-NOT <8 x float>
+;
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test([[FLOAT8]] [[X:%[^ ]+]]) !info [[MD:![0-9]+]]
+; CHECK-NEXT: ret [[FLOAT8]] [[X]]
+;
+; TODO Once dead functions are removed, add CHECK-NOT <8 x float>
+;
+; CHECK: [[MD]] = !{!"some metadata"}

--- a/test/LongVectorLowering/function.ll
+++ b/test/LongVectorLowering/function.ll
@@ -13,13 +13,14 @@ define spir_func <8 x float> @test(<8 x float> %x) !info !0 {
 
 !0 = !{!"some metadata"}
 
-; TODO Once dead functions are removed, add CHECK-NOT <8 x float>
+; CHECK-NOT: <8 x float>
 ;
 ; CHECK-LABEL: define spir_func
 ; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
 ; CHECK-SAME: @test([[FLOAT8]] [[X:%[^ ]+]]) !info [[MD:![0-9]+]]
 ; CHECK-NEXT: ret [[FLOAT8]] [[X]]
 ;
-; TODO Once dead functions are removed, add CHECK-NOT <8 x float>
+; CHECK-NOT: <8 x float>
+; CHECK-NOT: define
 ;
 ; CHECK: [[MD]] = !{!"some metadata"}


### PR DESCRIPTION
This brings support for user-defined functions that have long-vectors as parameters and/or return type, improving support for lowering long-vectors (#613).

New tests cover this feature but also increase testing coverage of `BinaryOperators` with `fadd` and `fdiv`.