### PR TITLE
Convert write_only images in CL2.0 and later for unspecialized images

### DIFF
--- a/test/SpecializeImageTypes/convert_write_only_with_no_uses.ll
+++ b/test/SpecializeImageTypes/convert_write_only_with_no_uses.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t -cl-std=CL2.0
+; RUN: FileCheck %s < %t
+
+; CHECK-NOT: %opencl.image2d_wo_t
+; CHECK: [[image:%opencl.image2d_rw_t.float]] = type opaque
+; CHECK-NOT: %opencl.image2d_wo_t
+; CHECK: @no_use([[image]] addrspace(1)* %image)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_wo_t = type opaque
+
+define spir_kernel void @no_use(%opencl.image2d_wo_t addrspace(1)* %image) {
+entry:
+  ret void
+}

--- a/test/SpecializeImageTypes/no_duplicate_storage_image_type.cl
+++ b/test/SpecializeImageTypes/no_duplicate_storage_image_type.cl
@@ -1,0 +1,6 @@
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 --inline-entry-points
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(write_only image2d_t im) { }
+
+kernel void bar(read_write image2d_t im) { }


### PR DESCRIPTION
Fixes #648

* Convert write_only images to read_write images in OpenCL 2.0 and later
  even when a specialization of the image is not found