### PR TITLE
Add support for -cl-std=CL3.0

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -139,6 +139,7 @@ enum class SourceLanguage {
   OpenCL_C_11,
   OpenCL_C_12,
   OpenCL_C_20,
+  OpenCL_C_30,
   OpenCL_CPP
 };
 
@@ -174,7 +175,8 @@ bool GlobalOffsetPushConstant();
 // Returns true when support for non uniform NDRanges is enabled.
 static bool NonUniformNDRangeSupported() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||
-         ((Language() == SourceLanguage::OpenCL_C_20));
+         (Language() == SourceLanguage::OpenCL_C_20) ||
+         (Language() == SourceLanguage::OpenCL_C_30);
 }
 
 enum class StorageClass : int {

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -395,6 +395,9 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   case clspv::Option::SourceLanguage::OpenCL_C_20:
     standard = clang::LangStandard::lang_opencl20;
     break;
+  case clspv::Option::SourceLanguage::OpenCL_C_30:
+    standard = clang::LangStandard::lang_opencl30;
+    break;
   case clspv::Option::SourceLanguage::OpenCL_CPP:
     standard = clang::LangStandard::lang_openclcpp;
     break;

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -166,6 +166,8 @@ llvm::cl::opt<clspv::Option::SourceLanguage> cl_std(
                                 "CL1.2", "OpenCL C 1.2"),
                      clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_20,
                                 "CL2.0", "OpenCL C 2.0"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_30,
+                                "CL3.0", "OpenCL C 3.0"),
                      clEnumValN(clspv::Option::SourceLanguage::OpenCL_CPP,
                                 "CLC++", "C++ for OpenCL")));
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2891,6 +2891,10 @@ void SPIRVProducerPass::GenerateModuleInfo() {
     LangID = spv::SourceLanguageOpenCL_C;
     LangVer = 200;
     break;
+  case clspv::Option::SourceLanguage::OpenCL_C_30:
+    LangID = spv::SourceLanguageOpenCL_C;
+    LangVer = 300;
+    break;
   case clspv::Option::SourceLanguage::OpenCL_CPP:
     LangID = spv::SourceLanguageOpenCL_CPP;
     LangVer = 100;

--- a/test/opsource.cl
+++ b/test/opsource.cl
@@ -23,12 +23,18 @@
 // RUN: FileCheck --check-prefix=CHECK20 %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv -cl-std=CL3.0 %s -o %t.spv
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK30 %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: OpSource OpenCL_C 120
 
 // CHECK10: OpSource OpenCL_C 100
 // CHECK11: OpSource OpenCL_C 110
 // CHECK12: OpSource OpenCL_C 120
 // CHECK20: OpSource OpenCL_C 200
+// CHECK30: OpSource OpenCL_C 300
 
 void kernel test() {}
 


### PR DESCRIPTION
Always enable support for non-uniform work-groups when compiling as
CL3.0.

Signed-off-by: Kévin Petit <kpet@free.fr>