### PR TITLE
Prevent duplicate types and decorations

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1868,7 +1868,8 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
     break;
   }
   case Type::IntegerTyID: {
-    uint32_t bit_width = static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
+    uint32_t bit_width =
+        static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
 
     if (clspv::Option::Int8Support() && bit_width == 8) {
       addCapability(spv::CapabilityInt8);
@@ -1895,7 +1896,8 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
   case Type::HalfTyID:
   case Type::FloatTyID:
   case Type::DoubleTyID: {
-    uint32_t bit_width = static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
+    uint32_t bit_width =
+        static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
     if (bit_width == 16) {
       addCapability(spv::CapabilityFloat16);
     } else if (bit_width == 64) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1629,7 +1629,7 @@ Type *SPIRVProducerPass::EquivalentType(Type *type) {
       auto *func_ty = cast<FunctionType>(type);
       auto *return_ty = EquivalentType(func_ty->getReturnType());
       SmallVector<Type *, 8> params;
-      for (auto i = 0; i < func_ty->getNumParams(); ++i) {
+      for (unsigned i = 0; i < func_ty->getNumParams(); ++i) {
         params.push_back(EquivalentType(func_ty->getParamType(i)));
       }
       return FunctionType::get(return_ty, params, func_ty->isVarArg());

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1609,6 +1609,7 @@ Type *SPIRVProducerPass::CanonicalType(Type *type) {
         return StructType::get(type->getContext(), subtypes,
                                cast<StructType>(type)->isPacked());
       }
+      break;
     }
     case Type::ArrayTyID: {
       auto *elem_ty = type->getArrayElementType();

--- a/test/different_address_space_same_function_type.cl
+++ b/test/different_address_space_same_function_type.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv -no-inline-single -no-dra
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+static float foo(__global float* data) {
+  return data[0];
+}
+
+static float bar(__constant float* data) {
+  return data[0];
+}
+
+kernel void baz(__global float* in1, __constant float* in2, __global float* out) {
+  out[0] = foo(in1);
+  out[1] = bar(in2);
+}
+
+// #651: Since __constant and __global are both mapped to StorageBuffer storage
+// class, ensure the function type for the helpers is correctly unique.
+//
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[ptr_ssbo_float:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+// CHECK: OpTypeFunction [[float]] [[ptr_ssbo_float]]
+// CHECK-NOT: OpTypeFunction [[float]] [[ptr_ssbo_float]]

--- a/test/different_address_space_same_pointer_array_stride.cl
+++ b/test/different_address_space_same_pointer_array_stride.cl
@@ -1,0 +1,27 @@
+// RUN: clspv %s -o %t.spv -no-inline-single -no-dra
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+static float foo(__global float* data) {
+  return data[1];
+}
+
+static float bar(__constant float* data) {
+  return data[2];
+}
+
+kernel void baz(__global float* in1, __constant float* in2, __global float* out) {
+  out[0] = foo(in1 + 1);
+  out[1] = bar(in2 + 2);
+}
+
+// #651: Since __constant and __global are both mapped to StorageBuffer storage
+// class, ensure the pointer parameter only receives a single array stride decoration.
+//
+// CHECK: OpDecorate [[rta_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK: OpDecorate [[ptr_ssbo_float:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK-NOT: OpDecorate [[ptr_ssbo_float]] ArrayStride 4
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[ptr_ssbo_float]] = OpTypePointer StorageBuffer [[float]]
+// CHECK-DAG: [[rta_float]] = OpTypeRuntimeArray [[float]]


### PR DESCRIPTION
Fixes #651

* Prevent duplicate types and decorations from being generated for
  equivalent pointer types
  * Due to the shared mapping of __global and __constant to
    StorageBuffer, type-based containers need extra uniquing to ensure
    equivalent types don't result in invalid SPIR-V
  * getSPIRVType no uses a helper function, EquivalentType to see in the
    appropriate __global or __constant pointer has already been
    generated
  * ArrayStride decorations now check based on the resulting SPIR-V
    result id instead of the LLVM type