### PR TITLE
Recusiverly lower instructions

### DIFF
--- a/test/LongVectorLowering/constants.ll
+++ b/test/LongVectorLowering/constants.ll
@@ -1,0 +1,62 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; This tests covers UndefValue, ConstantAggregateZero and ConstantDataVector.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x float> @test1() {
+  ret <8 x float> zeroinitializer
+}
+
+define spir_func <8 x i32> @test2() {
+  ret <8 x i32> zeroinitializer
+}
+
+define spir_func <16 x float> @test3() {
+  ret <16 x float> undef
+}
+
+define spir_func <16 x i32> @test4() {
+  ret <16 x i32> undef
+}
+
+define spir_func <8 x float> @test5() {
+  ret <8 x float> <float 0.0, float 1.0, float 2.0, float 3.0, float 4.0, float 5.0, float 6.0, float 7.0>
+}
+
+define spir_func <8 x i32> @test6() {
+  ret <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+}
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: @test6()
+; CHECK-NEXT: ret [[INT8]] { i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7 }
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test5()
+; CHECK-NEXT: ret [[FLOAT8]] { float 0[[SUFFIX:\.0+e\+0+]], float 1[[SUFFIX]], float 2[[SUFFIX]],
+; CHECK-SAME: float 3[[SUFFIX]], float 4[[SUFFIX]], float 5[[SUFFIX]], float 6[[SUFFIX]], float 7[[SUFFIX]] }
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[INT16:{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: @test4()
+; CHECK-NEXT: ret [[INT16]] undef
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[FLOAT16:{ float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test3()
+; CHECK-NEXT: ret [[FLOAT16]] undef
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[INT8]]
+; CHECK-SAME: @test2()
+; CHECK-NEXT: ret [[INT8]] zeroinitializer
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[FLOAT8]]
+; CHECK-SAME: @test1()
+; CHECK-NEXT: ret [[FLOAT8]] zeroinitializer

--- a/test/LongVectorLowering/elements.ll
+++ b/test/LongVectorLowering/elements.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x i32> @test(<8 x i32> %xs) {
+  %a = extractelement <8 x i32> %xs, i32 0
+  %b = extractelement <8 x i32> %xs, i32 1
+  %tmp = insertelement <8 x i32> %xs, i32 %a, i32 1
+  %ret = insertelement <8 x i32> %tmp, i32 %b, i32 0
+  ret <8 x i32> %ret
+}
+
+; CHECK-LABEL: @test
+; CHECK-SAME: ([[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]] [[XS:%[^ ]+]])
+; CHECK-DAG: [[A:%[^ ]+]] = extractvalue [[INT8]] [[XS]], 0
+; CHECK-DAG: [[B:%[^ ]+]] = extractvalue [[INT8]] [[XS]], 1
+; CHECK-DAG: insertvalue {{.*}} i32 [[A]], 1
+; CHECK-DAG: insertvalue {{.*}} i32 [[B]], 0

--- a/test/LongVectorLowering/shufflevector/shufflevector1.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector1.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+;
+; This test doesn't involve long-vectors, the pass should not modify the IR.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <2 x i32> @test() {
+entry:
+  %x = shufflevector <2 x i32> undef, <2 x i32> undef, <2 x i32> zeroinitializer
+  ret <2 x i32> %x
+}
+
+; CHECK-LABEL: @test
+; CHECK: %x = shufflevector <2 x i32> undef, <2 x i32> undef, <2 x i32> zeroinitializer

--- a/test/LongVectorLowering/shufflevector/shufflevector2.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector2.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <3 x float> @test(<8 x float> %a, <8 x float> %b) {
+entry:
+  %x = shufflevector <8 x float> %a, <8 x float> %b, <3 x i32> <i32 1, i32 4, i32 15>
+  ret <3 x float> %x
+}
+
+; CHECK: @test(
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]] [[A:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8]] [[B:%[^ ]+]])
+; CHECK-DAG: [[S0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1
+; CHECK-DAG: [[S1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 4
+; CHECK-DAG: [[S2:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 7
+; CHECK-DAG: [[TMP0:%[^ ]+]] = insertelement <3 x float> undef, float [[S0]], i64 0
+; CHECK-DAG: [[TMP1:%[^ ]+]] = insertelement <3 x float> [[TMP0]], float [[S1]], i64 1
+; CHECK-DAG: [[TMP2:%[^ ]+]] = insertelement <3 x float> [[TMP1]], float [[S2]], i64 2
+; CHECK: ret <3 x float> [[TMP2]]

--- a/test/LongVectorLowering/shufflevector/shufflevector3.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector3.ll
@@ -1,0 +1,33 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <8 x float> @test(<3 x float> %a, <3 x float> %b) {
+entry:
+  %x = shufflevector <3 x float> %a, <3 x float> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 5, i32 4, i32 3>
+  ret <8 x float> %x
+}
+
+; CHECK: define spir_func [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test(<3 x float> [[A:%[^ ]+]], <3 x float> [[B:%[^ ]+]])
+; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x float> [[A]], i64 0
+; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x float> [[A]], i64 1
+; CHECK-DAG: [[S2:%[^ ]+]] = extractelement <3 x float> [[A]], i64 2
+; CHECK-DAG: [[S5:%[^ ]+]] = extractelement <3 x float> [[B]], i64 2
+; CHECK-DAG: [[S6:%[^ ]+]] = extractelement <3 x float> [[B]], i64 1
+; CHECK-DAG: [[S7:%[^ ]+]] = extractelement <3 x float> [[B]], i64 0
+; CHECK-DAG: [[TMP0:%[^ ]+]] = insertvalue [[FLOAT8]] undef, float [[S0]], 0
+; CHECK-DAG: [[TMP1:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP0]], float [[S1]], 1
+; CHECK-DAG: [[TMP2:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP1]], float [[S2]], 2
+; CHECK-DAG: [[TMP3:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP2]], float undef,  3
+; CHECK-DAG: [[TMP4:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP3]], float undef,  4
+; CHECK-DAG: [[TMP5:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP4]], float [[S5]], 5
+; CHECK-DAG: [[TMP6:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP5]], float [[S6]], 6
+; CHECK-DAG: [[TMP7:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP6]], float [[S7]], 7
+; CHECK: ret [[FLOAT8]] [[TMP7]]

--- a/test/LongVectorLowering/shufflevector/shufflevector4.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector4.ll
@@ -1,0 +1,30 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <8 x float> @test(<8 x float> %a) {
+entry:
+  %x = shufflevector <8 x float> %a, <8 x float> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 15, i32 14, i32 13>
+  ret <8 x float> %x
+}
+
+; CHECK: define spir_func [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test([[FLOAT8]] [[A:%[^ ]+]])
+; CHECK-DAG: [[S0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 0
+; CHECK-DAG: [[S1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1
+; CHECK-DAG: [[S2:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 2
+; CHECK-DAG: [[TMP0:%[^ ]+]] = insertvalue [[FLOAT8]] undef, float [[S0]], 0
+; CHECK-DAG: [[TMP1:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP0]], float [[S1]], 1
+; CHECK-DAG: [[TMP2:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP1]], float [[S2]], 2
+; CHECK-DAG: [[TMP3:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP2]], float undef, 3
+; CHECK-DAG: [[TMP4:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP3]], float undef, 4
+; CHECK-DAG: [[TMP5:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP4]], float undef, 5
+; CHECK-DAG: [[TMP6:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP5]], float undef, 6
+; CHECK-DAG: [[TMP7:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP6]], float undef, 7
+; CHECK: ret [[FLOAT8]] [[TMP7]]

--- a/test/LongVectorLowering/shufflevector/shufflevector5.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector5.ll
@@ -1,0 +1,30 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <8 x i32> @test(<3 x i32> %a) {
+entry:
+  %x = shufflevector <3 x i32> %a, <3 x i32> zeroinitializer, <8 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 5, i32 4, i32 3>
+  ret <8 x i32> %x
+}
+
+; CHECK: define spir_func [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: @test(<3 x i32> [[A:%[^ ]+]])
+; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 0
+; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 1
+; CHECK-DAG: [[S2:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 2
+; CHECK-DAG: [[TMP0:%[^ ]+]] = insertvalue [[INT8]] undef, i32 [[S0]], 0
+; CHECK-DAG: [[TMP1:%[^ ]+]] = insertvalue [[INT8]] [[TMP0]], i32 [[S1]], 1
+; CHECK-DAG: [[TMP2:%[^ ]+]] = insertvalue [[INT8]] [[TMP1]], i32 [[S2]], 2
+; CHECK-DAG: [[TMP3:%[^ ]+]] = insertvalue [[INT8]] [[TMP2]], i32 undef,  3
+; CHECK-DAG: [[TMP4:%[^ ]+]] = insertvalue [[INT8]] [[TMP3]], i32 undef,  4
+; CHECK-DAG: [[TMP5:%[^ ]+]] = insertvalue [[INT8]] [[TMP4]], i32 0, 5
+; CHECK-DAG: [[TMP6:%[^ ]+]] = insertvalue [[INT8]] [[TMP5]], i32 0, 6
+; CHECK-DAG: [[TMP7:%[^ ]+]] = insertvalue [[INT8]] [[TMP6]], i32 0, 7
+; CHECK: ret [[INT8]] [[TMP7]]

--- a/test/LongVectorLowering/shufflevector/shufflevector6.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector6.ll
@@ -1,0 +1,33 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <8 x i32> @test(<3 x i32> %a) {
+entry:
+  %x = shufflevector
+    <3 x i32> %a,
+    <3 x i32> <i32 1, i32 2, i32 3>,
+    <8 x i32> <i32 0, i32 1, i32 2, i32 undef, i32 undef, i32 5, i32 4, i32 3>
+  ret <8 x i32> %x
+}
+
+; CHECK: define spir_func [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: @test(<3 x i32> [[A:%[^ ]+]])
+; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 0
+; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 1
+; CHECK-DAG: [[S2:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 2
+; CHECK-DAG: [[TMP0:%[^ ]+]] = insertvalue [[INT8]] undef, i32 [[S0]], 0
+; CHECK-DAG: [[TMP1:%[^ ]+]] = insertvalue [[INT8]] [[TMP0]], i32 [[S1]], 1
+; CHECK-DAG: [[TMP2:%[^ ]+]] = insertvalue [[INT8]] [[TMP1]], i32 [[S2]], 2
+; CHECK-DAG: [[TMP3:%[^ ]+]] = insertvalue [[INT8]] [[TMP2]], i32 undef,  3
+; CHECK-DAG: [[TMP4:%[^ ]+]] = insertvalue [[INT8]] [[TMP3]], i32 undef,  4
+; CHECK-DAG: [[TMP5:%[^ ]+]] = insertvalue [[INT8]] [[TMP4]], i32 3, 5
+; CHECK-DAG: [[TMP6:%[^ ]+]] = insertvalue [[INT8]] [[TMP5]], i32 2, 6
+; CHECK-DAG: [[TMP7:%[^ ]+]] = insertvalue [[INT8]] [[TMP6]], i32 1, 7
+; CHECK: ret [[INT8]] [[TMP7]]

--- a/test/LongVectorLowering/shufflevector/shufflevector7.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector7.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+;
+; LongVectorLoweringPass is known to generate many intermediate instructions.
+; We rely on the InstCombine pass to remove them and simplify this test case.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+
+define spir_func <3 x i32> @test() {
+entry:
+  %x = shufflevector
+    <8 x i32> <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8>,
+    <8 x i32> zeroinitializer,
+    <3 x i32> <i32 1, i32 4, i32 15>
+  ret <3 x i32> %x
+}
+
+; CHECK: define spir_func <3 x i32> @test()
+; CHECK: ret <3 x i32> <i32 2, i32 5, i32 0>


### PR DESCRIPTION
The first commit is almost a NFC. It refactors the code to use InstVisitor to make the pass more modular. In future commits, support for a new instruction will be added with a new method overriding InstVisitor's default behaviour. The only change is that the pass will no longer print "Value not handled" (or any other message) for instruction that do not need handling, as determined by `handlingRequired`.

The second commit recursively visits instructions and lowers their operands. It adds support for a few additional kind of instructions and constants, with tests covering these, that, together with the existing support for BinaryOperator, allow turning on assertion/llvm_unreachable to alert users about features not yet supported.