### PR TITLE
Lower function call and initial support for LLVM intrinsics

### DIFF
--- a/test/LongVectorLowering/fastmathflags.ll
+++ b/test/LongVectorLowering/fastmathflags.ll
@@ -1,10 +1,12 @@
 ; RUN: clspv-opt --LongVectorLowering %s -o %t
 ; RUN: FileCheck %s < %t
 
-; TODO cover fcmp, select and call
+; TODO cover fcmp and select
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
+
+declare <8 x float> @llvm.fmuladd.v8f32(<8 x float>, <8 x float>, <8 x float>)
 
 define spir_func <8 x float> @test(<8 x float> %x, <8 x float> %y, <8 x float> %z) {
 entry:
@@ -14,7 +16,8 @@ entry:
   %d = fmul nsz <8 x float> %c, %a
   %e = fdiv arcp contract <8 x float> %d, %b
   %f = frem reassoc <8 x float> %e, %c
-  ret <8 x float> %f
+  %g = call fast <8 x float> @llvm.fmuladd.v8f32(<8 x float> %d, <8 x float> %e, <8 x float> %f)
+  ret <8 x float> %g
 }
 
 ; CHECK: fadd fast
@@ -70,3 +73,12 @@ entry:
 ; CHECK: frem reassoc
 ; CHECK: frem reassoc
 ; CHECK: frem reassoc
+
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32
+; CHECK: call fast float @llvm.fmuladd.f32

--- a/test/LongVectorLowering/fmuladd.ll
+++ b/test/LongVectorLowering/fmuladd.ll
@@ -1,0 +1,29 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+declare <8 x half> @llvm.fmuladd.v8f16(<8 x half>, <8 x half>, <8 x half>) #1
+
+define spir_func <8 x half> @test(<8 x half> %a, <8 x half> %b, <8 x half> %c) {
+entry:
+  %x = call <8 x half> @llvm.fmuladd.v8f16(<8 x half> %a, <8 x half> %b, <8 x half> %c)
+  ret <8 x half> %x
+}
+
+attributes #1 = { nounwind readnone speculatable willreturn }
+
+; CHECK-NOT: declare <8 x half> @llvm.fmuladd.v8f16
+
+; CHECK-LABEL: @test
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+; CHECK: @llvm.fmuladd.f16
+
+; CHECK-NOT: declare <8 x half> @llvm.fmuladd.v8f16

--- a/test/LongVectorLowering/function.ll
+++ b/test/LongVectorLowering/function.ll
@@ -1,26 +1,60 @@
 ; RUN: clspv-opt --LongVectorLowering --early-cse --instcombine %s -o %t
 ; RUN: FileCheck %s < %t
 
-; Test that function arguments and return types can be lowered.
+; Test that function arguments and return types can be lowered;
+; also cover function calls.
 ; Rely on CSE and InstCombine to simplify the generated IR.
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-define spir_func <8 x float> @test(<8 x float> %x) !info !0 {
+; @foo doesn't require any lowering
+define spir_func i32 @foo() {
+  ret i32 42
+}
+
+; @id requires lowering for parameter and return types
+define spir_func <8 x float> @id(<8 x float> %x) {
   ret <8 x float> %x
+}
+
+; @test1 requires lowering for parameter and return types, and call instruction.
+; Ensures metadata is preserved.
+define spir_func <8 x float> @test1(<8 x float> %x) !info !0 {
+  %y = call spir_func <8 x float> @id(<8 x float> %x), !info !0
+  ret <8 x float> %y
+}
+
+; @test2 requires lowering for return type, but not for call instruction.
+define spir_func <8 x i32> @test2(i32 %a) {
+  %b = call spir_func i32 @foo()
+  %c = add i32 %a, %b
+  %d = insertelement <8 x i32> undef, i32 %c, i32 0
+  %e = shufflevector <8 x i32> %d, <8 x i32> undef, <8 x i32> zeroinitializer
+  ret <8 x i32> %e
 }
 
 !0 = !{!"some metadata"}
 
 ; CHECK-NOT: <8 x float>
+; CHECK-NOT: <8 x i32>
+;
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: @test2(i32 {{%[^ ]+}})
+; CHECK-NEXT: call spir_func i32 @foo()
+; CHECK: ret [[INT8]] {{%[^ ]+}}
 ;
 ; CHECK-LABEL: define spir_func
 ; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
-; CHECK-SAME: @test([[FLOAT8]] [[X:%[^ ]+]]) !info [[MD:![0-9]+]]
-; CHECK-NEXT: ret [[FLOAT8]] [[X]]
+; CHECK-SAME: @test1([[FLOAT8]] [[X:%[^ ]+]])
+; CHECK-SAME: !info [[MD:![0-9]+]]
+; CHECK-NEXT: [[Y:%[^ ]+]] = call spir_func [[FLOAT8]] @id([[FLOAT8]] [[X]])
+; CHECK-SAME: !info [[MD]]
+; CHECK-NEXT: ret [[FLOAT8]] [[Y]]
 ;
-; CHECK-NOT: <8 x float>
-; CHECK-NOT: define
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[FLOAT8]] @id([[FLOAT8]] [[X:%[^ ]+]])
+; CHECK-NEXT: ret [[FLOAT8]] [[X]]
 ;
 ; CHECK: [[MD]] = !{!"some metadata"}


### PR DESCRIPTION
Continuing on #613, this patch brings support for function calls with long vectors as arguments or return type.

It also adds support for `fmuladd`. Other intrinsics are left out of this prototype but the existing code should easily scale to support them.

Support for (some) OpenCL builtins will be added in a later PR.