### PR TITLE
Lower OpenCL vloadN and vstoreN

### DIFF
--- a/cmake/strip_banned_opencl_features.py
+++ b/cmake/strip_banned_opencl_features.py
@@ -30,7 +30,7 @@ def main():
     args = parser.parse_args()
 
     # Strip invalid features.
-    regex = re.compile('(char|short|int|long|float|double|half)(8|16)|convert_[a-zA-Z0-9]+(_rt[pn]|_sat)')
+    regex = re.compile('convert_[a-zA-Z0-9]+(_rt[pn]|_sat)')
     with open(args.input_file, "r") as input:
         with open(args.output_file, "w") as output:
             for line in input:

--- a/test/LongVectorLowering/bitcast.ll
+++ b/test/LongVectorLowering/bitcast.ll
@@ -1,0 +1,132 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck --enable-var-scope %s < %t
+
+; This test covers various forms of bitcasts.
+; TODO Add support for bitcast between scalar and vector types.
+; TODO Add support for bitcast between vector types
+; TODO Add support for vector of pointers, and bitcast between them.
+
+; define spir_func <8 x i32> @v2v_A(<8 x float> %x) {
+;     %y = bitcast <8 x float> %x to <8 x i32>
+;     ret <8 x i32> %y
+; }
+
+; This function is unchanged.
+define spir_func <4 x i32> @v2v_B(<4 x float> %x) {
+    %y = bitcast <4 x float> %x to <4 x i32>
+    ret <4 x i32> %y
+}
+
+; define spir_func i64 @v2s_A(<8 x i8> %x) {
+;     %y = bitcast <8 x i8> %x to i64
+;     ret i64 %y
+; }
+
+; This function is unchanged.
+define spir_func i32 @v2s_B(<4 x i8> %x) {
+    %y = bitcast <4 x i8> %x to i32
+    ret i32 %y
+}
+
+; define spir_func <8 x i8> @s2v_A(i64 %x) {
+;     %y = bitcast i64 %x to <8 x i8>
+;     ret <8 x i8> %y
+; }
+
+; This function is unchanged.
+define spir_func <2 x i32> @s2v_B(i64 %x) {
+    %y = bitcast i64 %x to <2 x i32>
+    ret <2 x i32> %y
+}
+
+define spir_func <8 x i32>* @ps2ps_A(<8 x float>* %x) {
+    %y = bitcast <8 x float>* %x to <8 x i32>*
+    ret <8 x i32>* %y
+}
+
+define spir_func <16 x i32> addrspace(5)* @ps2ps_B(<16 x float> addrspace(5)* %x) {
+    %y = bitcast <16 x float> addrspace(5)* %x to <16 x i32> addrspace(5)*
+    ret <16 x i32> addrspace(5)* %y
+}
+
+; This function is unchanged.
+define spir_func <2 x i32> addrspace(5)* @ps2ps_C(<2 x float> addrspace(5)* %x) {
+    %y = bitcast <2 x float> addrspace(5)* %x to <2 x i32> addrspace(5)*
+    ret <2 x i32> addrspace(5)* %y
+}
+
+; define spir_func <8 x i32*> @pv2pv_A(<8 x float*> %x) {
+;     %y = bitcast <8 x float*> %x to <8 x i32*>
+;     ret <8 x i32*> %y
+; }
+
+; define spir_func <16 x i16 addrspace(5)*> @pv2pv_B(<16 x half addrspace(5)*> %x) {
+;     %y = bitcast <16 x half addrspace(5)*> %x to <16 x i16 addrspace(5)*>
+;     ret <16 x i16 addrspace(5)*> %y
+; }
+
+; This function is unchanged.
+define spir_func <2 x i32 addrspace(5)*> @pv2pv_C(<2 x float addrspace(5)*> %x) {
+    %y = bitcast <2 x float addrspace(5)*> %x to <2 x i32 addrspace(5)*>
+    ret <2 x i32 addrspace(5)*> %y
+}
+
+; Note, the order of tests is dictated by the lowering phase: some functions
+; are lowered and replaced by an equivalent, others are kept as-is. In this
+; process re-order functions in the module.
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace\(5\)\*]]
+; CHECK-SAME: @ps2ps_B(
+; CHECK-SAME: [[IN:{ float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float } addrspace\(5\)\*]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:{ i32, i32, i32, i32, i32, i32, i32, i32 }\*]]
+; CHECK-SAME: @ps2ps_A(
+; CHECK-SAME: [[IN:{ float, float, float, float, float, float, float, float }\*]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:<4 x i32>]]
+; CHECK-SAME: @v2v_B(
+; CHECK-SAME: [[IN:<4 x float>]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:i32]]
+; CHECK-SAME: @v2s_B(
+; CHECK-SAME: [[IN:<4 x i8>]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:<2 x i32>]]
+; CHECK-SAME: @s2v_B(
+; CHECK-SAME: [[IN:i64]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:<2 x i32> addrspace\(5\)\*]]
+; CHECK-SAME: @ps2ps_C(
+; CHECK-SAME: [[IN:<2 x float> addrspace\(5\)\*]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]
+
+; CHECK-LABEL: define spir_func
+; CHECK-SAME: [[OUT:<2 x i32 addrspace\(5\)\*>]]
+; CHECK-SAME: @pv2pv_C(
+; CHECK-SAME: [[IN:<2 x float addrspace\(5\)\*>]]
+; CHECK-SAME: [[X:%[^ ]+]])
+; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
+; CHECK-NEXT: ret [[OUT]] [[Y]]

--- a/test/LongVectorLowering/builtinfunctions.cl
+++ b/test/LongVectorLowering/builtinfunctions.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s --long-vector -verify
+
+// Ensure all builtins are declared (i.e. there are no warnings about implicit
+// declaration).
+//
+// expected-no-diagnostics
+
+// TODO Check that the appropriate SPIR-V instructions are generated once max is
+// supported.
+
+kernel void test(global int *in, global int *out) {
+  {
+    int8 a = vload8(0, in);
+    int8 b = vload8(1, in);
+    int8 c = max(a, b);
+    vstore8(c, 0, out);
+  }
+
+  {
+    int4 a = vload4(0, in);
+    int4 b = vload4(1, in);
+    int4 c = max(a, b);
+    vstore4(c, 2, out);
+  }
+}

--- a/test/LongVectorLowering/memory.ll
+++ b/test/LongVectorLowering/memory.ll
@@ -1,0 +1,42 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+; This test covers alloca, load and store instructions.
+
+declare spir_func void @sink(i8* %x)
+
+define spir_func void @test1(<16 x half>* %ptr) {
+  %alloca = alloca <16 x half>, align 16
+  %value = load <16 x half>, <16 x half>* %ptr, align 16
+  store volatile <16 x half> %value, <16 x half>* %alloca, align 16
+  %cast = bitcast <16 x half>* %alloca to i8*
+  call spir_func void @sink(i8* %cast)
+  ret void
+}
+
+define spir_func void @test2(<8 x i32>* %ptr) {
+  %alloca = alloca <8 x i32>, align 32
+  %value = load volatile <8 x i32>, <8 x i32>* %ptr, align 32
+  store <8 x i32> %value, <8 x i32>* %alloca, align 32
+  %cast = bitcast <8 x i32>* %alloca to i8*
+  call spir_func void @sink(i8* %cast)
+  ret void
+}
+
+; CHECK-LABEL: define spir_func void @test2(
+; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]* [[PTR:%[^ ]+]])
+; CHECK: [[ALLOCA:%[^ ]+]] = alloca [[INT8]], align 32
+; CHECK: [[VALUE:%[^ ]+]] = load volatile [[INT8]], [[INT8]]* [[PTR]], align 32
+; CHECK: store [[INT8]] [[VALUE]], [[INT8]]* [[ALLOCA]], align 32
+; CHECK: [[CAST:%[^ ]+]] = bitcast [[INT8]]* [[ALLOCA]] to i8*
+; CHECK: call spir_func void @sink(i8* [[CAST]])
+; CHECK: ret void
+
+; CHECK-LABEL: define spir_func void @test1(
+; CHECK-SAME: [[HALF16:{ half, half, half, half, half, half, half, half, half, half, half, half, half, half, half, half }]]* [[PTR:%[^ ]+]])
+; CHECK: [[ALLOCA:%[^ ]+]] = alloca [[HALF16]], align 16
+; CHECK: [[VALUE:%[^ ]+]] = load [[HALF16]], [[HALF16]]* [[PTR]], align 16
+; CHECK: store volatile [[HALF16]] [[VALUE]], [[HALF16]]* [[ALLOCA]], align 16
+; CHECK: [[CAST:%[^ ]+]] = bitcast [[HALF16]]* [[ALLOCA]] to i8*
+; CHECK: call spir_func void @sink(i8* [[CAST]])
+; CHECK: ret void

--- a/test/VectorLoadStore/vload16_global_float16.cl
+++ b/test/VectorLoadStore/vload16_global_float16.cl
@@ -1,0 +1,106 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that vload for float16 is supported.
+
+// CHECK-DAG: [[UINT:%[0-9a-zA-Z_]+]]   = OpTypeInt 32 0
+// CHECK-DAG: [[FLOAT:%[0-9a-zA-Z_]+]]  = OpTypeFloat 32
+// CHECK-DAG: [[FLOAT_PTR:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[FLOAT]]
+//
+// CHECK-DAG: [[CST_0:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 0
+// CHECK-DAG: [[CST_1:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 1
+// CHECK-DAG: [[CST_2:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 2
+// CHECK-DAG: [[CST_3:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 3
+// CHECK-DAG: [[CST_4:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 4
+// CHECK-DAG: [[CST_5:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 5
+// CHECK-DAG: [[CST_6:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 6
+// CHECK-DAG: [[CST_7:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 7
+// CHECK-DAG: [[CST_8:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 8
+// CHECK-DAG: [[CST_9:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 9
+// CHECK-DAG: [[CST_10:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 10
+// CHECK-DAG: [[CST_11:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 11
+// CHECK-DAG: [[CST_12:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 12
+// CHECK-DAG: [[CST_13:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 13
+// CHECK-DAG: [[CST_14:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 14
+// CHECK-DAG: [[CST_15:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 15
+//
+//
+// CHECK-NOT: DAG BARRIER
+
+// We expect 16 loads from the StorageBuffer for "src".
+//
+// CHECK: [[BASE_OFFSET:%[0-9]+]] = OpShiftLeftLogical [[UINT]] {{%[0-9]+}} [[CST_4]]
+//
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC:%[0-9a-zA-Z_]+]]
+// CHECK-SAME: [[CST_0]] [[BASE_OFFSET]]
+
+// CHECK: [[LOAD_0:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_1]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_1:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_2]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_2:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_3]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_3:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_4]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_4:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_5]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_5:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_6]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_6:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_7]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_7:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_8]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_8:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_9]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_9:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_10]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_10:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_11]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_11:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_12]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_12:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_13]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_13:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_14]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_14:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_15]]
+// CHECK: [[PTR:%[0-9]+]]     = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_15:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+
+kernel void test(uint offset, global float *src, global float *dst) {
+  float16 in = vload16(offset, src);
+
+  // Sink value to disable optimisations.
+  dst[0] = in.s0 + in.s1 + in.s2 + in.s3 + in.s4 + in.s5 + in.s6 + in.s7 +
+           in.s8 + in.s9 + in.sA + in.sB + in.sC + in.sD + in.sE + in.sF;
+}

--- a/test/VectorLoadStore/vload8_global_float8.cl
+++ b/test/VectorLoadStore/vload8_global_float8.cl
@@ -1,0 +1,62 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that vload for float8 is supported.
+
+// CHECK-DAG: [[UINT:%[0-9a-zA-Z_]+]]   = OpTypeInt 32 0
+// CHECK-DAG: [[FLOAT:%[0-9a-zA-Z_]+]]  = OpTypeFloat 32
+//
+// CHECK-DAG: [[FLOAT_PTR:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[FLOAT]]
+//
+// CHECK-DAG: [[CST_0:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 0
+// CHECK-DAG: [[CST_1:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 1
+// CHECK-DAG: [[CST_2:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 2
+// CHECK-DAG: [[CST_3:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 3
+// CHECK-DAG: [[CST_4:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 4
+// CHECK-DAG: [[CST_5:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 5
+// CHECK-DAG: [[CST_6:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 6
+// CHECK-DAG: [[CST_7:%[0-9a-zA-Z_]+]] = OpConstant [[UINT]] 7
+//
+// CHECK-NOT: DAG BARRIER
+//
+// CHECK: [[BASE_OFFSET:%[0-9]+]] = OpShiftLeftLogical [[UINT]] {{%[0-9]+}} [[CST_3]]
+//
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC:%[0-9a-zA-Z_]+]]
+// CHECK-SAME: [[CST_0]] [[BASE_OFFSET]]
+// CHECK: [[LOAD_0:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_1]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_1:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_2]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_2:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_3]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_3:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_4]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_4:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_5]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_5:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_6]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_6:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+//
+// CHECK: [[OFFSET:%[0-9]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_7]]
+// CHECK: [[PTR:%[0-9]+]]    = OpAccessChain [[FLOAT_PTR]] [[SRC]] [[CST_0]] [[OFFSET]]
+// CHECK: [[LOAD_7:%[0-9]+]] = OpLoad [[FLOAT]] [[PTR]]
+
+kernel void test(uint offset, global float *src, global float *dst) {
+  float8 in = vload8(offset, src);
+
+  // Sink value to disable optimisations.
+  dst[0] = in.s0 + in.s1 + in.s2 + in.s3 + in.s4 + in.s5 + in.s6 + in.s7;
+}

--- a/test/VectorLoadStore/vstore16_global_float16.cl
+++ b/test/VectorLoadStore/vstore16_global_float16.cl
@@ -1,0 +1,152 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that vstore for float16 is supported.
+
+// CHECK-DAG: [[UINT:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[RUNTIME_UINT:%[^ ]+]] = OpTypeRuntimeArray [[UINT]]
+// CHECK-DAG: [[STRUCT_RUNTIME_UINT:%[^ ]+]] = OpTypeStruct [[RUNTIME_UINT]]
+// CHECK-DAG: [[PTR_UINT:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_UINT]]
+//
+// CHECK-DAG: [[FLOAT:%[^ ]+]] = OpTypeFloat 32
+// CHECK-DAG: [[RUNTIME_FLOAT:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT]]
+// CHECK-DAG: [[STRUCT_RUNTIME_FLOAT:%[^ ]+]] = OpTypeStruct [[RUNTIME_FLOAT]]
+// CHECK-DAG: [[PTR_FLOAT:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_FLOAT]]
+//
+// CHECK-DAG: [[FLOAT8:%[^ ]+]] = OpTypeVector [[FLOAT]] 4
+// CHECK-DAG: [[RUNTIME_FLOAT8:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT8]]
+// CHECK-DAG: [[STRUCT_RUNTIME_FLOAT8:%[^ ]+]] = OpTypeStruct [[RUNTIME_FLOAT8]]
+// CHECK-DAG: [[PTR_FLOAT8:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_FLOAT8]]
+//
+// CHECK-DAG: [[INT_PTR:%[^ ]+]] = OpTypePointer StorageBuffer [[UINT]]
+// CHECK-DAG: [[FLOAT_PTR_FLOAT8:%[^ ]+]] = OpTypePointer StorageBuffer [[FLOAT8]]
+// CHECK-DAG: [[BUFFER_FLOAT_PTR:%[^ ]+]] = OpTypePointer StorageBuffer [[FLOAT]]
+//
+// CHECK-DAG: [[CST_0:%[^ ]+]]  = OpConstant [[UINT]] 0
+// CHECK-DAG: [[CST_1:%[^ ]+]]  = OpConstant [[UINT]] 1
+// CHECK-DAG: [[CST_2:%[^ ]+]]  = OpConstant [[UINT]] 2
+// CHECK-DAG: [[CST_3:%[^ ]+]]  = OpConstant [[UINT]] 3
+// CHECK-DAG: [[CST_4:%[^ ]+]]  = OpConstant [[UINT]] 4
+// CHECK-DAG: [[CST_5:%[^ ]+]]  = OpConstant [[UINT]] 5
+// CHECK-DAG: [[CST_6:%[^ ]+]]  = OpConstant [[UINT]] 6
+// CHECK-DAG: [[CST_7:%[^ ]+]]  = OpConstant [[UINT]] 7
+// CHECK-DAG: [[CST_8:%[^ ]+]]  = OpConstant [[UINT]] 8
+// CHECK-DAG: [[CST_9:%[^ ]+]]  = OpConstant [[UINT]] 9
+// CHECK-DAG: [[CST_10:%[^ ]+]] = OpConstant [[UINT]] 10
+// CHECK-DAG: [[CST_11:%[^ ]+]] = OpConstant [[UINT]] 11
+// CHECK-DAG: [[CST_12:%[^ ]+]] = OpConstant [[UINT]] 12
+// CHECK-DAG: [[CST_13:%[^ ]+]] = OpConstant [[UINT]] 13
+// CHECK-DAG: [[CST_14:%[^ ]+]] = OpConstant [[UINT]] 14
+// CHECK-DAG: [[CST_15:%[^ ]+]] = OpConstant [[UINT]] 15
+//
+// CHECK-DAG: [[OFFSET:%[^ ]+]] = OpVariable [[PTR_UINT]]   StorageBuffer
+// CHECK-DAG: [[DST:%[^ ]+]]    = OpVariable [[PTR_FLOAT]]  StorageBuffer
+// CHECK-DAG: [[VALUES:%[^ ]+]] = OpVariable [[PTR_FLOAT8]] StorageBuffer
+//
+// CHECK-DAG: [[PTR:%[^ ]+]]   = OpAccessChain [[INT_PTR]] [[OFFSET]] [[CST_0]]
+// CHECK-DAG: [[VAL_0:%[^ ]+]] = OpLoad [[UINT]] [[PTR]]
+//
+// CHECK-DAG: [[PTR_0:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_0]]
+// CHECK-DAG: [[VAL_1:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_0]]
+//
+// CHECK-DAG: [[A:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 0
+// CHECK-DAG: [[B:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 1
+// CHECK-DAG: [[C:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 2
+// CHECK-DAG: [[D:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 3
+//
+// CHECK-DAG: [[PTR_1:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_1]]
+// CHECK-DAG: [[VAL_2:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_1]]
+//
+// CHECK-DAG: [[E:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 0
+// CHECK-DAG: [[F:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 1
+// CHECK-DAG: [[G:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 2
+// CHECK-DAG: [[H:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 3
+//
+// CHECK-DAG: [[PTR_2:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_2]]
+// CHECK-DAG: [[VAL_3:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_2]]
+//
+// CHECK-DAG: [[I:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_3]] 0
+// CHECK-DAG: [[J:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_3]] 1
+// CHECK-DAG: [[K:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_3]] 2
+// CHECK-DAG: [[L:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_3]] 3
+//
+// CHECK-DAG: [[PTR_3:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_3]]
+// CHECK-DAG: [[VAL_4:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_3]]
+//
+// CHECK-DAG: [[M:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_4]] 0
+// CHECK-DAG: [[N:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_4]] 1
+// CHECK-DAG: [[O:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_4]] 2
+// CHECK-DAG: [[P:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_4]] 3
+//
+// CHECK-DAG: [[BASE_OFFSET:%[^ ]+]] = OpShiftLeftLogical [[UINT]] [[VAL_0]] [[CST_4]]
+//
+// CHECK-DAG: [[PTR_A:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[BASE_OFFSET]]
+// CHECK-DAG: OpStore [[PTR_A]] [[A]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_1]]
+// CHECK-DAG: [[PTR_B:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_B]] [[B]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_2]]
+// CHECK-DAG: [[PTR_C:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_C]] [[C]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_3]]
+// CHECK-DAG: [[PTR_D:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:   OpStore [[PTR_D]] [[D]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_4]]
+// CHECK-DAG: [[PTR_E:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_E]] [[E]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]]  [[CST_5]]
+// CHECK-DAG: [[PTR_F:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_F]] [[F]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]]  [[BASE_OFFSET]]  [[CST_6]]
+// CHECK-DAG: [[PTR_G:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_G]] [[G]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]]  [[BASE_OFFSET]]  [[CST_7]]
+// CHECK-DAG: [[PTR_H:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_H]] [[H]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_8]]
+// CHECK-DAG: [[PTR_I:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_I]] [[I]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_9]]
+// CHECK-DAG: [[PTR_J:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:   OpStore [[PTR_J]] [[J]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_10]]
+// CHECK-DAG: [[PTR_K:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_K]] [[K]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]]  = OpBitwiseOr [[UINT]] [[BASE_OFFSET]]  [[CST_11]]
+// CHECK-DAG: [[PTR_L:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_L]] [[L]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]]  [[BASE_OFFSET]]  [[CST_12]]
+// CHECK-DAG: [[PTR_M:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_M]] [[M]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]]  [[BASE_OFFSET]]  [[CST_13]]
+// CHECK-DAG: [[PTR_N:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_N]] [[N]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_14]]
+// CHECK-DAG: [[PTR_O:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:  OpStore [[PTR_O]] [[O]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_15]]
+// CHECK-DAG: [[PTR_P:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG:   OpStore [[PTR_P]] [[P]]
+
+kernel void test(global uint *offset, global float *dst,
+                 global float4 *values) {
+  // The following is optimised into 16 load/store pairs of instructions.
+  float16 value = (float16)(values[0], values[1], values[2], values[3]);
+  vstore16(value, *offset, dst);
+}

--- a/test/VectorLoadStore/vstore8_global_float8.cl
+++ b/test/VectorLoadStore/vstore8_global_float8.cl
@@ -1,0 +1,93 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that vstore for float8 is supported.
+
+// CHECK-DAG: [[UINT:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[RUNTIME_UINT:%[^ ]+]] = OpTypeRuntimeArray [[UINT]]
+// CHECK-DAG: [[STRUCT_RUNTIME_UINT:%[^ ]+]] = OpTypeStruct [[RUNTIME_UINT]]
+// CHECK-DAG: [[PTR_UINT:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_UINT]]
+//
+// CHECK-DAG: [[FLOAT:%[^ ]+]] = OpTypeFloat 32
+// CHECK-DAG: [[RUNTIME_FLOAT:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT]]
+// CHECK-DAG: [[STRUCT_RUNTIME_FLOAT:%[^ ]+]] = OpTypeStruct [[RUNTIME_FLOAT]]
+// CHECK-DAG: [[PTR_FLOAT:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_FLOAT]]
+//
+// CHECK-DAG: [[FLOAT8:%[^ ]+]] = OpTypeVector [[FLOAT]] 4
+// CHECK-DAG: [[RUNTIME_FLOAT8:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT8]]
+// CHECK-DAG: [[STRUCT_RUNTIME_FLOAT8:%[^ ]+]] = OpTypeStruct [[RUNTIME_FLOAT8]]
+// CHECK-DAG: [[PTR_FLOAT8:%[^ ]+]] = OpTypePointer StorageBuffer [[STRUCT_RUNTIME_FLOAT8]]
+//
+// CHECK-DAG: [[INT_PTR:%[^ ]+]] = OpTypePointer StorageBuffer [[UINT]]
+// CHECK-DAG: [[FLOAT_PTR_FLOAT8:%[^ ]+]] = OpTypePointer StorageBuffer [[FLOAT8]]
+// CHECK-DAG: [[BUFFER_FLOAT_PTR:%[^ ]+]] = OpTypePointer StorageBuffer [[FLOAT]]
+//
+// CHECK-DAG: [[CST_0:%[^ ]+]] = OpConstant [[UINT]] 0
+// CHECK-DAG: [[CST_1:%[^ ]+]] = OpConstant [[UINT]] 1
+// CHECK-DAG: [[CST_2:%[^ ]+]] = OpConstant [[UINT]] 2
+// CHECK-DAG: [[CST_3:%[^ ]+]] = OpConstant [[UINT]] 3
+// CHECK-DAG: [[CST_4:%[^ ]+]] = OpConstant [[UINT]] 4
+// CHECK-DAG: [[CST_5:%[^ ]+]] = OpConstant [[UINT]] 5
+// CHECK-DAG: [[CST_6:%[^ ]+]] = OpConstant [[UINT]] 6
+// CHECK-DAG: [[CST_7:%[^ ]+]] = OpConstant [[UINT]] 7
+//
+// CHECK-DAG: [[OFFSET:%[^ ]+]] = OpVariable [[PTR_UINT]]   StorageBuffer
+// CHECK-DAG: [[DST:%[^ ]+]]    = OpVariable [[PTR_FLOAT]]  StorageBuffer
+// CHECK-DAG: [[VALUES:%[^ ]+]] = OpVariable [[PTR_FLOAT8]] StorageBuffer
+//
+// CHECK-DAG: [[PTR:%[^ ]+]]   = OpAccessChain [[INT_PTR]] [[OFFSET]] [[CST_0]]
+// CHECK-DAG: [[VAL_0:%[^ ]+]] = OpLoad [[UINT]] [[PTR]]
+//
+// CHECK-DAG: [[PTR_1:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_0]]
+// CHECK-DAG: [[VAL_1:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_1]]
+// CHECK-DAG: [[A:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 0
+// CHECK-DAG: [[B:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 1
+// CHECK-DAG: [[C:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 2
+// CHECK-DAG: [[D:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_1]] 3
+//
+// CHECK-DAG: [[PTR_0:%[^ ]+]] = OpAccessChain [[FLOAT_PTR_FLOAT8]] [[VALUES]] [[CST_0]] [[CST_1]]
+// CHECK-DAG: [[VAL_2:%[^ ]+]] = OpLoad [[FLOAT8]] [[PTR_0]]
+// CHECK-DAG: [[E:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 0
+// CHECK-DAG: [[F:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 1
+// CHECK-DAG: [[G:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 2
+// CHECK-DAG: [[H:%[^ ]+]] = OpCompositeExtract [[FLOAT]] [[VAL_2]] 3
+//
+// CHECK-DAG: [[BASE_OFFSET:%[^ ]+]] = OpShiftLeftLogical [[UINT]] [[VAL_0]] [[CST_3]]
+// CHECK-DAG: [[PTR_A:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[BASE_OFFSET]]
+// CHECK-DAG: OpStore [[PTR_A]] [[A]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_1]]
+// CHECK-DAG: [[PTR_B:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_B]] [[B]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_2]]
+// CHECK-DAG: [[PTR_C:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_C]] [[C]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_3]]
+// CHECK-DAG: [[PTR_D:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_D]] [[D]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_4]]
+// CHECK-DAG: [[PTR_E:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_E]] [[E]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_5]]
+// CHECK-DAG: [[PTR_F:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_F]] [[F]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_6]]
+// CHECK-DAG: [[PTR_G:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_G]] [[G]]
+//
+// CHECK-DAG: [[SHIFT:%[^ ]+]] = OpBitwiseOr [[UINT]] [[BASE_OFFSET]] [[CST_7]]
+// CHECK-DAG: [[PTR_H:%[^ ]+]] = OpAccessChain [[BUFFER_FLOAT_PTR]] [[DST]] [[CST_0]] [[SHIFT]]
+// CHECK-DAG: OpStore [[PTR_H]] [[H]]
+
+kernel void test(global uint *offset, global float *dst,
+                 global float4 *values) {
+  // The following is optimised into 8 load/store pairs of instructions.
+  float8 value = (float8)(values[0], values[1]);
+  vstore8(value, *offset, dst);
+}


### PR DESCRIPTION
Continuing on #613, this time lowering a few additional kind of instructions (AllocaInst, CastInst, LoadInst and StoreInst) which enable lowering of OpenCL vload/vstore builtin functions.

I've also replaced `isa<ConstantAggregateZero>(Cst)` with `Cst.isZeroValue()` to cover more cases ellegantly.