### PR TITLE
Implement isordered and isunordered

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -797,8 +797,7 @@ All supported.
 
 #### Relational Functions
 
-The `islessgreater()`, `isfinite()`, `isnormal()`, `isordered()` and
-`isunordered()` built-in functions **must not** be used.
+The `islessgreater()` and `isnormal()` built-in functions **must not** be used.
 
 #### Vector Data Load and Store Functions
 

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -3044,7 +3044,7 @@ bool ReplaceOpenCLBuiltinPass::replaceOrdered(Function &F, bool is_ordered) {
     // OpenCL CTS requires that vector versions use sign extension, but scalar
     // versions use zero extension.
     if (isa<VectorType>(Call->getType()))
-        return builder.CreateSExt(tmp, Call->getType());
+      return builder.CreateSExt(tmp, Call->getType());
     return builder.CreateZExt(tmp, Call->getType());
   });
 }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -279,6 +279,7 @@ private:
                    Instruction::BinaryOps join_opcode);
   bool replaceCountZeroes(Function &F, bool leading);
   bool replaceMadSat(Function &F, bool is_signed);
+  bool replaceOrdered(Function &F, bool is_ordered);
 
   // Caches struct types for { |type|, |type| }. This prevents
   // getOrInsertFunction from introducing a bitcasts between structs with
@@ -409,6 +410,12 @@ bool ReplaceOpenCLBuiltinPass::runOnFunction(Function &F) {
   case Builtins::kIsnotequal:
     return replaceRelational(F, CmpInst::FCMP_ONE,
                              FI.getParameter(0).vector_size ? -1 : 1);
+
+  case Builtins::kIsordered:
+    return replaceOrdered(F, true);
+
+  case Builtins::kIsunordered:
+    return replaceOrdered(F, false);
 
   case Builtins::kIsinf: {
     bool is_vec = FI.getParameter(0).vector_size != 0;
@@ -2983,5 +2990,61 @@ bool ReplaceOpenCLBuiltinPass::replaceMadSat(Function &F, bool is_signed) {
       auto cmp = builder.CreateICmpEQ(or_value, Constant::getNullValue(ty));
       return builder.CreateSelect(cmp, add, Constant::getAllOnesValue(ty));
     }
+  });
+}
+
+bool ReplaceOpenCLBuiltinPass::replaceOrdered(Function &F, bool is_ordered) {
+  if (!isa<IntegerType>(F.getReturnType()->getScalarType()))
+    return false;
+
+  if (F.getFunctionType()->getNumParams() != 2)
+    return false;
+
+  if (F.getFunctionType()->getParamType(0) !=
+      F.getFunctionType()->getParamType(1)) {
+    return false;
+  }
+
+  switch (F.getFunctionType()->getParamType(0)->getScalarType()->getTypeID()) {
+  case Type::FloatTyID:
+  case Type::HalfTyID:
+  case Type::DoubleTyID:
+    break;
+  default:
+    return false;
+  }
+
+  // Scalar versions all return an int, while vector versions return a vector
+  // of an equally sized integer types (e.g. short, int or long).
+  if (isa<VectorType>(F.getReturnType())) {
+    if (F.getReturnType()->getScalarSizeInBits() !=
+        F.getFunctionType()->getParamType(0)->getScalarSizeInBits()) {
+      return false;
+    }
+  } else {
+    if (F.getReturnType()->getScalarSizeInBits() != 32)
+      return false;
+  }
+
+  return replaceCallsWithValue(F, [is_ordered](CallInst *Call) {
+    // Replace with a floating point [un]ordered comparison followed by an
+    // extension.
+    auto x = Call->getArgOperand(0);
+    auto y = Call->getArgOperand(1);
+    IRBuilder<> builder(Call);
+    Value *tmp = nullptr;
+    if (is_ordered) {
+      // This leads to a slight inefficiency in the SPIR-V that is easy for
+      // drivers to optimize where the SPIR-V for the comparison and the
+      // extension could be fused to drop the inversion of the OpIsNan.
+      tmp = builder.CreateFCmpORD(x, y);
+    } else {
+      tmp = builder.CreateFCmpUNO(x, y);
+    }
+    // OpenCL CTS requires that vector versions use sign extension, but scalar
+    // versions use zero extension.
+    if (isa<VectorType>(Call->getType()))
+        return builder.CreateSExt(tmp, Call->getType());
+    return builder.CreateZExt(tmp, Call->getType());
   });
 }

--- a/test/RelationalBuiltins/isordered/double2_isordered.ll
+++ b/test/RelationalBuiltins/isordered/double2_isordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i64> @double2_isordered(<2 x double> %x, <2 x double> %y) {
+entry:
+  %call = call spir_func <2 x i64> @_Z9isorderedDv2_dS_(<2 x double> %x, <2 x double> %y)
+  ret <2 x i64> %call
+}
+
+declare spir_func <2 x i64> @_Z9isorderedDv2_dS_(<2 x double>, <2 x double>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord <2 x double> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i64>
+; CHECK: ret <2 x i64> [[sext]]
+

--- a/test/RelationalBuiltins/isordered/double_isordered.ll
+++ b/test/RelationalBuiltins/isordered/double_isordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @double_isordered(double %x, double %y) {
+entry:
+  %call = call spir_func i32 @_Z9isordereddd(double %x, double %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z9isordereddd(double, double)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord double %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]
+

--- a/test/RelationalBuiltins/isordered/double_spirv.cl
+++ b/test/RelationalBuiltins/isordered/double_spirv.cl
@@ -1,0 +1,48 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out, double x, double y) {
+  int i = 0;
+  out[i++] = isordered(0.0, 0.0);
+  out[i++] = isordered(as_double(0x7ff8000000000000), 0.0);
+  out[i++] = isordered(0.0, as_double(0x7ff0000000000001));
+  out[i++] = isordered(x, 0.0);
+  out[i++] = isordered(x, as_double(0x7ff0000010000000));
+  out[i++] = isordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[double:%[a-zA-Z0-9_]+]] = OpTypeFloat 64
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_1]]
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[double]] {{.*}} 0
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[double]] {{.*}} 1
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[or]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]
+

--- a/test/RelationalBuiltins/isordered/float2_isordered.ll
+++ b/test/RelationalBuiltins/isordered/float2_isordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i32> @float2_isordered(<2 x float> %x, <2 x float> %y) {
+entry:
+  %call = call spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float> %x, <2 x float> %y)
+  ret <2 x i32> %call
+}
+
+declare spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float>, <2 x float>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord <2 x float> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i32>
+; CHECK: ret <2 x i32> [[sext]]
+

--- a/test/RelationalBuiltins/isordered/float_isordered.ll
+++ b/test/RelationalBuiltins/isordered/float_isordered.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @float_isordered(float %x, float %y) {
+entry:
+  %call = call spir_func i32 @_Z9isorderedff(float %x, float %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z9isorderedff(float, float)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord float %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]

--- a/test/RelationalBuiltins/isordered/float_spirv.cl
+++ b/test/RelationalBuiltins/isordered/float_spirv.cl
@@ -1,0 +1,47 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out, float x, float y) {
+  int i = 0;
+  out[i++] = isordered(0.0f, 0.0f);
+  out[i++] = isordered(as_float(0x7ff00000), 0.0f);
+  out[i++] = isordered(0.0f, as_float(0x7f800001));
+  out[i++] = isordered(x, 0.0f);
+  out[i++] = isordered(x, as_float(0x7fc00000));
+  out[i++] = isordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_1]]
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 0
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 1
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[or]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]

--- a/test/RelationalBuiltins/isordered/half2_isordered.ll
+++ b/test/RelationalBuiltins/isordered/half2_isordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i16> @half2_isordered(<2 x half> %x, <2 x half> %y) {
+entry:
+  %call = call spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half> %x, <2 x half> %y)
+  ret <2 x i16> %call
+}
+
+declare spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half>, <2 x half>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord <2 x half> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i16>
+; CHECK: ret <2 x i16> [[sext]]
+

--- a/test/RelationalBuiltins/isordered/half_isordered.ll
+++ b/test/RelationalBuiltins/isordered/half_isordered.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @half_isordered(half %x, half %y) {
+entry:
+  %call = call spir_func i32 @_Z9isorderedDhDh(half %x, half %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z9isorderedDhDh(half, half)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp ord half %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]

--- a/test/RelationalBuiltins/isordered/half_spirv.cl
+++ b/test/RelationalBuiltins/isordered/half_spirv.cl
@@ -1,0 +1,55 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global int* out, float a, float b) {
+  half x = a;
+  half y = b;
+  int i = 0;
+  out[i++] = isordered((half)0.0f, (half)0.0f);
+  out[i++] = isordered(as_half((ushort)0x7e00), (half)0.0f);
+  out[i++] = isordered((half)0.0f, as_half((ushort)0x7c01));
+  out[i++] = isordered(x, (half)0.0f);
+  out[i++] = isordered(x, as_half((ushort)0x7c10));
+  out[i++] = isordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_1]]
+// CHECK-DAG: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 0
+// CHECK-DAG: [[b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 1
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpFConvert [[half]] [[a]]
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpFConvert [[half]] [[b]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_0]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[not:%[a-zA-Z0-9_]+]] = OpLogicalNot [[bool]] [[or]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[not]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]
+

--- a/test/RelationalBuiltins/isunordered/double2_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/double2_isunordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i64> @double2_isunordered(<2 x double> %x, <2 x double> %y) {
+entry:
+  %call = call spir_func <2 x i64> @_Z11isunorderedDv2_dS_(<2 x double> %x, <2 x double> %y)
+  ret <2 x i64> %call
+}
+
+declare spir_func <2 x i64> @_Z11isunorderedDv2_dS_(<2 x double>, <2 x double>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno <2 x double> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i64>
+; CHECK: ret <2 x i64> [[sext]]
+

--- a/test/RelationalBuiltins/isunordered/double_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/double_isunordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @double_isunordered(double %x, double %y) {
+entry:
+  %call = call spir_func i32 @_Z11isunordereddd(double %x, double %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z11isunordereddd(double, double)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno double %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]
+

--- a/test/RelationalBuiltins/isunordered/double_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/double_spirv.cl
@@ -1,0 +1,46 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out, double x, double y) {
+  int i = 0;
+  out[i++] = isunordered(0.0, 0.0);
+  out[i++] = isunordered(as_double(0x7ff8000000000000), 0.0);
+  out[i++] = isunordered(0.0, as_double(0x7ff0000000000001));
+  out[i++] = isunordered(x, 0.0);
+  out[i++] = isunordered(x, as_double(0x7ff0000010000000));
+  out[i++] = isunordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[double:%[a-zA-Z0-9_]+]] = OpTypeFloat 64
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_0]]
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[double]] {{.*}} 0
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[double]] {{.*}} 1
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[is_nan]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[or]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]
+

--- a/test/RelationalBuiltins/isunordered/float2_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/float2_isunordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i32> @float2_isunordered(<2 x float> %x, <2 x float> %y) {
+entry:
+  %call = call spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float> %x, <2 x float> %y)
+  ret <2 x i32> %call
+}
+
+declare spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float>, <2 x float>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno <2 x float> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i32>
+; CHECK: ret <2 x i32> [[sext]]
+

--- a/test/RelationalBuiltins/isunordered/float_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/float_isunordered.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @float_isunordered(float %x, float %y) {
+entry:
+  %call = call spir_func i32 @_Z11isunorderedff(float %x, float %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z11isunorderedff(float, float)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno float %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]

--- a/test/RelationalBuiltins/isunordered/float_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/float_spirv.cl
@@ -1,0 +1,45 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out, float x, float y) {
+  int i = 0;
+  out[i++] = isunordered(0.0f, 0.0f);
+  out[i++] = isunordered(as_float(0x7ff00000), 0.0f);
+  out[i++] = isunordered(0.0f, as_float(0x7f800001));
+  out[i++] = isunordered(x, 0.0f);
+  out[i++] = isunordered(x, as_float(0x7fc00000));
+  out[i++] = isunordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_0]]
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 0
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 1
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[is_nan]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[or]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]

--- a/test/RelationalBuiltins/isunordered/half2_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/half2_isunordered.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i16> @half2_isunordered(<2 x half> %x, <2 x half> %y) {
+entry:
+  %call = call spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half> %x, <2 x half> %y)
+  ret <2 x i16> %call
+}
+
+declare spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half>, <2 x half>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno <2 x half> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i16>
+; CHECK: ret <2 x i16> [[sext]]
+

--- a/test/RelationalBuiltins/isunordered/half_isunordered.ll
+++ b/test/RelationalBuiltins/isunordered/half_isunordered.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @half_isunordered(half %x, half %y) {
+entry:
+  %call = call spir_func i32 @_Z11isunorderedDhDh(half %x, half %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z11isunorderedDhDh(half, half)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp uno half %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]

--- a/test/RelationalBuiltins/isunordered/half_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/half_spirv.cl
@@ -1,0 +1,53 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global int* out, float a, float b) {
+  half x = a;
+  half y = b;
+  int i = 0;
+  out[i++] = isunordered((half)0.0f, (half)0.0f);
+  out[i++] = isunordered(as_half((ushort)0x7e00), (half)0.0f);
+  out[i++] = isunordered((half)0.0f, as_half((ushort)0x7c01));
+  out[i++] = isunordered(x, (half)0.0f);
+  out[i++] = isunordered(x, as_half((ushort)0x7c10));
+  out[i++] = isunordered(x, y);
+}
+
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK: OpLabel
+// CHECK-DAG: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_0]]
+// CHECK-DAG: OpStore [[gep]] [[uint_0]]
+// CHECK-DAG: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 0
+// CHECK-DAG: [[b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[float]] {{.*}} 1
+// CHECK-DAG: [[x:%[a-zA-Z0-9_]+]] = OpFConvert [[half]] [[a]]
+// CHECK-DAG: [[y:%[a-zA-Z0-9_]+]] = OpFConvert [[half]] [[b]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_1]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_2]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[is_nan]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[gep]] [[sel]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_4]]
+// CHECK: OpStore [[gep]] [[uint_1]]
+// CHECK: [[x_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[x]]
+// CHECK: [[y_is_nan:%[a-zA-Z0-9_]+]] = OpIsNan [[bool]] [[y]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpLogicalOr [[bool]] [[x_is_nan]] [[y_is_nan]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[uint]] [[or]] [[uint_1]] [[uint_0]]
+// CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint_0]] [[uint_5]]
+// CHECK: OpStore [[gep]] [[sel]]
+


### PR DESCRIPTION
* Implement in terms of `fcmp ord` and `fcmp uno` respectively followed
  by an extension
* SPIRVProducer support for `fcmp ord` and `fcmp uno` in terms of
  OpIsNan
* tests
* Passes OpenCL CTS for float, float2 and float4