### PR TITLE
Implement islessgreater

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -797,7 +797,7 @@ All supported.
 
 #### Relational Functions
 
-The `islessgreater()` and `isnormal()` built-in functions **must not** be used.
+The `isnormal()` built-in function **must not** be used.
 
 #### Vector Data Load and Store Functions
 

--- a/test/RelationalBuiltins/islessgreater/islessgreater_double.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_double.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @islessgreater_double(double %x, double %y) {
+entry:
+  %call = call spir_func i32 @_Z13islessgreaterdd(double %x, double %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z13islessgreaterdd(double, double)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one double %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]
+

--- a/test/RelationalBuiltins/islessgreater/islessgreater_double2.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_double2.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i64> @islessgreater_double2(<2 x double> %x, <2 x double> %y) {
+entry:
+  %call = call spir_func <2 x i64> @_Z13islessgreaterDv2_dS_(<2 x double> %x, <2 x double> %y)
+  ret <2 x i64> %call
+}
+
+declare spir_func <2 x i64> @_Z13islessgreaterDv2_dS_(<2 x double>, <2 x double>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one <2 x double> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i64>
+; CHECK: ret <2 x i64> [[sext]]
+

--- a/test/RelationalBuiltins/islessgreater/islessgreater_float.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_float.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @islessgreater_float(float %x, float %y) {
+entry:
+  %call = call spir_func i32 @_Z13islessgreaterff(float %x, float %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z13islessgreaterff(float, float)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one float %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]

--- a/test/RelationalBuiltins/islessgreater/islessgreater_float2.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_float2.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i32> @islessgreater_float2(<2 x float> %x, <2 x float> %y) {
+entry:
+  %call = call spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float> %x, <2 x float> %y)
+  ret <2 x i32> %call
+}
+
+declare spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float>, <2 x float>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one <2 x float> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i32>
+; CHECK: ret <2 x i32> [[sext]]
+

--- a/test/RelationalBuiltins/islessgreater/islessgreater_half.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_half.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define i32 @islessgreater_half(half %x, half %y) {
+entry:
+  %call = call spir_func i32 @_Z13islessgreaterDhDh(half %x, half %y)
+  ret i32 %call
+}
+
+declare spir_func i32 @_Z13islessgreaterDhDh(half, half)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one half %x, %y
+; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i1 [[cmp]] to i32
+; CHECK: ret i32 [[zext]]
+

--- a/test/RelationalBuiltins/islessgreater/islessgreater_half2.ll
+++ b/test/RelationalBuiltins/islessgreater/islessgreater_half2.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x i16> @islessgreater_half2(<2 x half> %x, <2 x half> %y) {
+entry:
+  %call = call spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half> %x, <2 x half> %y)
+  ret <2 x i16> %call
+}
+
+declare spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half>, <2 x half>)
+
+; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = fcmp one <2 x half> %x, %y
+; CHECK: [[sext:%[a-zA-Z0-9_.]+]] = sext <2 x i1> [[cmp]] to <2 x i16>
+; CHECK: ret <2 x i16> [[sext]]
+

--- a/test/RelationalBuiltins/isnotequal_float.cl
+++ b/test/RelationalBuiltins/isnotequal_float.cl
@@ -10,7 +10,7 @@
 // CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 // CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
 // CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdNotEqual %[[BOOL_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFUnordNotEqual %[[BOOL_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
 // CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[CMP_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_0_ID]]
 // CHECK: OpStore {{.*}} %[[CAS_ID]]
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global float* b)

--- a/test/RelationalBuiltins/isnotequal_float2.cl
+++ b/test/RelationalBuiltins/isnotequal_float2.cl
@@ -14,7 +14,7 @@
 // CHECK-DAG: %[[UINT2_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT2_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
 // CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT2_TYPE_ID]]
 // CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT2_TYPE_ID]]
-// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdNotEqual %[[BOOL2_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFUnordNotEqual %[[BOOL2_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
 // CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT2_TYPE_ID]] %[[CMP_ID]] %[[UINT2_CONSTANT_ALL_BITS_SET_ID]] %[[UINT2_CONSTANT_0_ID]]
 // CHECK: OpStore {{.*}} %[[CAS_ID]]
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2* a, global float2* b)

--- a/test/RelationalBuiltins/isnotequal_float3.cl
+++ b/test/RelationalBuiltins/isnotequal_float3.cl
@@ -14,7 +14,7 @@
 // CHECK-DAG: %[[UINT3_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT3_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
 // CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT3_TYPE_ID]]
 // CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT3_TYPE_ID]]
-// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdNotEqual %[[BOOL3_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFUnordNotEqual %[[BOOL3_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
 // CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT3_TYPE_ID]] %[[CMP_ID]] %[[UINT3_CONSTANT_ALL_BITS_SET_ID]] %[[UINT3_CONSTANT_0_ID]]
 // CHECK: OpStore {{.*}} %[[CAS_ID]]
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)

--- a/test/RelationalBuiltins/isnotequal_float4.cl
+++ b/test/RelationalBuiltins/isnotequal_float4.cl
@@ -14,7 +14,7 @@
 // CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
 // CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
 // CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
-// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdNotEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFUnordNotEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
 // CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
 // CHECK: OpStore {{.*}} %[[CAS_ID]]
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int4* a, global float4* b)


### PR DESCRIPTION
* Update docs
* islessgreater is implemented as `fcmp one`
* Fixed a bug in isnotequal
  * Changed to `fcmp une` instead of `fcmp one`
* Simplied `replaceRelational` to use an extension instead of select
* Re-tested math brute force and relational CTS for all affected
  functions