### PR TITLE
Lowers OpenCL builtin functions

### DIFF
--- a/lib/Builtins.h
+++ b/lib/Builtins.h
@@ -57,6 +57,7 @@ public:
   operator int() const { return type_; }
   const std::string &getName() const { return name_; }
   const ParamTypeInfo &getParameter(size_t arg) const;
+  ParamTypeInfo &getParameter(size_t arg);
   const ParamTypeInfo &getLastParameter() const { return params_.back(); }
   size_t getParameterCount() const { return params_.size(); }
   const ParamTypeInfo &getReturnType() const { return return_type_; }
@@ -80,6 +81,8 @@ inline const FunctionInfo &Lookup(llvm::Function *func) {
 std::string GetMangledFunctionName(const char *name, llvm::Type *type);
 
 std::string GetMangledFunctionName(const char *name);
+
+std::string GetMangledFunctionName(const FunctionInfo &Info);
 
 std::string GetMangledTypeName(llvm::Type *T);
 

--- a/test/CommonBuiltins/max/float8_max.cl
+++ b/test/CommonBuiltins/max/float8_max.cl
@@ -1,0 +1,26 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that max for float8 is supported.
+
+// CHECK: [[GLSL:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK: [[FLOAT:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+//
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+// CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
+
+void kernel test(global float *in, global float *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  float8 in0 = vload8(0, in);
+  float8 in1 = vload8(1, in);
+  float8 value = max(in0, in1);
+  vstore8(value, 0, out);
+}

--- a/test/IntegerBuiltins/max/max_int8.cl
+++ b/test/IntegerBuiltins/max/max_int8.cl
@@ -1,0 +1,27 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that max for int8 is supported.
+
+// CHECK: [[GLSL:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
+//
+// CHECK: [[INT:%[0-9a-zA-Z_]+]] = OpTypeInt 32
+//
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+// CHECK: OpExtInst [[INT]] [[GLSL]] SMax
+
+void kernel test(global int *in, global int *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  int8 in0 = vload8(0, in);
+  int8 in1 = vload8(1, in);
+  int8 value = max(in0, in1);
+  vstore8(value, 0, out);
+}

--- a/test/IntegerBuiltins/max/max_ushort8.cl
+++ b/test/IntegerBuiltins/max/max_ushort8.cl
@@ -1,0 +1,27 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that max for ushort8 is supported.
+
+// CHECK: [[GLSL:%[0-9a-zA-Z_]+]] = OpExtInstImport "GLSL.std.450"
+//
+// CHECK: [[USHORT:%[0-9a-zA-Z_]+]] = OpTypeInt 16
+//
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+// CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
+
+void kernel test(global ushort *in, global ushort *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  ushort8 in0 = vload8(0, in);
+  ushort8 in1 = vload8(1, in);
+  ushort8 value = max(in0, in1);
+  vstore8(value, 0, out);
+}

--- a/test/LongVectorLowering/builtinfunctions.cl
+++ b/test/LongVectorLowering/builtinfunctions.cl
@@ -1,17 +1,32 @@
 // RUN: clspv %s --long-vector -verify
+// RUN: clspv %s --long-vector -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // Ensure all builtins are declared (i.e. there are no warnings about implicit
 // declaration).
 //
 // expected-no-diagnostics
 
-// TODO Check that the appropriate SPIR-V instructions are generated once max is
-// supported.
+// Check that calling multiple overloads of a BIF is supported.
+
+// CHECK: [[EXT:%[0-9]+]] = OpExtInstImport "GLSL.std.450"
+//
+// CHECK-DAG: [[UINT:%[a-zA-Z0-9_]+]]  = OpTypeInt 32 0
+// CHECK-DAG: [[UINT4:%[a-zA-Z0-9_]+]] = OpTypeVector [[UINT]] 4
 
 kernel void test(global int *in, global int *out) {
   {
     int8 a = vload8(0, in);
     int8 b = vload8(1, in);
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
+    // CHECK: OpExtInst [[UINT]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
     int8 c = max(a, b);
     vstore8(c, 0, out);
   }
@@ -19,6 +34,7 @@ kernel void test(global int *in, global int *out) {
   {
     int4 a = vload4(0, in);
     int4 b = vload4(1, in);
+    // CHECK: OpExtInst [[UINT4]] [[EXT]] SMax {{%[0-9]+}} {{%[0-9]+}}
     int4 c = max(a, b);
     vstore4(c, 2, out);
   }


### PR DESCRIPTION
This adds logic to lowers OpenCL builtin functions. For now, only `max` (for `float` and `int`) is supported.

The first commit uses the short-term approach I've described in #613. The second commit actually improves on that by re-using some parts of `clspv::Builtins`. Because the de-mangling process is lossy, it is not possible to produce mangled names for all cases right now, but it should be good enough for the purpose of lowering of most (if not all) builtin functions.

Note that the new overload `GetMangledFunctionName(const Builtins::FunctionInfo &info)` handles signedness of parameters while the existing `GetMangledFunctionName(const char *name, llvm::Type *type)` does not. This ensures `SMax` is still used after lowering, and not `UMax`.

Let me know what you think.