### PR TITLE
Refactor some builtin support

### DIFF
--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -281,7 +281,8 @@ std::string Builtins::GetMangledFunctionName(const char *name, Type *type) {
   if (auto *func_type = dyn_cast<FunctionType>(type)) {
     Type *last_arg_type = nullptr;
     for (auto *arg_type : func_type->params()) {
-      if (arg_type == last_arg_type) {
+      std::string arg_name = GetMangledTypeName(arg_type);
+      if (arg_name.size() > 1 && arg_type == last_arg_type) {
         mangled_name += "S_";
       } else {
         mangled_name += GetMangledTypeName(arg_type);

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -85,17 +85,17 @@ bool ReplaceLLVMIntrinsicsPass::runOnModule(Module &M) {
 
 bool ReplaceLLVMIntrinsicsPass::runOnFunction(Function &F) {
   switch (F.getIntrinsicID()) {
-    case Intrinsic::fshl:
-      return replaceFshl(F);
-    case Intrinsic::copysign:
-      return replaceCopysign(F);
-    case Intrinsic::ctlz:
-      return replaceCountZeroes(F, true);
-    case Intrinsic::cttz:
-      return replaceCountZeroes(F, false);
+  case Intrinsic::fshl:
+    return replaceFshl(F);
+  case Intrinsic::copysign:
+    return replaceCopysign(F);
+  case Intrinsic::ctlz:
+    return replaceCountZeroes(F, true);
+  case Intrinsic::cttz:
+    return replaceCountZeroes(F, false);
 
-    default:
-      break;
+  default:
+    break;
   }
 
   return false;

--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -41,7 +41,7 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
 
   auto M = Insert->getModule();
   auto Int32Ty = Type::getInt32Ty(M->getContext());
-  Function* func = M->getFunction(MangledName);
+  Function *func = M->getFunction(MangledName);
   if (!func) {
     // Create a function in the module
     SmallVector<Type *, 8> ArgTypes = {Int32Ty};

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3741,13 +3741,8 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
         << glsl::ExtInst::ExtInstFindUMsb << Call->getArgOperand(0);
     auto find_msb = addSPIRVInst(spv::OpExtInst, Ops);
 
-    Constant *thirty_one =
-        ConstantInt::get(Call->getType()->getScalarType(),
-                         Call->getType()->getScalarSizeInBits() - 1);
-    if (auto vec_ty = dyn_cast<VectorType>(Call->getType())) {
-      thirty_one =
-          ConstantVector::getSplat(vec_ty->getElementCount(), thirty_one);
-    }
+    Constant *thirty_one = ConstantInt::get(
+        Call->getType(), Call->getType()->getScalarSizeInBits() - 1);
     Ops.clear();
     Ops << Call->getType() << thirty_one << find_msb;
     return addSPIRVInst(spv::OpISub, Ops);
@@ -3764,13 +3759,9 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
     auto find_lsb = addSPIRVInst(spv::OpExtInst, Ops);
 
     auto neg_one = Constant::getAllOnesValue(Call->getType());
-    Constant *width = ConstantInt::get(Call->getType()->getScalarType(),
-                                       Call->getType()->getScalarSizeInBits());
-    Type *i1_ty = Type::getInt1Ty(Call->getContext());
-    if (auto vec_ty = dyn_cast<VectorType>(Call->getType())) {
-      i1_ty = VectorType::get(i1_ty, vec_ty->getElementCount());
-      width = ConstantVector::getSplat(vec_ty->getElementCount(), width);
-    }
+    auto i1_ty = Call->getType()->getWithNewBitWidth(1);
+    auto width = ConstantInt::get(Call->getType(),
+                                  Call->getType()->getScalarSizeInBits());
 
     Ops.clear();
     Ops << i1_ty << find_lsb << neg_one;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -34,6 +34,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ValueSymbolTable.h"
@@ -3732,6 +3733,58 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
 
   SPIRVID RID;
 
+  switch (Call->getCalledFunction()->getIntrinsicID()) {
+  case Intrinsic::ctlz: {
+    // Implement as 31 - FindUMsb. Ignore the second operand of llvm.ctlz.
+    SPIRVOperandVec Ops;
+    Ops << Call->getType() << getOpExtInstImportID()
+        << glsl::ExtInst::ExtInstFindUMsb << Call->getArgOperand(0);
+    auto find_msb = addSPIRVInst(spv::OpExtInst, Ops);
+
+    Constant *thirty_one =
+        ConstantInt::get(Call->getType()->getScalarType(),
+                         Call->getType()->getScalarSizeInBits() - 1);
+    if (auto vec_ty = dyn_cast<VectorType>(Call->getType())) {
+      thirty_one =
+          ConstantVector::getSplat(vec_ty->getElementCount(), thirty_one);
+    }
+    Ops.clear();
+    Ops << Call->getType() << thirty_one << find_msb;
+    return addSPIRVInst(spv::OpISub, Ops);
+  }
+  case Intrinsic::cttz: {
+    // Implement as:
+    // lsb = FindILsb x
+    // res = lsb == -1 ? width : lsb
+    //
+    // Ignore the second operand of llvm.cttz.
+    SPIRVOperandVec Ops;
+    Ops << Call->getType() << getOpExtInstImportID()
+        << glsl::ExtInst::ExtInstFindILsb << Call->getArgOperand(0);
+    auto find_lsb = addSPIRVInst(spv::OpExtInst, Ops);
+
+    auto neg_one = Constant::getAllOnesValue(Call->getType());
+    Constant *width = ConstantInt::get(Call->getType()->getScalarType(),
+                                       Call->getType()->getScalarSizeInBits());
+    Type *i1_ty = Type::getInt1Ty(Call->getContext());
+    if (auto vec_ty = dyn_cast<VectorType>(Call->getType())) {
+      i1_ty = VectorType::get(i1_ty, vec_ty->getElementCount());
+      width = ConstantVector::getSplat(vec_ty->getElementCount(), width);
+    }
+
+    Ops.clear();
+    Ops << i1_ty << find_lsb << neg_one;
+    auto cmp = addSPIRVInst(spv::OpIEqual, Ops);
+
+    Ops.clear();
+    Ops << Call->getType() << cmp << width << find_lsb;
+    return addSPIRVInst(spv::OpSelect, Ops);
+  }
+
+  default:
+    break;
+  }
+
   switch (func_type) {
   case Builtins::kPopcount: {
     //
@@ -3748,7 +3801,8 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
   default: {
     glsl::ExtInst EInst = getDirectOrIndirectExtInstEnum(func_info);
 
-    if (EInst) {
+    // Do not replace functions with implementations.
+    if (EInst && Call->getCalledFunction()->isDeclaration()) {
       SPIRVID ExtInstImportID = getOpExtInstImportID();
 
       //
@@ -3796,32 +3850,7 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
           RID = addSPIRVInst(opcode, Ops);
         };
 
-        auto bitwidth = Call->getType()->getScalarSizeInBits();
         switch (IndirectExtInst) {
-        case glsl::ExtInstFindUMsb: // Implementing clz
-          generate_extra_inst(
-              spv::OpISub,
-              ConstantInt::get(Call->getType()->getScalarType(), bitwidth - 1));
-          break;
-        case glsl::ExtInstFindILsb: { // Implementing ctz
-          auto neg_one = Constant::getAllOnesValue(Call->getType());
-          Constant *int_32 =
-              ConstantInt::get(Call->getType()->getScalarType(), 32);
-          Type *i1_ty = Type::getInt1Ty(Call->getContext());
-          if (auto vec_ty = dyn_cast<VectorType>(Call->getType())) {
-            i1_ty = VectorType::get(i1_ty, vec_ty->getElementCount());
-            int_32 =
-                ConstantVector::getSplat(vec_ty->getElementCount(), int_32);
-          }
-
-          SPIRVOperandVec local_ops;
-          local_ops << i1_ty << RID << neg_one;
-          auto cmp = addSPIRVInst(spv::OpIEqual, local_ops);
-          local_ops.clear();
-          local_ops << Call->getType() << cmp << int_32 << RID;
-          RID = addSPIRVInst(spv::OpSelect, local_ops);
-          break;
-        }
         case glsl::ExtInstAcos:  // Implementing acospi
         case glsl::ExtInstAsin:  // Implementing asinpi
         case glsl::ExtInstAtan:  // Implementing atanpi
@@ -4995,8 +5024,21 @@ SPIRVProducerPass::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
     break;
   }
 
+  // TODO: improve this by checking the intrinsic id.
   if (func_info.getName().find("llvm.fmuladd.") == 0) {
     return glsl::ExtInst::ExtInstFma;
+  }
+  if (func_info.getName().find("llvm.sqrt.") == 0) {
+    return glsl::ExtInst::ExtInstSqrt;
+  }
+  if (func_info.getName().find("llvm.trunc.") == 0) {
+    return glsl::ExtInst::ExtInstTrunc;
+  }
+  if (func_info.getName().find("llvm.ctlz.") == 0) {
+    return glsl::ExtInst::ExtInstFindUMsb;
+  }
+  if (func_info.getName().find("llvm.cttz.") == 0) {
+    return glsl::ExtInst::ExtInstFindILsb;
   }
   return kGlslExtInstBad;
 }
@@ -5004,10 +5046,6 @@ SPIRVProducerPass::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
 glsl::ExtInst SPIRVProducerPass::getIndirectExtInstEnum(
     const Builtins::FunctionInfo &func_info) {
   switch (func_info.getType()) {
-  case Builtins::kClz:
-    return glsl::ExtInst::ExtInstFindUMsb;
-  case Builtins::kCtz:
-    return glsl::ExtInst::ExtInstFindILsb;
   case Builtins::kAcospi:
     return glsl::ExtInst::ExtInstAcos;
   case Builtins::kAsinpi:

--- a/test/IntegerBuiltins/clz/char2_clz.ll
+++ b/test/IntegerBuiltins/clz/char2_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,9 +14,9 @@ declare spir_func <2 x i8> @_Z3clzc(<2 x i8>)
 declare spir_func <2 x i32> @_Z3clzDv2_j(<2 x i32>)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext <2 x i8> %in to <2 x i32>
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3clzDv2_j(<2 x i32> [[zext]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.ctlz.v2i32(<2 x i32> [[zext]], i1 false)
 ; CHECK: [[sub:%[a-zA-Z0-9_.]+]] = sub <2 x i32> [[call]], <i32 24, i32 24>
 ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc <2 x i32> [[sub]] to <2 x i8>
 ; CHECK: ret <2 x i8> [[trunc]]
-; CHECK: declare spir_func <2 x i32> @_Z3clzDv2_j(<2 x i32>)
+; CHECK: declare <2 x i32> @llvm.ctlz.v2i32(<2 x i32>, i1 immarg)
 

--- a/test/IntegerBuiltins/clz/char_clz.ll
+++ b/test/IntegerBuiltins/clz/char_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,9 +14,9 @@ declare spir_func i8 @_Z3clzc(i8)
 declare spir_func i32 @_Z3clzj(i32)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i8 %in to i32
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @_Z3clzj(i32 [[zext]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @llvm.ctlz.i32(i32 [[zext]], i1 false)
 ; CHECK: [[sub:%[a-zA-Z0-9_.]+]] = sub i32 [[call]], 24
 ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[sub]] to i8
 ; CHECK: ret i8 [[trunc]]
-; CHECK: declare spir_func i32 @_Z3clzj(i32)
+; CHECK: declare i32 @llvm.ctlz.i32(i32, i1 immarg)
 

--- a/test/IntegerBuiltins/clz/long2_clz.ll
+++ b/test/IntegerBuiltins/clz/long2_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -15,12 +15,12 @@ declare <2 x i64> @_Z3clzl(<2 x i64>)
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr <2 x i64> %in, <i64 32, i64 32>
 ; CHECK: [[top:%[a-zA-Z0-9_.]+]] = trunc <2 x i64> [[shr]] to <2 x i32>
 ; CHECK: [[bot:%[a-zA-Z0-9_.]+]] = trunc <2 x i64> %in to <2 x i32>
-; CHECK: [[top_clz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3clzDv2_j(<2 x i32> [[top]])
-; CHECK: [[bot_clz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3clzDv2_j(<2 x i32> [[bot]])
+; CHECK: [[top_clz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.ctlz.v2i32(<2 x i32> [[top]], i1 false)
+; CHECK: [[bot_clz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.ctlz.v2i32(<2 x i32> [[bot]], i1 false)
 ; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq <2 x i32> [[top_clz]], <i32 32, i32 32>
 ; CHECK: [[bot_adjust:%[a-zA-Z0-9_.]+]] = add <2 x i32> [[bot_clz]], <i32 32, i32 32>
 ; CHECK: [[sel:%[a-zA-Z0-9_.]+]] = select <2 x i1> [[cmp]], <2 x i32> [[bot_adjust]], <2 x i32> [[top_clz]]
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext <2 x i32> [[sel]] to <2 x i64>
 ; CHECK: ret <2 x i64> [[zext]]
-; CHECK: declare <2 x i32> @_Z3clzDv2_j(<2 x i32>)
+; CHECK: declare <2 x i32> @llvm.ctlz.v2i32(<2 x i32>, i1 immarg)
 

--- a/test/IntegerBuiltins/clz/long_clz.ll
+++ b/test/IntegerBuiltins/clz/long_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -15,11 +15,11 @@ declare i64 @_Z3clzl(i64)
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 %in, 32
 ; CHECK: [[top:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i32
 ; CHECK: [[bot:%[a-zA-Z0-9_.]+]] = trunc i64 %in to i32
-; CHECK: [[top_clz:%[a-zA-Z0-9_.]+]] = call i32 @_Z3clzj(i32 [[top]])
-; CHECK: [[bot_clz:%[a-zA-Z0-9_.]+]] = call i32 @_Z3clzj(i32 [[bot]])
+; CHECK: [[top_clz:%[a-zA-Z0-9_.]+]] = call i32 @llvm.ctlz.i32(i32 [[top]], i1 false)
+; CHECK: [[bot_clz:%[a-zA-Z0-9_.]+]] = call i32 @llvm.ctlz.i32(i32 [[bot]], i1 false)
 ; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq i32 [[top_clz]], 32
 ; CHECK: [[bot_adjust:%[a-zA-Z0-9_.]+]] = add i32 [[bot_clz]], 32
 ; CHECK: [[sel:%[a-zA-Z0-9_.]+]] = select i1 [[cmp]], i32 [[bot_adjust]], i32 [[top_clz]]
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i32 [[sel]] to i64
 ; CHECK: ret i64 [[zext]]
-; CHECK: declare i32 @_Z3clzj(i32)
+; CHECK: declare i32 @llvm.ctlz.i32(i32, i1 immarg)

--- a/test/IntegerBuiltins/clz/short2_clz.ll
+++ b/test/IntegerBuiltins/clz/short2_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -13,9 +13,9 @@ entry:
 declare spir_func <2 x i16> @_Z3clzs(<2 x i16>)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext <2 x i16> %in to <2 x i32>
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3clzDv2_j(<2 x i32> [[zext]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.ctlz.v2i32(<2 x i32> [[zext]], i1 false)
 ; CHECK: [[sub:%[a-zA-Z0-9_.]+]] = sub <2 x i32> [[call]], <i32 16, i32 16>
 ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc <2 x i32> [[sub]] to <2 x i16>
 ; CHECK: ret <2 x i16> [[trunc]]
-; CHECK: declare <2 x i32> @_Z3clzDv2_j(<2 x i32>)
+; CHECK: declare <2 x i32> @llvm.ctlz.v2i32(<2 x i32>, i1 immarg)
 

--- a/test/IntegerBuiltins/clz/short_clz.ll
+++ b/test/IntegerBuiltins/clz/short_clz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: clspv-opt -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -13,8 +13,8 @@ entry:
 declare spir_func i16 @_Z3clzs(i16)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i16 %in to i32
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @_Z3clzj(i32 [[zext]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @llvm.ctlz.i32(i32 [[zext]], i1 false)
 ; CHECK: [[sub:%[a-zA-Z0-9_.]+]] = sub i32 [[call]], 16
 ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[sub]] to i16
 ; CHECK: ret i16 [[trunc]]
-; CHECK: declare i32 @_Z3clzj(i32)
+; CHECK: declare i32 @llvm.ctlz.i32(i32, i1 immarg)

--- a/test/IntegerBuiltins/ctz/uchar2_ctz.ll
+++ b/test/IntegerBuiltins/ctz/uchar2_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,5 +14,5 @@ declare spir_func <2 x i8> @_Z3ctzDv2_h(<2 x i8>)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext <2 x i8> %in to <2 x i32>
 ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or <2 x i32> [[zext]], <i32 256, i32 256>
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3ctzDv2_j(<2 x i32> [[or]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.cttz.v2i32(<2 x i32> [[or]], i1 false)
 ; CHECK: trunc <2 x i32> [[call]] to <2 x i8>

--- a/test/IntegerBuiltins/ctz/uchar_ctz.ll
+++ b/test/IntegerBuiltins/ctz/uchar_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,5 +14,5 @@ declare spir_func i8 @_Z3ctzh(i8)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i8 %in to i32
 ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i32 [[zext]], 256
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @_Z3ctzj(i32 [[or]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @llvm.cttz.i32(i32 [[or]], i1 false)
 ; CHECK: trunc i32 [[call]] to  i8

--- a/test/IntegerBuiltins/ctz/ulong2_ctz.ll
+++ b/test/IntegerBuiltins/ctz/ulong2_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -15,8 +15,8 @@ declare spir_func <2 x i64> @_Z3ctzDv2_m(<2 x i64>)
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr <2 x i64> %in, <i64 32, i64 32>
 ; CHECK: [[hi:%[a-zA-Z0-9_.]+]] = trunc <2 x i64> [[shr]] to <2 x i32>
 ; CHECK: [[lo:%[a-zA-Z0-9_.]+]] = trunc <2 x i64> %in to <2 x i32>
-; CHECK: [[hi_ctz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3ctzDv2_j(<2 x i32> [[hi]])
-; CHECK: [[lo_ctz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3ctzDv2_j(<2 x i32> [[lo]])
+; CHECK: [[hi_ctz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.cttz.v2i32(<2 x i32> [[hi]], i1 false)
+; CHECK: [[lo_ctz:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.cttz.v2i32(<2 x i32> [[lo]], i1 false)
 ; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq <2 x i32> [[lo_ctz]], <i32 32, i32 32>
 ; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add <2 x i32> [[hi_ctz]], <i32 32, i32 32>
 ; CHECK: [[sel:%[a-zA-Z0-9_.]+]] = select <2 x i1> [[cmp]], <2 x i32> [[add]], <2 x i32> [[lo_ctz]]

--- a/test/IntegerBuiltins/ctz/ulong_ctz.ll
+++ b/test/IntegerBuiltins/ctz/ulong_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -15,8 +15,8 @@ declare spir_func i64 @_Z3ctzm(i64)
 ; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 %in, 32
 ; CHECK: [[hi:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i32
 ; CHECK: [[lo:%[a-zA-Z0-9_.]+]] = trunc i64 %in to i32
-; CHECK: [[hi_ctz:%[a-zA-Z0-9_.]+]] = call i32 @_Z3ctzj(i32 [[hi]])
-; CHECK: [[lo_ctz:%[a-zA-Z0-9_.]+]] = call i32 @_Z3ctzj(i32 [[lo]])
+; CHECK: [[hi_ctz:%[a-zA-Z0-9_.]+]] = call i32 @llvm.cttz.i32(i32 [[hi]], i1 false)
+; CHECK: [[lo_ctz:%[a-zA-Z0-9_.]+]] = call i32 @llvm.cttz.i32(i32 [[lo]], i1 false)
 ; CHECK: [[cmp:%[a-zA-Z0-9_.]+]] = icmp eq i32 [[lo_ctz]], 32
 ; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[hi_ctz]], 32
 ; CHECK: [[sel:%[a-zA-Z0-9_.]+]] = select i1 [[cmp]], i32 [[add]], i32 [[lo_ctz]]

--- a/test/IntegerBuiltins/ctz/ushort2_ctz.ll
+++ b/test/IntegerBuiltins/ctz/ushort2_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,7 +14,7 @@ declare spir_func <2 x i16> @_Z3ctzDv2_t(<2 x i16>)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext <2 x i16> %in to <2 x i32>
 ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or <2 x i32> [[zext]], <i32 65536, i32 65536>
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @_Z3ctzDv2_j(<2 x i32> [[or]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call <2 x i32> @llvm.cttz.v2i32(<2 x i32> [[or]], i1 false)
 ; CHECK: trunc <2 x i32> [[call]] to <2 x i16>
 
 

--- a/test/IntegerBuiltins/ctz/ushort_ctz.ll
+++ b/test/IntegerBuiltins/ctz/ushort_ctz.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin
+; RUN: clspv-opt %s -o %t.ll -ReplaceOpenCLBuiltin -ReplaceLLVMIntrinsics
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -14,7 +14,7 @@ declare spir_func i16 @_Z3ctzt(i16)
 
 ; CHECK: [[zext:%[a-zA-Z0-9_.]+]] = zext i16 %in to i32
 ; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i32 [[zext]], 65536
-; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @_Z3ctzj(i32 [[or]])
+; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call i32 @llvm.cttz.i32(i32 [[or]], i1 false)
 ; CHECK: trunc i32 [[call]] to i16
 
 


### PR DESCRIPTION
* Don't replace builtins or intrinsics if they have a definition
* add implmemetations for llvm.trunc
* small change to name mangling
* fix an odd debug assertion in spirvop when reusing another function

Implement clz and ctz via llvm.ctlz and llvm.cttz

* Remove run of llvm intrinsic replacement before opencl builtin
  replacement
* add cleaner methodology for replacement ReplaceLLVMIntrinsicsPass
  * convert fshl to this style
* All clz and ctz functions are replaced with equivalent llvm intrinsics
  * Replace llvm intrinsics implements non-32-bit versions
  * update tests
* spirv producer updated to handle more llvm intrinsics
* Rotate, clz and ctz still pass CTS

Refactor copysign support

* Replace opencl builtin with llvm intrinsic
* move copysign implementation to llvm intrinsic replacement