### PR TITLE
Support more math builtins

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -107,7 +107,7 @@ bool ReplaceLLVMIntrinsicsPass::replaceCallsWithValue(
   for (auto &U : F.uses()) {
     if (auto Call = dyn_cast<CallInst>(U.getUser())) {
       auto replacement = Replacer(Call);
-      if (replacement != nullptr) {
+      if (replacement != nullptr && replacement != Call) {
         Call->replaceAllUsesWith(replacement);
         ToRemove.push_back(Call);
       }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -3056,7 +3056,7 @@ bool ReplaceOpenCLBuiltinPass::replaceRound(Function &F) {
     auto fabs = Intrinsic::getDeclaration(F.getParent(), Intrinsic::fabs,
                                           Call->getType());
     auto copysign = Intrinsic::getDeclaration(
-        F.getParent(), Intrinsic::copysign, Call->getType());
+        F.getParent(), Intrinsic::copysign, {Call->getType(), Call->getType()});
 
     IRBuilder<> builder(Call);
 
@@ -3068,7 +3068,7 @@ bool ReplaceOpenCLBuiltinPass::replaceRound(Function &F) {
         builder.CreateCall(F.getFunctionType(), clspv_fract_fn, {fabs_call});
     auto cmp = builder.CreateFCmpOGE(fract_call, halfway);
     auto sel = builder.CreateSelect(cmp, ceil_call, floor_call);
-    return builder.CreateCall(F.getFunctionType(), copysign, {sel, x});
+    return builder.CreateCall(copysign->getFunctionType(), copysign, {sel, x});
   });
 }
 

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -3077,10 +3077,7 @@ bool ReplaceOpenCLBuiltinPass::replaceTrigPi(Function &F,
   return replaceCallsWithValue(F, [&F, type](CallInst *Call) -> Value * {
     const auto x = Call->getArgOperand(0);
     const double k_pi = 0x1.921fb54442d18p+1;
-    Constant *pi = ConstantFP::get(x->getType()->getScalarType(), k_pi);
-    if (auto vec_ty = dyn_cast<VectorType>(x->getType())) {
-      pi = ConstantVector::getSplat(vec_ty->getElementCount(), pi);
-    }
+    Constant *pi = ConstantFP::get(x->getType(), k_pi);
 
     IRBuilder<> builder(Call);
     auto mul = builder.CreateFMul(x, pi);

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -282,6 +282,8 @@ private:
   bool replaceOrdered(Function &F, bool is_ordered);
   bool replaceIsNormal(Function &F);
   bool replaceFDim(Function &F);
+  bool replaceRound(Function &F);
+  bool replaceTrigPi(Function &F, Builtins::BuiltinType type);
 
   // Caches struct types for { |type|, |type| }. This prevents
   // getOrInsertFunction from introducing a bitcasts between structs with
@@ -381,6 +383,14 @@ bool ReplaceOpenCLBuiltinPass::runOnFunction(Function &F) {
 
   case Builtins::kFmod:
     return replaceFmod(F);
+
+  case Builtins::kRound:
+    return replaceRound(F);
+
+  case Builtins::kCospi:
+  case Builtins::kSinpi:
+  case Builtins::kTanpi:
+    return replaceTrigPi(F, FI.getType());
 
   case Builtins::kBarrier:
   case Builtins::kWorkGroupBarrier:
@@ -3017,5 +3027,87 @@ bool ReplaceOpenCLBuiltinPass::replaceFDim(Function &F) {
     auto cmp = builder.CreateFCmpUGT(x, y);
     return builder.CreateSelect(cmp, sub,
                                 Constant::getNullValue(Call->getType()));
+  });
+}
+
+bool ReplaceOpenCLBuiltinPass::replaceRound(Function &F) {
+  return replaceCallsWithValue(F, [&F](CallInst *Call) {
+    const auto x = Call->getArgOperand(0);
+    const double c_halfway = 0.5;
+    auto halfway = ConstantFP::get(Call->getType(), c_halfway);
+
+    const auto clspv_fract_name =
+        Builtins::GetMangledFunctionName("clspv.fract", F.getFunctionType());
+    Function *clspv_fract_fn = F.getParent()->getFunction(clspv_fract_name);
+    if (!clspv_fract_fn) {
+      // Make the clspv_fract function.
+      clspv_fract_fn = cast<Function>(
+          F.getParent()
+              ->getOrInsertFunction(clspv_fract_name, F.getFunctionType())
+              .getCallee());
+      clspv_fract_fn->addFnAttr(Attribute::ReadNone);
+      clspv_fract_fn->setCallingConv(CallingConv::SPIR_FUNC);
+    }
+
+    auto ceil = Intrinsic::getDeclaration(F.getParent(), Intrinsic::ceil,
+                                          Call->getType());
+    auto floor = Intrinsic::getDeclaration(F.getParent(), Intrinsic::floor,
+                                           Call->getType());
+    auto fabs = Intrinsic::getDeclaration(F.getParent(), Intrinsic::fabs,
+                                          Call->getType());
+    auto copysign = Intrinsic::getDeclaration(
+        F.getParent(), Intrinsic::copysign, Call->getType());
+
+    IRBuilder<> builder(Call);
+
+    auto fabs_call = builder.CreateCall(F.getFunctionType(), fabs, {x});
+    auto ceil_call = builder.CreateCall(F.getFunctionType(), ceil, {fabs_call});
+    auto floor_call =
+        builder.CreateCall(F.getFunctionType(), floor, {fabs_call});
+    auto fract_call =
+        builder.CreateCall(F.getFunctionType(), clspv_fract_fn, {fabs_call});
+    auto cmp = builder.CreateFCmpOGE(fract_call, halfway);
+    auto sel = builder.CreateSelect(cmp, ceil_call, floor_call);
+    return builder.CreateCall(F.getFunctionType(), copysign, {sel, x});
+  });
+}
+
+bool ReplaceOpenCLBuiltinPass::replaceTrigPi(Function &F,
+                                             Builtins::BuiltinType type) {
+  return replaceCallsWithValue(F, [&F, type](CallInst *Call) -> Value * {
+    const auto x = Call->getArgOperand(0);
+    const double k_pi = 0x1.921fb54442d18p+1;
+    Constant *pi = ConstantFP::get(x->getType()->getScalarType(), k_pi);
+    if (auto vec_ty = dyn_cast<VectorType>(x->getType())) {
+      pi = ConstantVector::getSplat(vec_ty->getElementCount(), pi);
+    }
+
+    IRBuilder<> builder(Call);
+    auto mul = builder.CreateFMul(x, pi);
+    switch (type) {
+    case Builtins::kSinpi: {
+      auto func = Intrinsic::getDeclaration(F.getParent(), Intrinsic::sin,
+                                            x->getType());
+      return builder.CreateCall(func->getFunctionType(), func, {mul});
+    }
+    case Builtins::kCospi: {
+      auto func = Intrinsic::getDeclaration(F.getParent(), Intrinsic::cos,
+                                            x->getType());
+      return builder.CreateCall(func->getFunctionType(), func, {mul});
+    }
+    case Builtins::kTanpi: {
+      auto sin = Intrinsic::getDeclaration(F.getParent(), Intrinsic::sin,
+                                           x->getType());
+      auto sin_call = builder.CreateCall(sin->getFunctionType(), sin, {mul});
+      auto cos = Intrinsic::getDeclaration(F.getParent(), Intrinsic::cos,
+                                           x->getType());
+      auto cos_call = builder.CreateCall(cos->getFunctionType(), cos, {mul});
+      return builder.CreateFDiv(sin_call, cos_call);
+    }
+    default:
+      llvm_unreachable("unexpected builtin");
+      break;
+    }
+    return nullptr;
   });
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5032,6 +5032,24 @@ SPIRVProducerPass::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
   if (func_info.getName().find("llvm.cttz.") == 0) {
     return glsl::ExtInst::ExtInstFindILsb;
   }
+  if (func_info.getName().find("llvm.ceil.") == 0) {
+    return glsl::ExtInst::ExtInstCeil;
+  }
+  if (func_info.getName().find("llvm.rint.") == 0) {
+    return glsl::ExtInst::ExtInstRoundEven;
+  }
+  if (func_info.getName().find("llvm.fabs.") == 0) {
+    return glsl::ExtInst::ExtInstFAbs;
+  }
+  if (func_info.getName().find("llvm.floor.") == 0) {
+    return glsl::ExtInst::ExtInstFloor;
+  }
+  if (func_info.getName().find("llvm.sin.") == 0) {
+    return glsl::ExtInst::ExtInstSin;
+  }
+  if (func_info.getName().find("llvm.cos.") == 0) {
+    return glsl::ExtInst::ExtInstCos;
+  }
   return kGlslExtInstBad;
 }
 

--- a/test/MathBuiltins/cospi/cospi_double2.ll
+++ b/test/MathBuiltins/cospi/cospi_double2.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x double> @cospi_double2(<2 x double> %x) {
+entry:
+  %call = call spir_func <2 x double> @_Z5cospiDv2_d(<2 x double> %x)
+  ret <2 x double> %call
+}
+
+declare spir_func <2 x double> @_Z5cospiDv2_d(<2 x double>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x double> %x, <double  0x400921FB54442D18, double  0x400921FB54442D18>
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call <2 x double> @llvm.cos.v2f64(<2 x double> [[mul]])
+

--- a/test/MathBuiltins/cospi/cospi_float.ll
+++ b/test/MathBuiltins/cospi/cospi_float.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define float @cospi_float(float %x) {
+entry:
+  %call = call spir_func float @_Z5cospif(float %x)
+  ret float %call
+}
+
+declare spir_func float @_Z5cospif(float)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul float %x, 0x400921FB60000000
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call float @llvm.cos.f32(float [[mul]])

--- a/test/MathBuiltins/cospi/cospi_float2.ll
+++ b/test/MathBuiltins/cospi/cospi_float2.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x float> @cospi_float2(<2 x float> %x) {
+entry:
+  %call = call spir_func <2 x float> @_Z5cospiDv2_f(<2 x float> %x)
+  ret <2 x float> %call
+}
+
+declare spir_func <2 x float> @_Z5cospiDv2_f(<2 x float>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x float> %x, <float 0x400921FB60000000, float 0x400921FB60000000>
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call <2 x float> @llvm.cos.v2f32(<2 x float> [[mul]])

--- a/test/MathBuiltins/cospi/cospi_half.ll
+++ b/test/MathBuiltins/cospi/cospi_half.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define half @cospi_half(half %x) {
+entry:
+  %call = call spir_func half @_Z5cospiDh(half %x)
+  ret half %call
+}
+
+declare spir_func half @_Z5cospiDh(half)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul half %x, 0xH4248
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call half @llvm.cos.f16(half [[mul]])
+

--- a/test/MathBuiltins/round/float2_round.cl
+++ b/test/MathBuiltins/round/float2_round.cl
@@ -3,12 +3,32 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
-// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Round %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+// CHECK-DAG: [[sign_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+// CHECK-DAG: [[sign_mask2:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int2]] [[sign_mask]] [[sign_mask]]
+// CHECK-DAG: [[rest_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+// CHECK-DAG: [[rest_mask2:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int2]] [[rest_mask]] [[rest_mask]]
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool2:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 2
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[float2:%[a-zA-Z0-9_]*]] = OpTypeVector [[float]] 2
+// CHECK-DAG: [[halfway:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 0.5
+// CHECK-DAG: [[halfway2:%[a-zA-Z0-9_]+]] = OpConstantComposite [[float2]] [[halfway]] [[halfway]]
+// CHECK: [[ld:%[a-zA-Z0-9_]*]] = OpLoad [[float2]]
+// CHECK: [[fabs:%[a-zA-Z0-9_]+]] = OpExtInst [[float2]] [[ext_inst]] FAbs [[ld]]
+// CHECK: [[ceil:%[a-zA-Z0-9_]+]] = OpExtInst [[float2]] [[ext_inst]] Ceil [[fabs]]
+// CHECK: [[floor:%[a-zA-Z0-9_]+]] = OpExtInst [[float2]] [[ext_inst]] Floor [[fabs]]
+// CHECK: [[fract:%[a-zA-Z0-9_]+]] = OpExtInst [[float2]] [[ext_inst]] Fract [[fabs]]
+// CHECK: [[gte:%[a-zA-Z0-9_]+]] = OpFOrdGreaterThanEqual [[bool2]] [[fract]] [[halfway2]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[float2]] [[gte]] [[ceil]] [[floor]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int2]] [[ld]]
+// CHECK: [[sign:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int2]] [[cast]] [[sign_mask2]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int2]] [[sel]]
+// CHECK: [[rest:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int2]] [[cast]] [[rest_mask2]]
+// CHECK: [[combine:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[int2]] [[rest]] [[sign]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[float2]] [[combine]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)
 {

--- a/test/MathBuiltins/round/float3_round.cl
+++ b/test/MathBuiltins/round/float3_round.cl
@@ -3,12 +3,32 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
-// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Round %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
+// CHECK-DAG: [[sign_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+// CHECK-DAG: [[sign_mask3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int3]] [[sign_mask]] [[sign_mask]] [[sign_mask]]
+// CHECK-DAG: [[rest_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+// CHECK-DAG: [[rest_mask3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int3]] [[rest_mask]] [[rest_mask]] [[rest_mask]]
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool3:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 3
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[float3:%[a-zA-Z0-9_]*]] = OpTypeVector [[float]] 3
+// CHECK-DAG: [[halfway:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 0.5
+// CHECK-DAG: [[halfway3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[float3]] [[halfway]] [[halfway]]
+// CHECK: [[ld:%[a-zA-Z0-9_]*]] = OpLoad [[float3]]
+// CHECK: [[fabs:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] FAbs [[ld]]
+// CHECK: [[ceil:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] Ceil [[fabs]]
+// CHECK: [[floor:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] Floor [[fabs]]
+// CHECK: [[fract:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] Fract [[fabs]]
+// CHECK: [[gte:%[a-zA-Z0-9_]+]] = OpFOrdGreaterThanEqual [[bool3]] [[fract]] [[halfway3]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[float3]] [[gte]] [[ceil]] [[floor]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int3]] [[ld]]
+// CHECK: [[sign:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int3]] [[cast]] [[sign_mask3]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int3]] [[sel]]
+// CHECK: [[rest:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int3]] [[cast]] [[rest_mask3]]
+// CHECK: [[combine:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[int3]] [[rest]] [[sign]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[float3]] [[combine]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/round/float4_round.cl
+++ b/test/MathBuiltins/round/float4_round.cl
@@ -3,12 +3,32 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Round %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK-DAG: [[sign_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+// CHECK-DAG: [[sign_mask4:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int4]] [[sign_mask]] [[sign_mask]] [[sign_mask]] [[sign_mask]]
+// CHECK-DAG: [[rest_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+// CHECK-DAG: [[rest_mask4:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int4]] [[rest_mask]] [[rest_mask]] [[rest_mask]] [[rest_mask]]
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[a-zA-Z0-9_]*]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[halfway:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 0.5
+// CHECK-DAG: [[halfway4:%[a-zA-Z0-9_]+]] = OpConstantComposite [[float4]] [[halfway]] [[halfway]]
+// CHECK: [[ld:%[a-zA-Z0-9_]*]] = OpLoad [[float4]]
+// CHECK: [[fabs:%[a-zA-Z0-9_]+]] = OpExtInst [[float4]] [[ext_inst]] FAbs [[ld]]
+// CHECK: [[ceil:%[a-zA-Z0-9_]+]] = OpExtInst [[float4]] [[ext_inst]] Ceil [[fabs]]
+// CHECK: [[floor:%[a-zA-Z0-9_]+]] = OpExtInst [[float4]] [[ext_inst]] Floor [[fabs]]
+// CHECK: [[fract:%[a-zA-Z0-9_]+]] = OpExtInst [[float4]] [[ext_inst]] Fract [[fabs]]
+// CHECK: [[gte:%[a-zA-Z0-9_]+]] = OpFOrdGreaterThanEqual [[bool4]] [[fract]] [[halfway4]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[float4]] [[gte]] [[ceil]] [[floor]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]] [[ld]]
+// CHECK: [[sign:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int4]] [[cast]] [[sign_mask4]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]] [[sel]]
+// CHECK: [[rest:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int4]] [[cast]] [[rest_mask4]]
+// CHECK: [[combine:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[int4]] [[rest]] [[sign]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[float4]] [[combine]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
 {

--- a/test/MathBuiltins/round/float_round.cl
+++ b/test/MathBuiltins/round/float_round.cl
@@ -3,11 +3,26 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Round %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[sign_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+// CHECK-DAG: [[rest_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[halfway:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 0.5
+// CHECK: [[ld:%[a-zA-Z0-9_]*]] = OpLoad [[float]]
+// CHECK: [[fabs:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] [[ext_inst]] FAbs [[ld]]
+// CHECK: [[ceil:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] [[ext_inst]] Ceil [[fabs]]
+// CHECK: [[floor:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] [[ext_inst]] Floor [[fabs]]
+// CHECK: [[fract:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] [[ext_inst]] Fract [[fabs]]
+// CHECK: [[gte:%[a-zA-Z0-9_]+]] = OpFOrdGreaterThanEqual [[bool]] [[fract]] [[halfway]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[gte]] [[ceil]] [[floor]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld]]
+// CHECK: [[sign:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast]] [[sign_mask]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[sel]]
+// CHECK: [[rest:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast]] [[rest_mask]]
+// CHECK: [[combine:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[int]] [[rest]] [[sign]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[combine]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
 {

--- a/test/MathBuiltins/sinpi/sinpi_double2.ll
+++ b/test/MathBuiltins/sinpi/sinpi_double2.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x double> @sinpi_double2(<2 x double> %x) {
+entry:
+  %call = call spir_func <2 x double> @_Z5sinpiDv2_d(<2 x double> %x)
+  ret <2 x double> %call
+}
+
+declare spir_func <2 x double> @_Z5sinpiDv2_d(<2 x double>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x double> %x, <double  0x400921FB54442D18, double  0x400921FB54442D18>
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call <2 x double> @llvm.sin.v2f64(<2 x double> [[mul]])
+
+

--- a/test/MathBuiltins/sinpi/sinpi_float.ll
+++ b/test/MathBuiltins/sinpi/sinpi_float.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define float @sinpi_float(float %x) {
+entry:
+  %call = call spir_func float @_Z5sinpif(float %x)
+  ret float %call
+}
+
+declare spir_func float @_Z5sinpif(float)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul float %x, 0x400921FB60000000
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call float @llvm.sin.f32(float [[mul]])
+

--- a/test/MathBuiltins/sinpi/sinpi_float2.ll
+++ b/test/MathBuiltins/sinpi/sinpi_float2.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x float> @sinpi_float2(<2 x float> %x) {
+entry:
+  %call = call spir_func <2 x float> @_Z5sinpiDv2_f(<2 x float> %x)
+  ret <2 x float> %call
+}
+
+declare spir_func <2 x float> @_Z5sinpiDv2_f(<2 x float>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x float> %x, <float 0x400921FB60000000, float 0x400921FB60000000>
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call <2 x float> @llvm.sin.v2f32(<2 x float> [[mul]])
+

--- a/test/MathBuiltins/sinpi/sinpi_half.ll
+++ b/test/MathBuiltins/sinpi/sinpi_half.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define half @sinpi_half(half %x) {
+entry:
+  %call = call spir_func half @_Z5sinpiDh(half %x)
+  ret half %call
+}
+
+declare spir_func half @_Z5sinpiDh(half)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul half %x, 0xH4248
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call half @llvm.sin.f16(half [[mul]])
+

--- a/test/MathBuiltins/tanpi/tanpi_double2.ll
+++ b/test/MathBuiltins/tanpi/tanpi_double2.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x double> @tanpi_double2(<2 x double> %x) {
+entry:
+  %call = call spir_func <2 x double> @_Z5tanpiDv2_d(<2 x double> %x)
+  ret <2 x double> %call
+}
+
+declare spir_func <2 x double> @_Z5tanpiDv2_d(<2 x double>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x double> %x, <double  0x400921FB54442D18, double  0x400921FB54442D18>
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call <2 x double> @llvm.sin.v2f64(<2 x double> [[mul]])
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call <2 x double> @llvm.cos.v2f64(<2 x double> [[mul]])
+; CHECK: [[div:%[a-zA-Z0-9_.]+]] = fdiv <2 x double> [[sin]], [[cos]]
+

--- a/test/MathBuiltins/tanpi/tanpi_float.ll
+++ b/test/MathBuiltins/tanpi/tanpi_float.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define float @tanpi_float(float %x) {
+entry:
+  %call = call spir_func float @_Z5tanpif(float %x)
+  ret float %call
+}
+
+declare spir_func float @_Z5tanpif(float)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul float %x, 0x400921FB60000000
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call float @llvm.sin.f32(float [[mul]])
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call float @llvm.cos.f32(float [[mul]])
+; CHECK: [[div:%[a-zA-Z0-9_.]+]] = fdiv float [[sin]], [[cos]]
+

--- a/test/MathBuiltins/tanpi/tanpi_float2.ll
+++ b/test/MathBuiltins/tanpi/tanpi_float2.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <2 x float> @tanpi_float2(<2 x float> %x) {
+entry:
+  %call = call spir_func <2 x float> @_Z5tanpiDv2_f(<2 x float> %x)
+  ret <2 x float> %call
+}
+
+declare spir_func <2 x float> @_Z5tanpiDv2_f(<2 x float>)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul <2 x float> %x, <float 0x400921FB60000000, float 0x400921FB60000000>
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call <2 x float> @llvm.sin.v2f32(<2 x float> [[mul]])
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call <2 x float> @llvm.cos.v2f32(<2 x float> [[mul]])
+; CHECK: [[div:%[a-zA-Z0-9_.]+]] = fdiv <2 x float> [[sin]], [[cos]]
+

--- a/test/MathBuiltins/tanpi/tanpi_half.ll
+++ b/test/MathBuiltins/tanpi/tanpi_half.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt -ReplaceOpenCLBuiltin %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define half @tanpi_half(half %x) {
+entry:
+  %call = call spir_func half @_Z5tanpiDh(half %x)
+  ret half %call
+}
+
+declare spir_func half @_Z5tanpiDh(half)
+
+; CHECK: [[mul:%[a-zA-Z0-9_.]+]] = fmul half %x, 0xH4248
+; CHECK: [[sin:%[a-zA-Z0-9_.]+]] = call half @llvm.sin.f16(half [[mul]])
+; CHECK: [[cos:%[a-zA-Z0-9_.]+]] = call half @llvm.cos.f16(half [[mul]])
+; CHECK: [[div:%[a-zA-Z0-9_.]+]] = fdiv half [[sin]], [[cos]]
+


### PR DESCRIPTION
* New implementation of round
  * glsl extended instruction is insufficient to pass CTS because the
    rounding mode is implementation defined
  * Passes CTS
* implementations of cospi, sinpi and tanpi
  * use llvm.sin and llvm.cos
  * not sufficient for full conformance, but passes relaxed requirements
* backend support for llvm.sin, llvm.cos, llvm.fabs, llvm.ceil,
  llvm.floor and llvm.rint