### PR TITLE
Lower OpenCL convert_* builtin functions

### DIFF
--- a/test/ConvertBuiltins/char/convert_char16_float16.cl
+++ b/test/ConvertBuiltins/char/convert_char16_float16.cl
@@ -1,0 +1,33 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that conversions from float16 to char16 is supported.
+
+// CHECK-DAG: [[CHAR:%[0-9a-zA-Z_]+]]  = OpTypeInt 8
+// CHECK-DAG: [[FLOAT:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+//
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+// CHECK: OpConvertFToS [[CHAR]]
+
+void kernel test(global float *in, global char *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload16 and vstore16 to read/write the values.
+  float16 x = vload16(0, in);
+  char16 y = convert_char16(x);
+  vstore16(y, 0, out);
+}

--- a/test/ConvertBuiltins/float/convert_float8_int8.cl
+++ b/test/ConvertBuiltins/float/convert_float8_int8.cl
@@ -1,0 +1,25 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that conversions from int8 to float8 is supported.
+
+// CHECK-DAG: [[INT:%[0-9a-zA-Z_]+]]   = OpTypeInt 32
+// CHECK-DAG: [[FLOAT:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+//
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+// CHECK: OpConvertSToF [[FLOAT]]
+
+void kernel test(global int *in, global float *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  int8 x = vload8(0, in);
+  float8 y = convert_float8(x);
+  vstore8(y, 0, out);
+}

--- a/test/ConvertBuiltins/half/convert_half8_short8.cl
+++ b/test/ConvertBuiltins/half/convert_half8_short8.cl
@@ -1,0 +1,25 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that conversions from short8 to half8 is supported.
+
+// CHECK-DAG: [[SHORT:%[0-9a-zA-Z_]+]] = OpTypeInt 16
+// CHECK-DAG: [[HALF:%[0-9a-zA-Z_]+]]  = OpTypeFloat 16
+//
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+// CHECK: OpConvertSToF [[HALF]]
+
+void kernel test(global short *in, global half *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  short8 x = vload8(0, in);
+  half8 y = convert_half8(x);
+  vstore8(y, 0, out);
+}

--- a/test/ConvertBuiltins/int/convert_int8_short8.cl
+++ b/test/ConvertBuiltins/int/convert_int8_short8.cl
@@ -1,0 +1,24 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that conversions from short8 to int8 is supported.
+
+// CHECK-DAG: [[INT:%[0-9a-zA-Z_]+]] = OpTypeInt 32
+//
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+// CHECK: OpSConvert [[INT]]
+
+void kernel test(global short *in, global int *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  short8 x = vload8(0, in);
+  int8 y = convert_int8(x);
+  vstore8(y, 0, out);
+}

--- a/test/ConvertBuiltins/short/convert_short8_int8.cl
+++ b/test/ConvertBuiltins/short/convert_short8_int8.cl
@@ -1,0 +1,24 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that conversions from int8 to short8 is supported.
+
+// CHECK-DAG: [[SHORT:%[0-9a-zA-Z_]+]]  = OpTypeInt 16
+//
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+// CHECK: OpUConvert [[SHORT]]
+
+void kernel test(global int *in, global short *out) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  int8 x = vload8(0, in);
+  short8 y = convert_short8(x);
+  vstore8(y, 0, out);
+}


### PR DESCRIPTION
Continuing submission for #613, this adds support for the various convert_* functions and CastInst instructions. As always, feedback welcome.

---

Add support for various CastInst subclasses.

Introduce tests covering the end-to-end compilation flow for a subset of
the OpenCL convert_* builtin functions. Not all cases are covered to
avoid increasing testing time too much.