### PR TITLE
Lower CmpInst, SelectInst, and OpenCL select()

### DIFF
--- a/test/LongVectorLowering/fastmathflags.ll
+++ b/test/LongVectorLowering/fastmathflags.ll
@@ -1,8 +1,6 @@
 ; RUN: clspv-opt --LongVectorLowering %s -o %t
 ; RUN: FileCheck %s < %t
 
-; TODO cover fcmp and select
-
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
@@ -17,6 +15,8 @@ entry:
   %e = fdiv arcp contract <8 x float> %d, %b
   %f = frem reassoc <8 x float> %e, %c
   %g = call fast <8 x float> @llvm.fmuladd.v8f32(<8 x float> %d, <8 x float> %e, <8 x float> %f)
+  %h = fcmp fast oeq <8 x float> %x, %g
+  %i = select fast <8 x i1> %h, <8 x float> %y, <8 x float> %z
   ret <8 x float> %g
 }
 
@@ -82,3 +82,21 @@ entry:
 ; CHECK: call fast float @llvm.fmuladd.f32
 ; CHECK: call fast float @llvm.fmuladd.f32
 ; CHECK: call fast float @llvm.fmuladd.f32
+
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+; CHECK: fcmp fast
+
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast
+; CHECK: select fast

--- a/test/LongVectorLowering/icmp.ll
+++ b/test/LongVectorLowering/icmp.ll
@@ -1,0 +1,25 @@
+; RUN: clspv-opt --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x i1> @test(<8 x i32> %a) {
+entry:
+  %cmp = icmp slt <8 x i32> %a, zeroinitializer
+  ret <8 x i1> %cmp
+}
+
+; CHECK-NOT: <8 x i32>
+
+; CHECK-LABEL: @test
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+; CHECK: icmp slt i32
+
+; CHECK-NOT: <8 x i32>

--- a/test/LongVectorLowering/select1.ll
+++ b/test/LongVectorLowering/select1.ll
@@ -1,0 +1,77 @@
+; RUN: clspv-opt --ReplaceOpenCLBuiltin --LongVectorLowering --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+declare spir_func <8 x float> @_Z6selectDv8_fS_Dv8_i(<8 x float>, <8 x float>, <8 x i32>)
+
+define spir_func <8 x float> @test(<8 x i32> %cond, <8 x float> %a, <8 x float> %b) {
+entry:
+  ; This is a valid OpenCL C select overload.
+  %value = call spir_func <8 x float> @_Z6selectDv8_fS_Dv8_i(<8 x float> %a, <8 x float> %b, <8 x i32> %cond)
+  ret <8 x float> %value
+}
+
+; CHECK: define spir_func
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test(
+; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]] [[COND:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8]] [[A:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8]] [[B:%[^ ]+]]) {
+
+; CHECK-DAG:  [[COND_0:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 0
+; CHECK-DAG:  [[COND_1:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 1
+; CHECK-DAG:  [[COND_2:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 2
+; CHECK-DAG:  [[COND_3:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 3
+; CHECK-DAG:  [[COND_4:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 4
+; CHECK-DAG:  [[COND_5:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 5
+; CHECK-DAG:  [[COND_6:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 6
+; CHECK-DAG:  [[COND_7:%[^ ]+]] = extractvalue [[INT8]] [[COND]], 7
+
+; CHECK-DAG:  [[A_0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 0
+; CHECK-DAG:  [[A_1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1
+; CHECK-DAG:  [[A_2:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 2
+; CHECK-DAG:  [[A_3:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 3
+; CHECK-DAG:  [[A_4:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 4
+; CHECK-DAG:  [[A_5:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 5
+; CHECK-DAG:  [[A_6:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 6
+; CHECK-DAG:  [[A_7:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 7
+
+; CHECK-DAG:  [[B_0:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 0
+; CHECK-DAG:  [[B_1:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 1
+; CHECK-DAG:  [[B_2:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 2
+; CHECK-DAG:  [[B_3:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 3
+; CHECK-DAG:  [[B_4:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 4
+; CHECK-DAG:  [[B_5:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 5
+; CHECK-DAG:  [[B_6:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 6
+; CHECK-DAG:  [[B_7:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 7
+
+; CHECK-DAG:  [[CMP_0:%[^ ]+]] = icmp slt i32 [[COND_0]], 0
+; CHECK-DAG:  [[CMP_1:%[^ ]+]] = icmp slt i32 [[COND_1]], 0
+; CHECK-DAG:  [[CMP_2:%[^ ]+]] = icmp slt i32 [[COND_2]], 0
+; CHECK-DAG:  [[CMP_3:%[^ ]+]] = icmp slt i32 [[COND_3]], 0
+; CHECK-DAG:  [[CMP_4:%[^ ]+]] = icmp slt i32 [[COND_4]], 0
+; CHECK-DAG:  [[CMP_5:%[^ ]+]] = icmp slt i32 [[COND_5]], 0
+; CHECK-DAG:  [[CMP_6:%[^ ]+]] = icmp slt i32 [[COND_6]], 0
+; CHECK-DAG:  [[CMP_7:%[^ ]+]] = icmp slt i32 [[COND_7]], 0
+
+; CHECK-DAG:  [[SELECT_0:%[^ ]+]] = select i1 [[CMP_0]], float [[B_0]], float [[A_0]]
+; CHECK-DAG:  [[SELECT_1:%[^ ]+]] = select i1 [[CMP_1]], float [[B_1]], float [[A_1]]
+; CHECK-DAG:  [[SELECT_2:%[^ ]+]] = select i1 [[CMP_2]], float [[B_2]], float [[A_2]]
+; CHECK-DAG:  [[SELECT_3:%[^ ]+]] = select i1 [[CMP_3]], float [[B_3]], float [[A_3]]
+; CHECK-DAG:  [[SELECT_4:%[^ ]+]] = select i1 [[CMP_4]], float [[B_4]], float [[A_4]]
+; CHECK-DAG:  [[SELECT_5:%[^ ]+]] = select i1 [[CMP_5]], float [[B_5]], float [[A_5]]
+; CHECK-DAG:  [[SELECT_6:%[^ ]+]] = select i1 [[CMP_6]], float [[B_6]], float [[A_6]]
+; CHECK-DAG:  [[SELECT_7:%[^ ]+]] = select i1 [[CMP_7]], float [[B_7]], float [[A_7]]
+
+; CHECK-DAG:  [[TMP_0:%[^ ]+]] = insertvalue [[FLOAT8]] undef,     float [[SELECT_0]], 0
+; CHECK-DAG:  [[TMP_1:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_0]], float [[SELECT_1]], 1
+; CHECK-DAG:  [[TMP_2:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_1]], float [[SELECT_2]], 2
+; CHECK-DAG:  [[TMP_3:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_2]], float [[SELECT_3]], 3
+; CHECK-DAG:  [[TMP_4:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_3]], float [[SELECT_4]], 4
+; CHECK-DAG:  [[TMP_5:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_4]], float [[SELECT_5]], 5
+; CHECK-DAG:  [[TMP_6:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_5]], float [[SELECT_6]], 6
+; CHECK-DAG:  [[VALUE:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_6]], float [[SELECT_7]], 7
+
+; CHECK:  ret [[FLOAT8]] [[VALUE]]

--- a/test/LongVectorLowering/select2.ll
+++ b/test/LongVectorLowering/select2.ll
@@ -1,0 +1,60 @@
+; RUN: clspv-opt --LongVectorLowering --early-cse --instcombine %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func <8 x float> @test(i1 %cond, <8 x float> %a, <8 x float> %b) {
+entry:
+  ; This is not derived from a regular OpenCL select overload.
+  %value = select i1 %cond, <8 x float> %a, <8 x float> %b
+  ret <8 x float> %value
+}
+
+; CHECK: define spir_func
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: @test(
+; CHECK-SAME: i1 [[COND:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8]] [[A:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8]] [[B:%[^ ]+]]) {
+
+; There should only be one select, but for compatibility with the SPIR-V
+; producer it is scalarised.
+
+; CHECK-DAG:  [[A_0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 0
+; CHECK-DAG:  [[A_1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1
+; CHECK-DAG:  [[A_2:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 2
+; CHECK-DAG:  [[A_3:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 3
+; CHECK-DAG:  [[A_4:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 4
+; CHECK-DAG:  [[A_5:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 5
+; CHECK-DAG:  [[A_6:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 6
+; CHECK-DAG:  [[A_7:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 7
+
+; CHECK-DAG:  [[B_0:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 0
+; CHECK-DAG:  [[B_1:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 1
+; CHECK-DAG:  [[B_2:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 2
+; CHECK-DAG:  [[B_3:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 3
+; CHECK-DAG:  [[B_4:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 4
+; CHECK-DAG:  [[B_5:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 5
+; CHECK-DAG:  [[B_6:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 6
+; CHECK-DAG:  [[B_7:%[^ ]+]] = extractvalue [[FLOAT8]] [[B]], 7
+
+; CHECK-DAG:  [[SELECT_0:%[^ ]+]] = select i1 [[COND]], float [[A_0]], float [[B_0]]
+; CHECK-DAG:  [[SELECT_1:%[^ ]+]] = select i1 [[COND]], float [[A_1]], float [[B_1]]
+; CHECK-DAG:  [[SELECT_2:%[^ ]+]] = select i1 [[COND]], float [[A_2]], float [[B_2]]
+; CHECK-DAG:  [[SELECT_3:%[^ ]+]] = select i1 [[COND]], float [[A_3]], float [[B_3]]
+; CHECK-DAG:  [[SELECT_4:%[^ ]+]] = select i1 [[COND]], float [[A_4]], float [[B_4]]
+; CHECK-DAG:  [[SELECT_5:%[^ ]+]] = select i1 [[COND]], float [[A_5]], float [[B_5]]
+; CHECK-DAG:  [[SELECT_6:%[^ ]+]] = select i1 [[COND]], float [[A_6]], float [[B_6]]
+; CHECK-DAG:  [[SELECT_7:%[^ ]+]] = select i1 [[COND]], float [[A_7]], float [[B_7]]
+
+; CHECK-DAG:  [[TMP_0:%[^ ]+]] = insertvalue [[FLOAT8]] undef,     float [[SELECT_0]], 0
+; CHECK-DAG:  [[TMP_1:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_0]], float [[SELECT_1]], 1
+; CHECK-DAG:  [[TMP_2:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_1]], float [[SELECT_2]], 2
+; CHECK-DAG:  [[TMP_3:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_2]], float [[SELECT_3]], 3
+; CHECK-DAG:  [[TMP_4:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_3]], float [[SELECT_4]], 4
+; CHECK-DAG:  [[TMP_5:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_4]], float [[SELECT_5]], 5
+; CHECK-DAG:  [[TMP_6:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_5]], float [[SELECT_6]], 6
+; CHECK-DAG:  [[VALUE:%[^ ]+]] = insertvalue [[FLOAT8]] [[TMP_6]], float [[SELECT_7]], 7
+
+; CHECK-NEXT: ret [[FLOAT8]] [[VALUE]]

--- a/test/RelationalBuiltins/select/select_float8_uint8.cl
+++ b/test/RelationalBuiltins/select/select_float8_uint8.cl
@@ -1,0 +1,41 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o - | FileCheck %s
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that select for float8/uint8 is supported.
+
+// CHECK-DAG: [[BOOL:%[^ ]+]]  = OpTypeBool
+// CHECK-DAG: [[UINT:%[^ ]+]]  = OpTypeInt 32
+// CHECK-DAG: [[FLOAT:%[^ ]+]] = OpTypeFloat 32
+//
+// CHECK-DAG: [[ZERO:%[^ ]+]] = OpConstant [[UINT]] 0
+//
+// CHECK-NOT: DAG BARRIER
+//
+// CHECK-DAG: [[COND_0:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_1:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_2:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_3:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_4:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_5:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_6:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+// CHECK-DAG: [[COND_7:%[^ ]+]] = OpSLessThan [[BOOL]] {{%[^ ]+}} [[ZERO]]
+//
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_0]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_1]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_2]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_3]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_4]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_5]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_6]] {{%[^ ]+}} {{%[^ ]+}}
+// CHECK-DAG: OpSelect [[FLOAT]] [[COND_7]] {{%[^ ]+}} {{%[^ ]+}}
+
+void kernel test(global float *out, global float *in1, global uint *in2) {
+  // Because long vectors are not supported as kernel argument, we rely on
+  // vload8 and vstore8 to read/write the values.
+  float8 a = vload8(0, in1);
+  float8 b = vload8(1, in1);
+  uint8 cond = vload8(0, in2);
+  float8 value = select(a, b, cond);
+  vstore8(value, 0, out);
+}


### PR DESCRIPTION
Continuing submission for #613, this adds support for some additional instructions. As always, feedback welcome.

---

Mark PHINode as unsupported for now. Test cases are required to
implement this feature.

Add tests covering icmp and the two forms of select instructions. Add
test covering OpenCL select builtin function. Update fast-math flag
test.
