### PR TITLE
Changes to the Amber test runner

### DIFF
--- a/kokoro/scripts/linux/build-amber.sh
+++ b/kokoro/scripts/linux/build-amber.sh
@@ -58,9 +58,9 @@ ninja
 echo $(date): Build completed.
 
 echo $(date): Starting amber tests...
-export VK_ICD_FILENAMES=$BUILD_ROOT/github/amber/build/Linux/vk_swiftshader_icd.json
 /usr/bin/python3 $SRC/amber/run_tests.py \
   --amber $BUILD_ROOT/github/amber/build/amber \
   --dir $SRC/amber \
-  --swiftshader
+  --swiftshader \
+  --vk-icd $BUILD_ROOT/github/amber/build/Linux/vk_swiftshader_icd.json
 echo $(date): Unit tests completed.


### PR DESCRIPTION
* Add an option to specify the Vulkan ICD location
  * Update kokoro build to use this option
* Add an option to avoid large globs
* Fix suppressions when only testing a single directory
* Fix delimiter consistency