### PR TITLE
docs: fix simple typo, variabls -> variables

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -338,7 +338,7 @@ llvm::ModulePass *createAllocateDescriptorsPass(
 /// Direct Resource Access
 /// @return An LLVM module pass.
 ///
-/// For kernel arguments that map to resource variabls (descriptors),
+/// For kernel arguments that map to resource variables (descriptors),
 /// try to avoid passing them by pointer down into helper functions.
 /// Find and exploit commonality among callees of each helper function.
 /// Assumes descriptors have been allocated and mapped to function


### PR DESCRIPTION
There is a small typo in include/clspv/Passes.h.

Should read `variables` rather than `variabls`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md