### PR TITLE
Lower kernel parameters

### DIFF
--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 The Clspv Authors. All rights reserved.
+// Copyright 2018-2021 The Clspv Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ private:
 
   enum CustomDiagnosticType {
     CustomDiagnosticVectorsMoreThan4Elements,
-    CustomDiagnosticUnsupportedKernelParameter,
     CustomDiagnosticVoidPointer,
     CustomDiagnosticUnalignedScalar,
     CustomDiagnosticUnalignedVec2,
@@ -191,16 +190,9 @@ private:
     if (auto *VT = llvm::dyn_cast<ExtVectorType>(canonicalType)) {
       // We don't support vectors with more than 4 elements under all
       // circumstances.
-      if (4 < VT->getNumElements()) {
-        if (clspv::Option::LongVectorSupport()) {
-          if (IsKernelParameter) {
-            Report(CustomDiagnosticUnsupportedKernelParameter, SR, SR);
-            return false;
-          }
-        } else {
-          Report(CustomDiagnosticVectorsMoreThan4Elements, SR, SR);
-          return false;
-        }
+      if (4 < VT->getNumElements() && !clspv::Option::LongVectorSupport()) {
+        Report(CustomDiagnosticVectorsMoreThan4Elements, SR, SR);
+        return false;
       }
 
       return true;
@@ -522,10 +514,6 @@ public:
         DE.getCustomDiagID(
             DiagnosticsEngine::Error,
             "vectors with more than 4 elements are not supported");
-    CustomDiagnosticsIDMap[CustomDiagnosticUnsupportedKernelParameter] =
-        DE.getCustomDiagID(DiagnosticsEngine::Error,
-                           "vectors with more than 4 elements are not "
-                           "supported as kernel parameters");
     CustomDiagnosticsIDMap[CustomDiagnosticVoidPointer] = DE.getCustomDiagID(
         DiagnosticsEngine::Error, "pointer-to-void is not supported");
     CustomDiagnosticsIDMap[CustomDiagnosticUnalignedScalar] =

--- a/test/CommonBuiltins/max/float8_max.cl
+++ b/test/CommonBuiltins/max/float8_max.cl
@@ -16,11 +16,6 @@
 // CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
 // CHECK: = OpExtInst [[FLOAT]] [[GLSL]] FMax
 
-void kernel test(global float *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 in0 = vload8(0, in);
-  float8 in1 = vload8(1, in);
-  float8 value = max(in0, in1);
-  vstore8(value, 0, out);
+void kernel test(global float8 *in, global float8 *out) {
+  *out = max(in[0], in[1]);
 }

--- a/test/ConvertBuiltins/char/convert_char16_float16.cl
+++ b/test/ConvertBuiltins/char/convert_char16_float16.cl
@@ -24,10 +24,6 @@
 // CHECK: OpConvertFToS [[CHAR]]
 // CHECK: OpConvertFToS [[CHAR]]
 
-void kernel test(global float *in, global char *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload16 and vstore16 to read/write the values.
-  float16 x = vload16(0, in);
-  char16 y = convert_char16(x);
-  vstore16(y, 0, out);
+void kernel test(global float16 *in, global char16 *out) {
+  *out = convert_char16(*in);
 }

--- a/test/ConvertBuiltins/float/convert_float8_int8.cl
+++ b/test/ConvertBuiltins/float/convert_float8_int8.cl
@@ -16,10 +16,6 @@
 // CHECK: OpConvertSToF [[FLOAT]]
 // CHECK: OpConvertSToF [[FLOAT]]
 
-void kernel test(global int *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  int8 x = vload8(0, in);
-  float8 y = convert_float8(x);
-  vstore8(y, 0, out);
+void kernel test(global int8 *in, global float8 *out) {
+  *out = convert_float8(*in);
 }

--- a/test/ConvertBuiltins/half/convert_half8_short8.cl
+++ b/test/ConvertBuiltins/half/convert_half8_short8.cl
@@ -16,10 +16,6 @@
 // CHECK: OpConvertSToF [[HALF]]
 // CHECK: OpConvertSToF [[HALF]]
 
-void kernel test(global short *in, global half *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  short8 x = vload8(0, in);
-  half8 y = convert_half8(x);
-  vstore8(y, 0, out);
+void kernel test(global short8 *in, global half8 *out) {
+  *out = convert_half8(*in);
 }

--- a/test/ConvertBuiltins/int/convert_int8_short8.cl
+++ b/test/ConvertBuiltins/int/convert_int8_short8.cl
@@ -15,10 +15,6 @@
 // CHECK: OpSConvert [[INT]]
 // CHECK: OpSConvert [[INT]]
 
-void kernel test(global short *in, global int *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  short8 x = vload8(0, in);
-  int8 y = convert_int8(x);
-  vstore8(y, 0, out);
+void kernel test(global short8 *in, global int8 *out) {
+  *out = convert_int8(*in);
 }

--- a/test/ConvertBuiltins/short/convert_short8_int8.cl
+++ b/test/ConvertBuiltins/short/convert_short8_int8.cl
@@ -15,10 +15,6 @@
 // CHECK: OpUConvert [[SHORT]]
 // CHECK: OpUConvert [[SHORT]]
 
-void kernel test(global int *in, global short *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  int8 x = vload8(0, in);
-  short8 y = convert_short8(x);
-  vstore8(y, 0, out);
+void kernel test(global int8 *in, global short8 *out) {
+  *out = convert_short8(*in);
 }

--- a/test/IntegerBuiltins/max/max_int8.cl
+++ b/test/IntegerBuiltins/max/max_int8.cl
@@ -17,11 +17,6 @@
 // CHECK: OpExtInst [[INT]] [[GLSL]] SMax
 // CHECK: OpExtInst [[INT]] [[GLSL]] SMax
 
-void kernel test(global int *in, global int *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  int8 in0 = vload8(0, in);
-  int8 in1 = vload8(1, in);
-  int8 value = max(in0, in1);
-  vstore8(value, 0, out);
+void kernel test(global int8 *in, global int8 *out) {
+  *out = max(in[0], in[1]);
 }

--- a/test/IntegerBuiltins/max/max_ushort8.cl
+++ b/test/IntegerBuiltins/max/max_ushort8.cl
@@ -17,11 +17,6 @@
 // CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
 // CHECK: OpExtInst [[USHORT]] [[GLSL]] UMax
 
-void kernel test(global ushort *in, global ushort *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  ushort8 in0 = vload8(0, in);
-  ushort8 in1 = vload8(1, in);
-  ushort8 value = max(in0, in1);
-  vstore8(value, 0, out);
+void kernel test(global ushort8 *in, global ushort8 *out) {
+  *out = max(in[0], in[1]);
 }

--- a/test/LongVectorLowering/Frontend/lowering_disabled_kernel_param_pointer.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_kernel_param_pointer.cl
@@ -1,0 +1,7 @@
+// RUN: clspv %s -verify
+//
+// Test that long-vector types are rejected when the support is not enabled.
+
+kernel void test(global float8* x) { // expected-error{{vectors with more than 4 elements are not supported}}
+  (void)x;
+}

--- a/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_array.cl
+++ b/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_array.cl
@@ -1,7 +1,7 @@
 // RUN: clspv %s --long-vector -verify
 //
-// Test that long-vector types are rejected when used through kernel parameters.
+// expected-no-diagnostics
 
-kernel void test(global float8 x[10]) { // expected-error{{vectors with more than 4 elements are not supported as kernel parameters}}
+kernel void test(global float8 x[10]) {
   (void)x;
 }

--- a/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_pointer.cl
+++ b/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_pointer.cl
@@ -1,7 +1,7 @@
 // RUN: clspv %s --long-vector -verify
 //
-// Test that long-vector types are rejected when used through kernel parameters.
+// expected-no-diagnostics
 
-kernel void test(global float8* x) { // expected-error{{vectors with more than 4 elements are not supported as kernel parameters}}
+kernel void test(global float8* x) {
   (void)x;
 }

--- a/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_scalar.cl
+++ b/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_scalar.cl
@@ -1,7 +1,7 @@
 // RUN: clspv %s --long-vector -verify
 //
-// Test that long-vector types are rejected when used through kernel parameters.
+// expected-no-diagnostics
 
-kernel void test(float8 x) { // expected-error{{vectors with more than 4 elements are not supported as kernel parameters}}
+kernel void test(float8 x) {
   (void)x;
 }

--- a/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_struct.cl
+++ b/test/LongVectorLowering/Frontend/lowering_enabled_kernel_param_struct.cl
@@ -1,11 +1,11 @@
 // RUN: clspv %s --long-vector -verify
 //
-// Test that long-vector types are rejected when used through kernel parameters.
+// expected-no-diagnostics
 
 typedef struct {
   float8 x;
 } S;
 
-kernel void test(global S *x) { // expected-error{{vectors with more than 4 elements are not supported as kernel parameters}}
+kernel void test(global S *x) {
   (void)x;
 }

--- a/test/LongVectorLowering/gep.ll
+++ b/test/LongVectorLowering/gep.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt --LongVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_func void @test() {
+entry:
+  %ptr = load <8 x float> addrspace(1)*, <8 x float> addrspace(1)** undef, align 4
+  %data = getelementptr inbounds <8 x float>, <8 x float> addrspace(1)* %ptr, i32 undef
+  ret void
+}
+
+; CHECK: getelementptr inbounds
+; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]],
+; CHECK-SAME: [[FLOAT8]] addrspace(1)* {{%[^ ]+}}, i32 undef

--- a/test/MathBuiltins/exp/float8_exp.cl
+++ b/test/MathBuiltins/exp/float8_exp.cl
@@ -17,10 +17,6 @@
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] Exp
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] Exp
 
-void kernel test(global float *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 x = vload8(0, in);
-  float8 y = exp(x);
-  vstore8(y, 0, out);
+void kernel test(global float8 *in, global float8 *out) {
+  *out = exp(*in);
 }

--- a/test/MathBuiltins/fma/float8_fma.cl
+++ b/test/MathBuiltins/fma/float8_fma.cl
@@ -17,12 +17,6 @@
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] Fma
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] Fma
 
-void kernel test(global float *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 in0 = vload8(0, in);
-  float8 in1 = vload8(1, in);
-  float8 in2 = vload8(2, in);
-  float8 value = fma(in0, in1, in2);
-  vstore8(value, 0, out);
+void kernel test(global float8 *in, global float8 *out) {
+  *out = fma(in[0], in[1], in[2]);
 }

--- a/test/MathBuiltins/fmax/float8_fmax.cl
+++ b/test/MathBuiltins/fmax/float8_fmax.cl
@@ -17,11 +17,6 @@
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] NMax
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] NMax
 
-void kernel test(global float *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 in0 = vload8(0, in);
-  float8 in1 = vload8(1, in);
-  float8 value = fmax(in0, in1);
-  vstore8(value, 0, out);
+void kernel test(global float8 *in, global float8 *out) {
+  *out = fmax(in[0], in[1]);
 }

--- a/test/MathBuiltins/fmin/float8_fmin.cl
+++ b/test/MathBuiltins/fmin/float8_fmin.cl
@@ -17,11 +17,6 @@
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] NMin
 // CHECK: OpExtInst [[FLOAT]] [[GLSL]] NMin
 
-void kernel test(global float *in, global float *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 in0 = vload8(0, in);
-  float8 in1 = vload8(1, in);
-  float8 value = fmin(in0, in1);
-  vstore8(value, 0, out);
+void kernel test(global float8 *in, global float8 *out) {
+  *out = fmin(in[0], in[1]);
 }

--- a/test/MathBuiltins/frexp/float8_frexp_private.cl
+++ b/test/MathBuiltins/frexp/float8_frexp_private.cl
@@ -6,21 +6,21 @@
 
 // CHECK: [[GLSL:%[^ ]+]] = OpExtInstImport "GLSL.std.450"
 //
-// CHECK-DAG: [[FLOAT:%[^ ]+]]         = OpTypeFloat 32
-// CHECK-DAG: [[RUNTIME_FLOAT:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT]]
-// CHECK-DAG: [[STRUCT_FLOAT:%[^ ]+]]  = OpTypeStruct [[RUNTIME_FLOAT]]
-// CHECK-DAG: [[BUFFER_FLOAT:%[^ ]+]]  = OpTypePointer StorageBuffer [[STRUCT_FLOAT]]
-// CHECK-DAG: [[PTR_FLOAT:%[^ ]+]]     = OpTypePointer StorageBuffer [[FLOAT]]
-
-// CHECK-DAG: [[INT:%[^ ]+]]           = OpTypeInt 32
-// CHECK-DAG: [[RUNTIME_INT:%[^ ]+]]   = OpTypeRuntimeArray [[INT]]
-// CHECK-DAG: [[STRUCT_INT:%[^ ]+]]    = OpTypeStruct [[RUNTIME_INT]]
-// CHECK-DAG: [[BUFFER_INT:%[^ ]+]]    = OpTypePointer StorageBuffer [[STRUCT_INT]]
-// CHECK-DAG: [[PTR_INT:%[^ ]+]]       = OpTypePointer StorageBuffer [[INT]]
-// CHECK-DAG: [[LOCAL_PTR_INT:%[^ ]+]] = OpTypePointer Function [[INT]]
+// CHECK-DAG: [[FLOAT:%[^ ]+]] = OpTypeFloat 32
+// CHECK-DAG: [[PTR_FLOAT:%[^ ]+]] = OpTypePointer StorageBuffer [[FLOAT]]
+//
+// CHECK-DAG: [[FLOAT8:%[^ ]+]] = OpTypeStruct [[FLOAT]] [[FLOAT]] [[FLOAT]] [[FLOAT]] [[FLOAT]] [[FLOAT]] [[FLOAT]] [[FLOAT]]
+// CHECK-DAG: [[RUNTIME_FLOAT8:%[^ ]+]] = OpTypeRuntimeArray [[FLOAT8]]
+// CHECK-DAG: [[WRAPPER_FLOAT8:%[^ ]+]] = OpTypeStruct [[RUNTIME_FLOAT8]]
+// CHECK-DAG: [[PTR_WRAPPER_FLOAT8:%[^ ]+]] = OpTypePointer StorageBuffer [[WRAPPER_FLOAT8]]
+//
+// CHECK-DAG: [[INT:%[^ ]+]] = OpTypeInt 32
+// CHECK-DAG: [[PTR_INT:%[^ ]+]] = OpTypePointer StorageBuffer [[INT]]
 //
 // CHECK-DAG: [[INT8:%[^ ]+]] = OpTypeStruct [[INT]] [[INT]] [[INT]] [[INT]] [[INT]] [[INT]] [[INT]] [[INT]]
-// CHECK-DAG: [[LOCAL_PTR_INT8:%[^ ]+]] = OpTypePointer Function [[INT8]]
+// CHECK-DAG: [[RUNTIME_INT8:%[^ ]+]] = OpTypeRuntimeArray [[INT8]]
+// CHECK-DAG: [[WRAPPER_INT8:%[^ ]+]] = OpTypeStruct [[RUNTIME_INT8]]
+// CHECK-DAG: [[PTR_WRAPPER_INT8:%[^ ]+]] = OpTypePointer StorageBuffer [[WRAPPER_INT8]]
 //
 // CHECK-DAG: [[CST_0:%[^ ]+]] = OpConstant [[INT]] 0
 // CHECK-DAG: [[CST_1:%[^ ]+]] = OpConstant [[INT]] 1
@@ -31,94 +31,56 @@
 // CHECK-DAG: [[CST_6:%[^ ]+]] = OpConstant [[INT]] 6
 // CHECK-DAG: [[CST_7:%[^ ]+]] = OpConstant [[INT]] 7
 //
-// CHECK-DAG: [[INOUT:%[^ ]+]] = OpVariable [[BUFFER_FLOAT]] StorageBuffer
-// CHECK-DAG: [[OUT:%[^ ]+]]   = OpVariable [[BUFFER_INT]] StorageBuffer
-// CHECK-DAG: [[PTR_Z:%[^ ]+]] = OpVariable [[LOCAL_PTR_INT8]] Function
+// CHECK-DAG: [[INOUT:%[^ ]+]] = OpVariable [[PTR_WRAPPER_FLOAT8]] StorageBuffer
+// CHECK-DAG: [[OUT:%[^ ]+]] = OpVariable [[PTR_WRAPPER_INT8]] StorageBuffer
 //
-// CHECK-DAG: [[PTR_XY_0:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]]
-// CHECK-DAG: [[PTR_XY_1:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_1]]
-// CHECK-DAG: [[PTR_XY_2:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_2]]
-// CHECK-DAG: [[PTR_XY_3:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_3]]
-// CHECK-DAG: [[PTR_XY_4:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_4]]
-// CHECK-DAG: [[PTR_XY_5:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_5]]
-// CHECK-DAG: [[PTR_XY_6:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_6]]
-// CHECK-DAG: [[PTR_XY_7:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_7]]
+// CHECK-DAG: [[PTR_INTOUT_0:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_0]]
+// CHECK-DAG: [[PTR_INTOUT_1:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_1]]
+// CHECK-DAG: [[PTR_INTOUT_2:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_2]]
+// CHECK-DAG: [[PTR_INTOUT_3:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_3]]
+// CHECK-DAG: [[PTR_INTOUT_4:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_4]]
+// CHECK-DAG: [[PTR_INTOUT_5:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_5]]
+// CHECK-DAG: [[PTR_INTOUT_6:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_6]]
+// CHECK-DAG: [[PTR_INTOUT_7:%[^ ]+]] = OpAccessChain [[PTR_FLOAT]] [[INOUT]] [[CST_0]] [[CST_0]] [[CST_7]]
 //
-// CHECK-DAG: [[PTR_Z_0:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_0]]
-// CHECK-DAG: [[PTR_Z_1:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_1]]
-// CHECK-DAG: [[PTR_Z_2:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_2]]
-// CHECK-DAG: [[PTR_Z_3:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_3]]
-// CHECK-DAG: [[PTR_Z_4:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_4]]
-// CHECK-DAG: [[PTR_Z_5:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_5]]
-// CHECK-DAG: [[PTR_Z_6:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_6]]
-// CHECK-DAG: [[PTR_Z_7:%[^ ]+]] = OpAccessChain [[LOCAL_PTR_INT]] [[PTR_Z]] [[CST_7]]
+// CHECK-DAG: [[PTR_OUT_0:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_0]]
+// CHECK-DAG: [[PTR_OUT_1:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_1]]
+// CHECK-DAG: [[PTR_OUT_2:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_2]]
+// CHECK-DAG: [[PTR_OUT_3:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_3]]
+// CHECK-DAG: [[PTR_OUT_4:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_4]]
+// CHECK-DAG: [[PTR_OUT_5:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_5]]
+// CHECK-DAG: [[PTR_OUT_6:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_6]]
+// CHECK-DAG: [[PTR_OUT_7:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]] [[CST_7]]
 //
-// CHECK-DAG: [[X_0:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_0]]
-// CHECK-DAG: [[X_1:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_1]]
-// CHECK-DAG: [[X_2:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_2]]
-// CHECK-DAG: [[X_3:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_3]]
-// CHECK-DAG: [[X_4:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_4]]
-// CHECK-DAG: [[X_5:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_5]]
-// CHECK-DAG: [[X_6:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_6]]
-// CHECK-DAG: [[X_7:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_XY_7]]
+// CHECK-DAG: [[X_0:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_0]]
+// CHECK-DAG: [[X_1:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_1]]
+// CHECK-DAG: [[X_2:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_2]]
+// CHECK-DAG: [[X_3:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_3]]
+// CHECK-DAG: [[X_4:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_4]]
+// CHECK-DAG: [[X_5:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_5]]
+// CHECK-DAG: [[X_6:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_6]]
+// CHECK-DAG: [[X_7:%[^ ]+]] = OpLoad [[FLOAT]] [[PTR_INTOUT_7]]
 //
-// CHECK-DAG: [[Y_0:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_0]] [[PTR_Z_0]]
-// CHECK-DAG: [[Y_1:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_1]] [[PTR_Z_1]]
-// CHECK-DAG: [[Y_2:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_2]] [[PTR_Z_2]]
-// CHECK-DAG: [[Y_3:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_3]] [[PTR_Z_3]]
-// CHECK-DAG: [[Y_4:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_4]] [[PTR_Z_4]]
-// CHECK-DAG: [[Y_5:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_5]] [[PTR_Z_5]]
-// CHECK-DAG: [[Y_6:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_6]] [[PTR_Z_6]]
-// CHECK-DAG: [[Y_7:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_7]] [[PTR_Z_7]]
+// CHECK-DAG: [[Y_0:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_0]] [[PTR_OUT_0]]
+// CHECK-DAG: [[Y_1:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_1]] [[PTR_OUT_1]]
+// CHECK-DAG: [[Y_2:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_2]] [[PTR_OUT_2]]
+// CHECK-DAG: [[Y_3:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_3]] [[PTR_OUT_3]]
+// CHECK-DAG: [[Y_4:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_4]] [[PTR_OUT_4]]
+// CHECK-DAG: [[Y_5:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_5]] [[PTR_OUT_5]]
+// CHECK-DAG: [[Y_6:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_6]] [[PTR_OUT_6]]
+// CHECK-DAG: [[Y_7:%[^ ]+]] = OpExtInst [[FLOAT]] [[GLSL]] Frexp [[X_7]] [[PTR_OUT_7]]
 //
-// CHECK-DAG: OpStore [[PTR_XY_0]] [[Y_0]]
-// CHECK-DAG: OpStore [[PTR_XY_1]] [[Y_1]]
-// CHECK-DAG: OpStore [[PTR_XY_2]] [[Y_2]]
-// CHECK-DAG: OpStore [[PTR_XY_3]] [[Y_3]]
-// CHECK-DAG: OpStore [[PTR_XY_4]] [[Y_4]]
-// CHECK-DAG: OpStore [[PTR_XY_5]] [[Y_5]]
-// CHECK-DAG: OpStore [[PTR_XY_6]] [[Y_6]]
-// CHECK-DAG: OpStore [[PTR_XY_7]] [[Y_7]]
-//
-// Currently, writing z to memory is implemented as
-//   for i in 0..7:
-//     out[i] = (&z)[i];
-// but it could be simplified to use, for example, one OpCopyMemory instruction
-// if the pointer types of out and &z were the same.
-//
-// CHECK-DAG: [[Z_0:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_0]]
-// CHECK-DAG: [[Z_1:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_1]]
-// CHECK-DAG: [[Z_2:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_2]]
-// CHECK-DAG: [[Z_3:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_3]]
-// CHECK-DAG: [[Z_4:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_4]]
-// CHECK-DAG: [[Z_5:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_5]]
-// CHECK-DAG: [[Z_6:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_6]]
-// CHECK-DAG: [[Z_7:%[^ ]+]] = OpLoad [[INT]] [[PTR_Z_7]]
-//
-// CHECK-DAG: [[PTR_OUT_0:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_0]]
-// CHECK-DAG: [[PTR_OUT_1:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_1]]
-// CHECK-DAG: [[PTR_OUT_2:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_2]]
-// CHECK-DAG: [[PTR_OUT_3:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_3]]
-// CHECK-DAG: [[PTR_OUT_4:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_4]]
-// CHECK-DAG: [[PTR_OUT_5:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_5]]
-// CHECK-DAG: [[PTR_OUT_6:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_6]]
-// CHECK-DAG: [[PTR_OUT_7:%[^ ]+]] = OpAccessChain [[PTR_INT]] [[OUT]] [[CST_0]] [[CST_7]]
-//
-// CHECK-DAG: OpStore [[PTR_OUT_0]] [[Z_0]]
-// CHECK-DAG: OpStore [[PTR_OUT_1]] [[Z_1]]
-// CHECK-DAG: OpStore [[PTR_OUT_2]] [[Z_2]]
-// CHECK-DAG: OpStore [[PTR_OUT_3]] [[Z_3]]
-// CHECK-DAG: OpStore [[PTR_OUT_4]] [[Z_4]]
-// CHECK-DAG: OpStore [[PTR_OUT_5]] [[Z_5]]
-// CHECK-DAG: OpStore [[PTR_OUT_6]] [[Z_6]]
-// CHECK-DAG: OpStore [[PTR_OUT_7]] [[Z_7]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_0]] [[Y_0]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_1]] [[Y_1]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_2]] [[Y_2]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_3]] [[Y_3]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_4]] [[Y_4]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_5]] [[Y_5]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_6]] [[Y_6]]
+// CHECK-DAG: OpStore [[PTR_INTOUT_7]] [[Y_7]]
 
-void kernel test(global float *inout, global int *out) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 x = vload8(0, inout);
-  int8 z;
-  float8 y = frexp(x, &z);
-  vstore8(y, 0, inout);
-  vstore8(z, 0, out);
+void kernel test(global float8 *inout, global int8 *out) {
+  float8 x = *inout;
+  float8 y = frexp(x, out);
+  *inout = y;
 }

--- a/test/RelationalBuiltins/select/select_float8_uint8.cl
+++ b/test/RelationalBuiltins/select/select_float8_uint8.cl
@@ -30,12 +30,6 @@
 // CHECK-DAG: OpSelect [[FLOAT]] [[COND_6]] {{%[^ ]+}} {{%[^ ]+}}
 // CHECK-DAG: OpSelect [[FLOAT]] [[COND_7]] {{%[^ ]+}} {{%[^ ]+}}
 
-void kernel test(global float *out, global float *in1, global uint *in2) {
-  // Because long vectors are not supported as kernel argument, we rely on
-  // vload8 and vstore8 to read/write the values.
-  float8 a = vload8(0, in1);
-  float8 b = vload8(1, in1);
-  uint8 cond = vload8(0, in2);
-  float8 value = select(a, b, cond);
-  vstore8(value, 0, out);
+void kernel test(global float8 *out, global float8 *in, global uint8 *cond) {
+  *out = select(in[0], in[1], *cond);
 }


### PR DESCRIPTION
This brings support for long-vector parameters for kernel functions. To implement this support, I added a limited support for GEPs -- I've updated #613 to list this as a current limitation of the prototype we've designed so far.