### PR TITLE
Use distinct nodes for clspv.next_spec_constant_id

### DIFF
--- a/lib/SpecConstant.cpp
+++ b/lib/SpecConstant.cpp
@@ -30,7 +30,7 @@ void InitSpecConstantMetadata(Module *module) {
   const uint32_t first_spec_id = 3;
   auto id_const = ValueAsMetadata::getConstant(ConstantInt::get(
       IntegerType::get(module->getContext(), 32), first_spec_id));
-  auto id_md = MDTuple::get(module->getContext(), {id_const});
+  auto id_md = MDTuple::getDistinct(module->getContext(), {id_const});
   next_spec_id_md->addOperand(id_md);
 
   auto spec_constant_list_md =

--- a/test/Reflection/global_size_and_work_dim.cl
+++ b/test/Reflection/global_size_and_work_dim.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* data) {
+  *data = get_global_size(0) + get_work_dim();
+}
+
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.1"
+// CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
+// CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_12:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 12
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
+//
+// CHECK-DAG: OpExtInst [[void]] [[import]] PushConstantGlobalSize [[uint_0]] [[uint_12]]
+// CHECK: OpExtInst [[void]] [[import]] SpecConstantWorkDim [[uint_3]]


### PR DESCRIPTION
Metadata nodes are uniqued by default, which means this counter was
sometimes being merged with other metadata values such as push
constant declarations. Subsequent updates to this counter would then
inadvertently change the type of the push constant.