### PR TITLE
Handle sitofp with i1 arguments

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3886,10 +3886,11 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
       auto OpTy = I.getOperand(0)->getType();
       auto toI8 = Ty == Type::getInt8Ty(Context);
       auto fromI32 = OpTy == Type::getInt32Ty(Context);
-      // Handle zext, sext and uitofp with i1 type specially.
+      // Handle zext, sext, uitofp, and sitofp with i1 type specially.
       if ((I.getOpcode() == Instruction::ZExt ||
            I.getOpcode() == Instruction::SExt ||
-           I.getOpcode() == Instruction::UIToFP) &&
+           I.getOpcode() == Instruction::UIToFP ||
+           I.getOpcode() == Instruction::SIToFP) &&
           OpTy->isIntOrIntVectorTy(1)) {
         //
         // Generate OpSelect.
@@ -3907,8 +3908,10 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
           Ops << ConstantInt::get(I.getType(), 1);
         } else if (I.getOpcode() == Instruction::SExt) {
           Ops << ConstantInt::getSigned(I.getType(), -1);
-        } else {
+        } else if (I.getOpcode() == Instruction::UIToFP) {
           Ops << ConstantFP::get(I.getType(), 1.0);
+        } else if (I.getOpcode() == Instruction::SIToFP) {
+          Ops << ConstantFP::get(I.getType(), -1.0);
         }
 
         if (I.getOpcode() == Instruction::ZExt) {

--- a/test/ConvertBuiltins/float/convert_float4_relational.cl
+++ b/test/ConvertBuiltins/float/convert_float4_relational.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global float4* output, int4 x) {
+  output[0] = convert_float4(x > 0);
+}
+
+// CHECK: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+// CHECK: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK: [[float_n1:%[a-zA-Z0-9_]+]] = OpConstant [[float]] -1
+// CHECK: [[float4_true:%[a-zA-Z0-9_]+]] = OpConstantComposite [[float4]] [[float_n1]] [[float_n1]] [[float_n1]] [[float_n1]]
+// CHECK: [[float4_false:%[a-zA-Z0-9_]+]] = OpConstantNull [[float4]]
+// CHECK: [[greater:%[a-zA-Z0-9_]+]] = OpSGreaterThan [[bool4]]
+// CHECK: [[select:%[a-zA-Z0-9_]+]] = OpSelect [[float4]] [[greater]] [[float4_true]] [[float4_false]]

--- a/test/ConvertBuiltins/half/convert_half4_relational.cl
+++ b/test/ConvertBuiltins/half/convert_half4_relational.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half4* output, int4 x) {
+  output[0] = convert_half4(x > 0);
+}
+
+// CHECK: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK: [[half_n1:%[a-zA-Z0-9_]+]] = OpConstant [[half]] -0x1p+0
+// CHECK: [[half4_true:%[a-zA-Z0-9_]+]] = OpConstantComposite [[half4]] [[half_n1]] [[half_n1]] [[half_n1]] [[half_n1]]
+// CHECK: [[half4_false:%[a-zA-Z0-9_]+]] = OpConstantNull [[half4]]
+// CHECK: [[greater:%[a-zA-Z0-9_]+]] = OpSGreaterThan [[bool4]]
+// CHECK: [[select:%[a-zA-Z0-9_]+]] = OpSelect [[half4]] [[greater]] [[half4_true]] [[half4_false]]


### PR DESCRIPTION
* Add sitofp to the special case for i1 conversions to generate an
  OpSelect instead of an OpConvertSToF

* Add tests that cause LLVM to generate these instructions