### PR TITLE
Add stub for array types in the long vector pass

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1066,6 +1066,15 @@ Type *LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
     return nullptr;
   }
 
+  if (auto *ArrayTy = dyn_cast<ArrayType>(Ty)) {
+    if (getEquivalentType(ArrayTy->getElementType()) != nullptr) {
+      llvm_unreachable(
+          "Nested types not yet supported, need test cases (array)");
+    }
+
+    return nullptr;
+  }
+
   if (auto *StructTy = dyn_cast<StructType>(Ty)) {
     unsigned Arity = StructTy->getStructNumElements();
     for (unsigned i = 0; i < Arity; ++i) {


### PR DESCRIPTION
Without this the pass bails when it encounters any array type, even if it does not contain wide vectors.

CC @mantognini: hopefully this doesn't cause you any rebase pain. I assume there is a patch for array types coming later but adding this stub now means that I can start testing this pass on some workloads that I'm looking at now.