### PR TITLE
Fix warning in GetArgKindForPodArgs

### DIFF
--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -117,6 +117,8 @@ ArgKind GetArgKindForPodArgs(Function &F) {
   case kSSBO:
     return ArgKind::Pod;
   }
+  errs() << "Unhandled case in clspv::GetArgKindForPodArgs: " << impl << "\n";
+  llvm_unreachable("Unhandled case in clspv::GetArgKindForPodArgs");
 }
 
 ArgKind GetArgKind(Argument &Arg) {


### PR DESCRIPTION
"control reaches end of non-void function"

Signed-off-by: Kévin Petit <kevin.petit@arm.com>