### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "master",
       "subdir" : "third_party/llvm",
-      "commit" : "82a29a62aba52d68d37309cd3025370ba98e37e4"
+      "commit" : "d0cb0d30a431578ecedb98c57780154789f3c594"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -463,7 +463,9 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   // We use the 32-bit pointer-width SPIR triple
   llvm::Triple triple("spir-unknown-unknown");
 
+  // We manually include the OpenCL headers below, so this vector is unused.
   std::vector<std::string> includes;
+
   instance.getInvocation().setLangDefaults(
       instance.getLangOpts(), clang::InputKind(clang::Language::OpenCL), triple,
       includes, standard);

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -507,7 +507,7 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
       new OpenCLBuiltinMemoryBuffer(opencl_builtins_header_data,
                                     opencl_builtins_header_size - 1));
 
-  instance.getPreprocessorOpts().Includes.push_back("openclc.h");
+  instance.getPreprocessorOpts().Includes.push_back("opencl-c.h");
 
   std::unique_ptr<llvm::MemoryBuffer> openCLBaseBuiltinMemoryBuffer(
       new OpenCLBuiltinMemoryBuffer(opencl_base_builtins_header_data,
@@ -535,7 +535,7 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
 #endif
 
   auto entry = instance.getFileManager().getVirtualFile(
-      includePrefix + "openclc.h", openCLBuiltinMemoryBuffer->getBufferSize(),
+      includePrefix + "opencl-c.h", openCLBuiltinMemoryBuffer->getBufferSize(),
       0);
 
   instance.getSourceManager().overrideFileContents(

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -463,9 +463,10 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   // We use the 32-bit pointer-width SPIR triple
   llvm::Triple triple("spir-unknown-unknown");
 
+  std::vector<std::string> includes;
   instance.getInvocation().setLangDefaults(
       instance.getLangOpts(), clang::InputKind(clang::Language::OpenCL), triple,
-      instance.getPreprocessorOpts(), standard);
+      includes, standard);
 
   // Override the C99 inline semantics to accommodate for more OpenCL C
   // programs in the wild.


### PR DESCRIPTION
* clang::CompilerInstance::setLangDefaults() now takes an output
  vector argument (for affected includes) instead of a
  PreprocessorOptions reference