### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "5a63045fe78834937785ed5081052e083a98077f"
+      "commit" : "60d71a286b5a03653fc99cd09423d603feb897de"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -123,7 +123,8 @@ bool UndoByvalPass::runOnModule(Module &M) {
 
       // Clone original function into new function.
       SmallVector<ReturnInst *, 4> RetInsts;
-      CloneFunctionInto(NewFunc, F, VMap, false, RetInsts);
+      CloneFunctionInto(NewFunc, F, VMap,
+                        CloneFunctionChangeType::LocalChangesOnly, RetInsts);
 
       // Store new arguments to their alloca space.
       for (Argument *Arg : ByValList) {

--- a/lib/UndoSRetPass.cpp
+++ b/lib/UndoSRetPass.cpp
@@ -123,7 +123,8 @@ bool UndoSRetPass::runOnModule(Module &M) {
 
         // Clone original function into new function.
         SmallVector<ReturnInst *, 4> RetInsts;
-        CloneFunctionInto(NewFunc, F, VMap, false, RetInsts);
+        CloneFunctionInto(NewFunc, F, VMap,
+                          CloneFunctionChangeType::LocalChangesOnly, RetInsts);
 
         // Change return instruction like this.
         //


### PR DESCRIPTION
* Fix uses of `CloneFunctionInto` in UndoByval and UndoSRet passes