### PR TITLE
Address linking issues with shared build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -97,7 +97,7 @@ foreach(clspv_lib clspv_core clspv_passes)
 
 endforeach(clspv_lib)
 
-set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore LLVMTransformUtils)
+set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore LLVMTransformUtils LLVMCodeGen)
 
 if(${EXTERNAL_LLVM} EQUAL 1)
   include(${CLSPV_LLVM_BINARY_DIR}/lib/cmake/llvm/LLVMConfig.cmake)


### PR DESCRIPTION
Link against LLVMCodeGen to solve the follow issues when doing a shared-library build:

    lib/libclspv_core.so: undefined reference to `llvm::createHardwareLoopsPass()'
    lib/libclspv_core.so: undefined reference to `llvm::createCodeGenPreparePass()'
    lib/libclspv_core.so: undefined reference to `llvm::createExpandMemCmpPass()'
    lib/libclspv_core.so: undefined reference to `llvm::createSafeStackPass()'

The issue was introduce with b41cfd36 (Update LLVM (#711), 2021-02-17).

----

Would it be possible to add a CI job to check shared builds? I'm not familiar with kokoro, but it might be possible to do the following:
1. Modify [kokoro/scripts/linux/build.sh](https://github.com/google/clspv/blob/master/kokoro/scripts/linux/build.sh) by adding `-DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS:-OFF}` to the CMake line.
2. Duplicate or re-purpose, say, [kokoro/linux-clang-release](https://github.com/google/clspv/blob/master/kokoro/linux-clang-release) or [kokoro/linux-gcc-debug](https://github.com/google/clspv/tree/master/kokoro/linux-gcc-debug) and add `--env BUILD_SHARED_LIBS=ON` to the Docker line in build.sh.

What do you think?
