### PR TITLE
Fix compilation for 32-bit systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ else()
 
   # Then pull in LLVM for building.
   add_subdirectory(${CLSPV_LLVM_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/third_party/llvm EXCLUDE_FROM_ALL)
+
+  # Ensure clspv and LLVM use the same build options (e.g. -D_FILE_OFFSET_BITS=64).
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/third_party/llvm/llvm/cmake/modules/)
+  include(HandleLLVMOptions)
 endif()
 
 set(CLSPV_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -146,7 +146,7 @@ enum class SourceLanguage {
 SourceLanguage Language();
 
 // Returns true when the source language makes use of the generic address space.
-static bool LanguageUsesGenericAddressSpace() {
+inline bool LanguageUsesGenericAddressSpace() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||
          ((Language() == SourceLanguage::OpenCL_C_20));
 }
@@ -173,7 +173,7 @@ bool GlobalOffset();
 bool GlobalOffsetPushConstant();
 
 // Returns true when support for non uniform NDRanges is enabled.
-static bool NonUniformNDRangeSupported() {
+inline bool NonUniformNDRangeSupported() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||
          (Language() == SourceLanguage::OpenCL_C_20) ||
          (Language() == SourceLanguage::OpenCL_C_30);

--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -57,7 +57,7 @@ std::string GetUnmangledName(const std::string &str, size_t *pos) {
     return "";
   }
   ptrdiff_t name_pos = end - str.data();
-  if (name_pos + name_len > str.size()) {
+  if (static_cast<std::size_t>(name_pos + name_len) > str.size()) {
     // Protect against maliciously large number.
     return "";
   }

--- a/lib/BuiltinsMap.inc
+++ b/lib/BuiltinsMap.inc
@@ -15,17 +15,19 @@
 #ifndef CLSPV_LIB_BUILTINSMAP_INC_
 #define CLSPV_LIB_BUILTINSMAP_INC_
 
+#include <cstdint>
+
 ////////////////////////////////////////////////////////////////////////////////
 // utilities for const char* map keys
 struct cstr_hash {
-#define FNV_PRIME_64 1099511628211ULL
-#define FNV_OFFSET_64 14695981039346656037ULL
+#define FNV_PRIME_64 UINT64_C(1099511628211)
+#define FNV_OFFSET_64 UINT64_C(14695981039346656037)
   // hash function for const char* hashmap based on FNV-1a
-  std::size_t operator()(const char *cstr) const {
-    std::size_t hash = FNV_OFFSET_64;
+  std::uint64_t operator()(const char *cstr) const {
+    std::uint64_t hash = FNV_OFFSET_64;
     for (char c = *cstr; c != '\0'; c = *(++cstr)) {
-      hash ^= static_cast<std::size_t>(c);
-      hash *= static_cast<std::size_t>(FNV_PRIME_64);
+      hash ^= static_cast<std::uint64_t>(c);
+      hash *= static_cast<std::uint64_t>(FNV_PRIME_64);
     }
     return hash;
   }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -98,7 +98,21 @@ foreach(clspv_lib clspv_core clspv_passes)
 
 endforeach(clspv_lib)
 
-set(CLSPV_LLVM_COMPONENTS LLVMAnalysis LLVMScalarOpts LLVMCore LLVMTransformUtils LLVMCodeGen)
+# Dependencies of clspv_lib
+set(CLSPV_LLVM_COMPONENTS
+  LLVMAggressiveInstCombine
+  LLVMAnalysis
+  LLVMCodeGen
+  LLVMCore
+  LLVMInstCombine
+  LLVMInstrumentation
+  LLVMObjCARCOpts
+  LLVMScalarOpts
+  LLVMSupport
+  LLVMTransformUtils
+  LLVMVectorize
+  LLVMipo
+)
 
 if(${EXTERNAL_LLVM} EQUAL 1)
   include(${CLSPV_LLVM_BINARY_DIR}/lib/cmake/llvm/LLVMConfig.cmake)
@@ -115,7 +129,15 @@ target_link_libraries(clspv_passes PRIVATE ${CLSPV_LLVM_COMPONENTS})
 # clspv_baked_opencl_header and clspv_builtin_library are used by Compiler.cpp.
 add_dependencies(clspv_core clspv_baked_opencl_header clspv_builtin_library)
 target_link_libraries(clspv_core PUBLIC clspv_passes)
-target_link_libraries(clspv_core PRIVATE clangCodeGen)
+target_link_libraries(clspv_core PRIVATE
+  LLVMIRReader
+  LLVMLinker
+  clangAST
+  clangBasic
+  clangCodeGen
+  clangFrontend
+  clangSerialization
+)
 
 if (MSVC)
   set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/SPIRVProducerPass.cpp"

--- a/lib/FixupStructuredCFGPass.cpp
+++ b/lib/FixupStructuredCFGPass.cpp
@@ -116,7 +116,7 @@ bool FixupStructuredCFGPass::FixLoopMerges(Function &F) {
             } else if (!phi_values.empty()) {
               auto new_phi = PHINode::Create(phi->getType(), phi_values.size(),
                                              "", new_exit->getTerminator());
-              for (auto i = 0; i < phi_values.size(); ++i) {
+              for (size_t i = 0; i < phi_values.size(); ++i) {
                 new_phi->addIncoming(phi_values[i], loop_preds[i]);
               }
               phi->addIncoming(new_phi, new_exit);

--- a/lib/InlineFuncWithPointerBitCastArgPass.cpp
+++ b/lib/InlineFuncWithPointerBitCastArgPass.cpp
@@ -90,6 +90,7 @@ bool InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
                 case Instruction::Call:
                   // We found a call instruction which needs to be inlined!
                   WorkList.insert(cast<CallInst>(Inst));
+                  // Fall-through
                 case Instruction::PHI:
                   // If we previously checked this phi...
                   if (0 < CheckedPhis.count(Inst)) {
@@ -98,6 +99,7 @@ bool InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
                   }
 
                   CheckedPhis.insert(Inst);
+                  // Fall-through
                 case Instruction::GetElementPtr:
                 case Instruction::BitCast:
                   // These pointer users could have a call user, and so we

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -961,12 +961,13 @@ Value *LongVectorLoweringPass::visitShuffleVectorInst(ShuffleVectorInst &I) {
   // Construct the equivalent shuffled vector, as a struct or a vector.
   Value *V = UndefValue::get(EquivalentType);
   for (unsigned i = 0; i < Arity; ++i) {
-    auto Mask = I.getMaskValue(i);
+    int Mask = I.getMaskValue(i);
+    assert(-1 <= Mask && "Unexpected mask value.");
 
     Value *Scalar = nullptr;
     if (Mask == -1) {
       Scalar = UndefValue::get(ScalarTy);
-    } else if (Mask < LHSArity) {
+    } else if (static_cast<unsigned>(Mask) < LHSArity) {
       Scalar = getScalar(EquivalentLHS, Mask);
     } else {
       Scalar = getScalar(EquivalentRHS, Mask - LHSArity);

--- a/lib/NormalizeGlobalVariable.cpp
+++ b/lib/NormalizeGlobalVariable.cpp
@@ -69,7 +69,7 @@ void FlattenConstant(Constant *constant, std::vector<Constant *> *flattened) {
     // Special cases for constant aggregate zero and constant data sequential
     // to populate the right number of constant elements into |flattened|.
     if (auto caz = dyn_cast<ConstantAggregateZero>(const_element)) {
-      for (auto i = 0; i != GetNumElements(element_ty); ++i) {
+      for (size_t i = 0; i != GetNumElements(element_ty); ++i) {
         if (element_ty->isStructTy()) {
           flattened->push_back(caz->getStructElement(i));
         } else {

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -87,13 +87,17 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc,
 
   // Find requested pc in metadata
   auto MD = GV->getMetadata(clspv::PushConstantsMetadataName());
+#ifndef NDEBUG
   bool found = false;
+#endif
   uint32_t idx = 0;
   for (auto &PCMD : MD->operands()) {
     auto mpc = static_cast<PushConstant>(
         mdconst::extract<ConstantInt>(PCMD)->getZExtValue());
     if (mpc == pc) {
+#ifndef NDEBUG
       found = true;
+#endif
       break;
     }
     idx++;

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -1535,7 +1535,8 @@ bool ReplaceOpenCLBuiltinPass::replaceStep(Function &F, bool is_smooth) {
 
     for (auto arg : ArgsToSplat) {
       Value *NewVectorArg = UndefValue::get(VecType);
-      for (auto i = 0; i < VecType->getElementCount().getKnownMinValue(); i++) {
+      for (size_t i = 0; i < VecType->getElementCount().getKnownMinValue();
+           i++) {
         auto index = ConstantInt::get(Type::getInt32Ty(M.getContext()), i);
         NewVectorArg =
             InsertElementInst::Create(NewVectorArg, arg, index, "", CI);
@@ -1623,7 +1624,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVstore(Function &F) {
     IRBuilder<> builder(CI);
     auto elems_const = builder.getInt32(elems);
     auto adjust = builder.CreateMul(offset, elems_const);
-    for (auto i = 0; i < elems; ++i) {
+    for (size_t i = 0; i < elems; ++i) {
       auto idx = builder.getInt32(i);
       auto add = builder.CreateAdd(adjust, idx);
       auto gep = builder.CreateGEP(ptr, add);
@@ -1660,7 +1661,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVload(Function &F) {
     auto elems_const = builder.getInt32(elems);
     V = UndefValue::get(ret_type);
     auto adjust = builder.CreateMul(offset, elems_const);
-    for (auto i = 0; i < elems; ++i) {
+    for (unsigned i = 0; i < elems; ++i) {
       auto idx = builder.getInt32(i);
       auto add = builder.CreateAdd(adjust, idx);
       auto gep = builder.CreateGEP(ptr, add);
@@ -1688,6 +1689,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F,
     if (!is_clspv_version) {
       return replaceVloadHalf(F);
     }
+    // Fall-through
   default:
     llvm_unreachable("Unsupported vload_half vector size");
     break;
@@ -2238,7 +2240,7 @@ bool ReplaceOpenCLBuiltinPass::replaceHalfReadImage(Function &F) {
   return replaceCallsWithValue(F, [&](CallInst *CI) {
     SmallVector<Type *, 3> types;
     SmallVector<Value *, 3> args;
-    for (auto i = 0; i < CI->getNumArgOperands(); ++i) {
+    for (size_t i = 0; i < CI->getNumArgOperands(); ++i) {
       types.push_back(CI->getArgOperand(i)->getType());
       args.push_back(CI->getArgOperand(i));
     }

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -488,7 +488,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                 unsigned DstVecTyNumElement =
                     DstVecTy->getElementCount().getKnownMinValue() / NumVector;
                 SmallVector<int32_t, 4> Idxs;
-                for (int i = 0; i < DstVecTyNumElement; i++) {
+                for (unsigned i = 0; i < DstVecTyNumElement; i++) {
                   Idxs.push_back(i + (DstVecTyNumElement * VIdx));
                 }
                 Value *UndefVal = UndefValue::get(DstTy);
@@ -512,7 +512,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                     DstVecTy->getElementCount().getKnownMinValue();
                 for (unsigned i = 0; i < NumElement; i++) {
                   SmallVector<int32_t, 4> Idxs;
-                  for (int j = 0; j < SrcNumElement; j++) {
+                  for (unsigned j = 0; j < SrcNumElement; j++) {
                     Idxs.push_back(i * SrcNumElement + j);
                   }
 
@@ -762,7 +762,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                 Value *Undef = UndefValue::get(SrcTy);
 
                 SmallVector<int32_t, 4> Idxs;
-                for (int i = 0; i < NumElement; i++) {
+                for (unsigned i = 0; i < NumElement; i++) {
                   Idxs.push_back(i);
                 }
                 DstVal = Builder.CreateShuffleVector(LDValues[0], Undef, Idxs);
@@ -876,7 +876,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
                     Values[i] = Builder.CreateBitCast(Values[i], TmpVecTy);
                   }
                   SmallVector<int32_t, 4> Idxs;
-                  for (int i = 0; i < (NumVector * 2); i++) {
+                  for (unsigned i = 0; i < (NumVector * 2); i++) {
                     Idxs.push_back(i);
                   }
                   for (unsigned i = 0; i < Values.size(); i = i + 2) {
@@ -909,7 +909,7 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
               SmallVector<Value *, 4> TmpLDValues;
               for (unsigned i = 0; i < LDValues.size(); i = i + 2) {
                 SmallVector<int32_t, 4> Idxs;
-                for (int j = 0; j < NumElement; j++) {
+                for (unsigned j = 0; j < NumElement; j++) {
                   Idxs.push_back(j);
                 }
                 Value *TmpVal = Builder.CreateShuffleVector(
@@ -1072,12 +1072,10 @@ bool ReplacePointerBitcastPass::runOnModule(Module &M) {
       SmallVector<std::pair<User *, bool>, 32> Users;
 
       GetElementPtrInst *GEP = nullptr;
-      Value *OrgGEPIdx = nullptr;
       if ((GEP = dyn_cast<GetElementPtrInst>(BitCastUser))) {
         IRBuilder<> Builder(GEP);
 
         // Build new src/dst address.
-        OrgGEPIdx = GEP->getOperand(1);
         NewAddrIdx = CalculateNewGEPIdx(SrcTyBitWidth, DstTyBitWidth, GEP);
 
         // If bitcast's user is gep, investigate gep's users too.

--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -65,4 +65,4 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
   return CallInst::Create(func, ArgValues, "", Insert);
 }
 
-}; // namespace clspv
+} // namespace clspv

--- a/lib/SPIRVOp.h
+++ b/lib/SPIRVOp.h
@@ -40,4 +40,4 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
                            ArrayRef<Attribute::AttrKind> Attributes,
                            Type *RetType, ArrayRef<Value *> Args);
 
-}; // namespace clspv
+} // namespace clspv

--- a/lib/UndoTruncateToOddIntegerPass.cpp
+++ b/lib/UndoTruncateToOddIntegerPass.cpp
@@ -44,7 +44,7 @@ private:
   // values are created.
   // TODO(dneto): Handle 64 bit case as well, but separately.
   Value *ZeroExtend(Value *v, uint32_t desired_bit_width) {
-    auto bit_width = 0;
+    unsigned bit_width = 0;
     if (v->getType()->isIntegerTy())
       bit_width = v->getType()->getIntegerBitWidth();
     if (bit_width > 32) {


### PR DESCRIPTION
Include `HandleLLVMOptions` to ensure LLVM and clspv components are compiled using the same defines (for example `-D_FILE_OFFSET_BITS=64` `-D_LARGEFILE_SOURCE`). This essentially fixes this undefined reference to
```
    clang::FileManager::getVirtualFile(llvm::StringRef, long, long)
```
while the following was actually defined
```
    clang::FileManager::getVirtualFile(llvm::StringRef, long long, long)
```
.

As a consequence, the compilation and link options are updated and require fixes to the dependency lists of `clspv_passes` and `clspv_core`.

The second commit address various warnings:

 * `-Wunused-function`: use `inline` instead of `static` in header.
 * `-Wunused-but-set-variable`: code is protected in `#ifndef NDEBUG` when it is only used for the purpose of assertions.
 * `-Wunused-function` and `-Wunused-but-set-variable`: dead code is removed.
 * `-Wsign-compare`: uses of `auto` are replaced with `unsigned` or `size_t`, or use `static_cast`.
 * `-Wimplicit-fallthrough`: this warning is silenced using special comments.
 * `-Wpedantic`: remove extra `;` on closing brace for namespace.
 * `-Woverflow`: use types explicitly sized (e.g. `std::uint64_t`) and appropriate macros for minimum-width integer constants instead of `size_t`.