### PR TITLE
Add options for fp16 and fp64 and disable unsupported CL3 features

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -190,6 +190,12 @@ bool Supports8BitStorageClass(StorageClass sc);
 // Returns true if -cl-native-math is enabled.
 bool NativeMath();
 
+// Returns true if cl_khr_fp16 is enabled
+bool FP16();
+
+// Returns true if FP64 support is enabled
+bool FP64();
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -372,6 +372,52 @@ int ParseSamplerMap(const std::string &sampler_map,
   return 0;
 }
 
+clang::TargetInfo *PrepareTargetInfo(CompilerInstance &instance) {
+  // Create target info
+  auto TargetInfo = clang::TargetInfo::CreateTargetInfo(
+      instance.getDiagnostics(),
+      std::make_shared<clang::TargetOptions>(instance.getTargetOpts()));
+
+  // The SPIR target enables all possible options, disable the ones we don't
+  // want
+  auto &Opts = TargetInfo->getSupportedOpenCLOpts();
+
+  // Conditionally disable extensions based on support
+  if (!clspv::Option::FP16()) {
+    Opts["cl_khr_fp16"] = false;
+  }
+  if (!clspv::Option::FP64()) {
+    Opts["cl_khr_fp64"] = false;
+  }
+
+  // Disable CL3.0 feature macros for unsupported features
+  if (instance.getLangOpts().LangStd == clang::LangStandard::lang_opencl30) {
+
+    // TODO: See #705, find a better solution for this.
+    // TODO(kpet): This is a Clang bug (the pragma isn't enabled when the macro
+    // is defined)
+    Opts["cl_khr_3d_image_writes"] = false;
+
+    // The following features are never supported
+    Opts["__opencl_c_pipes"] = false;
+    Opts["__opencl_c_generic_address_space"] = false;
+    Opts["__opencl_c_atomic_order_seq_cst"] = false;
+    Opts["__opencl_c_device_enqueue"] = false;
+    Opts["__opencl_c_read_write_images"] = false;
+    Opts["__opencl_c_program_scope_global_variables"] = false;
+
+    if (!clspv::Option::ImageSupport()) {
+      Opts["__opencl_c_images"] = false;
+    }
+
+    if (!clspv::Option::FP64()) {
+      Opts["__opencl_c_fp64"] = false;
+    }
+  }
+
+  return TargetInfo;
+}
+
 // Sets |instance|'s options for compiling. Returns 0 if successful.
 int SetCompilerInstanceOptions(CompilerInstance &instance,
                                const llvm::StringRef &overiddenInputFilename,
@@ -417,8 +463,6 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
     break;
   case clspv::Option::SourceLanguage::OpenCL_C_30:
     standard = clang::LangStandard::lang_opencl30;
-    // TODO: See #705, find a better solution for this.
-    instance.getPreprocessorOpts().addMacroUndef("cl_khr_3d_image_writes");
     break;
   case clspv::Option::SourceLanguage::OpenCL_CPP:
     standard = clang::LangStandard::lang_openclcpp;
@@ -535,9 +579,7 @@ int SetCompilerInstanceOptions(CompilerInstance &instance,
   // Add the __OPENCL_VERSION__ macro.
   instance.getPreprocessorOpts().addMacroDef("__OPENCL_VERSION__=120");
 
-  instance.setTarget(clang::TargetInfo::CreateTargetInfo(
-      instance.getDiagnostics(),
-      std::make_shared<clang::TargetOptions>(instance.getTargetOpts())));
+  instance.setTarget(PrepareTargetInfo(instance));
 
   instance.createFileManager();
   instance.createSourceManager(instance.getFileManager());

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -403,7 +403,6 @@ clang::TargetInfo *PrepareTargetInfo(CompilerInstance &instance) {
     Opts["__opencl_c_generic_address_space"] = false;
     Opts["__opencl_c_atomic_order_seq_cst"] = false;
     Opts["__opencl_c_device_enqueue"] = false;
-    Opts["__opencl_c_read_write_images"] = false;
     Opts["__opencl_c_program_scope_global_variables"] = false;
 
     if (!clspv::Option::ImageSupport()) {

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -242,6 +242,15 @@ static llvm::cl::opt<bool> cl_native_math(
                    "guarantee that OpenCL precision bounds are maintained. "
                    "Implies -cl-fast-relaxed-math."));
 
+static llvm::cl::opt<bool>
+    fp16("fp16", llvm::cl::init(true),
+         llvm::cl::desc("Enable support for cl_khr_fp16."));
+
+static llvm::cl::opt<bool>
+    fp64("fp64", llvm::cl::init(true),
+         llvm::cl::desc(
+             "Enable support for FP64 (cl_khr_fp64 and/or __opencl_c_fp64)."));
+
 } // namespace
 
 namespace clspv {
@@ -313,6 +322,9 @@ bool Supports8BitStorageClass(StorageClass sc) {
 }
 
 bool NativeMath() { return cl_native_math; }
+
+bool FP16() { return fp16; }
+bool FP64() { return fp64; }
 
 } // namespace Option
 } // namespace clspv

--- a/test/Features/cl3-disabled-features.cl
+++ b/test/Features/cl3-disabled-features.cl
@@ -1,0 +1,27 @@
+// RUN: clspv -cl-std=CL3.0 %s -verify
+
+#ifdef __opencl_c_pipes
+#error FAIL
+#endif
+
+#ifdef __opencl_c_generic_address_space
+#error FAIL
+#endif
+
+#ifdef __opencl_c_atomic_order_seq_cst
+#error FAIL
+#endif
+
+#ifdef __opencl_c_device_enqueue
+#error FAIL
+#endif
+
+#ifdef __opencl_c_read_write_images
+#error FAIL
+#endif
+
+#ifdef __opencl_c_program_scope_global_variables
+#error FAIL
+#endif
+
+//expected-no-diagnostics

--- a/test/Features/cl3-disabled-features.cl
+++ b/test/Features/cl3-disabled-features.cl
@@ -16,10 +16,6 @@
 #error FAIL
 #endif
 
-#ifdef __opencl_c_read_write_images
-#error FAIL
-#endif
-
 #ifdef __opencl_c_program_scope_global_variables
 #error FAIL
 #endif

--- a/test/Features/fp16-default.cl
+++ b/test/Features/fp16-default.cl
@@ -1,0 +1,6 @@
+// RUN: clspv %s -verify
+
+#ifndef cl_khr_fp16
+#error FAIL
+#endif
+//expected-no-diagnostics

--- a/test/Features/fp16-disabled.cl
+++ b/test/Features/fp16-disabled.cl
@@ -1,0 +1,6 @@
+// RUN: clspv -fp16=0 %s -verify
+
+#ifdef cl_khr_fp16
+#error FAIL
+#endif
+//expected-no-diagnostics

--- a/test/Features/fp64-default-cl3.cl
+++ b/test/Features/fp64-default-cl3.cl
@@ -1,0 +1,10 @@
+// RUN: clspv -cl-std=CL3.0 %s -verify
+
+#ifndef cl_khr_fp64
+#error FAIL
+#endif
+
+#ifndef __opencl_c_fp64
+#error FAIL
+#endif
+//expected-no-diagnostics

--- a/test/Features/fp64-default.cl
+++ b/test/Features/fp64-default.cl
@@ -1,0 +1,6 @@
+// RUN: clspv %s -verify
+
+#ifndef cl_khr_fp64
+#error FAIL
+#endif
+//expected-no-diagnostics

--- a/test/Features/fp64-disabled-cl3.cl
+++ b/test/Features/fp64-disabled-cl3.cl
@@ -1,0 +1,10 @@
+// RUN: clspv -cl-std=CL3.0 -fp64=0 %s -verify
+
+#ifdef cl_khr_fp64
+#error FAIL
+#endif
+
+#ifdef __opencl_c_fp64
+#error FAIL
+#endif
+//expected-no-diagnostics

--- a/test/Features/fp64-disabled.cl
+++ b/test/Features/fp64-disabled.cl
@@ -1,0 +1,6 @@
+// RUN: clspv -fp64=0 %s -verify
+
+#ifdef cl_khr_fp64
+#error FAIL
+#endif
+//expected-no-diagnostics


### PR DESCRIPTION
Some OpenCL applications (e.g. clpeak) conditionally enable FP16/FP64 in
kernels based on the presence of the cl_khr_fp{16,64} macros. When using
the SPIR target Clang always enables all OpenCL extensions and features
potantially resulting in applications attempting to use features not
supported on the target device.

Since Clang always enables all features when using the SPIR target,
it means that clspv must either pass a list of features to be disabled
to Clang (not sure this would be accepted upstream) or disable features
after the target-specific defaults have been applied. The latter is the
approach proposed in this change: extensions and features are disabled
after the creation of the TargetInfo and before the CompilerInstance
is configured to use it.

The new options are enabled by default for backwards compatibility.

As a side note, I looked into the issue with cl_khr_3d_image_writes
that is described in #705 and can confirm it is a Clang bug that
is trivial to fix, I'll upstream a fix there.


Signed-off-by: Kévin Petit <kevin.petit@arm.com>