### PR TITLE
Make it possible to specify workgroups as uniform

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -196,6 +196,12 @@ bool FP16();
 // Returns true if FP64 support is enabled
 bool FP64();
 
+// Returns true if cl_arm_non_uniform_work_group_size is enabled
+bool ArmNonUniformWorkGroupSize();
+
+// Returns true if uniform_workgroup_size is enabled
+bool UniformWorkgroupSize();
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -873,6 +873,13 @@ int ParseOptions(const int argc, const char *const argv[]) {
     }
   }
 
+  if (clspv::Option::ArmNonUniformWorkGroupSize() &&
+      clspv::Option::UniformWorkgroupSize()) {
+    llvm::errs() << "cannot enable Arm non-uniform workgroup extension support "
+                    "and assume uniform workgroup sizes\n";
+    return -1;
+  }
+
   return 0;
 }
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -298,9 +298,6 @@ bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool NonUniformNDRangeSupported() {
-  assert(!(cl_arm_non_uniform_work_group_size && uniform_workgroup_size) &&
-         "uniform-workgroup-size overrides cl-arm-non-uniform-work-group-size. "
-         "Use only one.");
   return ((Language() == SourceLanguage::OpenCL_CPP) ||
           (Language() == SourceLanguage::OpenCL_C_20) ||
           (Language() == SourceLanguage::OpenCL_C_30) ||
@@ -333,6 +330,9 @@ bool NativeMath() { return cl_native_math; }
 
 bool FP16() { return fp16; }
 bool FP64() { return fp64; }
+
+bool ArmNonUniformWorkGroupSize() { return cl_arm_non_uniform_work_group_size; }
+bool UniformWorkgroupSize() { return uniform_workgroup_size; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -251,6 +251,10 @@ static llvm::cl::opt<bool>
          llvm::cl::desc(
              "Enable support for FP64 (cl_khr_fp64 and/or __opencl_c_fp64)."));
 
+static llvm::cl::opt<bool> uniform_workgroup_size(
+    "uniform-workgroup-size", llvm::cl::init(false),
+    llvm::cl::desc("Disable support for non-uniform workgroup size."));
+
 } // namespace
 
 namespace clspv {
@@ -294,10 +298,11 @@ bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool NonUniformNDRangeSupported() {
-  return (Language() == SourceLanguage::OpenCL_CPP) ||
-         (Language() == SourceLanguage::OpenCL_C_20) ||
-         (Language() == SourceLanguage::OpenCL_C_30) ||
-         cl_arm_non_uniform_work_group_size;
+  return ((Language() == SourceLanguage::OpenCL_CPP) ||
+          (Language() == SourceLanguage::OpenCL_C_20) ||
+          (Language() == SourceLanguage::OpenCL_C_30) ||
+          cl_arm_non_uniform_work_group_size) &&
+         !uniform_workgroup_size;
 }
 bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -301,8 +301,8 @@ bool NonUniformNDRangeSupported() {
   return ((Language() == SourceLanguage::OpenCL_CPP) ||
           (Language() == SourceLanguage::OpenCL_C_20) ||
           (Language() == SourceLanguage::OpenCL_C_30) ||
-          cl_arm_non_uniform_work_group_size) &&
-         !uniform_workgroup_size;
+          ArmNonUniformWorkGroupSize()) &&
+         !UniformWorkgroupSize();
 }
 bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -253,7 +253,7 @@ static llvm::cl::opt<bool>
 
 static llvm::cl::opt<bool> uniform_workgroup_size(
     "uniform-workgroup-size", llvm::cl::init(false),
-    llvm::cl::desc("Disable support for non-uniform workgroup size."));
+    llvm::cl::desc("Assume all workgroups are uniformly sized."));
 
 } // namespace
 
@@ -298,6 +298,9 @@ bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool NonUniformNDRangeSupported() {
+  assert(!(cl_arm_non_uniform_work_group_size && uniform_workgroup_size) &&
+         "uniform-workgroup-size overrides cl-arm-non-uniform-work-group-size. "
+         "Use only one.");
   return ((Language() == SourceLanguage::OpenCL_CPP) ||
           (Language() == SourceLanguage::OpenCL_C_20) ||
           (Language() == SourceLanguage::OpenCL_C_30) ||

--- a/test/Reflection/uniform_workgroup_size.cl
+++ b/test/Reflection/uniform_workgroup_size.cl
@@ -1,0 +1,13 @@
+// RUN: clspv %s -o %t.spv -cl-std=CLC++ -inline-entry-points -uniform-workgroup-size
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* out) {
+  int gid = get_global_id(0);
+  out[gid] = gid;
+}
+
+// CHECK-NOT: OpTypePointer PushConstant
+// CHECK-NOT: PushConstantRegionOffset
+


### PR DESCRIPTION
This PR makes it possible to specify workgroups as uniform to disable some push constants' emission on frontends of variety.

# Why this hack (or unspecified flag)?

Using SPIR-V generated by `clspv` with C++ frontend enabled from simple Vulkan applications, having push constants emitted for "region offset" included causes vkCreateComputePipelines to throw an unknown error. When layout accommodates these push constant ranges, the error goes away, but this can be unexpected/unnecessary from the application's perspective. Despite what the application developer thinks, some (not all) drivers care about that part of the layout.

Maybe a more holistic (and nicer-looking) solution would be to "optimize away" these push constants when detected as not used by the module, but this works and is explicit.