### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "4eff9469475384a59a9da407e78aa00262edcdd0"
+      "commit" : "f4f7bc17374ef79646ffc97a204abc8377187f16"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -820,10 +820,12 @@ int ParseOptions(const int argc, const char *const argv[]) {
     }
   }
 
-  int llvmArgc = 2;
-  const char *llvmArgv[4];
+  int llvmArgc = 3;
+  const char *llvmArgv[5];
   llvmArgv[0] = argv[0];
   llvmArgv[1] = "-simplifycfg-sink-common=false";
+  // TODO(#738): find a better solution to this.
+  llvmArgv[2] = "-disable-vector-combine";
   if (!has_pre) {
     llvmArgv[llvmArgc++] = "-enable-pre=0";
   }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1887,9 +1887,21 @@ SPIRVID SPIRVProducerPass::getSPIRVInt32Constant(uint32_t CstVal) {
   return getSPIRVValue(Cst);
 }
 
-SPIRVID SPIRVProducerPass::getSPIRVConstant(Constant *Cst) {
+SPIRVID SPIRVProducerPass::getSPIRVConstant(Constant *C) {
   ValueMapType &VMap = getValueMap();
   const bool hack_undef = clspv::Option::HackUndef();
+
+  // Treat poison as an undef.
+  auto *Cst = C;
+  if (isa<PoisonValue>(Cst)) {
+    Cst = UndefValue::get(Cst->getType());
+  }
+
+  auto VI = VMap.find(Cst);
+  if (VI != VMap.end()) {
+    assert(VI->second.isValid());
+    return VI->second;
+  }
 
   SPIRVID RID;
 

--- a/test/vector_insert_element.cl
+++ b/test/vector_insert_element.cl
@@ -9,8 +9,12 @@
 // CHECK-DAG: %[[UINT_0:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 // CHECK-DAG: %[[UINT_1:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 // CHECK: %[[LOAD_ARG0_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]]
-// CHECK: %[[ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain {{.*}} %[[UINT_0]] %[[UINT_0]] %[[UINT_1]]
-// CHECK:         OpStore %[[ACCESS_CHAIN_ID]] %[[LOAD_ARG0_ID]]
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: [[insert:%[a-zA-Z0-9_]+]] = OpCompositeInsert %[[FLOAT_VECTOR_TYPE_ID]] %[[LOAD_ARG0_ID]] [[ld]] 1
+// CHECK: OpStore {{.*}} [[insert]]
+// TODO(#738): With vector combining disabled, the following optimization is not made.
+// check: %[[ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain {{.*}} %[[UINT_0]] %[[UINT_0]] %[[UINT_1]]
+// check:         OpStore %[[ACCESS_CHAIN_ID]] %[[LOAD_ARG0_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(float a, global float4 *b) 
 {


### PR DESCRIPTION
* Fix duplicate constants being generated (poison and undef)
* Disable vector combining
  * See #738
  * Fixes several unsupported pointer bitcasts from being generated, but
    leads to some small inefficiencies in generated code