### PR TITLE
Support SPIR-V 1.4 and 1.5

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -152,10 +152,12 @@ inline bool LanguageUsesGenericAddressSpace() {
 }
 
 // Return the SPIR-V binary version
-enum class SPIRVVersion {
-  SPIRV_1_0,
+enum class SPIRVVersion : uint32_t {
+  SPIRV_1_0 = 0,
+  // No SPIR-V 1.1 or 1.2 because they add purely OpenCL features.
   SPIRV_1_3,
-  SPIRV_1_5, // note that lack of command line option to specify it
+  SPIRV_1_4,
+  SPIRV_1_5,
 };
 
 SPIRVVersion SpvVersion();

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -153,9 +153,10 @@ llvm::ModulePass *createReplaceOpenCLBuiltinPass();
 /// Create a pass to emit SPIR-V for the module.
 /// @return An LLVM module pass.
 llvm::ModulePass *createSPIRVProducerPass(
-    llvm::raw_pwrite_stream &out,
-    llvm::ArrayRef<std::pair<unsigned, std::string>> samplerMap,
+    llvm::raw_pwrite_stream *out,
+    llvm::SmallVectorImpl<std::pair<unsigned, std::string>> *samplerMap,
     bool outputCInitList);
+llvm::ModulePass *createSPIRVProducerPass();
 
 /// Undo LLVM's bitcast instructions with pointer type.
 /// @return An LLVM module pass.

--- a/kokoro/scripts/linux/build-clvk.sh
+++ b/kokoro/scripts/linux/build-clvk.sh
@@ -65,7 +65,6 @@ echo $(date): Starting SwiftShader build...
 SWIFTSHADER_SRC="$BUILD_ROOT/github/swiftshader"
 SWIFTSHADER_BUILD="$SWIFTSHADER_SRC/kokoro-build"
 git clone https://swiftshader.googlesource.com/SwiftShader.git "$SWIFTSHADER_SRC"
-cd "$SWIFTSHADER_SRC" && git submodule update --init
 mkdir "$SWIFTSHADER_BUILD" && cd "$SWIFTSHADER_BUILD"
 cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DSWIFTSHADER_WARNINGS_AS_ERRORS=OFF  -DSWIFTSHADER_BUILD_VULKAN=ON -DSWIFTSHADER_BUILD_EGL=OFF -DSWIFTSHADER_BUILD_GLESv2=OFF \

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -771,7 +771,11 @@ int PopulatePassManager(
   // pointers.
   pm->add(clspv::createRemoveUnusedArgumentsPass());
 
-  pm->add(clspv::createSplatSelectConditionPass());
+  // SPIR-V 1.4 and higher do not need to splat scalar conditions for vector
+  // data.
+  if (clspv::Option::SpvVersion() < clspv::Option::SPIRVVersion::SPIRV_1_4) {
+    pm->add(clspv::createSplatSelectConditionPass());
+  }
   pm->add(clspv::createSignedCompareFixupPass());
   // This pass generates insertions that need to be rewritten.
   pm->add(clspv::createScalarizePass());

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -796,7 +796,7 @@ int PopulatePassManager(
   // This pass mucks with types to point where you shouldn't rely on DataLayout
   // anymore so leave this right before SPIR-V generation.
   pm->add(clspv::createUBOTypeTransformPass());
-  pm->add(clspv::createSPIRVProducerPass(*binaryStream, *SamplerMapEntries,
+  pm->add(clspv::createSPIRVProducerPass(binaryStream, SamplerMapEntries,
                                          OutputFormat == "c"));
 
   return 0;

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -182,7 +182,11 @@ llvm::cl::opt<clspv::Option::SPIRVVersion> spv_version(
         clEnumValN(clspv::Option::SPIRVVersion::SPIRV_1_0, "1.0",
                    "SPIR-V version 1.0 (Vulkan 1.0)"),
         clEnumValN(clspv::Option::SPIRVVersion::SPIRV_1_3, "1.3",
-                   "SPIR-V version 1.3 (Vulkan 1.1). Experimental")));
+                   "SPIR-V version 1.3 (Vulkan 1.1). Experimental"),
+        clEnumValN(clspv::Option::SPIRVVersion::SPIRV_1_4, "1.4",
+                   "SPIR-V version 1.4 (Vulkan 1.1). Experimental"),
+        clEnumValN(clspv::Option::SPIRVVersion::SPIRV_1_5, "1.5",
+                   "SPIR-V version 1.5 (Vulkan 1.2). Experimental")));
 
 static llvm::cl::opt<bool> images("images", llvm::cl::init(true),
                                   llvm::cl::desc("Enable support for images"));

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -47,6 +47,7 @@ void initializeClspvPasses(PassRegistry &r) {
   initializeShareModuleScopeVariablesPassPass(r);
   initializeSignedCompareFixupPassPass(r);
   initializeSimplifyPointerBitcastPassPass(r);
+  initializeSPIRVProducerPassPass(r);
   initializeSplatArgPassPass(r);
   initializeSplatSelectConditionPassPass(r);
   initializeSpecializeImageTypesPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -50,6 +50,7 @@ void initializeScalarizePassPass(PassRegistry &);
 void initializeShareModuleScopeVariablesPassPass(PassRegistry &);
 void initializeSignedCompareFixupPassPass(PassRegistry &);
 void initializeSimplifyPointerBitcastPassPass(PassRegistry &);
+void initializeSPIRVProducerPassPass(PassRegistry &);
 void initializeSplatArgPassPass(PassRegistry &);
 void initializeSplatSelectConditionPassPass(PassRegistry &);
 void initializeSpecializeImageTypesPassPass(PassRegistry &);

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -277,9 +277,9 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
     }
   };
 
+  SmallPtrSet<Instruction *, 8> BitCastsToForget;
   for (auto &F : M) {
     if (F.getName().startswith("llvm.memcpy")) {
-      SmallPtrSet<Instruction *, 8> BitCastsToForget;
       SmallVector<CallInst *, 8> CallsToReplaceWithSpirvCopyMemory;
 
       for (auto U : F.users()) {
@@ -433,10 +433,10 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         if (isa<BitCastInst>(Arg1))
           BitCastsToForget.insert(dyn_cast<BitCastInst>(Arg1));
       }
-      for (auto *Inst : BitCastsToForget) {
-        Inst->eraseFromParent();
-      }
     }
+  }
+  for (auto *Inst : BitCastsToForget) {
+    Inst->eraseFromParent();
   }
 
   return Changed;

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
+#include "clspv/Option.h"
 #include "spirv/unified1/spirv.hpp"
 
 #include "Constants.h"
@@ -349,8 +350,10 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         auto Arg3 = dyn_cast<ConstantInt>(CI->getArgOperand(3));
 
         auto I32Ty = Type::getInt32Ty(M.getContext());
-        auto Alignment =
-            ConstantInt::get(I32Ty, cast<MemIntrinsic>(CI)->getDestAlignment());
+        auto DstAlignment =
+            ConstantInt::get(I32Ty, cast<MemCpyInst>(CI)->getDestAlignment());
+        auto SrcAlignment =
+            ConstantInt::get(I32Ty, cast<MemCpyInst>(CI)->getSourceAlignment());
         auto Volatile = ConstantInt::get(I32Ty, Arg3->getZExtValue());
 
         auto Dst = Arg0->getOperand(0);
@@ -370,12 +373,20 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         IRBuilder<> Builder(CI);
 
         if (NumSrcUnpackings == 0 && NumDstUnpackings == 0) {
-          auto NewFType = FunctionType::get(
-              F.getReturnType(), {Dst->getType(), Src->getType(), I32Ty, I32Ty},
-              false);
+          SmallVector<Type *, 5> param_tys = {Dst->getType(), Src->getType(),
+                                              I32Ty, I32Ty};
+          SmallVector<Value *, 5> param_values = {Dst, Src, DstAlignment};
+          if (clspv::Option::SpvVersion() >=
+              clspv::Option::SPIRVVersion::SPIRV_1_4) {
+            param_tys.push_back(I32Ty);
+            param_values.push_back(SrcAlignment);
+          }
+          param_values.push_back(Volatile);
+          auto NewFType =
+              FunctionType::get(F.getReturnType(), param_tys, false);
           auto NewF =
               Function::Create(NewFType, F.getLinkage(), SPIRVIntrinsic, &M);
-          Builder.CreateCall(NewF, {Dst, Src, Alignment, Volatile}, "");
+          Builder.CreateCall(NewF, param_values, "");
         } else {
           auto Zero = ConstantInt::get(I32Ty, 0);
           SmallVector<Value *, 3> SrcIndices;
@@ -408,18 +419,24 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
             auto SrcElemPtr =
                 GetElementPtrInst::CreateInBounds(Src, SrcIndices, "", CI);
             auto DstElemPtr = Builder.CreateGEP(Dst, DstIndices);
+            SmallVector<Type *, 5> param_tys = {
+                DstElemPtr->getType(), SrcElemPtr->getType(), I32Ty, I32Ty};
+            SmallVector<Value *, 5> param_values = {DstElemPtr, SrcElemPtr,
+                                                    DstAlignment};
+            if (clspv::Option::SpvVersion() >=
+                clspv::Option::SPIRVVersion::SPIRV_1_4) {
+              param_tys.push_back(I32Ty);
+              param_values.push_back(SrcAlignment);
+            }
+            param_values.push_back(Volatile);
             NewFType =
                 NewFType != nullptr
                     ? NewFType
-                    : FunctionType::get(F.getReturnType(),
-                                        {DstElemPtr->getType(),
-                                         SrcElemPtr->getType(), I32Ty, I32Ty},
-                                        false);
+                    : FunctionType::get(F.getReturnType(), param_tys, false);
             NewF = NewF != nullptr ? NewF
                                    : Function::Create(NewFType, F.getLinkage(),
                                                       SPIRVIntrinsic, &M);
-            Builder.CreateCall(
-                NewF, {DstElemPtr, SrcElemPtr, Alignment, Volatile}, "");
+            Builder.CreateCall(NewF, param_values, "");
           }
         }
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1590,8 +1590,6 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
      }
   }
 
-  //llvm::errs() << "Mapping type: (" << layout << ") " << *Ty << "\n";
-
   // Perform the mapping with the canonical type.
 
   const auto &DL = module->getDataLayout();
@@ -1984,7 +1982,6 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
       entry.resize(2);
     }
     entry[layout] = RID;
-    //llvm::errs() << "  Mapped canonical (" << *Canonical << ") to (" << layout << ") " << RID.get() << "\n";
 
     if (Canonical != Ty) {
       // Also cache the original type.
@@ -1993,7 +1990,6 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
         base_entry.resize(2);
       }
       base_entry[layout] = RID;
-      //llvm::errs() << "  Mapped (" << *Ty << ") to (" << layout << ") " << RID.get() << "\n";
     }
   }
   return RID;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -141,12 +141,12 @@ public:
 enum SPIRVOperandType { NUMBERID, LITERAL_WORD, LITERAL_DWORD, LITERAL_STRING };
 
 struct SPIRVOperand {
-  explicit SPIRVOperand(SPIRVOperandType Ty, uint32_t Num) : Type(Ty) {
+  SPIRVOperand(SPIRVOperandType Ty, uint32_t Num) : Type(Ty) {
     LiteralNum[0] = Num;
   }
-  explicit SPIRVOperand(SPIRVOperandType Ty, const char *Str)
+  SPIRVOperand(SPIRVOperandType Ty, const char *Str)
       : Type(Ty), LiteralStr(Str) {}
-  explicit SPIRVOperand(SPIRVOperandType Ty, StringRef Str)
+  SPIRVOperand(SPIRVOperandType Ty, StringRef Str)
       : Type(Ty), LiteralStr(Str) {}
   explicit SPIRVOperand(ArrayRef<uint32_t> NumVec) {
     auto sz = NumVec.size();
@@ -252,7 +252,7 @@ struct SPIRVProducerPass final : public ModulePass {
   typedef DenseMap<FunctionType *, std::pair<FunctionType *, uint32_t>>
       GlobalConstFuncMapType;
 
-  explicit SPIRVProducerPass(
+  SPIRVProducerPass(
       raw_pwrite_stream *out,
       SmallVectorImpl<std::pair<unsigned, std::string>> *samplerMap,
       bool outputCInitList)
@@ -266,7 +266,7 @@ struct SPIRVProducerPass final : public ModulePass {
     Ptr = this;
   }
 
-  explicit SPIRVProducerPass()
+  SPIRVProducerPass()
       : ModulePass(ID), module(nullptr), samplerMap(nullptr), out(nullptr),
         binaryTempOut(binaryTempUnderlyingVector), binaryOut(nullptr),
         outputCInitList(false), patchBoundOffset(0), nextID(1),
@@ -1559,6 +1559,8 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
   if (!(isa<PointerType>(Ty) || isa<ArrayType>(Ty) || isa<StructType>(Ty))) {
     needs_layout = false;
   }
+  // |layout| is the index used for |Ty|'s entry in the type map. Each type
+  // stores a laid out and non-laid out version of the type.
   const unsigned layout = needs_layout ? 1 : 0;
 
   auto TI = TypeMap.find(Ty);
@@ -1575,7 +1577,6 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
     if (CanonicalTI != TypeMap.end()) {
       assert(layout < CanonicalTI->second.size());
       if (CanonicalTI->second[layout].isValid()) {
-        // return CanonicalTI->second[layout];
         auto id = CanonicalTI->second[layout];
         auto &base = TypeMap[Ty];
         if (base.empty()) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3282,16 +3282,14 @@ SPIRVProducerPass::GenerateClspvInstruction(CallInst *Call,
       // OpLoad
       // OpCopyLogical
       // OpStore
-      auto load_type_id = getSPIRVType(
-          src->getType()->getPointerElementType(),
-          GetPointerLayout(src->getType()->getPointerAddressSpace()));
+      auto load_type_id =
+          getSPIRVType(src->getType()->getPointerElementType(), src_layout);
       Ops << load_type_id << src << MemoryAccess
           << static_cast<uint32_t>(Alignment);
       auto load = addSPIRVInst(spv::OpLoad, Ops);
 
-      auto copy_type_id = getSPIRVType(
-          dst->getType()->getPointerElementType(),
-          GetPointerLayout(dst->getType()->getPointerAddressSpace()));
+      auto copy_type_id =
+          getSPIRVType(dst->getType()->getPointerElementType(), dst_layout);
       Ops.clear();
       Ops << copy_type_id << load;
       auto copy = addSPIRVInst(spv::OpCopyLogical, Ops);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -699,17 +699,14 @@ INITIALIZE_PASS(SPIRVProducerPass, "SPIRVProducerPass", "SPIR-V output pass",
                 false, false)
 
 namespace clspv {
-ModulePass *
-createSPIRVProducerPass(raw_pwrite_stream *out,
-                        SmallVectorImpl<std::pair<unsigned, std::string>> *samplerMap,
-                        bool outputCInitList) {
+ModulePass *createSPIRVProducerPass(
+    raw_pwrite_stream *out,
+    SmallVectorImpl<std::pair<unsigned, std::string>> *samplerMap,
+    bool outputCInitList) {
   return new SPIRVProducerPass(out, samplerMap, outputCInitList);
 }
 
-ModulePass *
-createSPIRVProducerPass() {
-  return new SPIRVProducerPass();
-}
+ModulePass *createSPIRVProducerPass() { return new SPIRVProducerPass(); }
 } // namespace clspv
 
 namespace {
@@ -873,21 +870,21 @@ void SPIRVProducerPass::outputHeader() {
                    sizeof(spv::MagicNumber));
   uint32_t minor = 0;
   switch (SpvVersion()) {
-    case SPIRVVersion::SPIRV_1_0:
-      minor = 0;
-      break;
-    case SPIRVVersion::SPIRV_1_3:
-      minor = 3;
-      break;
-    case SPIRVVersion::SPIRV_1_4:
-      minor = 4;
-      break;
-    case SPIRVVersion::SPIRV_1_5:
-      minor = 5;
-      break;
-    default:
-      llvm_unreachable("unhandled spir-v version");
-      break;
+  case SPIRVVersion::SPIRV_1_0:
+    minor = 0;
+    break;
+  case SPIRVVersion::SPIRV_1_3:
+    minor = 3;
+    break;
+  case SPIRVVersion::SPIRV_1_4:
+    minor = 4;
+    break;
+  case SPIRVVersion::SPIRV_1_5:
+    minor = 5;
+    break;
+  default:
+    llvm_unreachable("unhandled spir-v version");
+    break;
   }
   uint32_t version = (1 << 16) | (minor << 8);
   binaryOut->write(reinterpret_cast<const char *>(&version), sizeof(version));
@@ -1544,7 +1541,7 @@ bool SPIRVProducerPass::PointerRequiresLayout(unsigned aspace) {
       break;
     }
   }
-  return false;;
+  return false;
 }
 
 SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty) {
@@ -1574,20 +1571,20 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
 
   auto Canonical = CanonicalType(Ty);
   if (Canonical != Ty) {
-     auto CanonicalTI = TypeMap.find(Canonical);
-     if (CanonicalTI != TypeMap.end()) {
-       assert(layout < CanonicalTI->second.size());
-       if (CanonicalTI->second[layout].isValid()) {
-         //return CanonicalTI->second[layout];
-         auto id = CanonicalTI->second[layout];
-         auto &base = TypeMap[Ty];
-         if (base.empty()) {
-           base.resize(2);
-         }
-         base[layout] = id;
-         return id;
-       }
-     }
+    auto CanonicalTI = TypeMap.find(Canonical);
+    if (CanonicalTI != TypeMap.end()) {
+      assert(layout < CanonicalTI->second.size());
+      if (CanonicalTI->second[layout].isValid()) {
+        // return CanonicalTI->second[layout];
+        auto id = CanonicalTI->second[layout];
+        auto &base = TypeMap[Ty];
+        if (base.empty()) {
+          base.resize(2);
+        }
+        base[layout] = id;
+        return id;
+      }
+    }
   }
 
   // Perform the mapping with the canonical type.
@@ -1977,7 +1974,7 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
   }
 
   if (RID.isValid()) {
-    auto& entry = TypeMap[Canonical];
+    auto &entry = TypeMap[Canonical];
     if (entry.empty()) {
       entry.resize(2);
     }
@@ -2817,7 +2814,8 @@ void SPIRVProducerPass::GenerateModuleInfo() {
     addSPIRVInst<kCapabilities>(spv::OpCapability, Capability);
   }
 
-  // Storage buffer and variable pointer extensions were made core in SPIR-V 1.3.
+  // Storage buffer and variable pointer extensions were made core in SPIR-V
+  // 1.3.
   if (SpvVersion() < SPIRVVersion::SPIRV_1_3) {
     //
     // Generate OpExtension.
@@ -2904,7 +2902,8 @@ void SPIRVProducerPass::GenerateModuleInfo() {
       // If the kernel uses the global push constant interface it will not be
       // covered by the resource variable iteration above.
       if (GetPodArgsImpl(*F) == PodArgImpl::kGlobalPushConstant) {
-        auto *PC = module->getGlobalVariable(clspv::PushConstantsVariableName());
+        auto *PC =
+            module->getGlobalVariable(clspv::PushConstantsVariableName());
         assert(PC);
         Ops << getValueMap()[PC];
       }
@@ -3326,12 +3325,10 @@ SPIRVProducerPass::GenerateClspvInstruction(CallInst *Call,
       auto copy = addSPIRVInst(spv::OpCopyLogical, Ops);
 
       Ops.clear();
-      Ops << dst << copy << MemoryAccess
-          << static_cast<uint32_t>(Alignment);
+      Ops << dst << copy << MemoryAccess << static_cast<uint32_t>(Alignment);
       RID = addSPIRVInst(spv::OpStore, Ops);
     } else {
-      Ops << dst << src << MemoryAccess
-          << static_cast<uint32_t>(Alignment);
+      Ops << dst << src << MemoryAccess << static_cast<uint32_t>(Alignment);
 
       RID = addSPIRVInst(spv::OpCopyMemory, Ops);
     }
@@ -3415,8 +3412,7 @@ SPIRVProducerPass::GenerateImageInstruction(CallInst *Call,
       uint32_t mask = spv::ImageOperandsLodMask |
                       GetExtendMask(Call->getType(), is_int_image);
       Constant *CstFP0 = ConstantFP::get(Context, APFloat(0.0f));
-      Ops << result_type << SampledImageID << Coordinate
-          << mask << CstFP0;
+      Ops << result_type << SampledImageID << Coordinate << mask << CstFP0;
 
       RID = addSPIRVInst(spv::OpImageSampleExplicitLod, Ops);
 
@@ -3451,7 +3447,8 @@ SPIRVProducerPass::GenerateImageInstruction(CallInst *Call,
 
       Ops << result_type << Image << Coordinate;
       uint32_t mask = GetExtendMask(Call->getType(), is_int_image);
-      if (mask != 0) Ops << mask;
+      if (mask != 0)
+        Ops << mask;
       RID = addSPIRVInst(spv::OpImageRead, Ops);
 
       if (is_int_image) {
@@ -3536,7 +3533,8 @@ SPIRVProducerPass::GenerateImageInstruction(CallInst *Call,
     }
     Ops << Image << Coordinate << TexelID;
     uint32_t mask = GetExtendMask(Texel->getType(), is_int_image);
-    if (mask != 0) Ops << mask;
+    if (mask != 0)
+      Ops << mask;
     RID = addSPIRVInst(spv::OpImageWrite, Ops);
 
     // Image writes require StorageImageWriteWithoutFormat.

--- a/test/Spv1p4/copy.ll
+++ b/test/Spv1p4/copy.ll
@@ -30,12 +30,12 @@ entry:
   %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
   %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
   %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
-  call void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)* %gep_out, %struct.S addrspace(3)* %gep_mem, i32 16, i32 0)
+  call void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)* %gep_out, %struct.S addrspace(3)* %gep_mem, i32 16, i32 16, i32 0)
   ret void
 }
 
 declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
 
-declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32)
+declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32, i32)
 
 !1 = !{i32 2}

--- a/test/Spv1p4/copy.ll
+++ b/test/Spv1p4/copy.ll
@@ -1,0 +1,41 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; TODO: Enable validation
+; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
+; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
+; CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+; CHECK-DAG: [[dec_array]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[decorated]] = OpTypeStruct [[dec_array]] [[float4]]
+; CHECK-DAG: [[undecorated:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]] [[float4]]
+; CHECK: [[ld_undec:%[a-zA-Z0-9_]+]] = OpLoad [[undecorated]]
+; CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical [[decorated]] [[ld_undec]]
+; CHECK: OpStore {{.*}} [[copy]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
+  call void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)* %gep_out, %struct.S addrspace(3)* %gep_mem, i32 16, i32 0)
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32)
+

--- a/test/Spv1p4/copy.ll
+++ b/test/Spv1p4/copy.ll
@@ -1,8 +1,7 @@
 ; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
-; TODO: Enable validation
-; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
 
 ; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
 ; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
@@ -26,7 +25,7 @@ target triple = "spir-unknown-unknown"
 @foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-define spir_kernel void @foo(%struct.S addrspace(1)* %out) {
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
 entry:
   %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
   %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
@@ -39,3 +38,4 @@ declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i
 
 declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32)
 
+!1 = !{i32 2}

--- a/test/Spv1p4/copy_two_operands.ll
+++ b/test/Spv1p4/copy_two_operands.ll
@@ -1,0 +1,34 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpCopyMemory %{{.*}} %{{.*}} Aligned 16 Aligned 16
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x float], <4 x i32> }
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @foo(%struct.S addrspace(1)* nocapture %out, %struct.S addrspace(1)* nocapture readonly %in)!clspv.pod_args_impl !9 {
+entry:
+  %0 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %3 = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %2, i32 0, i32 0, i32 0
+  call void @_Z17spirv.copy_memory(%struct.S addrspace(1)* %1, %struct.S addrspace(1)* %3, i32 16, i32 16, i32 0)
+  ret void
+}
+
+declare void @llvm.memcpy.p1i8.p1i8.i32(i8 addrspace(1)* noalias nocapture writeonly, i8 addrspace(1)* noalias nocapture readonly, i32, i1 immarg)
+
+declare void @_Z17spirv.copy_memory(%struct.S addrspace(1)*, %struct.S addrspace(1)*, i32, i32, i32)
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!9 = !{i32 2}
+

--- a/test/Spv1p4/int_fetch.ll
+++ b/test/Spv1p4/int_fetch.ll
@@ -1,0 +1,33 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageFetch %{{.*}} %{{.*}} %{{.*}} Lod|SignExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t.int.sampled = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)*, <2 x i32>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.int.sampled addrspace(1)* %i)!clspv.pod_args_impl !10 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!10 = !{i32 2}
+
+

--- a/test/Spv1p4/int_read.ll
+++ b/test/Spv1p4/int_read.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageRead %{{.*}} %{{.*}} SignExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t.int = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.int(%opencl.image2d_rw_t.int addrspace(1)*, <2 x i32>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_rw_t.int addrspace(1)* %i) !clspv.pod_args_impl !11 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0)
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.int(%opencl.image2d_rw_t.int addrspace(1)* %2, <2 x i32> zeroinitializer)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!11 = !{i32 2}
+

--- a/test/Spv1p4/int_sample.ll
+++ b/test/Spv1p4/int_sample.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageSampleExplicitLod %{{.*}} %{{.*}} %{{.*}} Lod|SignExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t.int.sampled = type opaque
+%opencl.sampler_t = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.int.sampled addrspace(1)* %i, %opencl.sampler_t addrspace(2)* %s)!clspv.pod_args_impl !10 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0)
+  %4 = tail call <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
+  store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+
+!10 = !{i32 2}
+
+

--- a/test/Spv1p4/int_write.ll
+++ b/test/Spv1p4/int_write.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageWrite %{{.*}} %{{.*}} %{{.*}} SignExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_wo_t.int = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.int(%opencl.image2d_wo_t.int addrspace(1)*, <2 x i32>, <4 x i32>)
+
+define spir_kernel void @foo(%opencl.image2d_wo_t.int addrspace(1)* %i)!clspv.pod_args_impl !8 {
+entry:
+  %0 = call %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0)
+  tail call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.int(%opencl.image2d_wo_t.int addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  ret void
+}
+
+declare %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!8 = !{i32 2}
+

--- a/test/Spv1p4/interface_global_push_constant.ll
+++ b/test/Spv1p4/interface_global_push_constant.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "foo" [[pc:%[a-zA-Z0-9_]+]]
+; CHECK: [[pc]] = OpVariable {{.*}} PushConstant
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32> }
+
+@__push_constants = local_unnamed_addr addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define spir_kernel void @foo() !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
+entry:
+  ret void
+}
+
+!0 = !{i32 4}
+!1 = !{i32 3}
+!2 = !{i32 1, i32 1, i32 1}

--- a/test/Spv1p4/interface_global_workgroup.ll
+++ b/test/Spv1p4/interface_global_workgroup.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "foo" [[wg:%[a-zA-Z0-9_]+]]
+; CHECK: [[wg]] = OpVariable {{.*}} Workgroup
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@mem = local_unnamed_addr addrspace(3) global i32 undef, align 4
+
+define spir_kernel void @foo() !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
+entry:
+  %ld = load i32, i32 addrspace(3)* @mem
+  ret void
+}
+
+
+!1 = !{i32 2}
+!2 = !{i32 1, i32 1, i32 1}

--- a/test/Spv1p4/interface_pod_pushconstant.ll
+++ b/test/Spv1p4/interface_pod_pushconstant.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "foo" [[var:%[a-zA-Z0-9_]+]]
+; CHECK: [[var]] = OpVariable {{.*}} PushConstant
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo({ float, float } %podargs)!reqd_work_group_size !8 !clspv.pod_args_impl !9 !kernel_arg_map !10 {
+entry:
+  %0 = call { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32 -1, i32 0, i32 5, i32 0, i32 0, i32 0)
+  %1 = getelementptr { { float, float } }, { { float, float } } addrspace(9)* %0, i32 0, i32 0
+  %2 = load { float, float }, { float, float } addrspace(9)* %1, align 4
+  ret void
+}
+
+declare { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!8 = !{i32 1, i32 1, i32 1}
+!9 = !{i32 2}
+!10 = !{!11, !12}
+!11 = !{!"x", i32 0, i32 0, i32 0, i32 4, !"pod_pushconstant"}
+!12 = !{!"y", i32 1, i32 0, i32 4, i32 4, !"pod_pushconstant"}

--- a/test/Spv1p4/interface_private_builtin.ll
+++ b/test/Spv1p4/interface_private_builtin.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "foo" [[var:%[a-zA-Z0-9_]+]]
+; CHECK: [[var]] = OpVariable {{.*}} Private
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo() !clspv.pod_args_impl !0 {
+entry:
+  ret void
+}
+
+!0 = !{i32 2}
+

--- a/test/Spv1p4/interface_ssbo_resource.ll
+++ b/test/Spv1p4/interface_ssbo_resource.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "foo" [[ssbo:%[a-zA-Z0-9_]+]]
+; CHECK: [[ssbo]] = OpVariable {{.*}} StorageBuffer
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo(i32 addrspace(1)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!1 = !{i32 2}
+!2 = !{i32 1, i32 1, i32 1}
+

--- a/test/Spv1p4/interface_workgroup_resource.ll
+++ b/test/Spv1p4/interface_workgroup_resource.ll
@@ -1,0 +1,42 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK-DAG: OpEntryPoint GLCompute %{{.*}} "foo" [[foo_wg:%[a-zA-Z0-9_]+]]
+; CHECK-DAG: OpEntryPoint GLCompute %{{.*}} "bar" [[bar_wg:%[a-zA-Z0-9_]+]]
+; CHECK-DAG: [[foo_wg]] = OpVariable {{.*}} Workgroup
+; CHECK-DAG: [[bar_wg]] = OpVariable {{.*}} Workgroup
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo(i32 addrspace(3)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
+entry:
+  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3)
+  %gep = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 0
+  ret void
+}
+
+define spir_kernel void @bar(float addrspace(3)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
+entry:
+  %0 = call [0 x float] addrspace(3)* @_Z11clspv.local.4(i32 4)
+  %gep = getelementptr [0 x float], [0 x float] addrspace(3)* %0, i32 0, i32 0
+  ret void
+}
+
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32)
+declare [0 x float] addrspace(3)* @_Z11clspv.local.4(i32)
+
+!_Z20clspv.local_spec_ids = !{!3, !4}
+!clspv.next_spec_constant_id = !{!5}
+!clspv.spec_constant_list = !{!6, !7}
+
+!1 = !{i32 2}
+!2 = !{i32 1, i32 1, i32 1}
+!3 = !{void (i32 addrspace(3)*)* @foo, i32 0, i32 3}
+!4 = !{void (float addrspace(3)*)* @bar, i32 0, i32 4}
+!5 = distinct !{i32 4}
+!6 = !{i32 3, i32 3}
+!7 = !{i32 3, i32 4}
+

--- a/test/Spv1p4/load.ll
+++ b/test/Spv1p4/load.ll
@@ -1,0 +1,36 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; TODO: Enable validation
+; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
+; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
+; CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+; CHECK-DAG: [[dec_array]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[decorated]] = OpTypeStruct [[dec_array]] [[float4]]
+; CHECK-DAG: [[undecorated:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]] [[float4]]
+; CHECK: [[ld_dec:%[a-zA-Z0-9_]+]] = OpLoad [[decorated]]
+; CHECK: OpCopyLogical [[undecorated]] [[ld_dec]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %in) {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %gep = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %ld = load %struct.S, %struct.S addrspace(1)* %gep
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+

--- a/test/Spv1p4/load.ll
+++ b/test/Spv1p4/load.ll
@@ -1,8 +1,7 @@
 ; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
-; TODO: Enable validation
-; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
 
 ; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
 ; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
@@ -24,7 +23,7 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-define spir_kernel void @foo(%struct.S addrspace(1)* %in) {
+define spir_kernel void @foo(%struct.S addrspace(1)* %in) !clspv.pod_args_impl !1 {
 entry:
   %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
   %gep = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
@@ -33,4 +32,6 @@ entry:
 }
 
 declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!1 = !{i32 2}
 

--- a/test/Spv1p4/scalar_cond_vector_data.ll
+++ b/test/Spv1p4/scalar_cond_vector_data.ll
@@ -1,0 +1,39 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[true:%[a-zA-Z0-9_]+]] = OpConstantTrue [[bool]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[int4]]
+; CHECK: [[ld2:%[a-zA-Z0-9_]+]] = OpLoad [[int4]]
+; CHECK: OpSelect [[int4]] [[true]] [[ld1]] [[ld2]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @copy(i32 addrspace(1)* nocapture readonly %in, i32 addrspace(1)* nocapture %out) !clspv.pod_args_impl !9 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %3 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %2, i32 0, i32 0, i32 0
+  %4 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %5 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 1
+  %6 = load <4 x i32>, <4 x i32> addrspace(1)* %1, align 4
+  %7 = load <4 x i32>, <4 x i32> addrspace(1)* %5, align 4
+  %8 = select i1 true, <4 x i32> %6, <4 x i32> %7
+  store <4 x i32> %8, <4 x i32> addrspace(1)* %3, align 4
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!9 = !{i32 2}
+

--- a/test/Spv1p4/store.ll
+++ b/test/Spv1p4/store.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; TODO: Enable validation
+; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
+; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
+; CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+; CHECK-DAG: [[dec_array]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[uint_4]]
+; CHECK-DAG: [[decorated]] = OpTypeStruct [[dec_array]] [[float4]]
+; CHECK-DAG: [[undecorated:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]] [[float4]]
+; CHECK: [[ld_undec:%[a-zA-Z0-9_]+]] = OpLoad [[undecorated]]
+; CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical [[decorated]] [[ld_undec]]
+; CHECK: OpStore {{.*}} [[copy]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
+  %ld = load %struct.S, %struct.S addrspace(3)* %gep_mem
+  store %struct.S %ld, %struct.S addrspace(1)* %gep_out
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+

--- a/test/Spv1p4/store.ll
+++ b/test/Spv1p4/store.ll
@@ -1,8 +1,7 @@
 ; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
-; TODO: Enable validation
-; rUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
 
 ; CHECK: OpMemberDecorate [[decorated:%[a-zA-Z0-9_]+]] 1 Offset 16
 ; CHECK: OpDecorate [[dec_array:%[a-zA-Z0-9_]+]] ArrayStride 4
@@ -26,7 +25,7 @@ target triple = "spir-unknown-unknown"
 @foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-define spir_kernel void @foo(%struct.S addrspace(1)* %out) {
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
 entry:
   %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
   %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
@@ -38,3 +37,4 @@ entry:
 
 declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
 
+!1 = !{i32 2}

--- a/test/Spv1p4/uint_fetch.ll
+++ b/test/Spv1p4/uint_fetch.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageFetch %{{.*}} %{{.*}} %{{.*}} Lod|ZeroExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t.uint.sampled = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, <2 x i32>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.uint.sampled addrspace(1)* %i)!clspv.pod_args_impl !10 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!10 = !{i32 2}
+

--- a/test/Spv1p4/uint_read.ll
+++ b/test/Spv1p4/uint_read.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageRead %{{.*}} %{{.*}} ZeroExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_rw_t.uint = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.uint(%opencl.image2d_rw_t.uint addrspace(1)*, <2 x i32>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_rw_t.uint addrspace(1)* %i) !clspv.pod_args_impl !11 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0)
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.uint(%opencl.image2d_rw_t.uint addrspace(1)* %2, <2 x i32> zeroinitializer)
+  store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!11 = !{i32 2}
+

--- a/test/Spv1p4/uint_sample.ll
+++ b/test/Spv1p4/uint_sample.ll
@@ -1,0 +1,36 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageSampleExplicitLod %{{.*}} %{{.*}} %{{.*}} Lod|ZeroExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t.uint.sampled = type opaque
+%opencl.sampler_t = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+
+define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.uint.sampled addrspace(1)* %i, %opencl.sampler_t addrspace(2)* %s)!clspv.pod_args_impl !10 {
+entry:
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0)
+  %4 = tail call <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
+  store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16
+  ret void
+}
+
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+
+!10 = !{i32 2}
+

--- a/test/Spv1p4/uint_write.ll
+++ b/test/Spv1p4/uint_write.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpImageWrite %{{.*}} %{{.*}} %{{.*}} ZeroExtend
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_wo_t.uint = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare spir_func void @_Z13write_imageui14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.uint(%opencl.image2d_wo_t.uint addrspace(1)*, <2 x i32>, <4 x i32>)
+
+define spir_kernel void @foo(%opencl.image2d_wo_t.uint addrspace(1)* %i)!clspv.pod_args_impl !8 {
+entry:
+  %0 = call %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0)
+  tail call spir_func void @_Z13write_imageui14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.uint(%opencl.image2d_wo_t.uint addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  ret void
+}
+
+declare %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!8 = !{i32 2}
+

--- a/tools/reflection/main.cpp
+++ b/tools/reflection/main.cpp
@@ -66,6 +66,7 @@ int main(const int argc, const char *const argv[]) {
       case SPV_ENV_UNIVERSAL_1_5:
       case SPV_ENV_VULKAN_1_0:
       case SPV_ENV_VULKAN_1_1:
+      case SPV_ENV_VULKAN_1_1_SPIRV_1_4:
       case SPV_ENV_VULKAN_1_2:
         break;
       default:


### PR DESCRIPTION
Major changes:
* SPIRVProducerPass is now unit testable
  * uses a simple constructor and outputs spir-v to a special file (specified via an option)
* SPIR-V 1.4 support
  * Layout decorations are only applied to storage buffer, uniform and push constant storage classes
    * uses OpCopyLogical to convert aggregates 
    * when loading, copying and storing only the memory has a layout and internal values have no layout
    * type mapping now tracks laid out and non-laid out versions of the type
  * Interfaces include all used global variables
    * resources are specific to the entry point
    * static globals are added to all entry points
  * storage buffer and variable pointer extensions no longer added to 1.3 and higher
  * select condition splatting does not happen for 1.4 or higher
  * Add ZeroExtend and SignExtend image operands for reads and writes
  * Memcpy uses both memory operands now
* Fixed a bug in memcpy replacement that erased some casts too early
* Fixed some type caching issues 