### PR TITLE
Ignore metadata types on LongVector support

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1098,7 +1098,7 @@ Type *LongVectorLoweringPass::getEquivalentType(Type *Ty) {
 
 Type *LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   if (Ty->isIntegerTy() || Ty->isFloatingPointTy() || Ty->isVoidTy() ||
-      Ty->isLabelTy()) {
+      Ty->isLabelTy() || Ty->isMetadataTy()) {
     // No lowering required.
     return nullptr;
   }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3934,9 +3934,17 @@ SPIRVID SPIRVProducerPass::GenerateInstructionFromCall(CallInst *Call) {
         }
       }
     } else {
-      // A real function call (not builtin)
-      // Call instruction is deferred because it needs function's ID.
-      RID = addSPIRVPlaceholder(Call);
+      switch (Call->getIntrinsicID()) {
+      // These LLVM intrinsics have no SPV equivalent.
+      // Because they are optimiser hints, we can safely discard them.
+      case Intrinsic::experimental_noalias_scope_decl:
+        break;
+      default:
+        // A real function call (not builtin)
+        // Call instruction is deferred because it needs function's ID.
+        RID = addSPIRVPlaceholder(Call);
+        break;
+      }
     }
 
     break;

--- a/test/longvector-metadata.ll
+++ b/test/longvector-metadata.ll
@@ -1,4 +1,5 @@
 ; RUN: clspv-opt -LongVectorLowering %s
+; RUN: clspv -x ir %s
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/longvector-metadata.ll
+++ b/test/longvector-metadata.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt -LongVectorLowering %s
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: convergent norecurse nounwind
+define spir_kernel void @test() #0 {
+entry:
+  call void @llvm.experimental.noalias.scope.decl(metadata !0)
+  ret void
+}
+
+; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
+declare void @llvm.experimental.noalias.scope.decl(metadata) #1
+
+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="128" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { inaccessiblememonly nofree nosync nounwind willreturn }
+
+!0 = !{!1}
+!1 = distinct !{!1, !2, !"test.inner: %input"}
+!2 = distinct !{!2, !"test.inner"}
+


### PR DESCRIPTION
When expanding vectors of 8 or more components, the pass was crashing on instructions with Metadata operands.
Skip trying to handle these instructions.

Also ignore alias scope intrinsic markers when generating output.