### PR TITLE
Add test output file for longvector-metadata.ll

### DIFF
--- a/test/longvector-metadata.ll
+++ b/test/longvector-metadata.ll
@@ -1,5 +1,5 @@
 ; RUN: clspv-opt -LongVectorLowering %s
-; RUN: clspv -x ir %s
+; RUN: clspv -x ir %s -o %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 


### PR DESCRIPTION
The default output file name is causing file permission errors in
downstream builds, so replace with an explicit file name.