### PR TITLE
Allow function private storage pointers

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4147,6 +4147,7 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
         getTypesNeedingArrayStride().insert(GEP->getPointerOperandType());
         break;
       case spv::StorageClassWorkgroup:
+      case spv::StorageClassFunction:
         break;
       default:
         llvm_unreachable(

--- a/test/private_ptr_phi.cl
+++ b/test/private_ptr_phi.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+static void load_data(global int* buffer, int* data, int end)
+{
+	for (int i = 0; i < end; ++i)
+	{
+		data[i] = buffer[i];
+		data[i] = buffer[i];
+		buffer += 2;
+		data += 2;
+	}
+}
+
+kernel void test(global int* buffer, constant int* ends)
+{
+	int data[16];
+	load_data(buffer, data, *ends);
+}
+


### PR DESCRIPTION
The SPIRV producer has special cases for GEP handling, particularly when
the first index is 0.  However, when using pointer variables incremented
in a for-loop, the GEP operand becomes a PHINode, where the first offset
is not 0.  This causes the associated code in the SPIRV generator to
crash when it does not expect this access chain type.

Signed-off-by: Pedro Olsen Ferreira <pedro.olsenferreira@arm.com>