### PR TITLE
Remove the need for the type list

### DIFF
--- a/test/LLVMIntrinsics/smax.ll
+++ b/test/LLVMIntrinsics/smax.ll
@@ -7,10 +7,10 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
-; CHECK: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
-; CHECK: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-; CHECK: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
+; CHECK-DAG: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
+; CHECK-DAG: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
+; CHECK-DAG: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+; CHECK-DAG: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
 
 define spir_kernel void @smax_i8(i8 addrspace(1)* %out, i8 %a, i8 %b) {
 entry:

--- a/test/LLVMIntrinsics/smin.ll
+++ b/test/LLVMIntrinsics/smin.ll
@@ -7,10 +7,10 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
-; CHECK: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
-; CHECK: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
-; CHECK: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
-; CHECK: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
+; CHECK-DAG: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
+; CHECK-DAG: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
+; CHECK-DAG: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+; CHECK-DAG: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
 
 define spir_kernel void @smin_i8(i8 addrspace(1)* %out, i8 %a, i8 %b) {
 entry:

--- a/test/ProgramScopeConstants/constant_array.cl
+++ b/test/ProgramScopeConstants/constant_array.cl
@@ -9,16 +9,16 @@ void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
 {
   *a = b[get_local_id(0)];
 }
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_uint_4:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 4
-// CHECK:  [[__arr_uint_uint_4:%[0-9a-zA-Z_]+]] = OpTypeArray [[_uint]] [[_uint_4]]
-// CHECK:  [[__ptr_Private__arr_uint_uint_4:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[__arr_uint_uint_4]]
-// CHECK:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
-// CHECK:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
-// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
-// CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_19:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_4]] [[_uint_42]] [[_uint_13]] [[_uint_0]] [[_uint_5]]
-// CHECK:  [[__ptr_Private_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_uint]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[_uint_4:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 4
+// CHECK-DAG:  [[__arr_uint_uint_4:%[0-9a-zA-Z_]+]] = OpTypeArray [[_uint]] [[_uint_4]]
+// CHECK-DAG:  [[__ptr_Private__arr_uint_uint_4:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[__arr_uint_uint_4]]
+// CHECK-DAG:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
+// CHECK-DAG:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
+// CHECK-DAG:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK-DAG:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK-DAG:  [[_19:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_4]] [[_uint_42]] [[_uint_13]] [[_uint_0]] [[_uint_5]]
+// CHECK-DAG:  [[__ptr_Private_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[_uint]]
 // CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private__arr_uint_uint_4]] Private [[_19]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[_21]]
 // CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_28]]

--- a/test/Reflection/literal_sampler.cl
+++ b/test/Reflection/literal_sampler.cl
@@ -21,9 +21,13 @@ kernel void foo(global float4* data, read_only image2d_t im) {
 
 // CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.1"
 // CHECK-DAG: OpDecorate [[s1:%[a-zA-Z0-9_]+]] Binding 3
+// CHECK-DAG: OpDecorate [[s1]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[s2:%[a-zA-Z0-9_]+]] Binding 2
+// CHECK-DAG: OpDecorate [[s2]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[s3:%[a-zA-Z0-9_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[s3]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[s4:%[a-zA-Z0-9_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[s4]] DescriptorSet 0
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint_19:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 19
@@ -37,26 +41,27 @@ kernel void foo(global float4* data, read_only image2d_t im) {
 // CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[float2:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
 // CHECK-DAG: [[float2_0:%[a-zA-Z0-9_]+]] = OpConstantNull [[float2]]
+// CHECK-DAG: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
 //
 // CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[uint_0]] [[uint_0]]
-// CHECK: [[s1_ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[s1]]
+// CHECK: [[s1_ld:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[s1]]
 // CHECK: [[s1_combined:%[a-zA-Z0-9_]+]] = OpSampledImage {{.*}} {{.*}} [[s1_ld]]
 // CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod {{.*}} [[s1_combined]]
 // CHECK: OpStore [[gep0]] [[read]]
 //
-// CHECK: [[s2_ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[s2]]
+// CHECK: [[s2_ld:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[s2]]
 // CHECK: [[s2_combined:%[a-zA-Z0-9_]+]] = OpSampledImage {{.*}} {{.*}} [[s2_ld]]
 // CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod {{.*}} [[s2_combined]]
 // CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[uint_0]] [[uint_1]]
 // CHECK: OpStore [[gep1]] [[read]]
 //
-// CHECK: [[s3_ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[s3]]
+// CHECK: [[s3_ld:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[s3]]
 // CHECK: [[s3_combined:%[a-zA-Z0-9_]+]] = OpSampledImage {{.*}} {{.*}} [[s3_ld]]
 // CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod {{.*}} [[s3_combined]]
 // CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[uint_0]] [[uint_2]]
 // CHECK: OpStore [[gep2]] [[read]]
 //
-// CHECK: [[s4_ld:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[s4]]
+// CHECK: [[s4_ld:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[s4]]
 // CHECK: [[s4_combined:%[a-zA-Z0-9_]+]] = OpSampledImage {{.*}} {{.*}} [[s4_ld]]
 // CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod {{.*}} [[s4_combined]]
 // CHECK: [[gep3:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[uint_0]] [[uint_3]]

--- a/test/UBO/constant_and_image.cl
+++ b/test/UBO/constant_and_image.cl
@@ -27,29 +27,30 @@ kernel void foo(read_only image2d_t i, sampler_t s, constant float4* offset, flo
 // CHECK-DAG: OpDecorate [[c_var]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[data_var:%[0-9a-zA-Z_]+]] Binding 4
 // CHECK-DAG: OpDecorate [[data_var]] DescriptorSet 0
-// CHECK: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK: [[image:%[0-9a-zA-Z_]+]] = OpTypeImage [[float]] 2D 0 0 0 1 Unknown
-// CHECK: [[sampled_image:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[image]]
-// CHECK: [[image_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[image]]
-// CHECK: [[sampler:%[0-9a-zA-Z_]+]] = OpTypeSampler
-// CHECK: [[sampler_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[sampler]]
-// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK: [[v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
-// CHECK: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
-// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[v4float]] [[int_4096]]
-// CHECK: [[ubo_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
-// CHECK: [[offset_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_struct]]
-// CHECK: [[v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 2
-// CHECK: [[struct_v2float:%[0-9a-zA-Z_]+]] = OpTypeStruct [[v2float]]
-// CHECK: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct_v2float]]
-// CHECK: [[runtime]] = OpTypeRuntimeArray [[v4float]]
-// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
-// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
-// CHECK: [[ptr_uniform_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v4float]]
-// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
-// CHECK: [[ptr_uniform_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v2float]]
-// CHECK: [[ptr_storagebuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[v4float]]
-// CHECK: [[float_zero:%[0-9a-zA-Z_]+]] = OpConstant [[float]] 0
+// CHECK-NOT: OpExtension
+// CHECK-DAG: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[image:%[0-9a-zA-Z_]+]] = OpTypeImage [[float]] 2D 0 0 0 1 Unknown
+// CHECK-DAG: [[sampled_image:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[image]]
+// CHECK-DAG: [[image_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[image]]
+// CHECK-DAG: [[sampler:%[0-9a-zA-Z_]+]] = OpTypeSampler
+// CHECK-DAG: [[sampler_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer UniformConstant [[sampler]]
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[v4float]] [[int_4096]]
+// CHECK-DAG: [[ubo_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
+// CHECK-DAG: [[offset_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_struct]]
+// CHECK-DAG: [[v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 2
+// CHECK-DAG: [[struct_v2float:%[0-9a-zA-Z_]+]] = OpTypeStruct [[v2float]]
+// CHECK-DAG: [[c_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct_v2float]]
+// CHECK-DAG: [[runtime]] = OpTypeRuntimeArray [[v4float]]
+// CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK-DAG: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+// CHECK-DAG: [[ptr_uniform_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v4float]]
+// CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[ptr_uniform_v2float:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[v2float]]
+// CHECK-DAG: [[ptr_storagebuffer_v4float:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[v4float]]
+// CHECK-DAG: [[float_zero:%[0-9a-zA-Z_]+]] = OpConstant [[float]] 0
 // CHECK: [[image_var]] = OpVariable [[image_ptr]] UniformConstant
 // CHECK: [[sampler_var]] = OpVariable [[sampler_ptr]] UniformConstant
 // CHECK: [[offset_var]] = OpVariable [[offset_ptr]] Uniform

--- a/test/UBO/copy_nested.cl
+++ b/test/UBO/copy_nested.cl
@@ -24,17 +24,17 @@ __kernel void foo(__global outer* data, __constant outer* c) {
 // CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[var]] Binding 1
 // CHECK: OpDecorate [[array:%[0-9a-zA-Z_]+]] ArrayStride 16
-// CHECK: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK: [[float4:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
-// CHECK: [[inner:%[0-9a-zA-Z_]+]] = OpTypeStruct [[float4]]
-// CHECK: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner]]
-// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
-// CHECK: [[array]] = OpTypeArray [[outer]] [[int_4096]]
-// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
-// CHECK: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
-// CHECK: [[ptr_float4:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[float4]]
-// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[inner:%[0-9a-zA-Z_]+]] = OpTypeStruct [[float4]]
+// CHECK-DAG: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner]]
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[array]] = OpTypeArray [[outer]] [[int_4096]]
+// CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
+// CHECK-DAG: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
+// CHECK-DAG: [[ptr_float4:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[float4]]
+// CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
 // CHECK: [[var]] = OpVariable [[ptr]] Uniform
 // CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_float4]] [[var]] [[zero]] [[zero]] [[zero]]
 // CHECK: OpLoad [[float4]] [[gep]]

--- a/test/UBO/transform_local.cl
+++ b/test/UBO/transform_local.cl
@@ -26,25 +26,26 @@ __kernel void foo(__global data_type* data, __constant data_type* c_arg, __local
 // CHECK-DAG: OpDecorate [[c_arg:%[0-9a-zA-Z_]+]] Binding 1
 // CHECK-DAG: OpDecorate [[c_arg]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[spec_id:%[0-9a-zA-Z_]+]] SpecId 3
-// CHECK: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK: [[data_type]] = OpTypeStruct [[int]] [[int]]
-// CHECK: [[runtime]] = OpTypeRuntimeArray [[data_type]]
-// CHECK: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
-// CHECK: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
-// CHECK: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
-// CHECK: [[ubo_array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[int_4096]]
-// CHECK: [[ubo_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
-// CHECK: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_struct]]
-// CHECK: [[size1:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
-// CHECK: [[size2:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
-// CHECK: [[size3:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
-// CHECK: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
-// CHECK: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
-// CHECK: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]
-// CHECK: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
-// CHECK: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
-// CHECK: [[l_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[int]]
-// CHECK: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
+// CHECK-NOT: OpExtension
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[data_type]] = OpTypeStruct [[int]] [[int]]
+// CHECK-DAG: [[runtime]] = OpTypeRuntimeArray [[data_type]]
+// CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
+// CHECK-DAG: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[ubo_array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[int_4096]]
+// CHECK-DAG: [[ubo_struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[c_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_struct]]
+// CHECK-DAG: [[size1:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK-DAG: [[size2:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK-DAG: [[size3:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK-DAG: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
+// CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
+// CHECK-DAG: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]
+// CHECK-DAG: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
+// CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[l_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[int]]
+// CHECK-DAG: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
 // CHECK: [[data]] = OpVariable [[data_ptr]] StorageBuffer
 // CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform
 // CHECK: [[l_arg:%[0-9a-zA-Z_]+]] = OpVariable [[l_arg_ptr]] Workgroup

--- a/test/VaryingLocalSizes/one_kernel.cl
+++ b/test/VaryingLocalSizes/one_kernel.cl
@@ -9,9 +9,9 @@
 // CHECK: OpDecorate %[[BUILTIN_Z_ID:[a-zA-Z0-9_]*]] SpecId 2
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
-// CHECK: %[[BUILTIN_X_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[BUILTIN_Y_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
-// CHECK: %[[BUILTIN_Z_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[BUILTIN_X_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[BUILTIN_Y_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[BUILTIN_Z_ID]] = OpSpecConstant %[[UINT_TYPE_ID]] 1
 // CHECK: %[[BUILTIN_ID]] = OpSpecConstantComposite %[[UINT3_TYPE_ID]] %[[BUILTIN_X_ID]] %[[BUILTIN_Y_ID]] %[[BUILTIN_Z_ID]]
 // CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 

--- a/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
@@ -13,13 +13,13 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) foo(global uint* a)
 // CHECK:  OpEntryPoint GLCompute [[_20:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpExecutionMode [[_20]] LocalSize 42 13 5
 // CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
-// CHECK:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
-// CHECK:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
-// CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_42]] [[_uint_13]] [[_uint_5]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
+// CHECK-DAG:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
+// CHECK-DAG:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK-DAG:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK-DAG:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_42]] [[_uint_13]] [[_uint_5]]
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
 // CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_23]] 0
 // CHECK:  OpStore {{.*}} [[_24]]

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -25,13 +25,13 @@ void kernel __attribute__((reqd_work_group_size(42, 13, 5))) bar(global uint* a)
 // CHECK:  OpExecutionMode [[_20]] LocalSize 42 13 5
 // CHECK:  OpExecutionMode [[_32]] LocalSize 42 13 5
 // CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
-// CHECK:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
-// CHECK:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
-// CHECK:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
-// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_42]] [[_uint_13]] [[_uint_5]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG:  [[_uint_42:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 42
+// CHECK-DAG:  [[_uint_13:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 13
+// CHECK-DAG:  [[_uint_5:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 5
+// CHECK-DAG:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK-DAG:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_42]] [[_uint_13]] [[_uint_5]]
 // CHECK:  [[_20]] = OpFunction
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]
 // CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_23]] 0

--- a/test/VaryingLocalSizes/two_kernels.cl
+++ b/test/VaryingLocalSizes/two_kernels.cl
@@ -29,10 +29,10 @@ void kernel bar(global uint* a)
 // CHECK: OpDecorate [[_16:%[a-zA-Z0-9_]+]] SpecId 2
 // CHECK-DAG: [[_uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[_v3uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[_uint]] 3
-// CHECK: [[_14]] = OpSpecConstant [[_uint]] 1
-// CHECK: [[_15]] = OpSpecConstant [[_uint]] 1
-// CHECK: [[_16]] = OpSpecConstant [[_uint]] 1
-// CHECK: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_14]] [[_15]] [[_16]]
+// CHECK-DAG: [[_14]] = OpSpecConstant [[_uint]] 1
+// CHECK-DAG: [[_15]] = OpSpecConstant [[_uint]] 1
+// CHECK-DAG: [[_16]] = OpSpecConstant [[_uint]] 1
+// CHECK-DAG: [[_gl_WorkGroupSize]] = OpSpecConstantComposite [[_v3uint]] [[_14]] [[_15]] [[_16]]
 // CHECK-DAG: [[_uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 1
 // CHECK: [[_20]] = OpFunction
 // CHECK: [[_23:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[_v3uint]] [[_gl_WorkGroupSize]] [[_gl_WorkGroupSize]]

--- a/test/WorkItemBuiltins/get_enqueued_local_size.cl
+++ b/test/WorkItemBuiltins/get_enqueued_local_size.cl
@@ -7,13 +7,9 @@
 
 // DMAP: pushconstant,name,enqueued_local_size,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_10]] Block
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
-// CHECK-DAG: %[[_struct_10]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_10:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_10]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
+++ b/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
@@ -3,16 +3,12 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_12:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_12]] Block
 // CHECK:     OpDecorate %[[gl_GlobalInvocationID:[0-9a-zA-Z_]+]] BuiltIn GlobalInvocationId
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
 // CHECK-DAG: %[[_ptr_Input_v3uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[v3uint]]
 // CHECK-DAG: %[[_ptr_Input_uint:[0-9a-zA-Z_]+]] = OpTypePointer Input %[[uint]]
-// CHECK-DAG: %[[_struct_12]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_12:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_12:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_12]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.cl
@@ -4,22 +4,18 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK:     OpDecorate %[[_runtimearr_uint:[0-9a-zA-Z_]+]] ArrayStride 4
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_11:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_11]] Block
 // CHECK:     OpDecorate %[[__original_id_19:[0-9]+]] DescriptorSet 0
 // CHECK:     OpDecorate %[[__original_id_19]] Binding 0
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[_runtimearr_uint]] = OpTypeRuntimeArray %[[uint]]
-// CHECK-DAG: %[[_struct_3]] = OpTypeStruct %[[_runtimearr_uint]]
+// CHECK-DAG: %[[_struct_3:[0-9a-zA-Z_]+]] = OpTypeStruct %[[_runtimearr_uint]]
 // CHECK-DAG: %[[_ptr_StorageBuffer__struct_3:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[_struct_3]]
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK-DAG: %[[__original_id_7:[0-9]+]] = OpTypeFunction %[[void]]
 // CHECK-DAG: %[[_ptr_StorageBuffer_uint:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[uint]]
 // CHECK-DAG: %[[__original_id_9:[0-9]+]] = OpTypeFunction %[[uint]] %[[uint]]
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
-// CHECK-DAG: %[[_struct_11]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_11:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_11:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_11]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/WorkItemBuiltins/get_global_offset-push-constant.cl
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant.cl
@@ -7,13 +7,9 @@
 
 // DMAP: pushconstant,name,global_offset,offset,0,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_10]] Block
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
-// CHECK-DAG: %[[_struct_10]] = OpTypeStruct %[[v3uint]]
+// CHECK-DAG: %[[_struct_10:[0-9a-zA-Z_]+]] = OpTypeStruct %[[v3uint]]
 // CHECK-DAG: %[[_ptr_PushConstant__struct_10:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[_struct_10]]
 // CHECK-DAG: %[[_ptr_PushConstant_uint:[0-9a-zA-Z_]+]] = OpTypePointer PushConstant %[[uint]]
 // CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0

--- a/test/WorkItemBuiltins/get_global_size.cl
+++ b/test/WorkItemBuiltins/get_global_size.cl
@@ -12,13 +12,13 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 
 // CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
 // CHECK:  OpDecorate [[_gl_NumWorkGroups:%[0-9a-zA-Z_]+]] BuiltIn NumWorkgroups
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
-// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
-// CHECK:  [[_bool:%[0-9a-zA-Z_]+]] = OpTypeBool
-// CHECK:  [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
-// CHECK:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_1]] [[_uint_1]] [[_uint_1]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK-DAG:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
+// CHECK-DAG:  [[_bool:%[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG:  [[_uint_3:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 3
+// CHECK-DAG:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_1]] [[_uint_1]] [[_uint_1]]
 // CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpVariable {{.*}} Private [[_gl_WorkGroupSize]]
 // CHECK:  [[_gl_NumWorkGroups]] = OpVariable {{.*}} Input
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]

--- a/test/WorkItemBuiltins/get_global_size_hack_initializers.cl
+++ b/test/WorkItemBuiltins/get_global_size_hack_initializers.cl
@@ -12,9 +12,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
 }
 
 // CHECK:  OpDecorate [[_gl_WorkGroupSize:%[0-9a-zA-Z_]+]] BuiltIn WorkgroupSize
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
-// CHECK:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_1]] [[_uint_1]] [[_uint_1]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK-DAG:  [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
+// CHECK-DAG:  [[_gl_WorkGroupSize]] = OpConstantComposite [[_v3uint]] [[_uint_1]] [[_uint_1]] [[_uint_1]]
 // CHECK:  [[_21:%[0-9a-zA-Z_]+]] = OpVariable {{.*}} Private [[_gl_WorkGroupSize]]
 // CHECK:  OpStore [[_21]] [[_gl_WorkGroupSize]]

--- a/test/WorkItemBuiltins/multiple-push-constant.cl
+++ b/test/WorkItemBuiltins/multiple-push-constant.cl
@@ -8,11 +8,7 @@
 // DMAP: pushconstant,name,global_offset,offset,0,size,12
 // DMAP: pushconstant,name,enqueued_local_size,offset,16,size,12
 
-// CHECK:     OpMemberDecorate %[[_struct_3:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpDecorate %[[_struct_3]] Block
-// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 0 Offset 0
-// CHECK:     OpMemberDecorate %[[_struct_10]] 1 Offset 16
-// CHECK:     OpDecorate %[[_struct_10]] Block
+// CHECK:     OpMemberDecorate %[[_struct_10:[0-9a-zA-Z_]+]] 1 Offset 16
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
 // CHECK-DAG: %[[_struct_10]] = OpTypeStruct %[[v3uint]] %[[v3uint]]

--- a/test/reuse_kernel_arg_var.cl
+++ b/test/reuse_kernel_arg_var.cl
@@ -42,24 +42,25 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 
 // CHECK:  OpEntryPoint GLCompute [[foo:%[0-9a-zA-Z_]+]] "foo"
 // CHECK:  OpEntryPoint GLCompute [[bar:%[0-9a-zA-Z_]+]] "bar"
-// CHECK:  OpDecorate [[A_R:%[0-9a-zA-Z_]+]] Binding 0
-// CHECK:  OpDecorate [[B_S:%[0-9a-zA-Z_]+]] Binding 1
-// CHECK:  OpDecorate [[C:%[0-9a-zA-Z_]+]] Binding 2
-// CHECK:  OpDecorate [[D:%[0-9a-zA-Z_]+]] Binding 3
-// CHECK:  OpDecorate [[f_y:%[0-9a-zA-Z_]+]] Binding 4
-// CHECK:  OpDecorate [[g:%[0-9a-zA-Z_]+]] Binding 5
-// CHECK:  OpDecorate [[T:%[0-9a-zA-Z_]+]] Binding 2
-// CHECK:  OpDecorate [[x:%[0-9a-zA-Z_]+]] Binding 3
-// CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[__runtimearr_float:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_float]]
-// CHECK:  [[__struct_3:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
-// CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[__runtimearr_uint:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_uint]]
-// CHECK:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_uint]]
-// CHECK:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
-// CHECK:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]]
-// CHECK:  [[__ptr_Uniform__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_9]]
+// CHECK-DAG:  OpDecorate [[A_R:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG:  OpDecorate [[B_S:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG:  OpDecorate [[C:%[0-9a-zA-Z_]+]] Binding 2
+// CHECK-DAG:  OpDecorate [[D:%[0-9a-zA-Z_]+]] Binding 3
+// CHECK-DAG:  OpDecorate [[f_y:%[0-9a-zA-Z_]+]] Binding 4
+// CHECK-DAG:  OpDecorate [[g:%[0-9a-zA-Z_]+]] Binding 5
+// CHECK-DAG:  OpDecorate [[T:%[0-9a-zA-Z_]+]] Binding 2
+// CHECK-DAG:  OpDecorate [[x:%[0-9a-zA-Z_]+]] Binding 3
+// CHECK-NOT: OpExtension
+// CHECK-DAG:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG:  [[__runtimearr_float:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_float]]
+// CHECK-DAG:  [[__struct_3:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_float]]
+// CHECK-DAG:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CHECK-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[__runtimearr_uint:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_uint]]
+// CHECK-DAG:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_uint]]
+// CHECK-DAG:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CHECK-DAG:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]]
+// CHECK-DAG:  [[__ptr_Uniform__struct_9:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[__struct_9]]
 // CHECK:  [[A_R]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[B_S]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CHECK:  [[C]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer
@@ -84,22 +85,23 @@ kernel void bar(global float* R, global float* S, global float* T, float x, floa
 
 // CLUSTER:  OpEntryPoint GLCompute [[foo:%[0-9a-zA-Z_]+]] "foo"
 // CLUSTER:  OpEntryPoint GLCompute [[bar:%[0-9a-zA-Z_]+]] "bar"
-// CLUSTER:  OpDecorate [[A_R:%[0-9a-zA-Z_]+]] Binding 0
-// CLUSTER:  OpDecorate [[B_S:%[0-9a-zA-Z_]+]] Binding 1
-// CLUSTER:  OpDecorate [[C:%[0-9a-zA-Z_]+]] Binding 2
-// CLUSTER:  OpDecorate [[D:%[0-9a-zA-Z_]+]] Binding 3
-// CLUSTER:  OpDecorate [[T:%[0-9a-zA-Z_]+]] Binding 2
-// CLUSTER:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CLUSTER:  [[__runtimearr_float:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_float]]
-// CLUSTER:  [[__struct_3:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_float]]
-// CLUSTER:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
-// CLUSTER:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CLUSTER:  [[__runtimearr_uint:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_uint]]
-// CLUSTER:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_uint]]
-// CLUSTER:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
-// CLUSTER:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]] [[_float]]
-// CLUSTER:  [[__struct_10:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__struct_9]]
-// CLUSTER:  [[__ptr_PushConstant__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer PushConstant [[__struct_10]]
+// CLUSTER-DAG:  OpDecorate [[A_R:%[0-9a-zA-Z_]+]] Binding 0
+// CLUSTER-DAG:  OpDecorate [[B_S:%[0-9a-zA-Z_]+]] Binding 1
+// CLUSTER-DAG:  OpDecorate [[C:%[0-9a-zA-Z_]+]] Binding 2
+// CLUSTER-DAG:  OpDecorate [[D:%[0-9a-zA-Z_]+]] Binding 3
+// CLUSTER-DAG:  OpDecorate [[T:%[0-9a-zA-Z_]+]] Binding 2
+// CLUSTER-NOT: OpExtension
+// CLUSTER-DAG:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CLUSTER-DAG:  [[__runtimearr_float:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_float]]
+// CLUSTER-DAG:  [[__struct_3:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_float]]
+// CLUSTER-DAG:  [[__ptr_StorageBuffer__struct_3:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_3]]
+// CLUSTER-DAG:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CLUSTER-DAG:  [[__runtimearr_uint:%[0-9a-zA-Z_]+]] = OpTypeRuntimeArray [[_uint]]
+// CLUSTER-DAG:  [[__struct_7:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__runtimearr_uint]]
+// CLUSTER-DAG:  [[__ptr_StorageBuffer__struct_7:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[__struct_7]]
+// CLUSTER-DAG:  [[__struct_9:%[0-9a-zA-Z_]+]] = OpTypeStruct [[_float]] [[_float]]
+// CLUSTER-DAG:  [[__struct_10:%[0-9a-zA-Z_]+]] = OpTypeStruct [[__struct_9]]
+// CLUSTER-DAG:  [[__ptr_PushConstant__struct_10:%[0-9a-zA-Z_]+]] = OpTypePointer PushConstant [[__struct_10]]
 // CLUSTER:  [[A_R]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CLUSTER:  [[B_S]] = OpVariable [[__ptr_StorageBuffer__struct_3]] StorageBuffer
 // CLUSTER:  [[C]] = OpVariable [[__ptr_StorageBuffer__struct_7]] StorageBuffer


### PR DESCRIPTION
* Since the refactor of the producer, the type list is no longer needed
  as dependencies are automatically generated correctly
  * remove all references to the type list
* update tests to be more agnostic to type declaration order