### PR TITLE
Add support for llvm.{umax,umin} intrinsics

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5103,6 +5103,12 @@ SPIRVProducerPass::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
   if (func_info.getName().find("llvm.smin.") == 0) {
     return glsl::ExtInst::ExtInstSMin;
   }
+  if (func_info.getName().find("llvm.umax.") == 0) {
+    return glsl::ExtInst::ExtInstUMax;
+  }
+  if (func_info.getName().find("llvm.umin.") == 0) {
+    return glsl::ExtInst::ExtInstUMin;
+  }
   return kGlslExtInstBad;
 }
 

--- a/test/LLVMIntrinsics/umax.ll
+++ b/test/LLVMIntrinsics/umax.ll
@@ -1,0 +1,64 @@
+; RUN: clspv -x ir %s -o %t
+; RUN: spirv-val %t
+; RUN: spirv-dis -o %t2 %t
+; RUN: FileCheck %s < %t2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
+; CHECK-DAG: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
+; CHECK-DAG: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+; CHECK-DAG: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
+
+define spir_kernel void @umax_i8(i8 addrspace(1)* %out, i8 %a, i8 %b) {
+entry:
+  %result = call i8 @llvm.umax.i8(i8 %a, i8 %b)
+  store i8 %result, i8 addrspace(1)* %out
+  ret void
+}
+declare i8 @llvm.umax.i8(i8, i8)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umax_i16(i16 addrspace(1)* %out, i16 %a, i16 %b) {
+entry:
+  %result = call i16 @llvm.umax.i16(i16 %a, i16 %b)
+  store i16 %result, i16 addrspace(1)* %out
+  ret void
+}
+declare i16 @llvm.umax.i16(i16, i16)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umax_i32(i32 addrspace(1)* %out, i32 %a, i32 %b) {
+entry:
+  %result = call i32 @llvm.umax.i32(i32 %a, i32 %b)
+  store i32 %result, i32 addrspace(1)* %out
+  ret void
+}
+declare i32 @llvm.umax.i32(i32, i32)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umax_i64(i64 addrspace(1)* %out, i64 %a, i64 %b) {
+entry:
+  %result = call i64 @llvm.umax.i64(i64 %a, i64 %b)
+  store i64 %result, i64 addrspace(1)* %out
+  ret void
+}
+declare i64 @llvm.umax.i64(i64, i64)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]

--- a/test/LLVMIntrinsics/umin.ll
+++ b/test/LLVMIntrinsics/umin.ll
@@ -1,0 +1,64 @@
+; RUN: clspv -x ir %s -o %t
+; RUN: spirv-val %t
+; RUN: spirv-dis -o %t2 %t
+; RUN: FileCheck %s < %t2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[INT8_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 8 0
+; CHECK-DAG: %[[INT16_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 16 0
+; CHECK-DAG: %[[INT32_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+; CHECK-DAG: %[[INT64_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 64 0
+
+define spir_kernel void @umin_i8(i8 addrspace(1)* %out, i8 %a, i8 %b) {
+entry:
+  %result = call i8 @llvm.umin.i8(i8 %a, i8 %b)
+  store i8 %result, i8 addrspace(1)* %out
+  ret void
+}
+declare i8 @llvm.umin.i8(i8, i8)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umin_i16(i16 addrspace(1)* %out, i16 %a, i16 %b) {
+entry:
+  %result = call i16 @llvm.umin.i16(i16 %a, i16 %b)
+  store i16 %result, i16 addrspace(1)* %out
+  ret void
+}
+declare i16 @llvm.umin.i16(i16, i16)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umin_i32(i32 addrspace(1)* %out, i32 %a, i32 %b) {
+entry:
+  %result = call i32 @llvm.umin.i32(i32 %a, i32 %b)
+  store i32 %result, i32 addrspace(1)* %out
+  ret void
+}
+declare i32 @llvm.umin.i32(i32, i32)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]
+
+
+define spir_kernel void @umin_i64(i64 addrspace(1)* %out, i64 %a, i64 %b) {
+entry:
+  %result = call i64 @llvm.umin.i64(i64 %a, i64 %b)
+  store i64 %result, i64 addrspace(1)* %out
+  ret void
+}
+declare i64 @llvm.umin.i64(i64, i64)
+; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
+; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: OpStore {{.*}} %[[OP_ID]]


### PR DESCRIPTION
LLVM optimisations are generating them as part of loop unrolling
(the test_compiler::pragma_unroll CTS test triggers this behaviour).

Signed-off-by: Kévin Petit <kevin.petit@arm.com>