### PR TITLE
A few fixes to SPIR-V 1.4 support

### DIFF
--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -33,6 +33,7 @@
 #include "clspv/Option.h"
 
 #include "ArgKind.h"
+#include "Constants.h"
 #include "NormalizeGlobalVariable.h"
 #include "Passes.h"
 
@@ -110,7 +111,7 @@ bool ClusterModuleScopeConstantVars::runOnModule(Module &M) {
         ConstantStruct::get(type, initializers_as_vec);
     GlobalVariable *clustered_gv = new GlobalVariable(
         M, type, true, GlobalValue::InternalLinkage, clustered_initializer,
-        "clspv.clustered_constants", nullptr,
+        clspv::ClusteredConstantsVariableName(), nullptr,
         GlobalValue::ThreadLocalMode::NotThreadLocal,
         clspv::AddressSpace::Constant);
     assert(clustered_gv);

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -79,6 +79,11 @@ inline std::string PodArgsImplMetadataName() { return "clspv.pod_args_impl"; }
 // Clustered arguments mapping metadata name.
 inline std::string KernelArgMapMetadataName() { return "kernel_arg_map"; }
 
+// Clustered constants global variable name.
+inline std::string ClusteredConstantsVariableName() {
+  return "clspv.clustered_constants";
+}
+
 } // namespace clspv
 
 #endif

--- a/test/Spv1p4/function-pointer-parameter-that-needs-layout.ll
+++ b/test/Spv1p4/function-pointer-parameter-that-needs-layout.ll
@@ -1,0 +1,33 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpTypePointer StorageBuffer %uint
+; CHECK-NOT: OpTypePointer StorageBuffer %uint
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_func void @func(i32 addrspace(1)* nocapture %ptr) local_unnamed_addr {
+entry:
+  store i32 42, i32 addrspace(1)* %ptr, align 4
+  ret void
+}
+
+define dso_local spir_kernel void @test(i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !8 {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 3
+  tail call spir_func void @func(i32 addrspace(1)* %1)
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 1}
+!8 = !{i32 2}

--- a/test/Spv1p4/interface_module_constants_in_storage_buffer.ll
+++ b/test/Spv1p4/interface_module_constants_in_storage_buffer.ll
@@ -1,0 +1,45 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -module-constants-in-storage-buffer
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "test" {{.*}} [[constant_data_storage_buffer_var:%[a-zA-Z0-9_]+]]
+; CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK: [[uint_16:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 16
+; CHECK: [[uint_array_16:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[uint_16]]
+; CHECK: [[struct_module_constants:%[a-zA-Z0-9_]+]] = OpTypeStruct [[uint_array_16]]
+; CHECK: [[struct_module_constants_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[struct_module_constants]]
+; CHECK: [[constant_data_storage_buffer_var]] = OpVariable [[struct_module_constants_ptr]] StorageBuffer
+
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+@clspv.clustered_constants = internal addrspace(2) constant { [16 x i32] } { [16 x i32] [i32 17, i32 1, i32 11, i32 12, i32 1955, i32 11, i32 5, i32 1985, i32 113, i32 1, i32 24, i32 1984, i32 7, i32 23, i32 1979, i32 97] }
+
+define spir_kernel void @test(i32 addrspace(1)* nocapture %out, { i32 } %podargs) local_unnamed_addr !clspv.pod_args_impl !9 !kernel_arg_map !10 {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32 -1, i32 1, i32 5, i32 1, i32 1, i32 0)
+  %3 = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %2, i32 0, i32 0
+  %4 = load { i32 }, { i32 } addrspace(9)* %3, align 4
+  %idx = extractvalue { i32 } %4, 0
+  %5 = getelementptr inbounds { [16 x i32] }, { [16 x i32] } addrspace(2)* @clspv.clustered_constants, i32 0, i32 0, i32 %idx
+  %6 = load i32, i32 addrspace(2)* %5, align 4
+  store i32 %6, i32 addrspace(1)* %1, align 4
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 1}
+!9 = !{i32 2}
+!10 = !{!11, !12}
+!11 = !{!"out", i32 0, i32 0, i32 0, i32 0, !"buffer"}
+!12 = !{!"idx", i32 1, i32 1, i32 0, i32 4, !"pod_pushconstant"}

--- a/test/Spv1p4/interface_sampler.ll
+++ b/test/Spv1p4/interface_sampler.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpEntryPoint GLCompute %{{.*}} "test" {{.*}} [[sampler:%[a-zA-Z0-9_]+]]
+; CHECK: [[sampler_type:%[a-zA-Z0-9_]+]] = OpTypeSampler
+; CHECK: [[sampler_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[sampler_type]]
+; CHECK: [[sampler]] = OpVariable [[sampler_ptr]] UniformConstant
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image2d_ro_t.float.sampled = type opaque
+%opencl.sampler_t = type opaque
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+declare <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+
+define spir_kernel void @test(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, <4 x float> addrspace(1)* nocapture %out) !clspv.pod_args_impl !4 {
+entry:
+  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0)
+  %1 = call { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %2 = getelementptr { [0 x <4 x float>] }, { [0 x <4 x float>] } addrspace(1)* %1, i32 0, i32 0, i32 0
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 16)
+  %4 = tail call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)* %0, %opencl.sampler_t addrspace(2)* %3, <2 x float> <float 1.000000e+00, float 2.000000e+00>)
+  store <4 x float> %4, <4 x float> addrspace(1)* %2, align 16
+  ret void
+}
+
+declare %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32, i32, i32)
+
+declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 2}

--- a/test/Spv1p4/pod-in-ubo.ll
+++ b/test/Spv1p4/pod-in-ubo.ll
@@ -1,0 +1,43 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -max-pushconstant-size=8
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK: OpDecorate {{.*}} Block
+; CHECK: OpDecorate [[pod_struct:%[a-zA-Z0-9_]+]] Block
+; CHECK: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+; CHECK: [[pod_struct_members:%[a-zA-Z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK: [[pod_struct]] = OpTypeStruct [[pod_struct_members]]
+; CHECK: [[pod_struct_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Uniform [[pod_struct]]
+; CHECK: OpVariable [[pod_struct_ptr]] Uniform
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @sample_test(i64 addrspace(1)* nocapture %result, { i64, i64 } %podargs) !clspv.pod_args_impl !4 !kernel_arg_map !9 {
+entry:
+  %0 = call { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = getelementptr { [0 x i64] }, { [0 x i64] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %2 = call { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32 0, i32 1, i32 4, i32 1, i32 1, i32 0)
+  %3 = getelementptr { { i64, i64 } }, { { i64, i64 } } addrspace(6)* %2, i32 0, i32 0
+  %4 = load { i64, i64 }, { i64, i64 } addrspace(6)* %3, align 8
+  %arg0 = extractvalue { i64, i64 } %4, 0
+  %arg1 = extractvalue { i64, i64 } %4, 1
+  %add.i = add nsw i64 %arg0, %arg1
+  store i64 %add.i, i64 addrspace(1)* %1, align 8
+  ret void
+}
+
+declare { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 1}
+!9 = !{!10, !11, !12}
+!10 = !{!"result", i32 2, i32 0, i32 0, i32 0, !"buffer"}
+!11 = !{!"arg0", i32 0, i32 1, i32 0, i32 8, !"pod_ubo"}
+!12 = !{!"arg1", i32 1, i32 1, i32 8, i32 8, !"pod_ubo"}


### PR DESCRIPTION
- Add literal samplers to the entry point interface lists.

- Add the constant args buffer to the interface lists when present.

- Add Uniform to the list of address spaces to which pointers always require layout.

- Don't generate duplicate types when functions with pointer arguments in storage
  classes that require layout are present. When generating OpTypeFunction, types for
  parameters were always generated with needs_layout = false, potentially leading to
  duplicate types when the type with explicit layout was otherwise produced.

These fixes enable clvk to use SPIR-V 1.5 with no OpenCL CTS tests regressions.

Signed-off-by: Kévin Petit <kevin.petit@arm.com>