### PR TITLE
Support some pointer comparisons when targeting SPIR-V 1.4+

### DIFF
--- a/test/Spv1p4/pointer_comparisons.ll
+++ b/test/Spv1p4/pointer_comparisons.ll
@@ -1,0 +1,77 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK-NOT: OpCapability VariablePointers
+; CHECK-DAG: OpCapability VariablePointersStorageBuffer
+; CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[uint_storage_buffer_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+; CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+; CHECK-DAG: [[uint_13:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 13
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK: [[arg0ptr:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_storage_buffer_ptr]] [[arg0:%[a-zA-Z0-9_]+]] [[uint_0]] [[uint_0]]
+; CHECK: [[arg0ptr2:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_storage_buffer_ptr]] [[arg0]] [[uint_0]] [[uint_13]]
+; CHECK: [[arg1ptr:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_storage_buffer_ptr]] [[arg1:%[a-zA-Z0-9_]+]] [[uint_0]] [[uint_0]]
+; CHECK: OpPtrEqual [[bool]] [[arg0ptr]] [[arg1ptr]]
+; CHECK: OpPtrNotEqual [[bool]] [[arg0ptr]] [[arg1ptr]]
+; CHECK: [[diff_ugt:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSGreaterThan [[bool]] [[diff_ugt]] [[uint_0]]
+; CHECK: [[diff_ult:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSLessThan [[bool]] [[diff_ult]] [[uint_0]]
+; CHECK: [[diff_uge:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSGreaterThanEqual [[bool]] [[diff_uge]] [[uint_0]]
+; CHECK: [[diff_ule:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSLessThanEqual [[bool]] [[diff_ule]] [[uint_0]]
+
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @test(i32 addrspace(1)* readnone %ptr0, i32 addrspace(1)* readnone %ptr1, i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !9 {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %arg0ptr = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 0
+  %arg0ptr2 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 13
+  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %arg1ptr = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 0
+  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0)
+  %3 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 0
+  %cmp = icmp eq i32 addrspace(1)* %arg0ptr, %arg1ptr
+  %conv = zext i1 %cmp to i32
+  store i32 %conv, i32 addrspace(1)* %3, align 4
+  %cmp1 = icmp ne i32 addrspace(1)* %arg0ptr, %arg1ptr
+  %conv2 = zext i1 %cmp1 to i32
+  %4 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 1
+  store i32 %conv2, i32 addrspace(1)* %4, align 4
+  %cmp4 = icmp ugt i32 addrspace(1)* %arg0ptr, %arg0ptr2
+  %conv5 = zext i1 %cmp4 to i32
+  %5 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 2
+  store i32 %conv5, i32 addrspace(1)* %5, align 4
+  %cmp7 = icmp ult i32 addrspace(1)* %arg0ptr, %arg0ptr2
+  %conv8 = zext i1 %cmp7 to i32
+  %6 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 3
+  store i32 %conv8, i32 addrspace(1)* %6, align 4
+  %cmp10 = icmp uge i32 addrspace(1)* %arg0ptr, %arg0ptr2
+  %conv11 = zext i1 %cmp10 to i32
+  %7 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 4
+  store i32 %conv11, i32 addrspace(1)* %7, align 4
+  %cmp13 = icmp ule i32 addrspace(1)* %arg0ptr, %arg0ptr2
+  %conv14 = zext i1 %cmp13 to i32
+  %8 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 5
+  store i32 %conv14, i32 addrspace(1)* %8, align 4
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 1}
+!9 = !{i32 2}

--- a/test/Spv1p4/pointer_comparisons_with_null.ll
+++ b/test/Spv1p4/pointer_comparisons_with_null.ll
@@ -1,0 +1,57 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[uint_15:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 15
+; CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+; CHECK-DAG: [[uint_storage_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+; CHECK-DAG: [[null:%[a-zA-Z0-9_]+]] = OpConstantNull [[uint_storage_ptr]]
+; CHECK: [[addr:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_storage_ptr]] {{.*}} [[uint_0]] [[uint_15]]
+; CHECK: OpPtrEqual [[bool]] [[addr]] [[null]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @test(i32 addrspace(1)* nocapture readnone %ptr0, i32 addrspace(1)* nocapture %out, { i32 } %podargs) local_unnamed_addr !clspv.pod_args_impl !9 !kernel_arg_map !10 {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %2 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 0
+  %3 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0)
+  %4 = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %3, i32 0, i32 0
+  %5 = load { i32 }, { i32 } addrspace(9)* %4, align 4
+  %val = extractvalue { i32 } %5, 0
+  %cmp.i = icmp ne i32 %val, 68
+  %6 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 15
+  %phi.cmp = icmp eq i32 addrspace(1)* %6, null
+  %ptr.i.0 = select i1 %cmp.i, i1 true, i1 %phi.cmp
+  br i1 %ptr.i.0, label %if.then2.i, label %test.inner.exit
+
+if.then2.i:                                       ; preds = %entry
+  store i32 13, i32 addrspace(1)* %2, align 4
+  br label %test.inner.exit
+
+test.inner.exit:                                  ; preds = %if.then2.i, %entry
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 1}
+!9 = !{i32 2}
+!10 = !{!11, !12, !13}
+!11 = !{!"ptr0", i32 0, i32 0, i32 0, i32 0, !"buffer"}
+!12 = !{!"out", i32 1, i32 1, i32 0, i32 0, !"buffer"}
+!13 = !{!"val", i32 2, i32 2, i32 0, i32 4, !"pod_pushconstant"}
+

--- a/test/Spv1p4/pointer_comparisons_workgroup.ll
+++ b/test/Spv1p4/pointer_comparisons_workgroup.ll
@@ -1,0 +1,89 @@
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv
+
+; CHECK-NOT: OpCapability VariablePointersStorageBuffer
+; CHECK-DAG: OpCapability VariablePointers
+; CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[uint_storage_buffer_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
+; CHECK-DAG: [[uint_workgroup_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[uint]]
+; CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+; CHECK-DAG: [[uint_13:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 13
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK: [[arg0ptr:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_workgroup_ptr]] [[arg0:%[a-zA-Z0-9_]+]] [[uint_0]]
+; CHECK: [[arg0ptr2:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_workgroup_ptr]] [[arg0]] [[uint_13]]
+; CHECK: [[arg1ptr:%[a-zA-Z0-9_]+]] = OpAccessChain [[uint_workgroup_ptr]] [[arg1:%[a-zA-Z0-9_]+]] [[uint_0]]
+; CHECK: OpPtrNotEqual [[bool]] [[arg0ptr]] [[arg1ptr]]
+; CHECK: OpPtrEqual [[bool]] [[arg0ptr]] [[arg1ptr]]
+; CHECK: [[diff_ugt:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSGreaterThan [[bool]] [[diff_ugt]] [[uint_0]]
+; CHECK: [[diff_uge:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSGreaterThanEqual [[bool]] [[diff_uge]] [[uint_0]]
+; CHECK: [[diff_ult:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSLessThan [[bool]] [[diff_ult]] [[uint_0]]
+; CHECK: [[diff_ule:%[a-zA-Z0-9_]+]] = OpPtrDiff [[uint]] [[arg0ptr]] [[arg0ptr2]]
+; CHECK: OpSLessThanEqual [[bool]] [[diff_ule]] [[uint_0]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = external local_unnamed_addr addrspace(8) global <3 x i32>
+
+define dso_local spir_kernel void @test(i32 addrspace(3)* readnone %ptr0, i32 addrspace(3)* readnone %ptr1, i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !17 {
+entry:
+  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3)
+  %arg0ptr = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 0
+  %arg0ptr2 = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 13
+  %1 = call [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32 4)
+  %arg1ptr = getelementptr [0 x i32], [0 x i32] addrspace(3)* %1, i32 0, i32 0
+  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 2, i32 0, i32 0)
+  %3 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 0
+  %cmp = icmp ne i32 addrspace(3)* %arg0ptr, %arg1ptr
+  %conv = zext i1 %cmp to i32
+  store i32 %conv, i32 addrspace(1)* %3, align 4
+  %cmp1 = icmp eq i32 addrspace(3)* %arg0ptr, %arg1ptr
+  %conv2 = zext i1 %cmp1 to i32
+  %4 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 1
+  store i32 %conv2, i32 addrspace(1)* %4, align 4
+  %cmp4 = icmp ugt i32 addrspace(3)* %arg0ptr, %arg0ptr2
+  %conv5 = zext i1 %cmp4 to i32
+  %5 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 2
+  store i32 %conv5, i32 addrspace(1)* %5, align 4
+  %cmp7 = icmp uge i32 addrspace(3)* %arg0ptr, %arg0ptr2
+  %conv8 = zext i1 %cmp7 to i32
+  %6 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 3
+  store i32 %conv8, i32 addrspace(1)* %6, align 4
+  %cmp10 = icmp ult i32 addrspace(3)* %arg0ptr, %arg0ptr2
+  %conv11 = zext i1 %cmp10 to i32
+  %7 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 4
+  store i32 %conv11, i32 addrspace(1)* %7, align 4
+  %cmp13 = icmp ule i32 addrspace(3)* %arg0ptr, %arg0ptr2
+  %conv14 = zext i1 %cmp13 to i32
+  %8 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 5
+  store i32 %conv14, i32 addrspace(1)* %8, align 4
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32)
+
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32)
+
+!clspv.descriptor.index = !{!4}
+!clspv.next_spec_constant_id = !{!5}
+!clspv.spec_constant_list = !{!6, !7, !8, !9, !10}
+!_Z20clspv.local_spec_ids = !{!11, !12}
+
+!4 = !{i32 1}
+!5 = distinct !{i32 5}
+!6 = !{i32 3, i32 3}
+!7 = !{i32 3, i32 4}
+!8 = !{i32 0, i32 0}
+!9 = !{i32 1, i32 1}
+!10 = !{i32 2, i32 2}
+!11 = !{void (i32 addrspace(3)*, i32 addrspace(3)*, i32 addrspace(1)*)* @test, i32 0, i32 3}
+!12 = !{void (i32 addrspace(3)*, i32 addrspace(3)*, i32 addrspace(1)*)* @test, i32 1, i32 4}
+!17 = !{i32 2}
+


### PR DESCRIPTION
No attempt was made to validate that the operands to OpPtrDiff are
"pointers to element numbers in [0, L] in the same array". This means
users can easily produce SPIR-V triggering undefined behaviour when
this doesn't hold.

We could maybe check that both pointers are derived from the same resource
var and even check that all but one indices match when pointers are
produced with a single GEP from a resource var.

Fixes #383

Signed-off-by: Kévin Petit <kevin.petit@arm.com>