### PR TITLE
Fix type for --max-ubo-size and --max-pushconstant-size options

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -98,7 +98,7 @@ bool ConstantArgsInUniformBuffer();
 // Returns the maximum UBO size. This size is specified in bytes and is used to
 // calculate the size of UBO arrays for constant arguments if
 // ConstantArgsInUniformBuffer returns true.
-uint64_t MaxUniformBufferSize();
+uint32_t MaxUniformBufferSize();
 
 // Returns the maximum push constant interface size. This size is specified in
 // bytes and is used to validate the the size of the POD kernel interface

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -122,11 +122,11 @@ llvm::cl::opt<bool> constant_args_in_uniform_buffer(
     llvm::cl::desc("Put pointer-to-constant kernel args in UBOs."));
 
 // Default to 64kB.
-llvm::cl::opt<int> maximum_ubo_size(
+llvm::cl::opt<uint32_t> maximum_ubo_size(
     "max-ubo-size", llvm::cl::init(64 << 10),
     llvm::cl::desc("Specify the maximum UBO array size in bytes."));
 
-llvm::cl::opt<int> maximum_pushconstant_size(
+llvm::cl::opt<uint32_t> maximum_pushconstant_size(
     "max-pushconstant-size", llvm::cl::init(128),
     llvm::cl::desc(
         "Specify the maximum push constant interface size in bytes."));
@@ -285,7 +285,7 @@ bool PodArgsInUniformBuffer() { return pod_ubo; }
 bool PodArgsInPushConstants() { return pod_pushconstant; }
 bool ShowIDs() { return show_ids; }
 bool ConstantArgsInUniformBuffer() { return constant_args_in_uniform_buffer; }
-uint64_t MaxUniformBufferSize() { return maximum_ubo_size; }
+uint32_t MaxUniformBufferSize() { return maximum_ubo_size; }
 uint32_t MaxPushConstantsSize() { return maximum_pushconstant_size; }
 bool RelaxedUniformBufferLayout() { return relaxed_ubo_layout; }
 bool Std430UniformBufferLayout() { return std430_ubo_layout; }


### PR DESCRIPTION
The corresponding Vulkan limits are uint32_t values and some implementations
report values greater than INT_MAX

See https://github.com/kpet/clvk/issues/318

Signed-off-by: Kévin Petit <kevin.petit@arm.com>