### PR TITLE
fix removed unclear attribute methods

### DIFF
--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -266,7 +266,7 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
     SmallVector<std::pair<unsigned, AttributeSet>, 8> AttrBuildInfo;
 
     // Return attributes have to come first
-    if (Attributes.hasAttributes(AttributeList::ReturnIndex)) {
+    if (Attributes.hasAttributeAtIndex(AttributeList::ReturnIndex)) {
       auto idx = AttributeList::ReturnIndex;
       auto attrs = Attributes.getRetAttrs();
       AttrBuildInfo.push_back(std::make_pair(idx, attrs));
@@ -285,7 +285,7 @@ bool ClusterPodKernelArgumentsPass::runOnModule(Module &M) {
     }
 
     // And finally function attributes.
-    if (Attributes.hasAttributes(AttributeList::FunctionIndex)) {
+    if (Attributes.hasAttributeAtIndex(AttributeList::FunctionIndex)) {
       auto idx = AttributeList::FunctionIndex;
       auto attrs = Attributes.getFnAttrs();
       AttrBuildInfo.push_back(std::make_pair(idx, attrs));

--- a/lib/UndoSRetPass.cpp
+++ b/lib/UndoSRetPass.cpp
@@ -159,7 +159,7 @@ bool UndoSRetPass::runOnModule(Module &M) {
                 AttributeList::get(Context, AttributeList::FunctionIndex,
                                    AttrBuilder(attrs.getFnAttrs())));
             new_attrs =
-                new_attrs.addAttributes(Context, AttributeList::ReturnIndex,
+                new_attrs.addAttributesAtIndex(Context, AttributeList::ReturnIndex,
                                         AttrBuilder(attrs.getRetAttrs()));
             for (unsigned i = 1; i < Call->getNumArgOperands(); i++) {
               new_attrs = new_attrs.addParamAttributes(


### PR DESCRIPTION
Renamed 3 attribute methods because of this change in llvm:
[NFC] Remove some unclear attribute methods
https://github.com/llvm/llvm-project/commit/85b732b55903be80a2fc0b9eb6abb7de4a931430#diff-c4d0fdba47d5f6f464ba74facca8f7ecb6a8fd66fb1e368501346cf6374cb85f