### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "dea76ccaf40f1762915213d0ea91d0c707705683"
+      "commit" : "c597594461bb3ba34a9699b744be09135635cbc7"
     },
     {
       "name" : "SPIRV-Headers",

--- a/test/LongVectorLowering/gep.ll
+++ b/test/LongVectorLowering/gep.ll
@@ -65,7 +65,7 @@ define dso_local spir_kernel void @test6(<8 x float> addrspace(1)* %out) {
 
 ; CHECK-LABEL: @test4(
 ; CHECK: load [[FLOAT8]], [[FLOAT8]] addrspace(3)*
-; CHECK-SAME: getelementptr ([1 x [[FLOAT8]]], [1 x [[FLOAT8]]] addrspace(3)* @global, i32 0, i32 undef),
+; CHECK-SAME: getelementptr inbounds ([1 x [[FLOAT8]]], [1 x [[FLOAT8]]] addrspace(3)* @global, i32 0, i32 undef),
 ; CHECK-SAME: align 32
 
 ; CHECK-LABEL: @test3(


### PR DESCRIPTION
* Update long-vector-lowering test output, to account for 'inbounds'
  annotation now being added.