### PR TITLE
RFC: Rewrite private-AS GEP increments in loops

### DIFF
--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -20,6 +20,7 @@ namespace llvm {
 // This is against Google C++ style guide.
 class FunctionPass;
 class ModulePass;
+class LoopPass;
 class raw_pwrite_stream;
 class raw_ostream;
 template <typename T> class ArrayRef;
@@ -419,4 +420,6 @@ llvm::ModulePass *createAutoPodArgsPass();
 /// provide faster, lower precision alternatives.
 llvm::ModulePass *createNativeMathPass();
 
+/// Simplifies GEPs used as loop variables into a counter+GEP pair.
+llvm::Pass *createGEPVarPass();
 } // namespace clspv

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/DirectResourceAccessPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FixupStructuredCFGPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/GEPLoopVar.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineEntryPointsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -721,6 +721,9 @@ int PopulatePassManager(
     pm->add(llvm::createInstructionCombiningPass());
   }
 
+  // Any GEPs used as Loop variables need to be adjusted.
+  // This can generate chain GEPs which can be combined with InstCombine.
+  pm->add(clspv::createGEPVarPass());
   // Now we add any of the LLVM optimizations we wanted
   pmBuilder.populateModulePassManager(*pm);
 

--- a/lib/GEPLoopVar.cpp
+++ b/lib/GEPLoopVar.cpp
@@ -1,0 +1,201 @@
+// Copyright 2020-2021 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/LoopPass.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/Local.h"
+
+#include "clspv/Passes.h"
+#include "Passes.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "GEPLoopVariable"
+
+namespace {
+/// This pass will gather Pointer PHIs on a loop,
+/// where those pointers are incremented inside the loop.
+/// Because the SPIRVProducer will use the 1st element of the GEP
+/// to figure out whether to generate a spv::OpPtrAccessChain or
+/// a spv::OpAccessChain, we cannot have chained-GEPs.
+/// LLVM will simplify a sequence of GEPs during CFG simplification,
+/// but where loops are involved, we must do so manually.
+class GEPLoopVariable final
+    : public LoopPass {
+public:
+  GEPLoopVariable() : LoopPass(ID) {}
+
+  bool runOnLoop(Loop *L, LPPassManager &LPM) override;
+  StringRef getPassName() const override { return "Simplify GEP as Loop Variable"; }
+
+  static char ID;
+};
+
+bool ReplacePHINode(Loop *L, PHINode *Node) {
+  const unsigned NumValues = Node->getNumIncomingValues();
+  SmallVector<Value *, 16> Offsets;
+  Offsets.reserve(NumValues);
+  Value *SourcePointer = nullptr;
+  Type *OffsetType = nullptr;
+
+  LLVM_DEBUG(dbgs() << "Finding incoming pointers for " << *Node << '\n');
+
+  for (unsigned i = 0; i < NumValues; ++i) {
+    auto *Value = Node->getIncomingValue(i);
+    auto *Block = Node->getIncomingBlock(i);
+    if (L->contains(Block)) {
+      if (Node == Value) {
+        if (!OffsetType)
+          // Guess at 32-bit offsets.
+          OffsetType = IntegerType::get(Node->getContext(), 32);
+        // Self-reference; increment is 0.
+        Offsets.push_back(ConstantInt::get(OffsetType, 0, false));
+        LLVM_DEBUG(dbgs() << " * " << *Value << " -> offset 0\n");
+      } else if (auto *GEP = dyn_cast<GetElementPtrInst>(Value)) {
+        // This is an incremented pointer. Figure out by how much.
+        // If this isn't a self-reference increment, then skip.
+        if (GEP->getPointerOperand() != Node)
+          return false;
+        if (GEP->getNumIndices() != 1)
+          return false;
+        Offsets.push_back(*GEP->idx_begin());
+        if (!OffsetType)
+          OffsetType = Offsets.back()->getType();
+        LLVM_DEBUG(dbgs() << " * " << *Value << " -> offset " << *Offsets.back() << '\n');
+      } else {
+        return false;
+      }
+    } else {
+      // This is a loop-incoming value.
+      Offsets.push_back(nullptr);
+      if (!SourcePointer)
+        SourcePointer = Value;
+      else if (SourcePointer != Value)
+        // Multiple incoming pointers; can't handle.
+        return false;
+    }
+  }
+
+  assert(SourcePointer && "No Loop-incoming pointer");
+
+  // This would imply that the PHINode is loop-invariant,
+  // and should be hoisted.
+  assert(OffsetType && "No Loop-dependent offsets found");
+
+  // Ensure that all offset types match.
+  for (auto *Offset : Offsets) {
+    if (!Offset)
+      continue;
+
+    assert(OffsetType == Offset->getType() && "Typecasting required");
+  }
+
+  auto *Header = Node->getParent();
+  PHINode *NewNode = PHINode::Create(OffsetType, NumValues, "LoopGEPOffset", Node);
+
+  LLVM_DEBUG(dbgs() << " Imported offsets: " << *NewNode <<'\n');
+
+  // Ensure we don't create sequences of GEPs.
+  LLVM_DEBUG(dbgs() << " Source pointer: " << *SourcePointer << '\n');
+  SmallVector<Value *, 16> NewGepIndices;
+  while (auto *GEP = dyn_cast<GetElementPtrInst>(SourcePointer)) {
+    LLVM_DEBUG(dbgs() << " Importing gep indices: " << *SourcePointer << '\n');
+    NewGepIndices.insert(NewGepIndices.begin(),
+                         GEP->indices().begin(), GEP->indices().end());
+    SourcePointer = GEP->getPointerOperand();
+  }
+
+  Value *TrailIndex;
+  if (NewGepIndices.empty())
+    TrailIndex = ConstantInt::get(OffsetType, 0, false);
+  else
+    TrailIndex = NewGepIndices.pop_back_val();
+  LLVM_DEBUG(dbgs() << " PHI incoming offset: " << *TrailIndex << '\n');
+
+  assert(NumValues == Offsets.size());
+  // Build a PHINode with incoming offsets.
+  for (unsigned i = 0; i < NumValues; ++i) {
+    Value *Offset = Offsets[i];
+    auto *Block = Node->getIncomingBlock(i);
+
+    if (!Offset) {
+      NewNode->addIncoming(TrailIndex, Block);
+      continue;
+    }
+
+    auto *I = cast<Instruction>(Node->getIncomingValue(i));
+
+    auto *Add = BinaryOperator::CreateAdd(NewNode, Offset, "LoopGEPInc", I);
+    NewNode->addIncoming(Add, Block);
+    LLVM_DEBUG(dbgs() << " Incoming offset: " << *Add << " from " << *I <<'\n');
+    // We need to remove the instruction so that a RAUW later works correctly.
+    assert(isa<GetElementPtrInst>(I));
+    assert(I->getOperand(0) == Node);
+    I->replaceAllUsesWith(UndefValue::get(I->getType()));
+    I->eraseFromParent();
+  }
+
+  // Now the PHI needs to be replaced with a GEP using the accumulated offset.
+  NewGepIndices.push_back(NewNode);
+  auto *InsertPoint = &*Header->getFirstInsertionPt();
+  auto *PointeeTy = SourcePointer->getType()->getPointerElementType();
+  auto *GEP = GetElementPtrInst::Create(PointeeTy, SourcePointer, NewGepIndices, "LoopGEPReplacement", InsertPoint);
+  LLVM_DEBUG(dbgs() << " PHI replaced with " << *GEP << '\n');
+  Node->replaceAllUsesWith(GEP);
+  RecursivelyDeleteDeadPHINode(Node);
+
+  return true;
+}
+} // anon namespace
+
+char GEPLoopVariable::ID = 0;
+
+bool GEPLoopVariable::runOnLoop(Loop *L, LPPassManager &LPM) {
+  // Search for any pointers incremented in the loop.
+  // This is done by finding PHINodes on the header.
+  auto *Header = L->getHeader();
+  assert(Header && "Loop has no header");
+
+  SmallVector<PHINode *, 4> Pointers;
+  for (auto &I : Header->getInstList()) {
+    if (auto *PHI = dyn_cast<PHINode>(&I)) {
+      if (PHI->getType()->isPointerTy() && PHI->getType()->getPointerAddressSpace() == 0)
+        Pointers.push_back(PHI);
+    } else {
+      // PHINodes must be at the start of the block.
+      // If this isn't a PHINode, we're done.
+      break;
+    }
+  }
+
+  if (Pointers.empty())
+    return false;
+
+  bool Modified = false;
+  for (auto *Node : Pointers)
+    Modified |= ReplacePHINode(L, Node);
+
+  return Modified;
+}
+
+
+INITIALIZE_PASS(GEPLoopVariable, "GepLoopVar",
+                "Simplify GEP as Loop Variable", false, false)
+
+llvm::Pass *clspv::createGEPVarPass() {
+  return new GEPLoopVariable();
+}

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -33,6 +33,7 @@ void initializeClspvPasses(PassRegistry &r) {
   initializeInlineFuncWithPointerBitCastArgPassPass(r);
   initializeInlineFuncWithPointerToFunctionArgPassPass(r);
   initializeInlineFuncWithSingleCallSitePassPass(r);
+  initializeGEPLoopVariablePass(r);
   initializeLongVectorLoweringPassPass(r);
   initializeMultiVersionUBOFunctionsPassPass(r);
   initializeNativeMathPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -36,6 +36,7 @@ void initializeInlineEntryPointsPassPass(PassRegistry &);
 void initializeInlineFuncWithPointerBitCastArgPassPass(PassRegistry &);
 void initializeInlineFuncWithPointerToFunctionArgPassPass(PassRegistry &);
 void initializeInlineFuncWithSingleCallSitePassPass(PassRegistry &);
+void initializeGEPLoopVariablePass(PassRegistry &);
 void initializeLongVectorLoweringPassPass(PassRegistry &);
 void initializeMultiVersionUBOFunctionsPassPass(PassRegistry &);
 void initializeNativeMathPassPass(PassRegistry &);

--- a/test/private_ptr_phi.cl
+++ b/test/private_ptr_phi.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+static void load_data(global int* buffer, int* data, int end)
+{
+	for (int i = 0; i < end; ++i)
+	{
+		data[i] = buffer[i];
+		data[i] = buffer[i];
+		buffer += 2;
+		data += 2;
+	}
+}
+
+kernel void test(global int* buffer, constant int* ends)
+{
+	int data[16];
+	load_data(buffer, data, *ends);
+}

--- a/test/private_ptr_phi.ll
+++ b/test/private_ptr_phi.ll
@@ -1,0 +1,102 @@
+; RUN: clspv-opt -GepLoopVar %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+; ModuleID = '/home/pedols01/src/clspv/test/private_ptr_phi.cl'
+source_filename = "private_ptr_phi.cl"
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent norecurse nounwind
+define dso_local spir_kernel void @test(i32 addrspace(1)* %buffer, i32 addrspace(2)* %ends) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !4 !clspv.pod_args_impl !5 {
+entry:
+  %data = alloca [16 x i32], align 4
+  %data.repack = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 0
+  store i32 0, i32* %data.repack, align 4
+  %data.repack1 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 1
+  store i32 0, i32* %data.repack1, align 4
+  %data.repack2 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 2
+  store i32 0, i32* %data.repack2, align 4
+  %data.repack3 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 3
+  store i32 0, i32* %data.repack3, align 4
+  %data.repack4 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 4
+  store i32 0, i32* %data.repack4, align 4
+  %data.repack5 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 5
+  store i32 0, i32* %data.repack5, align 4
+  %data.repack6 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 6
+  store i32 0, i32* %data.repack6, align 4
+  %data.repack7 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 7
+  store i32 0, i32* %data.repack7, align 4
+  %data.repack8 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 8
+  store i32 0, i32* %data.repack8, align 4
+  %data.repack9 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 9
+  store i32 0, i32* %data.repack9, align 4
+  %data.repack10 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 10
+  store i32 0, i32* %data.repack10, align 4
+  %data.repack11 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 11
+  store i32 0, i32* %data.repack11, align 4
+  %data.repack12 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 12
+  store i32 0, i32* %data.repack12, align 4
+  %data.repack13 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 13
+  store i32 0, i32* %data.repack13, align 4
+  %data.repack14 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 14
+  store i32 0, i32* %data.repack14, align 4
+  %data.repack15 = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 15
+  store i32 0, i32* %data.repack15, align 4
+  %arraydecay = getelementptr inbounds [16 x i32], [16 x i32]* %data, i32 0, i32 0
+  %0 = load i32, i32 addrspace(2)* %ends, align 4
+  %1 = call i32 @clspv.wrap_constant_load.0(i32 %0) #2
+  br label %for.cond.i
+
+for.cond.i:                                       ; preds = %for.body.i, %entry
+  %i.0.i = phi i32 [ 0, %entry ], [ %inc.i, %for.body.i ]
+  ; CHECK: %LoopGEPOffset = phi i32 [ 0, %entry ], [ %LoopGEPInc, %for.body.i ]
+  ; CHECK-NOT: %data.addr.0.i = phi i32* [ %arraydecay, %entry ], [ %add.ptr4.i, %for.body.i ]
+  %data.addr.0.i = phi i32* [ %arraydecay, %entry ], [ %add.ptr4.i, %for.body.i ]
+  %buffer.addr.0.i = phi i32 addrspace(1)* [ %buffer, %entry ], [ %add.ptr.i, %for.body.i ]
+  %cmp.i = icmp slt i32 %i.0.i, %1
+  br i1 %cmp.i, label %for.body.i, label %load_data.exit
+
+for.body.i:                                       ; preds = %for.cond.i
+  ; CHECK: %LoopGEPReplacement = getelementptr [16 x i32], [16 x i32]* %data, i32 0, i32 %LoopGEPOffset
+  %arrayidx.i = getelementptr inbounds i32, i32 addrspace(1)* %buffer.addr.0.i, i32 %i.0.i
+  %2 = load i32, i32 addrspace(1)* %arrayidx.i, align 4
+  ; CHECK: %arrayidx1.i = getelementptr inbounds i32, i32* %LoopGEPReplacement, i32 %i.0.i
+  ; CHECK-NOT: %arrayidx1.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 %i.0.i
+  %arrayidx1.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 %i.0.i
+  store i32 %2, i32* %arrayidx1.i, align 4
+  %arrayidx2.i = getelementptr inbounds i32, i32 addrspace(1)* %buffer.addr.0.i, i32 %i.0.i
+  %3 = load i32, i32 addrspace(1)* %arrayidx2.i, align 4
+  ; CHECK: %arrayidx3.i = getelementptr inbounds i32, i32* %LoopGEPReplacement, i32 %i.0.i
+  ; CHECK-NOT: %arrayidx3.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 %i.0.i
+  %arrayidx3.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 %i.0.i
+  store i32 %3, i32* %arrayidx3.i, align 4
+  ; CHECK: %LoopGEPInc = add i32 %LoopGEPOffset, 2
+  ; CHECK-NOT: %add.ptr4.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 2
+  %add.ptr4.i = getelementptr inbounds i32, i32* %data.addr.0.i, i32 2
+  %add.ptr.i = getelementptr inbounds i32, i32 addrspace(1)* %buffer.addr.0.i, i32 2
+  %inc.i = add nuw nsw i32 %i.0.i, 1
+  br label %for.cond.i
+
+load_data.exit:                                   ; preds = %for.cond.i
+  ret void
+}
+
+; Function Attrs: readonly
+declare i32 @clspv.wrap_constant_load.0(i32 %0) #1
+
+attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { readonly }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"none", !"none"}
+!3 = !{!"int*", !"int*"}
+!4 = !{!"", !"const"}
+!5 = !{i32 2}
+


### PR DESCRIPTION
When a pointer in the private address space is incremented in a loop, the first offset in the GEP will not be a 0. This breaks the assumptions in the SPV writer pass, leading to an assertion.
Rewrite GEPs in loops to use an offset counter instead.

I have not done extensive testing on this pass, as I am not sure this is the right solution going forward. The pattern searched for in this pass is fragile, and this is effectively working-around a deficiency in the SPV spec (or the SPV writer), but I can't think of a different way to solve the problem.

A reduced test case is attached, along with a .ll file where the FileCheck checks describe what the pass is doing.

Signed-off-by: Pedro Olsen Ferreira <pedro.olsenferreira@arm.com>
Change-Id: I0abf1eeff2035101f01de0ccfddfbc663e92b998