### PR TITLE
Add pass to transform vec3 to vec4

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -207,6 +207,10 @@ bool UniformWorkgroupSize();
 // Returns true if kernel argument info production is enabled
 bool KernelArgInfo();
 
+// Returns true if lowering to vec3 to vec4 should be done whether or not it
+// seems necessary
+bool Vec3ToVec4();
+
 } // namespace Option
 } // namespace clspv
 

--- a/include/clspv/Passes.h
+++ b/include/clspv/Passes.h
@@ -41,6 +41,10 @@ namespace clspv {
 /// Vulkan SPIR-V.
 llvm::ModulePass *createLongVectorLoweringPass();
 
+// Process vectors of 3 elements into a vector of 4 elements to be able to
+// access the padding element of vec3 when cast are use in OpenCL.
+llvm::ModulePass *createThreeElementVectorLoweringPass();
+
 /// Declare a structure with all enabled push constants and attach metadata to
 /// the module for use by the utilities that abstract push constant usage.
 /// @return An LLVM module pass.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/LongVectorLoweringPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/ThreeElementVectorLoweringPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeMathPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NormalizeGlobalVariable.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -662,6 +662,8 @@ int PopulatePassManager(
   }
   pm->add(clspv::createReplaceOpenCLBuiltinPass());
 
+  pm->add(clspv::createThreeElementVectorLoweringPass());
+
   // Lower longer vectors when requested. Note that this pass depends on
   // ReplaceOpenCLBuiltinPass and expects DeadCodeEliminationPass to be run
   // afterwards.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -263,6 +263,10 @@ static llvm::cl::opt<bool>
     cl_kernel_arg_info("cl-kernel-arg-info", llvm::cl::init(false),
                        llvm::cl::desc("Produce kernel argument info."));
 
+static llvm::cl::opt<bool>
+    force_vec3_to_vec4("vec3-to-vec4", llvm::cl::init(false),
+                       llvm::cl::desc("Force lowering vec3 to vec4"));
+
 } // namespace
 
 namespace clspv {
@@ -343,6 +347,8 @@ bool ArmNonUniformWorkGroupSize() { return cl_arm_non_uniform_work_group_size; }
 bool UniformWorkgroupSize() { return uniform_workgroup_size; }
 
 bool KernelArgInfo() { return cl_kernel_arg_info; }
+
+bool Vec3ToVec4() { return force_vec3_to_vec4; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Passes.cpp
+++ b/lib/Passes.cpp
@@ -52,6 +52,7 @@ void initializeClspvPasses(PassRegistry &r) {
   initializeSplatSelectConditionPassPass(r);
   initializeSpecializeImageTypesPassPass(r);
   initializeStripFreezePassPass(r);
+  initializeThreeElementVectorLoweringPassPass(r);
   initializeUBOTypeTransformPassPass(r);
   initializeUndoBoolPassPass(r);
   initializeUndoByvalPassPass(r);

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -55,6 +55,7 @@ void initializeSplatArgPassPass(PassRegistry &);
 void initializeSplatSelectConditionPassPass(PassRegistry &);
 void initializeSpecializeImageTypesPassPass(PassRegistry &);
 void initializeStripFreezePassPass(PassRegistry &);
+void initializeThreeElementVectorLoweringPassPass(PassRegistry &);
 void initializeUBOTypeTransformPassPass(PassRegistry &);
 void initializeUndoBoolPassPass(PassRegistry &);
 void initializeUndoByvalPassPass(PassRegistry &);

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -1,0 +1,1419 @@
+// Copyright 2020-2021 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/ValueHandle.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/Local.h"
+
+#include "BuiltinsEnum.h"
+#include "Constants.h"
+#include "clspv/Option.h"
+#include "clspv/Passes.h"
+
+#include "Builtins.h"
+#include "Passes.h"
+
+#include <array>
+#include <functional>
+
+using namespace llvm;
+
+#define DEBUG_TYPE "ThreeElementVectorLowering"
+
+namespace {
+
+class ThreeElementVectorLoweringPass final
+    : public ModulePass,
+      public InstVisitor<ThreeElementVectorLoweringPass, Value *> {
+public:
+  static char ID;
+
+public:
+  ThreeElementVectorLoweringPass() : ModulePass(ID) {}
+
+  /// Lower the content of the given module @p M.
+  bool runOnModule(Module &M) override;
+
+private:
+  // Implementation details for InstVisitor.
+
+  using Visitor = InstVisitor<ThreeElementVectorLoweringPass, Value *>;
+  using Visitor::visit;
+  friend Visitor;
+
+  /// Higher-level dispatcher. This is not provided by InstVisitor.
+  /// Returns nullptr if no lowering is required.
+  Value *visit(Value *V);
+
+  /// Visit Constant. This is not provided by InstVisitor.
+  Value *visitConstant(Constant &Cst);
+
+  /// Visit Unary or Binary Operator. This is not provided by InstVisitor.
+  Value *visitNAryOperator(Instruction &I);
+
+  /// InstVisitor impl, general "catch-all" function.
+  Value *visitInstruction(Instruction &I);
+
+  // InstVisitor impl, specific cases.
+  Value *visitAllocaInst(AllocaInst &I);
+  Value *visitBinaryOperator(BinaryOperator &I);
+  Value *visitCallInst(CallInst &I);
+  Value *visitCastInst(CastInst &I);
+  Value *visitCmpInst(CmpInst &I);
+  Value *visitExtractElementInst(ExtractElementInst &I);
+  Value *visitExtractValueInst(ExtractValueInst &I);
+  Value *visitGetElementPtrInst(GetElementPtrInst &I);
+  Value *visitInsertElementInst(InsertElementInst &I);
+  Value *visitInsertValueInst(InsertValueInst &I);
+  Value *visitLoadInst(LoadInst &I);
+  Value *visitPHINode(PHINode &I);
+  Value *visitSelectInst(SelectInst &I);
+  Value *visitShuffleVectorInst(ShuffleVectorInst &I);
+  Value *visitStoreInst(StoreInst &I);
+  Value *visitUnaryOperator(UnaryOperator &I);
+
+private:
+  // Helpers for lowering values.
+
+  /// Return true if the given @p U needs to be lowered.
+  ///
+  /// This only looks at the types involved, not the opcodes or anything else.
+  bool handlingRequired(User &U);
+
+  /// Return the lowered version of @p U or @p U itself when no lowering is
+  /// required.
+  Value *visitOrSelf(Value *U) {
+    auto *V = visit(U);
+    return V ? V : U;
+  }
+
+  /// Register the replacement of @p U with @p V.
+  ///
+  /// If @p U and @p V have the same type, replace the relevant usages as well
+  /// to ensure the rest of the program is using the new instructions.
+  void registerReplacement(Value &U, Value &V);
+
+private:
+  // Helpers for lowering types.
+
+  /// Get a vector of 4 elements equivalent for this type, if it uses a vector
+  /// of 3 elements. Returns nullptr if no lowering is required.
+  Type *getEquivalentType(Type *Ty);
+
+  /// Implementation details of getEquivalentType.
+  Type *getEquivalentTypeImpl(Type *Ty);
+
+  /// Return the equivalent type for @p Ty or @p Ty if no lowering is needed.
+  Type *getEquivalentTypeOrSelf(Type *Ty) {
+    auto *EquivalentTy = getEquivalentType(Ty);
+    return EquivalentTy ? EquivalentTy : Ty;
+  }
+
+private:
+  // High-level implementation details of runOnModule.
+
+  /// Lower all global variables in the module.
+  bool runOnGlobals(Module &M);
+
+  /// Lower the given function.
+  bool runOnFunction(Function &F);
+
+  /// Map the call @p CI to an OpenCL builtin function or an LLVM intrinsic to
+  /// the same calls but reworking the args and the return value.
+  Value *convertBuiltinCall(CallInst &CI, Type *EquivalentReturnTy,
+                            ArrayRef<Value *> EquivalentArgs);
+
+  /// Map the call @p CI to an OpenCL builtin function or an LLVM intrinsic to
+  /// a calls with vec4 without reworking the args and the return value.
+  Value *convertSIMDBuiltinCall(CallInst &CI, Type *EquivalentReturnTy,
+                                ArrayRef<Value *> EquivalentArgs);
+
+  // Map calls of Spirv Operators builtin that cannot be convert using
+  // convertBuiltinCall or convertSIMDBuiltinCall
+  Value *convertSpirvOpBuiltinCall(CallInst &CI, Type *EquivalentReturnTy,
+                                   ArrayRef<Value *> EquivalentArgs);
+
+  /// Create an alternative version of @p F that doesn't have vec3 as parameter
+  /// or return types.
+  /// Returns nullptr if no lowering is required.
+  Function *convertUserDefinedFunction(Function &F);
+
+  /// Create (and insert) a call to the equivalent user-defined function.
+  CallInst *convertUserDefinedFunctionCall(CallInst &CI,
+                                           ArrayRef<Value *> EquivalentArgs);
+
+  /// Clears the dead instructions and others that might be rendered dead
+  /// by their removal.
+  void cleanDeadInstructions();
+
+  /// Remove all long-vector functions that were lowered.
+  void cleanDeadFunctions();
+
+  /// Remove all long-vector globals that were lowered.
+  void cleanDeadGlobals();
+
+private:
+  /// A map between 3 elements vector types and their equivalent representation.
+  DenseMap<Type *, Type *> TypeMap;
+
+  /// A map between original values and their replacement.
+  ///
+  /// The content of this mapping is valid only for the function being visited
+  /// at a given time. The keys in this mapping should be removed from the
+  /// function once all instructions in the current function have been visited
+  /// and transformed. Instructions are not removed from the function as they
+  /// are visited because this would invalidate iterators.
+  DenseMap<Value *, Value *> ValueMap;
+
+  /// A map between functions and their replacement. This includes OpenCL
+  /// builtin declarations.
+  ///
+  /// The keys in this mapping should be deleted when finishing processing the
+  /// module.
+  DenseMap<Function *, Function *> FunctionMap;
+
+  /// A map between global variables and their replacement.
+  ///
+  /// The map is filled before any functions are visited, yet the original
+  /// globals are not removed from the module. Their removal is deferred once
+  /// all functions have been visited.
+  DenseMap<GlobalVariable *, GlobalVariable *> GlobalVariableMap;
+};
+
+char ThreeElementVectorLoweringPass::ID = 0;
+
+using PartitionCallback = std::function<void(Instruction *)>;
+
+bool isSpirvGlobalVariable(llvm::StringRef Name) {
+  return Name.startswith("__spirv_") || Name == "__push_constants";
+}
+
+/// Partition the @p Instructions based on their liveness.
+void partitionInstructions(ArrayRef<WeakTrackingVH> Instructions,
+                           PartitionCallback OnDead,
+                           PartitionCallback OnAlive) {
+  for (auto OldValueHandle : Instructions) {
+    // Handle situations when the weak handle is no longer valid.
+    if (!OldValueHandle.pointsToAliveValue()) {
+      continue; // Nothing else to do for this handle.
+    }
+
+    auto *OldInstruction = cast<Instruction>(OldValueHandle);
+    bool Dead = OldInstruction->use_empty();
+    if (Dead) {
+      OnDead(OldInstruction);
+    } else {
+      OnAlive(OldInstruction);
+    }
+  }
+}
+
+/// Convert the given value @p V to a value of the given @p EquivalentTy.
+///
+/// @return @p V when @p V's type is @p newType.
+/// @return an equivalent pointer when both @p V and @p newType are pointers.
+/// @return an equivalent 4 elements vector when @p V is a 3 elements vector.
+Value *convertEquivalentValue(IRBuilder<> &B, Value *V, Type *EquivalentTy) {
+  Type *Ty = V->getType();
+  if (Ty == EquivalentTy) {
+    return V;
+  }
+
+  if (EquivalentTy->isPointerTy()) {
+    assert(Ty->isPointerTy());
+    return B.CreateBitCast(V, EquivalentTy);
+  }
+
+  Value *NewValue = UndefValue::get(EquivalentTy);
+
+  if (EquivalentTy->isStructTy()) {
+    StructType *StructTy = dyn_cast<StructType>(EquivalentTy);
+    unsigned Arity = StructTy->getStructNumElements();
+    if (Arity == 0)
+      return nullptr;
+    for (unsigned i = 0; i < Arity; ++i) {
+      Type *ElementType = StructTy->getContainedType(i);
+      Value *Element = B.CreateExtractValue(V, {i});
+      Value *NewElement = convertEquivalentValue(B, Element, ElementType);
+      NewValue = B.CreateInsertValue(NewValue, NewElement, {i});
+    }
+  } else if (EquivalentTy->isVectorTy()) {
+    assert(Ty->isVectorTy());
+
+    unsigned Arity = dyn_cast<FixedVectorType>(Ty)->getNumElements();
+    for (unsigned i = 0; i < Arity; ++i) {
+      Value *Scalar = B.CreateExtractElement(V, i);
+      NewValue = B.CreateInsertElement(NewValue, Scalar, i);
+    }
+  } else {
+    return nullptr;
+  }
+
+  if (V->hasName()) {
+    NewValue->takeName(V);
+  }
+
+  return NewValue;
+}
+
+/// Map the arguments of the wrapper function (which are either not vec3
+/// or aggregates of scalars) to the original arguments of the user-defined
+/// function (which can be vec3). Handle pointers as well.
+SmallVector<Value *, 16> mapWrapperArgsToWrappeeArgs(IRBuilder<> &B,
+                                                     Function &Wrappee,
+                                                     Function &Wrapper) {
+  SmallVector<Value *, 16> Args;
+
+  std::size_t ArgumentCount = Wrapper.arg_size();
+  Args.reserve(ArgumentCount);
+
+  for (std::size_t i = 0; i < ArgumentCount; ++i) {
+    auto *NewArg = Wrapper.getArg(i);
+    auto *OldArgTy = Wrappee.getFunctionType()->getParamType(i);
+    auto *EquivalentArg = convertEquivalentValue(B, NewArg, OldArgTy);
+    Args.push_back(EquivalentArg);
+  }
+
+  return Args;
+}
+
+/// Create a new, equivalent function with no vec3 types.
+///
+/// This is achieved by creating a new function (the "wrapper") which inlines
+/// the given function (the "wrappee"). Only the parameters and return types are
+/// mapped. The function body still needs to be lowered.
+Function *createFunctionWithMappedTypes(Function &F,
+                                        FunctionType *EquivalentFunctionTy) {
+  assert(!F.isVarArg() && "varargs not supported");
+
+  auto *Wrapper = Function::Create(EquivalentFunctionTy, F.getLinkage());
+  Wrapper->takeName(&F);
+  Wrapper->setCallingConv(F.getCallingConv());
+  Wrapper->copyAttributesFrom(&F);
+  Wrapper->copyMetadata(&F, /* offset */ 0);
+
+  for (std::size_t i = 0; i < Wrapper->arg_size(); ++i) {
+    auto *WrapperArg = Wrapper->getArg(i);
+    auto *FArg = F.getArg(i);
+
+    if (FArg->hasName()) {
+      WrapperArg->takeName(FArg);
+    }
+  }
+
+  BasicBlock::Create(F.getContext(), "", Wrapper);
+  IRBuilder<> B(&Wrapper->getEntryBlock());
+
+  // Fill in the body of the wrapper function.
+  auto WrappeeArgs = mapWrapperArgsToWrappeeArgs(B, F, *Wrapper);
+  CallInst *Call = B.CreateCall(&F, WrappeeArgs);
+  if (Call->getType()->isVoidTy()) {
+    B.CreateRetVoid();
+  } else {
+    auto *EquivalentReturnTy = EquivalentFunctionTy->getReturnType();
+    Value *ReturnValue = convertEquivalentValue(B, Call, EquivalentReturnTy);
+    B.CreateRet(ReturnValue);
+  }
+
+  // Ensure wrapper has a parent or InlineFunction will crash.
+  F.getParent()->getFunctionList().push_front(Wrapper);
+
+  // Inline the original function.
+  InlineFunctionInfo Info;
+  auto Result = InlineFunction(*Call, Info);
+  if (!Result.isSuccess()) {
+    LLVM_DEBUG(dbgs() << "Failed to inline " << F.getName() << '\n');
+    LLVM_DEBUG(dbgs() << "Reason: " << Result.getFailureReason() << '\n');
+    llvm_unreachable("Unexpected failure when inlining function.");
+  }
+
+  return Wrapper;
+}
+
+std::string getVec4Name(const clspv::Builtins::FunctionInfo &IInfo) {
+  // Copy the informations about the vector version.
+  // Return type is not important for mangling.
+  // Only update arguments to have vec4 instead of vec3.
+  clspv::Builtins::FunctionInfo Info = IInfo;
+  for (size_t i = 0; i < Info.getParameterCount(); ++i) {
+    if (Info.getParameter(i).vector_size == 3) {
+      Info.getParameter(i).vector_size = 4;
+    }
+  }
+  return clspv::Builtins::GetMangledFunctionName(Info);
+}
+
+/// In order not to overflow, we need to copy elements one by one when
+/// CopyMemory arguments are transformed from vec3 to vec4.
+Value *convertOpCopyMemoryOperation(CallInst &VectorCall,
+                                    ArrayRef<Value *> EquivalentArgs) {
+  auto *DstOperand = EquivalentArgs[1];
+  auto *SrcOperand = EquivalentArgs[2];
+  assert(DstOperand->getType()->getPointerElementType()->isVectorTy());
+  assert(dyn_cast<VectorType>(DstOperand->getType()->getPointerElementType())
+             ->getElementCount()
+             .getKnownMinValue() == 4);
+
+  IRBuilder<> B(&VectorCall);
+  Value *ReturnValue = nullptr;
+
+  // for each element
+  for (unsigned eachElem = 0; eachElem < 3; eachElem++) {
+    auto *SrcGEP =
+        B.CreateGEP(SrcOperand, {B.getInt32(0), B.getInt32(eachElem)});
+    auto *Val = B.CreateLoad(SrcGEP);
+    auto *DstGEP =
+        B.CreateGEP(DstOperand, {B.getInt32(0), B.getInt32(eachElem)});
+    ReturnValue = B.CreateStore(Val, DstGEP);
+  }
+
+  return ReturnValue;
+}
+
+/// SIMD Builtin are builtin where the instruction uses only 1 data element
+bool isBuiltinSIMD(clspv::Builtins::BuiltinType Builtin) {
+  if (Builtin > clspv::Builtins::kType_Math_Start &&
+      Builtin < clspv::Builtins::kType_Math_End)
+    return true;
+  if (Builtin > clspv::Builtins::kType_Integer_Start &&
+      Builtin < clspv::Builtins::kType_Integer_End)
+    return true;
+  switch (Builtin) {
+  default:
+    return false;
+  }
+}
+
+/// Look for bitcast of vec3 inside the function
+bool vec3BitcastInFunction(Function &F) {
+  for (Instruction &I : instructions(F)) {
+    if (auto *Inst = dyn_cast<CastInst>(&I)) {
+      auto *Type = Inst->getSrcTy();
+      if (Type->isPointerTy()) {
+        auto *PointeeType = Type->getPointerElementType();
+        if (auto *VectorType = dyn_cast<FixedVectorType>(PointeeType)) {
+          if (VectorType->getElementCount().getKnownMinValue())
+            return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/// Returns whether the vec3 should be transform into vec4
+bool vec3ShouldBeLowered(Module &M) {
+  if (clspv::Option::Vec3ToVec4())
+    return true;
+
+  for (auto &F : M.functions()) {
+    if (vec3BitcastInFunction(F))
+      return true;
+  }
+  return false;
+}
+
+bool ThreeElementVectorLoweringPass::runOnModule(Module &M) {
+  if (!vec3ShouldBeLowered(M))
+    return false;
+
+  bool Modified = runOnGlobals(M);
+
+  for (auto &F : M.functions()) {
+    Modified |= runOnFunction(F);
+  }
+
+  cleanDeadFunctions();
+  cleanDeadGlobals();
+
+  return Modified;
+}
+
+Value *ThreeElementVectorLoweringPass::visit(Value *V) {
+  // Already handled?
+  auto it = ValueMap.find(V);
+  if (it != ValueMap.end()) {
+    return it->second;
+  }
+
+  if (isa<Argument>(V)) {
+    return nullptr;
+  }
+
+  assert(isa<User>(V) && "Kind of llvm::Value not yet supported.");
+  if (!handlingRequired(*cast<User>(V))) {
+    return nullptr;
+  }
+
+  if (auto *I = dyn_cast<Instruction>(V)) {
+    // Dispatch to the appropriate method using InstVisitor.
+    return visit(I);
+  }
+
+  if (auto *C = dyn_cast<Constant>(V)) {
+    return visitConstant(*C);
+  }
+
+#ifndef NDEBUG
+  dbgs() << "Value not handled: " << *V << '\n';
+#endif
+  llvm_unreachable("Kind of value not handled yet.");
+}
+
+Value *ThreeElementVectorLoweringPass::visitConstant(Constant &Cst) {
+  auto *EquivalentTy = getEquivalentType(Cst.getType());
+  // Can happen because of the recursive call of visitConstant
+  if (EquivalentTy == nullptr) {
+    return dyn_cast<Value>(&Cst);
+  }
+
+  if (Cst.isZeroValue()) {
+    return Constant::getNullValue(EquivalentTy);
+  }
+
+  if (isa<UndefValue>(Cst)) {
+    return UndefValue::get(EquivalentTy);
+  }
+
+  if (auto *Vector = dyn_cast<ConstantDataVector>(&Cst)) {
+    SmallVector<Constant *, 16> Elements;
+    for (unsigned i = 0; i < Vector->getNumElements(); ++i) {
+      Elements.push_back(Vector->getElementAsConstant(i));
+    }
+    Elements.push_back(Vector->getElementAsConstant(0));
+
+    return ConstantVector::get(Elements);
+  }
+
+  if (auto *Vector = dyn_cast<ConstantVector>(&Cst)) {
+    SmallVector<Constant *, 16> Elements;
+    for (unsigned i = 0; i < Vector->getNumOperands(); ++i) {
+      Elements.push_back(
+          dyn_cast<Constant>(visitConstant(*Vector->getOperand(i))));
+    }
+    Elements.push_back(
+        dyn_cast<Constant>(visitConstant(*Vector->getOperand(0))));
+
+    return ConstantVector::get(Elements);
+  }
+
+  if (auto *Array = dyn_cast<ConstantArray>(&Cst)) {
+    SmallVector<Constant *, 16> Elements;
+    for (unsigned i = 0; i < Array->getNumOperands(); ++i) {
+      Elements.push_back(
+          dyn_cast<Constant>(visitConstant(*Array->getOperand(i))));
+    }
+    return ConstantArray::get(dyn_cast<ArrayType>(EquivalentTy), Elements);
+  }
+
+  if (auto *GV = dyn_cast<GlobalVariable>(&Cst)) {
+    auto *EquivalentGV = GlobalVariableMap[GV];
+
+    // Can happen due to '__spirv_' global variables not been lower to vec4
+    if (EquivalentGV == nullptr)
+      return GV;
+
+    return EquivalentGV;
+  }
+
+  if (auto *CE = dyn_cast<ConstantExpr>(&Cst)) {
+    switch (CE->getOpcode()) {
+    case Instruction::GetElementPtr: {
+      auto *GEP = cast<GEPOperator>(CE);
+      if (isSpirvGlobalVariable(GEP->getPointerOperand()->getName())) {
+        return CE;
+      }
+      auto *EquivalentSourceTy = getEquivalentType(GEP->getSourceElementType());
+      auto *EquivalentPointer = cast<Constant>(visit(GEP->getPointerOperand()));
+      SmallVector<Value *, 4> Indices(GEP->idx_begin(), GEP->idx_end());
+
+      auto *EquivalentGEP = ConstantExpr::getGetElementPtr(
+          EquivalentSourceTy, EquivalentPointer, Indices, GEP->isInBounds(),
+          GEP->getInRangeIndex());
+
+      return EquivalentGEP;
+    }
+
+    default:
+#ifndef NDEBUG
+      dbgs() << "Constant Expression not handled: " << *CE << '\n';
+      dbgs() << "Constant Expression Opcode: " << CE->getOpcodeName() << '\n';
+#endif
+      llvm_unreachable("Unsupported kind of ConstantExpr");
+    }
+  }
+
+#ifndef NDEBUG
+  dbgs() << "Constant not handled: " << Cst << '\n';
+#endif
+  llvm_unreachable("Unsupported kind of constant");
+}
+
+Value *ThreeElementVectorLoweringPass::visitNAryOperator(Instruction &I) {
+  SmallVector<Value *, 16> EquivalentArgs;
+  for (auto &Operand : I.operands()) {
+    Value *EquivalentOperand = visit(Operand.get());
+    assert(EquivalentOperand && "operand not lowered");
+    EquivalentArgs.push_back(EquivalentOperand);
+  }
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateNAryOp(I.getOpcode(), EquivalentArgs);
+  if (isa<Instruction>(V))
+    cast<Instruction>(V)->copyIRFlags(&I);
+
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitInstruction(Instruction &I) {
+#ifndef NDEBUG
+  dbgs() << "Instruction not handled: " << I << '\n';
+#endif
+  llvm_unreachable("Missing support for instruction");
+}
+
+Value *ThreeElementVectorLoweringPass::visitAllocaInst(AllocaInst &I) {
+  auto *EquivalentTy = getEquivalentType(I.getAllocatedType());
+  assert(EquivalentTy && "type not lowered");
+
+  IRBuilder<> B(&I);
+  unsigned AS = I.getType()->getAddressSpace();
+  auto *V = B.CreateAlloca(EquivalentTy, AS);
+  V->setAlignment(I.getAlign());
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitBinaryOperator(BinaryOperator &I) {
+  return visitNAryOperator(I);
+}
+
+Value *ThreeElementVectorLoweringPass::visitCallInst(CallInst &I) {
+  SmallVector<Value *, 16> EquivalentArgs;
+  for (auto &ArgUse : I.args()) {
+    Value *Arg = ArgUse.get();
+    Value *EquivalentArg = visitOrSelf(Arg);
+    EquivalentArgs.push_back(EquivalentArg);
+  }
+
+  auto *ReturnTy = I.getType();
+  auto *EquivalentReturnTy = getEquivalentTypeOrSelf(ReturnTy);
+
+#ifndef NDEBUG
+  bool NeedHandling = false;
+  NeedHandling |= (EquivalentReturnTy != ReturnTy);
+  NeedHandling |=
+      !std::equal(I.arg_begin(), I.arg_end(), std::begin(EquivalentArgs),
+                  [](auto const &ArgUse, Value *EquivalentArg) {
+                    return ArgUse.get() == EquivalentArg;
+                  });
+  assert(NeedHandling && "Expected something to lower for this call.");
+#endif
+
+  Function *F = I.getCalledFunction();
+  assert(F && "Only function calls are supported.");
+
+  const auto &Info = clspv::Builtins::Lookup(F);
+  bool SpirvOpBuiltin = (Info.getType() == clspv::Builtins::kSpirvOp);
+  bool OpenCLBuiltin = (Info.getType() != clspv::Builtins::kBuiltinNone);
+  bool Builtin = (OpenCLBuiltin || F->isIntrinsic());
+
+  Value *V = nullptr;
+  if (Builtin && F->isDeclaration() && !SpirvOpBuiltin) {
+    if (isBuiltinSIMD(Info.getType())) {
+      V = convertSIMDBuiltinCall(I, EquivalentReturnTy, EquivalentArgs);
+    } else {
+      V = convertBuiltinCall(I, EquivalentReturnTy, EquivalentArgs);
+    }
+  } else if (SpirvOpBuiltin && F->isDeclaration()) {
+    V = convertSpirvOpBuiltinCall(I, EquivalentReturnTy, EquivalentArgs);
+  } else {
+    V = convertUserDefinedFunctionCall(I, EquivalentArgs);
+  }
+
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitCastInst(CastInst &I) {
+  auto *OriginalValue = I.getOperand(0);
+  auto *EquivalentValue = visitOrSelf(OriginalValue);
+  auto *OriginalDestTy = I.getDestTy();
+  auto *EquivalentDestTy = getEquivalentTypeOrSelf(OriginalDestTy);
+
+  // We expect something to lower, or this function shouldn't have been called.
+  assert(((OriginalValue != EquivalentValue) ||
+          (OriginalDestTy != EquivalentDestTy)) &&
+         "nothing to lower");
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateCast(I.getOpcode(), EquivalentValue, EquivalentDestTy,
+                          I.getName());
+  if (isa<Instruction>(V))
+    cast<Instruction>(V)->copyIRFlags(&I);
+
+  assert(V);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitCmpInst(CmpInst &I) {
+  std::array<Value *, 2> EquivalentArgs{{
+      visit(I.getOperand(0)),
+      visit(I.getOperand(1)),
+  }};
+  assert(EquivalentArgs[0] && EquivalentArgs[1] && "argument(s) not lowered");
+
+  IRBuilder<> B(&I);
+  Value *V = nullptr;
+  if (I.isIntPredicate()) {
+    V = B.CreateICmp(I.getPredicate(), EquivalentArgs[0], EquivalentArgs[1]);
+  } else {
+    V = B.CreateFCmp(I.getPredicate(), EquivalentArgs[0], EquivalentArgs[1]);
+  }
+  if (isa<Instruction>(V))
+    cast<Instruction>(V)->copyIRFlags(&I);
+
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitExtractElementInst(ExtractElementInst &I) {
+  Value *EquivalentValue = visit(I.getOperand(0));
+  assert(EquivalentValue && "value not lowered");
+
+  Value *Index = I.getOperand(1);
+
+  assert(EquivalentValue->getType()->isVectorTy());
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateExtractElement(EquivalentValue, Index);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitExtractValueInst(ExtractValueInst &I) {
+  Value *EquivalentValue = visit(I.getOperand(0));
+  assert(EquivalentValue && "value not lowered");
+
+  auto Indices = I.getIndices();
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateExtractValue(EquivalentValue, Indices);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitGetElementPtrInst(GetElementPtrInst &I) {
+  // do not lower GEP of spirv global variables as we do not lower them to vec4
+  if (isSpirvGlobalVariable(I.getPointerOperand()->getName())) {
+    return &I;
+  }
+
+  auto *EquivalentPointer = visit(I.getPointerOperand());
+  assert(EquivalentPointer && "pointer not lowered");
+
+  IRBuilder<> B(&I);
+  SmallVector<Value *, 4> Indices(I.indices());
+  auto *V = B.CreateInBoundsGEP(
+      EquivalentPointer->getType()->getScalarType()->getPointerElementType(),
+      EquivalentPointer, Indices);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitInsertElementInst(InsertElementInst &I) {
+  Value *EquivalentValue = visit(I.getOperand(0));
+  assert(EquivalentValue && "value not lowered");
+
+  Value *ScalarElement = I.getOperand(1);
+  assert(ScalarElement->getType()->isIntegerTy() ||
+         ScalarElement->getType()->isFloatingPointTy());
+
+  ConstantInt *CI = dyn_cast<ConstantInt>(I.getOperand(2));
+  assert(CI && "Dynamic indices not supported yet");
+  unsigned Index = CI->getZExtValue();
+
+  assert(EquivalentValue->getType()->isVectorTy());
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateInsertElement(EquivalentValue, ScalarElement, Index);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitInsertValueInst(InsertValueInst &I) {
+  Value *EquivalentAggregate = visit(I.getOperand(0));
+  Value *EquivalentInsertValue = visit(I.getOperand(1));
+  auto Idxs = I.getIndices();
+
+  IRBuilder<> B(&I);
+  Value *V =
+      B.CreateInsertValue(EquivalentAggregate, EquivalentInsertValue, Idxs);
+  registerReplacement(I, *V);
+
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitLoadInst(LoadInst &I) {
+  // do not lower load of spirv global variables as we do not lower them to vec4
+  if (isSpirvGlobalVariable(I.getPointerOperand()->getName())) {
+    return &I;
+  }
+
+  Value *EquivalentPointer = visit(I.getPointerOperand());
+  assert(EquivalentPointer && "pointer not lowered");
+  Type *EquivalentTy = getEquivalentType(I.getType());
+  assert(EquivalentTy && "type not lowered");
+
+  IRBuilder<> B(&I);
+  auto *V = B.CreateAlignedLoad(EquivalentTy, EquivalentPointer, I.getAlign(),
+                                I.isVolatile());
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitPHINode(PHINode &I) {
+  // TODO Handle PHIs.
+  //
+  // PHIs are tricky because they require their incoming values
+  // to be handled first, which may not have been defined yet.
+  // We can't explicitly visit them because a PHI may depend on itself,
+  // leading to infinite loops. Defer until we have a test case.
+  //
+  // TODO Add PHI instruction with fast math flag to fastmathflags.ll test.
+  llvm_unreachable("PHI node not yet supported");
+}
+
+Value *ThreeElementVectorLoweringPass::visitSelectInst(SelectInst &I) {
+  auto *EquivalentCondition = visitOrSelf(I.getCondition());
+  auto *EquivalentTrueValue = visitOrSelf(I.getTrueValue());
+  auto *EquivalentFalseValue = visitOrSelf(I.getFalseValue());
+
+  assert(((EquivalentCondition != I.getCondition()) ||
+          (EquivalentTrueValue != I.getTrueValue()) ||
+          (EquivalentFalseValue != I.getFalseValue())) &&
+         "nothing to lower");
+
+  IRBuilder<> B(&I);
+  Value *V = B.CreateSelect(EquivalentCondition, EquivalentTrueValue,
+                            EquivalentFalseValue);
+
+  if (isa<Instruction>(V))
+    cast<Instruction>(V)->copyIRFlags(&I);
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *
+ThreeElementVectorLoweringPass::visitShuffleVectorInst(ShuffleVectorInst &I) {
+  assert(isa<FixedVectorType>(I.getType()) &&
+         "shufflevector on scalable vectors is not supported.");
+
+  auto *EquivalentLHS = visitOrSelf(I.getOperand(0));
+  auto *EquivalentRHS = visitOrSelf(I.getOperand(1));
+  auto *EquivalentType = getEquivalentTypeOrSelf(I.getType());
+
+  assert(((EquivalentLHS != I.getOperand(0)) ||
+          (EquivalentRHS != I.getOperand(1)) ||
+          (EquivalentType != I.getType())) &&
+         "nothing to lower");
+
+  IRBuilder<> B(&I);
+
+  // Extract the scalar at the given index using the appropriate method.
+  auto getScalar = [&B](Value *Vector, unsigned Index) {
+    if (Vector->getType()->isVectorTy()) {
+      return B.CreateExtractElement(Vector, Index);
+    } else {
+      assert(Vector->getType()->isStructTy());
+      return B.CreateExtractValue(Vector, Index);
+    }
+  };
+
+  auto setScalar = [&B](Value *Vector, Value *Scalar, unsigned Index) {
+    if (Vector->getType()->isVectorTy()) {
+      return B.CreateInsertElement(Vector, Scalar, Index);
+    } else {
+      assert(Vector->getType()->isStructTy());
+      return B.CreateInsertValue(Vector, Scalar, Index);
+    }
+  };
+
+  unsigned Arity = I.getShuffleMask().size();
+  auto *ScalarTy = I.getType()->getElementType();
+
+  auto *LHSTy = cast<VectorType>(I.getOperand(0)->getType());
+  assert(!LHSTy->getElementCount().isScalable() && "broken assumption");
+  unsigned LHSArity = LHSTy->getElementCount().getFixedValue();
+
+  // Construct the equivalent shuffled vector, as a struct or a vector.
+  Value *V = UndefValue::get(EquivalentType);
+  for (unsigned i = 0; i < Arity; ++i) {
+    int Mask = I.getMaskValue(i);
+    assert(-1 <= Mask && "Unexpected mask value.");
+
+    Value *Scalar = nullptr;
+    if (Mask == -1) {
+      Scalar = UndefValue::get(ScalarTy);
+    } else if (static_cast<unsigned>(Mask) < LHSArity) {
+      Scalar = getScalar(EquivalentLHS, Mask);
+    } else {
+      Scalar = getScalar(EquivalentRHS, Mask - LHSArity);
+    }
+
+    V = setScalar(V, Scalar, i);
+  }
+
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitStoreInst(StoreInst &I) {
+  Value *EquivalentValue = visit(I.getValueOperand());
+  assert(EquivalentValue && "value not lowered");
+  Value *EquivalentPointer = visit(I.getPointerOperand());
+  assert(EquivalentPointer && "pointer not lowered");
+
+  IRBuilder<> B(&I);
+  auto *V = B.CreateAlignedStore(EquivalentValue, EquivalentPointer,
+                                 I.getAlign(), I.isVolatile());
+  registerReplacement(I, *V);
+  return V;
+}
+
+Value *ThreeElementVectorLoweringPass::visitUnaryOperator(UnaryOperator &I) {
+  return visitNAryOperator(I);
+}
+
+bool ThreeElementVectorLoweringPass::handlingRequired(User &U) {
+  if (getEquivalentType(U.getType()) != nullptr) {
+    return true;
+  }
+
+  for (auto &Operand : U.operands()) {
+    auto *OperandTy = Operand.get()->getType();
+    if (getEquivalentType(OperandTy) != nullptr) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void ThreeElementVectorLoweringPass::registerReplacement(Value &U, Value &V) {
+  LLVM_DEBUG(dbgs() << "Replacement for " << U << ": " << V << '\n');
+  assert(ValueMap.count(&U) == 0 && "Value already registered");
+  ValueMap.insert({&U, &V});
+
+  if (U.getType() == V.getType()) {
+    LLVM_DEBUG(dbgs() << "\tAnd replace its usages.\n");
+    U.replaceAllUsesWith(&V);
+  }
+
+  if (U.hasName()) {
+    V.takeName(&U);
+  }
+
+  auto *I = dyn_cast<Instruction>(&U);
+  auto *J = dyn_cast<Instruction>(&V);
+  if (I && J) {
+    J->copyMetadata(*I);
+  }
+}
+
+Type *ThreeElementVectorLoweringPass::getEquivalentType(Type *Ty) {
+  auto it = TypeMap.find(Ty);
+  if (it != TypeMap.end()) {
+    return it->second;
+  }
+
+  // Recursive implementation, taking advantage of the cache.
+  auto *EquivalentTy = getEquivalentTypeImpl(Ty);
+  TypeMap.insert({Ty, EquivalentTy});
+
+  if (EquivalentTy) {
+    LLVM_DEBUG(dbgs() << "Generating equivalent type for " << *Ty << ": "
+                      << *EquivalentTy << '\n');
+  }
+
+  return EquivalentTy;
+}
+
+Type *ThreeElementVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
+  if (Ty->isIntegerTy() || Ty->isFloatingPointTy() || Ty->isVoidTy() ||
+      Ty->isLabelTy() || Ty->isMetadataTy()) {
+    // No lowering required.
+    return nullptr;
+  }
+
+  if (auto *VectorTy = dyn_cast<VectorType>(Ty)) {
+    unsigned Arity = VectorTy->getElementCount().getKnownMinValue();
+    bool RequireLowering = (Arity == 3);
+
+    if (RequireLowering) {
+      assert(!VectorTy->getElementCount().isScalable() &&
+             "Unsupported scalable vector");
+
+      // This assumes that the element type of the vector is a primitive scalar.
+      // That is, no vectors of pointers for example.
+      Type *ScalarTy = VectorTy->getElementType();
+      assert((ScalarTy->isFloatingPointTy() || ScalarTy->isIntegerTy()) &&
+             "Unsupported scalar type");
+
+      return VectorType::get(ScalarTy, 4, false);
+    }
+
+    return nullptr;
+  }
+
+  if (auto *PointerTy = dyn_cast<PointerType>(Ty)) {
+    if (auto *ElementTy = getEquivalentType(PointerTy->getElementType())) {
+      return ElementTy->getPointerTo(PointerTy->getAddressSpace());
+    }
+
+    return nullptr;
+  }
+
+  if (auto *ArrayTy = dyn_cast<ArrayType>(Ty)) {
+    if (auto *ElementTy = getEquivalentType(ArrayTy->getElementType())) {
+      return ArrayType::get(ElementTy, ArrayTy->getNumElements());
+    }
+
+    return nullptr;
+  }
+
+  if (auto *StructTy = dyn_cast<StructType>(Ty)) {
+    unsigned Arity = StructTy->getStructNumElements();
+    if (Arity == 0)
+      return nullptr;
+    LLVMContext &Ctx = StructTy->getContainedType(0)->getContext();
+    SmallVector<Type *, 16> Types;
+    bool RequiredLowering = false;
+    for (unsigned i = 0; i < Arity; ++i) {
+      Type *CTy = StructTy->getContainedType(i);
+      auto *EquivalentTy = getEquivalentType(CTy);
+      if (EquivalentTy != nullptr) {
+        Types.push_back(EquivalentTy);
+        RequiredLowering = true;
+      } else {
+        Types.push_back(CTy);
+      }
+    }
+
+    if (RequiredLowering) {
+      return StructType::get(Ctx, Types, StructTy->isPacked());
+    } else {
+      return nullptr;
+    }
+  }
+
+  if (auto *FunctionTy = dyn_cast<FunctionType>(Ty)) {
+    assert(!FunctionTy->isVarArg() && "VarArgs not supported");
+
+    bool RequireLowering = false;
+
+    // Convert parameter types.
+    SmallVector<Type *, 16> EquivalentParamTys;
+    EquivalentParamTys.reserve(FunctionTy->getNumParams());
+    for (auto *ParamTy : FunctionTy->params()) {
+      auto *EquivalentParamTy = getEquivalentTypeOrSelf(ParamTy);
+      EquivalentParamTys.push_back(EquivalentParamTy);
+      RequireLowering |= (EquivalentParamTy != ParamTy);
+    }
+
+    // Convert return type.
+    auto *ReturnTy = FunctionTy->getReturnType();
+    auto *EquivalentReturnTy = getEquivalentTypeOrSelf(ReturnTy);
+    RequireLowering |= (EquivalentReturnTy != ReturnTy);
+
+    if (RequireLowering) {
+      return FunctionType::get(EquivalentReturnTy, EquivalentParamTys,
+                               FunctionTy->isVarArg());
+    } else {
+      return nullptr;
+    }
+  }
+
+#ifndef NDEBUG
+  dbgs() << "Unsupported type: " << *Ty << '\n';
+#endif
+  llvm_unreachable("Unsupported kind of Type.");
+}
+
+bool ThreeElementVectorLoweringPass::runOnGlobals(Module &M) {
+  assert(GlobalVariableMap.empty());
+
+  // Iterate over the globals, generate equivalent ones when needed. Insert the
+  // new globals before the existing one in the module's list to avoid visiting
+  // it again.
+  for (auto &GV : M.globals()) {
+    if (isSpirvGlobalVariable(GV.getName())) {
+      continue;
+    }
+    if (auto *EquivalentTy = getEquivalentType(GV.getValueType())) {
+      Constant *EquivalentInitializer = nullptr;
+      if (GV.hasInitializer()) {
+        auto *Initializer = GV.getInitializer();
+        EquivalentInitializer = cast<Constant>(visitConstant(*Initializer));
+      }
+
+      auto *EquivalentGV = new GlobalVariable(
+          M, EquivalentTy, GV.isConstant(), GV.getLinkage(),
+          EquivalentInitializer, "",
+          /* insert before: */ &GV, GV.getThreadLocalMode(),
+          GV.getAddressSpace(), GV.isExternallyInitialized());
+      EquivalentGV->takeName(&GV);
+      EquivalentGV->setAlignment(GV.getAlign());
+      EquivalentGV->copyMetadata(&GV, /* offset: */ 0);
+      EquivalentGV->copyAttributesFrom(&GV);
+
+      LLVM_DEBUG(dbgs() << "Mapping global variable:\n\toriginal: " << GV
+                        << "\n\toriginal type: " << *(GV.getValueType())
+                        << "\n\treplacement: " << *EquivalentGV
+                        << "\n\treplacement type: " << *EquivalentTy << "\n");
+
+      GlobalVariableMap.insert({&GV, EquivalentGV});
+    }
+  }
+
+  bool Modified = !GlobalVariableMap.empty();
+  return Modified;
+}
+
+bool ThreeElementVectorLoweringPass::runOnFunction(Function &F) {
+  LLVM_DEBUG(dbgs() << "Processing " << F.getName() << '\n');
+
+  // Skip declarations.
+  if (F.isDeclaration()) {
+    return false;
+  }
+
+  // Lower the function parameters and return type if needed.
+  // It is possible the function was already partially processed when visiting a
+  // call site. If this is the case, a wrapper function has been created for it.
+  // However, its instructions haven't been visited yet.
+  Function *FunctionToVisit = convertUserDefinedFunction(F);
+  if (FunctionToVisit == nullptr) {
+    // The parameters don't rely on long vectors, but maybe some instructions in
+    // the function body do.
+    FunctionToVisit = &F;
+  }
+
+  bool Modified = (FunctionToVisit != &F);
+  for (Instruction &I : instructions(FunctionToVisit)) {
+    // Use the Value overload of visit to ensure cache is used.
+    Modified |= (visit(static_cast<Value *>(&I)) != nullptr);
+  }
+
+  cleanDeadInstructions();
+
+  LLVM_DEBUG(dbgs() << "Final version for " << F.getName() << '\n');
+  LLVM_DEBUG(dbgs() << *FunctionToVisit << '\n');
+
+  return Modified;
+}
+
+Value *ThreeElementVectorLoweringPass::convertBuiltinCall(
+    CallInst &VectorCall, Type *EquivalentReturnTy,
+    ArrayRef<Value *> EquivalentArgs) {
+  Function *VectorFunction = VectorCall.getCalledFunction();
+  assert(VectorFunction);
+
+  IRBuilder<> B(&VectorCall);
+
+  SmallVector<Value *, 16> Args;
+  for (Value *Arg : EquivalentArgs) {
+    if (Arg->getType()->isVectorTy()) {
+      Value *NewArg = UndefValue::get(
+          VectorType::get(Arg->getType()->getScalarType(), 3, false));
+      Value *tmp = B.CreateExtractElement(Arg, (uint64_t)0);
+      NewArg = B.CreateInsertElement(NewArg, tmp, (uint64_t)0);
+      tmp = B.CreateExtractElement(Arg, (uint64_t)1);
+      NewArg = B.CreateInsertElement(NewArg, tmp, (uint64_t)1);
+      tmp = B.CreateExtractElement(Arg, (uint64_t)2);
+      NewArg = B.CreateInsertElement(NewArg, tmp, (uint64_t)2);
+      Args.push_back(NewArg);
+    } else {
+      Args.push_back(Arg);
+    }
+  }
+
+  CallInst *NewVectorCall = B.CreateCall(VectorFunction, Args);
+  NewVectorCall->copyIRFlags(&VectorCall);
+  NewVectorCall->copyMetadata(VectorCall);
+  NewVectorCall->setCallingConv(VectorCall.getCallingConv());
+
+  Type *RetTy = VectorFunction->getReturnType();
+
+  if (RetTy->isVectorTy()) {
+    Value *NewRet = UndefValue::get(RetTy);
+    Value *tmp = B.CreateExtractElement(NewVectorCall, (uint64_t)0);
+    NewRet = B.CreateInsertElement(NewRet, tmp, (uint64_t)0);
+    tmp = B.CreateExtractElement(NewVectorCall, (uint64_t)1);
+    NewRet = B.CreateInsertElement(NewRet, tmp, (uint64_t)1);
+    tmp = B.CreateExtractElement(NewVectorCall, (uint64_t)2);
+    NewRet = B.CreateInsertElement(NewRet, tmp, (uint64_t)2);
+
+    return NewRet;
+  }
+
+  return dyn_cast<Value>(NewVectorCall);
+}
+
+Value *ThreeElementVectorLoweringPass::convertSIMDBuiltinCall(
+    CallInst &VectorCall, Type *EquivalentReturnTy,
+    ArrayRef<Value *> EquivalentArgs) {
+  Function *InitialFunction = VectorCall.getCalledFunction();
+
+  std::string FunctionName =
+      getVec4Name(clspv::Builtins::Lookup(InitialFunction));
+
+  auto *M = InitialFunction->getParent();
+
+  SmallVector<Type *, 4> ParamTys;
+  for (Value *Arg : EquivalentArgs) {
+    ParamTys.push_back(Arg->getType());
+  }
+
+  Function *Fct =
+      Function::Create(FunctionType::get(EquivalentReturnTy, ParamTys, false),
+                       InitialFunction->getLinkage(), FunctionName);
+
+  Fct->setCallingConv(InitialFunction->getCallingConv());
+  Fct->copyAttributesFrom(InitialFunction);
+
+  M->getFunctionList().push_front(Fct);
+
+  IRBuilder<> B(&VectorCall);
+
+  CallInst *Call = B.CreateCall(Fct, EquivalentArgs);
+  Call->copyIRFlags(&VectorCall);
+  Call->copyMetadata(VectorCall);
+  Call->setCallingConv(VectorCall.getCallingConv());
+
+  return Call;
+}
+
+Value *ThreeElementVectorLoweringPass::convertSpirvOpBuiltinCall(
+    CallInst &VectorCall, Type *EquivalentReturnTy,
+    ArrayRef<Value *> EquivalentArgs) {
+  if (auto *SpirvIdValue = dyn_cast<ConstantInt>(VectorCall.getOperand(0))) {
+    switch (SpirvIdValue->getZExtValue()) {
+    case 63: // OpCopyMemory
+      return convertOpCopyMemoryOperation(VectorCall, EquivalentArgs);
+    case 151: // OpUMulExtended
+    case 152: // OpSMulExtended
+    case 156: // OpIsNan
+    case 157: // OpIsInf
+      return convertSIMDBuiltinCall(VectorCall, EquivalentReturnTy,
+                                    EquivalentArgs);
+    }
+  }
+  return convertBuiltinCall(VectorCall, EquivalentReturnTy, EquivalentArgs);
+}
+
+Function *
+ThreeElementVectorLoweringPass::convertUserDefinedFunction(Function &F) {
+  auto it = FunctionMap.find(&F);
+  if (it != FunctionMap.end()) {
+    return it->second;
+  }
+
+  LLVM_DEBUG(dbgs() << "Handling of user defined function:\n");
+  LLVM_DEBUG(dbgs() << F << '\n');
+
+  auto *FunctionTy = F.getFunctionType();
+  auto *EquivalentFunctionTy =
+      cast_or_null<FunctionType>(getEquivalentType(FunctionTy));
+
+  // If no work is needed, mark it as so for future reference and bail out.
+  if (EquivalentFunctionTy == nullptr) {
+    LLVM_DEBUG(dbgs() << "No need of wrapper function\n");
+    FunctionMap.insert({&F, nullptr});
+    return nullptr;
+  }
+
+  Function *EquivalentFunction =
+      createFunctionWithMappedTypes(F, EquivalentFunctionTy);
+
+  LLVM_DEBUG(dbgs() << "Wrapper function:\n" << *EquivalentFunction << "\n");
+
+  // The body of the new function is intentionally not visited right now because
+  // we could be currently visiting a call instruction. Instead, it is being
+  // visited in runOnFunction. This is to ensure the state of the lowering pass
+  // remains valid.
+  FunctionMap.insert({&F, EquivalentFunction});
+  return EquivalentFunction;
+}
+
+CallInst *ThreeElementVectorLoweringPass::convertUserDefinedFunctionCall(
+    CallInst &Call, ArrayRef<Value *> EquivalentArgs) {
+  Function *Callee = Call.getCalledFunction();
+  assert(Callee);
+
+  Function *EquivalentFunction = convertUserDefinedFunction(*Callee);
+  assert(EquivalentFunction);
+
+  IRBuilder<> B(&Call);
+  CallInst *NewCall = B.CreateCall(EquivalentFunction, EquivalentArgs);
+
+  NewCall->copyIRFlags(&Call);
+  NewCall->copyMetadata(Call);
+  NewCall->setCallingConv(Call.getCallingConv());
+
+  return NewCall;
+}
+
+void ThreeElementVectorLoweringPass::cleanDeadInstructions() {
+  // Collect all instructions that have been replaced by another one, and remove
+  // them from the function. To address dependencies, use a fixed-point
+  // algorithm:
+  //  1. Collect the instructions that have been replaced.
+  //  2. Collect among these instructions the ones which have no uses and remove
+  //     them.
+  //  3. Repeat step 2 until no progress is made.
+
+  // Select instructions that were replaced by another one.
+  // Ignore constants as they are not owned by the module and therefore don't
+  // need to be removed.
+  using WeakInstructions = SmallVector<WeakTrackingVH, 32>;
+  WeakInstructions OldInstructions;
+  for (const auto &Mapping : ValueMap) {
+    if (Mapping.getSecond() != nullptr) {
+      if (auto *OldInstruction = dyn_cast<Instruction>(Mapping.getFirst())) {
+        OldInstructions.push_back(OldInstruction);
+      } else {
+        assert(isa<Constant>(Mapping.getFirst()) &&
+               "Only Instruction and Constant are expected in ValueMap");
+      }
+    }
+  }
+
+  // Erase any mapping, as they won't be valid anymore.
+  ValueMap.clear();
+
+  for (bool Progress = true; Progress;) {
+    std::size_t PreviousSize = OldInstructions.size();
+
+    // Identify instructions that are actually dead and can be removed using
+    // RecursivelyDeleteTriviallyDeadInstructions.
+    // Use a third buffer to capture the instructions that are still alive to
+    // avoid mutating OldInstructions while iterating over it.
+    WeakInstructions NextBatch;
+    WeakInstructions TriviallyDeads;
+    partitionInstructions(
+        OldInstructions,
+        [&TriviallyDeads](Instruction *DeadInstruction) {
+          // Additionally, manually remove from the parent instructions with
+          // possible side-effect, generally speaking, such as call or alloca
+          // instructions. Those are not trivially dead.
+          if (isInstructionTriviallyDead(DeadInstruction)) {
+            TriviallyDeads.push_back(DeadInstruction);
+          } else {
+            DeadInstruction->eraseFromParent();
+          }
+        },
+        [&NextBatch](Instruction *AliveInstruction) {
+          NextBatch.push_back(AliveInstruction);
+        });
+
+    RecursivelyDeleteTriviallyDeadInstructions(TriviallyDeads);
+
+    // Update OldInstructions for the next iteration of the fixed-point.
+    OldInstructions = std::move(NextBatch);
+    Progress = (OldInstructions.size() < PreviousSize);
+  }
+
+#ifndef NDEBUG
+  if (!OldInstructions.empty()) {
+    dbgs() << "These values were expected to be removed:\n";
+    for (auto ValueHandle : OldInstructions) {
+      dbgs() << '\t' << *ValueHandle << '\n';
+    }
+    llvm_unreachable("Not all supposedly-dead instruction were removed!");
+  }
+#endif
+}
+
+void ThreeElementVectorLoweringPass::cleanDeadFunctions() {
+  // Take into account dependencies between functions when removing them.
+  // First collect all dead functions.
+  using Functions = SmallVector<Function *, 32>;
+  Functions DeadFunctions;
+  for (const auto &Mapping : FunctionMap) {
+    if (Mapping.getSecond() != nullptr) {
+      Function *F = Mapping.getFirst();
+      DeadFunctions.push_back(F);
+    }
+  }
+
+  // Erase any mapping, as they won't be valid anymore.
+  FunctionMap.clear();
+
+  for (bool Progress = true; Progress;) {
+    std::size_t PreviousSize = DeadFunctions.size();
+
+    Functions NextBatch;
+    for (auto *F : DeadFunctions) {
+      bool Dead = F->use_empty();
+      if (Dead) {
+        LLVM_DEBUG(dbgs() << "Removing " << F->getName()
+                          << " from the module.\n");
+        F->eraseFromParent();
+        Progress = true;
+      } else {
+        NextBatch.push_back(F);
+      }
+    }
+
+    DeadFunctions = std::move(NextBatch);
+    Progress = (DeadFunctions.size() < PreviousSize);
+  }
+
+  assert(DeadFunctions.empty() &&
+         "Not all supposedly-dead functions were removed!");
+}
+
+void ThreeElementVectorLoweringPass::cleanDeadGlobals() {
+  for (auto const &Mapping : GlobalVariableMap) {
+    auto *GV = Mapping.first;
+    GV->eraseFromParent();
+  }
+}
+
+} // namespace
+
+INITIALIZE_PASS(ThreeElementVectorLoweringPass, "ThreeElementVectorLowering",
+                "Three Element Vector Lowering Pass", false, false)
+
+llvm::ModulePass *clspv::createThreeElementVectorLoweringPass() {
+  return new ThreeElementVectorLoweringPass();
+}

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -262,8 +262,9 @@ Value *convertEquivalentValue(IRBuilder<> &B, Value *V, Type *EquivalentTy) {
     assert(Ty->isVectorTy());
 
     unsigned OldArity = dyn_cast<FixedVectorType>(Ty)->getNumElements();
-    unsigned NewArity = dyn_cast<FixedVectorType>(EquivalentTy)->getNumElements();
-    SmallVector<int , 4> Idxs;
+    unsigned NewArity =
+        dyn_cast<FixedVectorType>(EquivalentTy)->getNumElements();
+    SmallVector<int, 4> Idxs;
     for (unsigned i = 0; i < NewArity; i++) {
       if (i < OldArity) {
         Idxs.push_back(i);

--- a/test/CommonBuiltins/clamp/float3_clamp_novec3.cl
+++ b/test/CommonBuiltins/clamp/float3_clamp_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[COMPOSITE_FLOAT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NClamp %[[LOADB_ID]] %[[COMPOSITE_FLOAT_0_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = clamp(*b, 0.0f, 1.0f);
+}

--- a/test/CommonBuiltins/clamp/half3_clamp_novec3.cl
+++ b/test/CommonBuiltins/clamp/half3_clamp_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld2:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK: OpExtInst [[half4]] [[EXT]] NClamp [[ld0]] [[ld1]] [[ld2]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = clamp(in[0], in[1], in[2]);
+}
+
+

--- a/test/CommonBuiltins/float3_degrees_novec3.cl
+++ b/test/CommonBuiltins/float3_degrees_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] Degrees %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = degrees(*b);
+}

--- a/test/CommonBuiltins/float3_radians_novec3.cl
+++ b/test/CommonBuiltins/float3_radians_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] Radians %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = radians(*b);
+}

--- a/test/CommonBuiltins/float3_sign_novec3.cl
+++ b/test/CommonBuiltins/float3_sign_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] FSign %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = sign(*b);
+}

--- a/test/CommonBuiltins/max/float3_max_novec3.cl
+++ b/test/CommonBuiltins/max/float3_max_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = max(*b, 1.0f);
+}

--- a/test/CommonBuiltins/max/half3_fmax_novec3.cl
+++ b/test/CommonBuiltins/max/half3_fmax_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK: OpExtInst [[half4]] [[EXT]] NMax [[ld0]] [[ld1]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = fmax(in[0], in[1]);
+}
+

--- a/test/CommonBuiltins/max/half3_max_novec3.cl
+++ b/test/CommonBuiltins/max/half3_max_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK: OpExtInst [[half4]] [[EXT]] FMax [[ld0]] [[ld1]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = max(in[0], in[1]);
+}
+

--- a/test/CommonBuiltins/min/float3_min_novec3.cl
+++ b/test/CommonBuiltins/min/float3_min_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = min(*b, 1.0f);
+}

--- a/test/CommonBuiltins/min/half3_fmin_novec3.cl
+++ b/test/CommonBuiltins/min/half3_fmin_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK: OpExtInst [[half4]] [[EXT]] NMin [[ld0]] [[ld1]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = fmin(in[0], in[1]);
+}
+

--- a/test/CommonBuiltins/min/half3_min_novec3.cl
+++ b/test/CommonBuiltins/min/half3_min_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK: OpExtInst [[half4]] [[EXT]] FMin [[ld0]] [[ld1]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = min(in[0], in[1]);
+}
+

--- a/test/CommonBuiltins/mix/float3_mix_novec3.cl
+++ b/test/CommonBuiltins/mix/float3_mix_novec3.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_FLOAT_0_5_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0.5
+// CHECK-DAG: %[[COMPOSITE_FLOAT_0_5_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR3_TYPE_ID]] %[[CONSTANT_FLOAT_0_5_ID]] %[[CONSTANT_FLOAT_0_5_ID]] %[[CONSTANT_FLOAT_0_5_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] FMix %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]] %[[COMPOSITE_FLOAT_0_5_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = mix(*a, *b, 0.5f);
+}

--- a/test/CommonBuiltins/mix/half3_mix_novec3.cl
+++ b/test/CommonBuiltins/mix/half3_mix_novec3.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+// CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4
+// CHECK-DAG: [[half3:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 3
+// CHECK-DAG: [[undefh4:%[a-zA-Z0-9_]+]] = OpUndef [[half4]]
+// CHECK-DAG: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld2:%[a-zA-Z0-9_]+]] = OpLoad [[half4]]
+// CHECK-DAG: [[ld0_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[half3]] [[ld0]] [[undefh4]] 0 1 2
+// CHECK-DAG: [[ld1_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[half3]] [[ld1]] [[undefh4]] 0 1 2
+// CHECK-DAG: [[ld2_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[half3]] [[ld2]] [[undefh4]] 0 1 2
+// CHECK: OpExtInst [[half3]] [[EXT]] FMix [[ld0_shuffle]] [[ld1_shuffle]] [[ld2_shuffle]]
+
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half3* in, global half3* out) {
+  *out = mix(in[0], in[1], in[2]);
+}
+

--- a/test/CommonBuiltins/smoothstep/smoothstep_float3_novec3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float3_novec3.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[SHUFFLEC_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADC_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]] %[[SHUFFLEC_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3* c, global float3*o)
+{
+  *o = smoothstep(*a, *b, *c);
+}

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
@@ -12,10 +12,10 @@
 // CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
 // CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
-// CHECK: %[[INSERTA_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR3]] 0
-// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTA_ID]] %[[UNDEF_VECTOR3]] 0 0 0
-// CHECK: %[[INSERTB_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR3]] 0
-// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTB_ID]] %[[UNDEF_VECTOR3]] 0 0 0
+// CHECK: %[[INSERTA_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR4_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR4]] 0
+// CHECK: %[[INSERTB_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR4_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTA_ID]] %[[UNDEF_VECTOR4]] 0 0 0
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTB_ID]] %[[UNDEF_VECTOR4]] 0 0 0
 // CHECK: %[[SHUFFLEC_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADC_ID]] %[[UNDEF_VECTOR4]] 0 1 2
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]] %[[SHUFFLEC_ID]]
 // CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
@@ -1,0 +1,28 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[INSERTA_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR3]] 0
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTA_ID]] %[[UNDEF_VECTOR3]] 0 0 0
+// CHECK: %[[INSERTB_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR3]] 0
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[INSERTB_ID]] %[[UNDEF_VECTOR3]] 0 0 0
+// CHECK: %[[SHUFFLEC_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADC_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] SmoothStep %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]] %[[SHUFFLEC_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b, global float3* c)
+{
+    *c = smoothstep(*a, *b, *c);
+}
+

--- a/test/CommonBuiltins/step/float3_step.cl
+++ b/test/CommonBuiltins/step/float3_step.cl
@@ -8,8 +8,14 @@ kernel void foo(global float3 *A, float3 edge, float3 x) {
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Step [[_28]] [[_30]]
-// CHECK: OpStore {{.*}} [[_31]]
+// CHECK-DAG: [[undefv4:%[a-zA-Z0-9_]+]] = OpUndef [[_v4float]]
+// CHECK-DAG: [[undefv3:%[a-zA-Z0-9_]+]] = OpUndef [[_v3float]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_28_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[_v3float]] [[_28]] [[undefv4]] 0 1 2
+// CHECK: [[_30_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[_v3float]] [[_30]] [[undefv4]] 0 1 2
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Step [[_28_shuffle]] [[_30_shuffle]]
+// CHECK: [[_31_shuffle:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[_v4float]] [[_31]] [[undefv3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} [[_31_shuffle]]

--- a/test/CommonBuiltins/step/step_float3_novec3.cl
+++ b/test/CommonBuiltins/step/step_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR4_TYPE_ID]]
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR3_TYPE_ID]] %[[EXT_INST]] Step %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3*o)
+{
+  *o = step(*a, *b);
+}

--- a/test/CommonBuiltins/step/step_float_float3_novec3.cl
+++ b/test/CommonBuiltins/step/step_float_float3_novec3.cl
@@ -1,0 +1,25 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[v3float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 3
+// CHECK-DAG: %[[undefv4:[0-9]+]] = OpUndef %[[v4float]]
+// CHECK-DAG: %[[undefv3:[0-9]+]] = OpUndef %[[v3float]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[float]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpCompositeInsert %[[v3float]] %[[__original_id_23]] %[[undefv3]] 0
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpVectorShuffle %[[v3float]] %[[__original_id_25]] %[[undefv3]] 0 0 0
+// CHECK:     %[[__original_id_24_shuffle:[0-9]+]] = OpVectorShuffle %[[v3float]] %[[__original_id_24]] %[[undefv4]] 0 1 2
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpExtInst %[[v3float]] %[[__original_id_1]] Step %[[__original_id_26]] %[[__original_id_24_shuffle]]
+// CHECK:     %[[__original_id_27_shuffle:[0-9]+]] = OpVectorShuffle %[[v4float]] %[[__original_id_27]] %[[undefv3]] 0 1 2 4294967295
+// CHECK:     OpStore {{.*}} %[[__original_id_27_shuffle]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+    *b = step(*a, *b);
+}
+

--- a/test/CommonBuiltins/step/step_float_float3_novec3.cl
+++ b/test/CommonBuiltins/step/step_float_float3_novec3.cl
@@ -11,8 +11,8 @@
 // CHECK-DAG: %[[undefv3:[0-9]+]] = OpUndef %[[v3float]]
 // CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[float]]
 // CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4float]]
-// CHECK:     %[[__original_id_25:[0-9]+]] = OpCompositeInsert %[[v3float]] %[[__original_id_23]] %[[undefv3]] 0
-// CHECK:     %[[__original_id_26:[0-9]+]] = OpVectorShuffle %[[v3float]] %[[__original_id_25]] %[[undefv3]] 0 0 0
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpCompositeInsert %[[v4float]] %[[__original_id_23]] %[[undefv4]] 0
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpVectorShuffle %[[v3float]] %[[__original_id_25]] %[[undefv4]] 0 0 0
 // CHECK:     %[[__original_id_24_shuffle:[0-9]+]] = OpVectorShuffle %[[v3float]] %[[__original_id_24]] %[[undefv4]] 0 1 2
 // CHECK:     %[[__original_id_27:[0-9]+]] = OpExtInst %[[v3float]] %[[__original_id_1]] Step %[[__original_id_26]] %[[__original_id_24_shuffle]]
 // CHECK:     %[[__original_id_27_shuffle:[0-9]+]] = OpVectorShuffle %[[v4float]] %[[__original_id_27]] %[[undefv3]] 0 1 2 4294967295

--- a/test/GeometricBuiltins/float3_cross_novec3.cl
+++ b/test/GeometricBuiltins/float3_cross_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT3_TYPE_ID]] %[[EXT_INST]] Cross %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_FLOAT3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = cross(*a, *b);
+}

--- a/test/GeometricBuiltins/float3_distance_novec3.cl
+++ b/test/GeometricBuiltins/float3_distance_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB1_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[SHUFFLEB1_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB1_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Distance %[[SHUFFLEB0_ID]] %[[SHUFFLEB1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+  *a = distance(b[0], b[1]);
+}

--- a/test/GeometricBuiltins/float3_dot_novec3.cl
+++ b/test/GeometricBuiltins/float3_dot_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB1_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[SHUFFLEB1_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB1_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpDot %[[FLOAT_TYPE_ID]] %[[SHUFFLEB0_ID]] %[[SHUFFLEB1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+  *a = dot(b[0], b[1]);
+}

--- a/test/GeometricBuiltins/float3_fast_distance_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_distance_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB1_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[SHUFFLEB1_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB1_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Distance %[[SHUFFLEB0_ID]] %[[SHUFFLEB1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+  *a = fast_distance(b[0], b[1]);
+}

--- a/test/GeometricBuiltins/float3_fast_length_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_length_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Length %[[SHUFFLEB0_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+  *a = fast_length(b[0]);
+}

--- a/test/GeometricBuiltins/float3_fast_normalize_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_normalize_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT3_TYPE_ID]] %[[EXT_INST]] Normalize %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_FLOAT3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fast_normalize(*b);
+}

--- a/test/GeometricBuiltins/float3_length_novec3.cl
+++ b/test/GeometricBuiltins/float3_length_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Length %[[SHUFFLEB0_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float3* b)
+{
+  *a = length(b[0]);
+}

--- a/test/GeometricBuiltins/float3_normalize_novec3.cl
+++ b/test/GeometricBuiltins/float3_normalize_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_FLOAT3:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_FLOAT4:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_FLOAT4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT3_TYPE_ID]] %[[EXT_INST]] Normalize %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT4_TYPE_ID]] %[[OP_ID]] %[[UNDEF_FLOAT3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SHUFFLEOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = normalize(*b);
+}

--- a/test/GeometricBuiltins/float4_cross_novec3.cl
+++ b/test/GeometricBuiltins/float4_cross_novec3.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+
+// CHECK: %[[FLOAT4_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[FLOAT3_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT3_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[SHUFFLEA_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADA_ID]] %[[FLOAT4_UNDEF_ID]] 0 1 2
+// CHECK: %[[SHUFFLEB_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT3_TYPE_ID]] %[[LOADB_ID]] %[[FLOAT4_UNDEF_ID]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT3_TYPE_ID]] %[[EXT_INST]] Cross %[[SHUFFLEA_ID]] %[[SHUFFLEB_ID]]
+// CHECK: %[[SHUFFLEOP_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT4_TYPE_ID]] %[[OP_ID]] %[[FLOAT3_UNDEF_ID]] 0 1 2 4294967295
+// CHECK: %[[INSERTOP_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT4_TYPE_ID]] %[[FLOAT_CONSTANT_0_ID]] %[[SHUFFLEOP_ID]] 3
+// CHECK: OpStore {{.*}} %[[INSERTOP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
+{
+  *a = cross(*a, *b);
+}

--- a/test/GeometricBuiltins/half3_dot_novec3.cl
+++ b/test/GeometricBuiltins/half3_dot_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-DAG: %[[HALF4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
+// CHECK-DAG: %[[HALF3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 3
+// CHECK-DAG: %[[UNDEF_HALF4:[a-zA-Z0-9_]*]] = OpUndef %[[HALF4_TYPE_ID]]
+// CHECK: %[[LOADB0_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF4_TYPE_ID]]
+// CHECK: %[[LOADB1_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF4_TYPE_ID]]
+// CHECK: %[[SHUFFLEB0_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[HALF3_TYPE_ID]] %[[LOADB0_ID]] %[[UNDEF_HALF4]] 0 1 2
+// CHECK: %[[SHUFFLEB1_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[HALF3_TYPE_ID]] %[[LOADB1_ID]] %[[UNDEF_HALF4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpDot %[[HALF_TYPE_ID]] %[[SHUFFLEB0_ID]] %[[SHUFFLEB1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* a, global half3* b)
+{
+  *a = dot(b[0], b[1]);
+}

--- a/test/Int8/char_struct_ssbo_novec3.cl
+++ b/test/Int8/char_struct_ssbo_novec3.cl
@@ -1,0 +1,36 @@
+// RUN: clspv %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct S {
+  char a;
+  char b;
+  char2 c;
+  char3 d;
+  char4 e;
+  char f[4];
+} S;
+
+kernel void foo(global S* data) { }
+
+// CHECK: OpCapability Int8
+// CHECK: OpMemberDecorate [[struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[struct]] 1 Offset 1
+// CHECK: OpMemberDecorate [[struct]] 2 Offset 2
+// CHECK: OpMemberDecorate [[struct]] 3 Offset 4
+// CHECK: OpMemberDecorate [[struct]] 4 Offset 8
+// CHECK: OpMemberDecorate [[struct]] 5 Offset 12
+// CHECK: OpDecorate [[rta:%[a-zA-Z0-9_]+]] ArrayStride 16
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet
+// CHECK: OpDecorate [[array:%[a-zA-Z0-9_]+]] ArrayStride 1
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char2:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 2
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[four:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 4
+// CHECK: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[four]]
+// CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]] [[char]] [[char2]] [[char4]] [[char4]] [[array]]
+// CHECK: [[rta:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[struct]]
+// CHECK: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[rta]]
+// CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+// CHECK: [[var]] = OpVariable [[ptr]] StorageBuffer

--- a/test/IntegerBuiltins/abs/abs_char3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_char3_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uchar3* a, global char3* b) {
+  *a = abs(*b);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[abs:%[a-zA-Z0-9_]+]] = OpExtInst [[char4]] {{.*}} SAbs [[ld]]
+// CHECK: OpStore {{.*}} [[abs]]

--- a/test/IntegerBuiltins/abs/abs_int3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_int3_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] SAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global int3* b)
+{
+  *a = abs(*b);
+}

--- a/test/IntegerBuiltins/abs/abs_long3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_long3_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpExtInst %[[v4ulong]] %[[__original_id_1]] SAbs %[[__original_id_18]]
+// CHECK:     OpStore {{.*}} %[[__original_id_19]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global long3* b)
+{
+    *a = abs(*b);
+}
+

--- a/test/IntegerBuiltins/abs/abs_short3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_short3_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpExtInst %[[v4ushort]] %[[__original_id_1]] SAbs %[[__original_id_18]]
+// CHECK:     OpStore {{.*}} %[[__original_id_19]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global short3* b)
+{
+    *a = abs(*b);
+}
+

--- a/test/IntegerBuiltins/abs/abs_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar3_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uchar3* a, global uchar3* b) {
+  *a = abs(*b);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: OpStore {{.*}} [[ld]]
+
+

--- a/test/IntegerBuiltins/abs/abs_uint3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_uint3_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: OpStore {{.*}} %[[LOADB_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = abs(*b);
+}

--- a/test/IntegerBuiltins/abs/abs_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong3_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     OpStore {{.*}} %[[__original_id_17]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b)
+{
+    *a = abs(*b);
+}
+

--- a/test/IntegerBuiltins/abs/abs_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort3_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     OpStore {{.*}} %[[__original_id_17]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b)
+{
+    *a = abs(*b);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_char3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_char3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4uchar]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4uchar]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4uchar]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar3* a, global char3* b, global char3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_int3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_int3_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpISub %[[v4uint]] %[[__original_id_20:[0-9]+]] %[[__original_id_21:[0-9]+]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4uint]] %[[__original_id_21]] %[[__original_id_20]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSGreaterThan %[[v4bool]] %[[__original_id_21]] %[[__original_id_20]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_23]] %[[__original_id_22]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global int3* b, global int3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_long3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_long3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4ulong]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4ulong]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global long3* b, global long3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_short3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_short3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4ushort]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4ushort]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global short3* b, global short3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_uchar3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4uchar]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4uchar]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpUGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4uchar]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar3* a, global uchar3* b, global uchar3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_uint3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_uint3_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpISub %[[v4uint]] %[[__original_id_20:[0-9]+]] %[[__original_id_21:[0-9]+]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4uint]] %[[__original_id_21]] %[[__original_id_20]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpUGreaterThan %[[v4bool]] %[[__original_id_21]] %[[__original_id_20]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_23]] %[[__original_id_22]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b, global uint3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_ulong3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4ulong]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4ulong]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpUGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global ulong3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/abs_diff/abs_diff_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_ushort3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpISub %[[v4ushort]] %[[__original_id_21:[0-9]+]] %[[__original_id_22:[0-9]+]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpISub %[[v4ushort]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpUGreaterThan %[[v4bool]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_24]] %[[__original_id_23]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global ushort3* c)
+{
+    *a = abs_diff(*b, *c);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_char3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char3_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK:     %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK:     OpExtInst %[[v4uchar]] %[[glsl_ext]] SClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global char3* out, global char3* in)
+{
+    *out = clamp(*in, (char3)7, (char3)42);
+}
+
+

--- a/test/IntegerBuiltins/clamp/clamp_int3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:     %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     OpExtInst %[[v4uint]] %[[glsl_ext]] SClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global int3* out, global int3* in)
+{
+    *out = clamp(*in, (int3)7, (int3)42);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_long3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK:     %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     OpExtInst %[[v4ulong]] %[[glsl_ext]] SClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global long3* out, global long3* in)
+{
+    *out = clamp(*in, (long3)7, (long3)42);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_short3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK:     %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK:     OpExtInst %[[v4ushort]] %[[glsl_ext]] SClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global short3* out, global short3* in)
+{
+    *out = clamp(*in, (short3)7, (short3)42);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar3_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK:     %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[uchar_7:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_7]] %[[uchar_7]] %[[uchar_7]]
+// CHECK-DAG: %[[uchar_42:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_42]] %[[uchar_42]] %[[uchar_42]]
+// CHECK:     OpExtInst %[[v4uchar]] %[[glsl_ext]] UClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global uchar3* out, global uchar3* in)
+{
+    *out = clamp(*in, (uchar3)7, (uchar3)42);
+}
+
+

--- a/test/IntegerBuiltins/clamp/clamp_uint3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK:     %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_7:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_7]] %[[uint_7]] %[[uint_7]]
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     OpExtInst %[[v4uint]] %[[glsl_ext]] UClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global uint3* out, global uint3* in)
+{
+    *out = clamp(*in, (uint3)7, (uint3)42);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK:     %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ulong_7:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_7]] %[[ulong_7]] %[[ulong_7]]
+// CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     OpExtInst %[[v4ulong]] %[[glsl_ext]] UClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global ulong3* out, global ulong3* in)
+{
+    *out = clamp(*in, (ulong3)7, (ulong3)42);
+}
+

--- a/test/IntegerBuiltins/clamp/clamp_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK:     %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ushort_7:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 7
+// CHECK-DAG: %[[lovec:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_7]] %[[ushort_7]] %[[ushort_7]]
+// CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
+// CHECK-DAG: %[[hivec:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK:     OpExtInst %[[v4ushort]] %[[glsl_ext]] UClamp {{.*}} %[[lovec]] %[[hivec]]
+
+kernel void test_clamp(global ushort3* out, global ushort3* in)
+{
+    *out = clamp(*in, (ushort3)7, (ushort3)42);
+}
+

--- a/test/IntegerBuiltins/clz/int3_clz_novec3.cl
+++ b/test/IntegerBuiltins/clz/int3_clz_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
+// CHECK-DAG: %[[UINT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_31_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 31
+// CHECK-DAG: [[vec31:%[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR3_TYPE_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR3_TYPE_ID]] %[[EXT_INST]] FindUMsb %[[LOADB_SHUFFLE]]
+// CHECK: %[[SUB_ID:[a-zA-Z0-9_]*]] = OpISub %[[UINT_VECTOR3_TYPE_ID]] [[vec31]] %[[OP_ID]]
+// CHECK: %[[SUB_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR4_TYPE_ID]] %[[SUB_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SUB_SHUFFLE]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = clz(*b);
+}

--- a/test/IntegerBuiltins/clz/uint3_clz_novec3.cl
+++ b/test/IntegerBuiltins/clz/uint3_clz_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
+// CHECK-DAG: %[[UINT_VECTOR4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[UNDEF_VECTOR3:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR3_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_VECTOR4:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_31_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 31
+// CHECK-DAG: [[vec31:%[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR3_TYPE_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR4_TYPE_ID]]
+// CHECK: %[[LOADB_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR3_TYPE_ID]] %[[LOADB_ID]] %[[UNDEF_VECTOR4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR3_TYPE_ID]] %[[EXT_INST]] FindUMsb %[[LOADB_SHUFFLE]]
+// CHECK: %[[SUB_ID:[a-zA-Z0-9_]*]] = OpISub %[[UINT_VECTOR3_TYPE_ID]] [[vec31]] %[[OP_ID]]
+// CHECK: %[[SUB_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR4_TYPE_ID]] %[[SUB_ID]] %[[UNDEF_VECTOR3]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[SUB_SHUFFLE]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = clz(*b);
+}

--- a/test/IntegerBuiltins/int3_mad24_novec3.cl
+++ b/test/IntegerBuiltins/int3_mad24_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK-DAG: %[[CONSTANT_3_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 3
+// CHECK-DAG: %[[COMPOSITE_3_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_3_ID]] %[[CONSTANT_3_ID]] %[[CONSTANT_3_ID]] %[[CONSTANT_3_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpIMul %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: %[[ADD_ID:[a-zA-Z0-9_]*]] = OpIAdd %[[UINT_VECTOR_TYPE_ID]] %[[MUL_ID]] %[[COMPOSITE_3_ID]]
+// CHECK: OpStore {{.*}} %[[ADD_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = mad24(*b, 42, 3);
+}

--- a/test/IntegerBuiltins/int3_max_var_novec3.cl
+++ b/test/IntegerBuiltins/int3_max_var_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[CONSTANT_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_TYPE_ID]]
+// CHECK: %[[COMPOSITE_INSERT_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[UINT_VECTOR_TYPE_ID]] %[[LOADC_ID]] %[[CONSTANT_UNDEF_ID]] 0
+// CHECK: %[[VECTOR_SHUFFLE_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR_TYPE_ID]] %[[COMPOSITE_INSERT_ID]] %[[CONSTANT_UNDEF_ID]] 0 0 0
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] SMax %[[LOADB_ID]] %[[VECTOR_SHUFFLE_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b, global int* c)
+{
+  *a = max(*b, *c);
+}

--- a/test/IntegerBuiltins/int3_min_var_novec3.cl
+++ b/test/IntegerBuiltins/int3_min_var_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[CONSTANT_UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_TYPE_ID]]
+// CHECK: %[[COMPOSITE_INSERT_ID:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[UINT_VECTOR_TYPE_ID]] %[[LOADC_ID]] %[[CONSTANT_UNDEF_ID]] 0
+// CHECK: %[[VECTOR_SHUFFLE_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[UINT_VECTOR_TYPE_ID]] %[[COMPOSITE_INSERT_ID]] %[[CONSTANT_UNDEF_ID]] 0 0 0
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] SMin %[[LOADB_ID]] %[[VECTOR_SHUFFLE_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b, global int* c)
+{
+  *a = min(*b, *c);
+}

--- a/test/IntegerBuiltins/int3_mul24_novec3.cl
+++ b/test/IntegerBuiltins/int3_mul24_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpIMul %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: OpStore {{.*}} %[[MUL_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = mul24(*b, 42);
+}

--- a/test/IntegerBuiltins/mad_hi/mad_hi_all_overloads_novec3.cl
+++ b/test/IntegerBuiltins/mad_hi/mad_hi_all_overloads_novec3.cl
@@ -1,0 +1,117 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v2uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 2
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v2ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 2
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[v2uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 2
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v2ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 2
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar_10:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 10
+// CHECK-DAG: %[[uchar_2:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 2
+// CHECK-DAG: %[[__original_id_54:[0-9]+]] = OpConstantComposite %[[v2uchar]] %[[uchar_10]] %[[uchar_10]]
+// CHECK-DAG: %[[__original_id_55:[0-9]+]] = OpConstantComposite %[[v2uchar]] %[[uchar_2]] %[[uchar_2]]
+// CHECK-DAG: %[[__original_id_58:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_10]] %[[uchar_10]] %[[uchar_10]] %[[uchar_10]]
+// CHECK-DAG: %[[__original_id_59:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_2]] %[[uchar_2]] %[[uchar_2]] %[[uchar_2]]
+// CHECK-DAG: %[[ushort_10:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 10
+// CHECK-DAG: %[[ushort_2:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 2
+// CHECK-DAG: %[[__original_id_62:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[ushort_10]] %[[ushort_10]]
+// CHECK-DAG: %[[__original_id_63:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[ushort_2]] %[[ushort_2]]
+// CHECK-DAG: %[[__original_id_66:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_10]] %[[ushort_10]] %[[ushort_10]] %[[ushort_10]]
+// CHECK-DAG: %[[__original_id_67:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_2]] %[[ushort_2]] %[[ushort_2]] %[[ushort_2]]
+// CHECK-DAG: %[[uint_10:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 10
+// CHECK-DAG: %[[uint_2:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 2
+// CHECK-DAG: %[[__original_id_70:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_10]] %[[uint_10]]
+// CHECK-DAG: %[[__original_id_71:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_2]] %[[uint_2]]
+// CHECK-DAG: %[[__original_id_74:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_10]] %[[uint_10]] %[[uint_10]] %[[uint_10]]
+// CHECK-DAG: %[[__original_id_75:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_2]] %[[uint_2]] %[[uint_2]] %[[uint_2]]
+// CHECK-DAG: %[[ulong_10:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 10
+// CHECK-DAG: %[[ulong_2:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 2
+// CHECK-DAG: %[[__original_id_78:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_10]] %[[ulong_10]]
+// CHECK-DAG: %[[__original_id_79:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_2]] %[[ulong_2]]
+// CHECK-DAG: %[[__original_id_82:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_10]] %[[ulong_10]] %[[ulong_10]] %[[ulong_10]]
+// CHECK-DAG: %[[__original_id_83:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_2]] %[[ulong_2]] %[[ulong_2]] %[[ulong_2]]
+// CHECK:     %[[__original_id_91:[0-9]+]] = OpSMulExtended %[[_struct_5:[0-9a-zA-Z_]+]] %[[uchar_10]] %[[uchar_2]]
+// CHECK:     %[[__original_id_92:[0-9]+]] = OpSMulExtended %[[_struct_7:[0-9a-zA-Z_]+]] %[[__original_id_54]] %[[__original_id_55]]
+// CHECK:     %[[__original_id_93:[0-9]+]] = OpSMulExtended %[[_struct_9:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_94:[0-9]+]] = OpSMulExtended %[[_struct_11:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_95:[0-9]+]] = OpUMulExtended %[[_struct_12:[0-9a-zA-Z_]+]] %[[uchar_10]] %[[uchar_2]]
+// CHECK:     %[[__original_id_96:[0-9]+]] = OpUMulExtended %[[_struct_13:[0-9a-zA-Z_]+]] %[[__original_id_54]] %[[__original_id_55]]
+// CHECK:     %[[__original_id_97:[0-9]+]] = OpUMulExtended %[[_struct_14:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_98:[0-9]+]] = OpUMulExtended %[[_struct_15:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_99:[0-9]+]] = OpSMulExtended %[[_struct_17:[0-9a-zA-Z_]+]] %[[ushort_10]] %[[ushort_2]]
+// CHECK:     %[[__original_id_100:[0-9]+]] = OpSMulExtended %[[_struct_19:[0-9a-zA-Z_]+]] %[[__original_id_62]] %[[__original_id_63]]
+// CHECK:     %[[__original_id_101:[0-9]+]] = OpSMulExtended %[[_struct_21:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_102:[0-9]+]] = OpSMulExtended %[[_struct_23:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_103:[0-9]+]] = OpUMulExtended %[[_struct_24:[0-9a-zA-Z_]+]] %[[ushort_10]] %[[ushort_2]]
+// CHECK:     %[[__original_id_104:[0-9]+]] = OpUMulExtended %[[_struct_25:[0-9a-zA-Z_]+]] %[[__original_id_62]] %[[__original_id_63]]
+// CHECK:     %[[__original_id_105:[0-9]+]] = OpUMulExtended %[[_struct_26:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_106:[0-9]+]] = OpUMulExtended %[[_struct_27:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_107:[0-9]+]] = OpSMulExtended %[[_struct_28:[0-9a-zA-Z_]+]] %[[uint_10]] %[[uint_2]]
+// CHECK:     %[[__original_id_108:[0-9]+]] = OpSMulExtended %[[_struct_30:[0-9a-zA-Z_]+]] %[[__original_id_70]] %[[__original_id_71]]
+// CHECK:     %[[__original_id_109:[0-9]+]] = OpSMulExtended %[[_struct_32:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_110:[0-9]+]] = OpSMulExtended %[[_struct_34:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_111:[0-9]+]] = OpUMulExtended %[[_struct_35:[0-9a-zA-Z_]+]] %[[uint_10]] %[[uint_2]]
+// CHECK:     %[[__original_id_112:[0-9]+]] = OpUMulExtended %[[_struct_36:[0-9a-zA-Z_]+]] %[[__original_id_70]] %[[__original_id_71]]
+// CHECK:     %[[__original_id_113:[0-9]+]] = OpUMulExtended %[[_struct_37:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_114:[0-9]+]] = OpUMulExtended %[[_struct_38:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_115:[0-9]+]] = OpSMulExtended %[[_struct_40:[0-9a-zA-Z_]+]] %[[ulong_10]] %[[ulong_2]]
+// CHECK:     %[[__original_id_116:[0-9]+]] = OpSMulExtended %[[_struct_42:[0-9a-zA-Z_]+]] %[[__original_id_78]] %[[__original_id_79]]
+// CHECK:     %[[__original_id_117:[0-9]+]] = OpSMulExtended %[[_struct_44:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_118:[0-9]+]] = OpSMulExtended %[[_struct_46:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_119:[0-9]+]] = OpUMulExtended %[[_struct_47:[0-9a-zA-Z_]+]] %[[ulong_10]] %[[ulong_2]]
+// CHECK:     %[[__original_id_120:[0-9]+]] = OpUMulExtended %[[_struct_48:[0-9a-zA-Z_]+]] %[[__original_id_78]] %[[__original_id_79]]
+// CHECK:     %[[__original_id_121:[0-9]+]] = OpUMulExtended %[[_struct_49:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_122:[0-9]+]] = OpUMulExtended %[[_struct_50:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+
+void kernel test() {
+    volatile char c1 = mad_hi((char)10, (char)2, (char)7);
+    volatile char2 c2 = mad_hi((char2)10, (char2)2, (char)7);
+    volatile char3 c3 = mad_hi((char3)10, (char3)2, (char)7);
+    volatile char4 c4 = mad_hi((char4)10, (char4)2, (char)7);
+
+    volatile uchar uc1 = mad_hi((uchar)10, (uchar)2, (uchar)7);
+    volatile uchar2 uc2 = mad_hi((uchar2)10, (uchar2)2, (uchar)7);
+    volatile uchar3 uc3 = mad_hi((uchar3)10, (uchar3)2, (uchar)7);
+    volatile uchar4 uc4 = mad_hi((uchar4)10, (uchar4)2, (uchar)7);
+
+    volatile short s1 = mad_hi((short)10, (short)2, (short)7);
+    volatile short2 s2 = mad_hi((short2)10, (short2)2, (short)7);
+    volatile short3 s3 = mad_hi((short3)10, (short3)2, (short)7);
+    volatile short4 s4 = mad_hi((short4)10, (short4)2, (short)7);
+
+    volatile ushort us1 = mad_hi((ushort)10, (ushort)2, (ushort)7);
+    volatile ushort2 us2 = mad_hi((ushort2)10, (ushort2)2, (ushort)7);
+    volatile ushort3 us3 = mad_hi((ushort3)10, (ushort3)2, (ushort)7);
+    volatile ushort4 us4 = mad_hi((ushort4)10, (ushort4)2, (ushort)7);
+
+    volatile int i1 = mad_hi((int)10, (int)2, (int)7);
+    volatile int2 i2 = mad_hi((int2)10, (int2)2, (int)7);
+    volatile int3 i3 = mad_hi((int3)10, (int3)2, (int)7);
+    volatile int4 i4 = mad_hi((int4)10, (int4)2, (int)7);
+
+    volatile uint ui1 = mad_hi((uint)10, (uint)2, (uint)7);
+    volatile uint2 ui2 = mad_hi((uint2)10, (uint2)2, (uint)7);
+    volatile uint3 ui3 = mad_hi((uint3)10, (uint3)2, (uint)7);
+    volatile uint4 ui4 = mad_hi((uint4)10, (uint4)2, (uint)7);
+
+    volatile long l1 = mad_hi((long)10, (long)2, (long)7);
+    volatile long2 l2 = mad_hi((long2)10, (long2)2, (long)7);
+    volatile long3 l3 = mad_hi((long3)10, (long3)2, (long)7);
+    volatile long4 l4 = mad_hi((long4)10, (long4)2, (long)7);
+
+    volatile ulong ul1 = mad_hi((ulong)10, (ulong)2, (ulong)7);
+    volatile ulong2 ul2 = mad_hi((ulong2)10, (ulong2)2, (ulong)7);
+    volatile ulong3 ul3 = mad_hi((ulong3)10, (ulong3)2, (ulong)7);
+    volatile ulong4 ul4 = mad_hi((ulong4)10, (ulong4)2, (ulong)7);
+}
+

--- a/test/IntegerBuiltins/max/max_char3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_char3_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global char3* a, global char3* b, global char3* c) {
+  *a = max(*b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[max:%[a-zA-Z0-9_]+]] = OpExtInst [[char4]] {{.*}} SMax [[ld_b]] [[ld_c]]
+
+

--- a/test/IntegerBuiltins/max/max_int3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_int3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] SMax %[[LOADB_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = max(*b, 1);
+}

--- a/test/IntegerBuiltins/max/max_long3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_long3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ulong]] %[[__original_id_1]] SMax %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long3* a, global long3* b, global long3* c)
+{
+    *a = max(*b, *c);
+}
+

--- a/test/IntegerBuiltins/max/max_short3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_short3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ushort]] %[[__original_id_1]] SMax %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short3* a, global short3* b, global short3* c)
+{
+    *a = max(*b, *c);
+}
+

--- a/test/IntegerBuiltins/max/max_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_uchar3_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uchar3* a, global uchar3* b, global uchar3* c) {
+  *a = max(*b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[max:%[a-zA-Z0-9_]+]] = OpExtInst [[char4]] {{.*}} UMax [[ld_b]] [[ld_c]]
+

--- a/test/IntegerBuiltins/max/max_uint3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_uint3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] UMax %[[LOADB_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = max(*b, (uint)1);
+}

--- a/test/IntegerBuiltins/max/max_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_ulong3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ulong]] %[[__original_id_1]] UMax %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global ulong3* c)
+{
+    *a = max(*b, *c);
+}
+

--- a/test/IntegerBuiltins/max/max_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_ushort3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ushort]] %[[__original_id_1]] UMax %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global ushort3* c)
+{
+    *a = max(*b, *c);
+}
+

--- a/test/IntegerBuiltins/min/min_char3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_char3_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char3* a, global char3* b, global char3* c)
+{
+    *a = min(*b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[char4]] {{.*}} SMin [[ld_b]] [[ld_c]]
+// CHECK: OpStore {{.*}} [[min]]
+

--- a/test/IntegerBuiltins/min/min_int3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_int3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] SMin %[[LOADB_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = min(*b, 1);
+}

--- a/test/IntegerBuiltins/min/min_long3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_long3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ulong]] %[[__original_id_1]] SMin %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long3* a, global long3* b, global long3* c)
+{
+    *a = min(*b, *c);
+}
+

--- a/test/IntegerBuiltins/min/min_short3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_short3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ushort]] %[[__original_id_1]] SMin %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short3* a, global short3* b, global short3* c)
+{
+    *a = min(*b, *c);
+}
+

--- a/test/IntegerBuiltins/min/min_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_uchar3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar3* a, global uchar3* b, global uchar3* c)
+{
+    *a = min(*b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[char4]] {{.*}} UMin [[ld_b]] [[ld_c]]
+// CHECK: OpStore {{.*}} [[min]]
+
+

--- a/test/IntegerBuiltins/min/min_uint3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_uint3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_VECTOR_TYPE_ID]] %[[EXT_INST]] UMin %[[LOADB_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = min(*b, (uint)1);
+}

--- a/test/IntegerBuiltins/min/min_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_ulong3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ulong]] %[[__original_id_1]] UMin %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global ulong3* c)
+{
+    *a = min(*b, *c);
+}
+

--- a/test/IntegerBuiltins/min/min_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_ushort3_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpExtInst %[[v4ushort]] %[[__original_id_1]] UMin %[[__original_id_20]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_22]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global ushort3* c)
+{
+    *a = min(*b, *c);
+}
+

--- a/test/IntegerBuiltins/mul_hi/mul_hi_all_overloads_novec3.cl
+++ b/test/IntegerBuiltins/mul_hi/mul_hi_all_overloads_novec3.cl
@@ -1,0 +1,121 @@
+// RUN: clspv -int8 %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[v2uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 2
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v2ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 2
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[v2uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 2
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v2ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 2
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[uchar_10:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 10
+// CHECK-DAG: %[[uchar_2:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 2
+// CHECK-DAG: %[[__original_id_54:[0-9]+]] = OpConstantComposite %[[v2uchar]] %[[uchar_10]] %[[uchar_10]]
+// CHECK-DAG: %[[__original_id_55:[0-9]+]] = OpConstantComposite %[[v2uchar]] %[[uchar_2]] %[[uchar_2]]
+// CHECK-DAG: %[[__original_id_58:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_10]] %[[uchar_10]] %[[uchar_10]] %[[uchar_10]]
+// CHECK-DAG: %[[__original_id_59:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[uchar_2]] %[[uchar_2]] %[[uchar_2]] %[[uchar_2]]
+// CHECK-DAG: %[[ushort_10:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 10
+// CHECK-DAG: %[[ushort_2:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 2
+// CHECK-DAG: %[[__original_id_62:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[ushort_10]] %[[ushort_10]]
+// CHECK-DAG: %[[__original_id_63:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[ushort_2]] %[[ushort_2]]
+// CHECK-DAG: %[[__original_id_66:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_10]] %[[ushort_10]] %[[ushort_10]] %[[ushort_10]]
+// CHECK-DAG: %[[__original_id_67:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_2]] %[[ushort_2]] %[[ushort_2]] %[[ushort_2]]
+// CHECK-DAG: %[[uint_10:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 10
+// CHECK-DAG: %[[uint_2:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 2
+// CHECK-DAG: %[[__original_id_70:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_10]] %[[uint_10]]
+// CHECK-DAG: %[[__original_id_71:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[uint_2]] %[[uint_2]]
+// CHECK-DAG: %[[__original_id_74:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_10]] %[[uint_10]] %[[uint_10]] %[[uint_10]]
+// CHECK-DAG: %[[__original_id_75:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_2]] %[[uint_2]] %[[uint_2]] %[[uint_2]]
+// CHECK-DAG: %[[ulong_10:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 10
+// CHECK-DAG: %[[ulong_2:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 2
+// CHECK-DAG: %[[__original_id_78:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_10]] %[[ulong_10]]
+// CHECK-DAG: %[[__original_id_79:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[ulong_2]] %[[ulong_2]]
+// CHECK-DAG: %[[__original_id_82:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_10]] %[[ulong_10]] %[[ulong_10]] %[[ulong_10]]
+// CHECK-DAG: %[[__original_id_83:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_2]] %[[ulong_2]] %[[ulong_2]] %[[ulong_2]]
+// CHECK:     %[[__original_id_91:[0-9]+]] = OpSMulExtended %[[_struct_5:[0-9a-zA-Z_]+]] %[[uchar_10]] %[[uchar_2]]
+// CHECK:     %[[__original_id_92:[0-9]+]] = OpSMulExtended %[[_struct_7:[0-9a-zA-Z_]+]] %[[__original_id_54]] %[[__original_id_55]]
+// CHECK:     %[[__original_id_93:[0-9]+]] = OpSMulExtended %[[_struct_9:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_94:[0-9]+]] = OpSMulExtended %[[_struct_11:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_95:[0-9]+]] = OpUMulExtended %[[_struct_12:[0-9a-zA-Z_]+]] %[[uchar_10]] %[[uchar_2]]
+// CHECK:     %[[__original_id_96:[0-9]+]] = OpUMulExtended %[[_struct_13:[0-9a-zA-Z_]+]] %[[__original_id_54]] %[[__original_id_55]]
+// CHECK:     %[[__original_id_97:[0-9]+]] = OpUMulExtended %[[_struct_14:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_98:[0-9]+]] = OpUMulExtended %[[_struct_15:[0-9a-zA-Z_]+]] %[[__original_id_58]] %[[__original_id_59]]
+// CHECK:     %[[__original_id_99:[0-9]+]] = OpSMulExtended %[[_struct_17:[0-9a-zA-Z_]+]] %[[ushort_10]] %[[ushort_2]]
+// CHECK:     %[[__original_id_100:[0-9]+]] = OpSMulExtended %[[_struct_19:[0-9a-zA-Z_]+]] %[[__original_id_62]] %[[__original_id_63]]
+// CHECK:     %[[__original_id_101:[0-9]+]] = OpSMulExtended %[[_struct_21:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_102:[0-9]+]] = OpSMulExtended %[[_struct_23:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_103:[0-9]+]] = OpUMulExtended %[[_struct_24:[0-9a-zA-Z_]+]] %[[ushort_10]] %[[ushort_2]]
+// CHECK:     %[[__original_id_104:[0-9]+]] = OpUMulExtended %[[_struct_25:[0-9a-zA-Z_]+]] %[[__original_id_62]] %[[__original_id_63]]
+// CHECK:     %[[__original_id_105:[0-9]+]] = OpUMulExtended %[[_struct_26:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_106:[0-9]+]] = OpUMulExtended %[[_struct_27:[0-9a-zA-Z_]+]] %[[__original_id_66]] %[[__original_id_67]]
+// CHECK:     %[[__original_id_107:[0-9]+]] = OpSMulExtended %[[_struct_28:[0-9a-zA-Z_]+]] %[[uint_10]] %[[uint_2]]
+// CHECK:     %[[__original_id_108:[0-9]+]] = OpSMulExtended %[[_struct_30:[0-9a-zA-Z_]+]] %[[__original_id_70]] %[[__original_id_71]]
+// CHECK:     %[[__original_id_109:[0-9]+]] = OpSMulExtended %[[_struct_32:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_110:[0-9]+]] = OpSMulExtended %[[_struct_34:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_111:[0-9]+]] = OpUMulExtended %[[_struct_35:[0-9a-zA-Z_]+]] %[[uint_10]] %[[uint_2]]
+// CHECK:     %[[__original_id_112:[0-9]+]] = OpUMulExtended %[[_struct_36:[0-9a-zA-Z_]+]] %[[__original_id_70]] %[[__original_id_71]]
+// CHECK:     %[[__original_id_113:[0-9]+]] = OpUMulExtended %[[_struct_37:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_114:[0-9]+]] = OpUMulExtended %[[_struct_38:[0-9a-zA-Z_]+]] %[[__original_id_74]] %[[__original_id_75]]
+// CHECK:     %[[__original_id_115:[0-9]+]] = OpSMulExtended %[[_struct_40:[0-9a-zA-Z_]+]] %[[ulong_10]] %[[ulong_2]]
+// CHECK:     %[[__original_id_116:[0-9]+]] = OpSMulExtended %[[_struct_42:[0-9a-zA-Z_]+]] %[[__original_id_78]] %[[__original_id_79]]
+// CHECK:     %[[__original_id_117:[0-9]+]] = OpSMulExtended %[[_struct_44:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_118:[0-9]+]] = OpSMulExtended %[[_struct_46:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_119:[0-9]+]] = OpUMulExtended %[[_struct_47:[0-9a-zA-Z_]+]] %[[ulong_10]] %[[ulong_2]]
+// CHECK:     %[[__original_id_120:[0-9]+]] = OpUMulExtended %[[_struct_48:[0-9a-zA-Z_]+]] %[[__original_id_78]] %[[__original_id_79]]
+// CHECK:     %[[__original_id_121:[0-9]+]] = OpUMulExtended %[[_struct_49:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+// CHECK:     %[[__original_id_122:[0-9]+]] = OpUMulExtended %[[_struct_50:[0-9a-zA-Z_]+]] %[[__original_id_82]] %[[__original_id_83]]
+
+void kernel test() {
+    volatile char c1 = mul_hi((char)10, (char)2);
+    volatile char2 c2 = mul_hi((char2)10, (char2)2);
+    volatile char3 c3 = mul_hi((char3)10, (char3)2);
+    volatile char4 c4 = mul_hi((char4)10, (char4)2);
+
+    volatile uchar uc1 = mul_hi((uchar)10, (uchar)2);
+    volatile uchar2 uc2 = mul_hi((uchar2)10, (uchar2)2);
+    volatile uchar3 uc3 = mul_hi((uchar3)10, (uchar3)2);
+    volatile uchar4 uc4 = mul_hi((uchar4)10, (uchar4)2);
+
+    volatile short s1 = mul_hi((short)10, (short)2);
+    volatile short2 s2 = mul_hi((short2)10, (short2)2);
+    volatile short3 s3 = mul_hi((short3)10, (short3)2);
+    volatile short4 s4 = mul_hi((short4)10, (short4)2);
+
+    volatile ushort us1 = mul_hi((ushort)10, (ushort)2);
+    volatile ushort2 us2 = mul_hi((ushort2)10, (ushort2)2);
+    volatile ushort3 us3 = mul_hi((ushort3)10, (ushort3)2);
+    volatile ushort4 us4 = mul_hi((ushort4)10, (ushort4)2);
+
+    volatile int i1 = mul_hi((int)10, (int)2);
+    volatile int2 i2 = mul_hi((int2)10, (int2)2);
+    volatile int3 i3 = mul_hi((int3)10, (int3)2);
+    volatile int4 i4 = mul_hi((int4)10, (int4)2);
+
+    volatile uint ui1 = mul_hi((uint)10, (uint)2);
+    volatile uint2 ui2 = mul_hi((uint2)10, (uint2)2);
+    volatile uint3 ui3 = mul_hi((uint3)10, (uint3)2);
+    volatile uint4 ui4 = mul_hi((uint4)10, (uint4)2);
+
+    volatile long l1 = mul_hi((long)10, (long)2);
+    volatile long2 l2 = mul_hi((long2)10, (long2)2);
+    volatile long3 l3 = mul_hi((long3)10, (long3)2);
+    volatile long4 l4 = mul_hi((long4)10, (long4)2);
+
+    volatile ulong ul1 = mul_hi((ulong)10, (ulong)2);
+    volatile ulong2 ul2 = mul_hi((ulong2)10, (ulong2)2);
+    volatile ulong3 ul3 = mul_hi((ulong3)10, (ulong3)2);
+    volatile ulong4 ul4 = mul_hi((ulong4)10, (ulong4)2);
+    ul1 = mul_hi((ulong)10, (ulong)2);
+    ul2 = mul_hi((ulong2)10, (ulong2)2);
+    ul3 = mul_hi((ulong3)10, (ulong3)2);
+    ul4 = mul_hi((ulong4)10, (ulong4)2);
+}
+

--- a/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global char3* a, global char3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/int3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/int3_popcount_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpBitCount %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b)
+{
+  *a = popcount(*b);
+}

--- a/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global long3* a, global long3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global short3* a, global short3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
+// CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uchar3* a, global uchar3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/uint3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/uint3_popcount_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpBitCount %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = popcount(*b);
+}

--- a/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global ulong3* a, global ulong3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global ushort3* a, global ushort3* b) {
+  *a = popcount(*b);
+}
+
+// CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
+// CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
+// CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/uint3_mad24_novec3.cl
+++ b/test/IntegerBuiltins/uint3_mad24_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK-DAG: %[[CONSTANT_3_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 3
+// CHECK-DAG: %[[COMPOSITE_3_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_3_ID]] %[[CONSTANT_3_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpIMul %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: %[[ADD_ID:[a-zA-Z0-9_]*]] = OpIAdd %[[UINT_VECTOR_TYPE_ID]] %[[MUL_ID]] %[[COMPOSITE_3_ID]]
+// CHECK: OpStore {{.*}} %[[ADD_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = mad24(*b, (uint)42, (uint)3);
+}

--- a/test/IntegerBuiltins/uint3_mul24_novec3.cl
+++ b/test/IntegerBuiltins/uint3_mul24_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpIMul %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: OpStore {{.*}} %[[MUL_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b)
+{
+  *a = mul24(*b, (uint)42);
+}

--- a/test/IntegerBuiltins/upsample/upsample_char3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_char3.cl
@@ -4,16 +4,16 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
-// CHECK-DAG: %[[v3ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 3
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
-// CHECK-DAG: %[[v3uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 3
+// CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
 // CHECK-DAG: %[[ushort_8:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 8
-// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v3ushort]] %[[ushort_8]] %[[ushort_8]] %[[ushort_8]]
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_8]] %[[ushort_8]] %[[ushort_8]]
 // CHECK-DAG: %[[ushort_42:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 42
-// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v3ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
-// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v3ushort]] {{.*}}
-// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v3ushort]] %[[hicast]] %[[shiftamount]]
-// CHECK:     OpBitwiseOr %[[v3ushort]] %[[hishifted]] %[[locst]]
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_42]] %[[ushort_42]] %[[ushort_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v4ushort]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v4ushort]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v4ushort]] %[[hishifted]] %[[locst]]
 
 kernel void test_upsample(global short3* out, char3 a)
 {

--- a/test/IntegerBuiltins/upsample/upsample_int3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_int3.cl
@@ -4,16 +4,16 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
-// CHECK-DAG: %[[v3ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 3
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[ulong_32:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 32
-// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v3ulong]] %[[ulong_32]] %[[ulong_32]] %[[ulong_32]]
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_32]] %[[ulong_32]] %[[ulong_32]]
 // CHECK-DAG: %[[ulong_42:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 42
-// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v3ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
-// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v3ulong]] {{.*}}
-// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v3ulong]] %[[hicast]] %[[shiftamount]]
-// CHECK:     OpBitwiseOr %[[v3ulong]] %[[hishifted]] %[[locst]]
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_42]] %[[ulong_42]] %[[ulong_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v4ulong]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v4ulong]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v4ulong]] %[[hishifted]] %[[locst]]
 
 kernel void test_upsample(global long3* out, int3 a)
 {

--- a/test/IntegerBuiltins/upsample/upsample_short3.cl
+++ b/test/IntegerBuiltins/upsample/upsample_short3.cl
@@ -4,16 +4,16 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK-DAG: %[[v3uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 3
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
-// CHECK-DAG: %[[v3ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 3
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[uint_16:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 16
-// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v3uint]] %[[uint_16]] %[[uint_16]] %[[uint_16]]
+// CHECK-DAG: %[[shiftamount:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_16]] %[[uint_16]] %[[uint_16]]
 // CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
-// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v3uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
-// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v3uint]] {{.*}}
-// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v3uint]] %[[hicast]] %[[shiftamount]]
-// CHECK:     OpBitwiseOr %[[v3uint]] %[[hishifted]] %[[locst]]
+// CHECK-DAG: %[[locst:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_42]] %[[uint_42]] %[[uint_42]]
+// CHECK:     %[[hicast:[0-9]+]] = OpUConvert %[[v4uint]] {{.*}}
+// CHECK:     %[[hishifted:[0-9]+]] = OpShiftLeftLogical %[[v4uint]] %[[hicast]] %[[shiftamount]]
+// CHECK:     OpBitwiseOr %[[v4uint]] %[[hishifted]] %[[locst]]
 
 kernel void test_upsample(global int3* out, short3 a)
 {

--- a/test/MathBuiltins/acos/float3_acos_novec3.cl
+++ b/test/MathBuiltins/acos/float3_acos_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Acos %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = acos(*b);
+}

--- a/test/MathBuiltins/acos/float3_acosh_novec3.cl
+++ b/test/MathBuiltins/acos/float3_acosh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Acosh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = acosh(*b);
+}

--- a/test/MathBuiltins/acos/float3_acospi.cl
+++ b/test/MathBuiltins/acos/float3_acospi.cl
@@ -10,9 +10,11 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Acos [[_29]]
+// CHECK: [[_shuffle:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_29]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Acos [[_shuffle]]
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/acos/float3_acospi.cl
+++ b/test/MathBuiltins/acos/float3_acospi.cl
@@ -9,10 +9,10 @@ void kernel foo(global float3* A, float3 x)
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Acos [[_29]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
+// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Acos [[_29]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/asin/float3_asin_novec3.cl
+++ b/test/MathBuiltins/asin/float3_asin_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Asin %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = asin(*b);
+}

--- a/test/MathBuiltins/asin/float3_asinh_novec3.cl
+++ b/test/MathBuiltins/asin/float3_asinh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Asinh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = asinh(*b);
+}

--- a/test/MathBuiltins/asin/float3_asinpi.cl
+++ b/test/MathBuiltins/asin/float3_asinpi.cl
@@ -9,10 +9,10 @@ void kernel foo(global float3* A, float3 x)
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Asin [[_29]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
+// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Asin [[_29]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/asin/float3_asinpi.cl
+++ b/test/MathBuiltins/asin/float3_asinpi.cl
@@ -10,9 +10,11 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Asin [[_29]]
+// CHECK: [[_shuffle:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_29]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Asin [[_shuffle]]
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/atan/float3_atan2_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atan2_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Atan2 %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3* c)
+{
+  *a = atan2(*b, *c);
+}

--- a/test/MathBuiltins/atan/float3_atan2pi.cl
+++ b/test/MathBuiltins/atan/float3_atan2pi.cl
@@ -10,10 +10,13 @@ void kernel foo(global float3* A, float3 y, float3 x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_shuffle30:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_30]] [[_v4undef]] 0 1 2 4294967295
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan2 [[_30]] [[_32]]
+// CHECK: [[_shuffle32:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_32]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan2 [[_shuffle30]] [[_shuffle32]]
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_33]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/atan/float3_atan2pi.cl
+++ b/test/MathBuiltins/atan/float3_atan2pi.cl
@@ -9,11 +9,11 @@ void kernel foo(global float3* A, float3 y, float3 x)
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan2 [[_30]] [[_32]]
-// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_33]]
+// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan2 [[_30]] [[_32]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_33]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/atan/float3_atan_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atan_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Atan %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = atan(*b);
+}

--- a/test/MathBuiltins/atan/float3_atanh_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atanh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Atanh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = atanh(*b);
+}

--- a/test/MathBuiltins/atan/float3_atanpi.cl
+++ b/test/MathBuiltins/atan/float3_atanpi.cl
@@ -9,10 +9,10 @@ void kernel foo(global float3* A, float3 x)
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan [[_29]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
+// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan [[_29]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/atan/float3_atanpi.cl
+++ b/test/MathBuiltins/atan/float3_atanpi.cl
@@ -10,9 +10,11 @@ void kernel foo(global float3* A, float3 x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan [[_29]]
+// CHECK: [[_shuffle:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_29]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan [[_shuffle]]
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/ceil/float3_ceil_novec3.cl
+++ b/test/MathBuiltins/ceil/float3_ceil_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Ceil %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = ceil(*b);
+}

--- a/test/MathBuiltins/cos/float3_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_cos_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Cos %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = cos(*b);
+}

--- a/test/MathBuiltins/cos/float3_cosh_novec3.cl
+++ b/test/MathBuiltins/cos/float3_cosh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Cosh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = cosh(*b);
+}

--- a/test/MathBuiltins/cos/float3_half_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_half_cos_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Cos %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_cos(*b);
+}

--- a/test/MathBuiltins/cos/float3_native_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_native_cos_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Cos %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_cos(*b);
+}

--- a/test/MathBuiltins/divide/float3_half_divide_novec3.cl
+++ b/test/MathBuiltins/divide/float3_half_divide_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -inline-entry-points -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42
+// CHECK-DAG: %[[UNDEF_FLOAT:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_TYPE_ID]]
+// CHECK-DAG: %[[UNDEF_FLOAT_VECTOR:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[COMPOSITE_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[UNDEF_FLOAT]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_FLOAT_42_ID]]
+// CHECK: %[[OP_ID_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[UNDEF_FLOAT_VECTOR]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[OP_ID_SHUFFLE]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_divide(*b, 42.0f);
+}

--- a/test/MathBuiltins/divide/float3_half_divide_novec3.cl
+++ b/test/MathBuiltins/divide/float3_half_divide_novec3.cl
@@ -7,12 +7,11 @@
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42
 // CHECK-DAG: %[[UNDEF_FLOAT:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_TYPE_ID]]
-// CHECK-DAG: %[[UNDEF_FLOAT_VECTOR:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR_TYPE_ID]]
 // CHECK-DAG: %[[COMPOSITE_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[UNDEF_FLOAT]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_FLOAT_42_ID]]
-// CHECK: %[[OP_ID_SHUFFLE:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[UNDEF_FLOAT_VECTOR]] 0 1 2 4294967295
-// CHECK: OpStore {{.*}} %[[OP_ID_SHUFFLE]]
+// CHECK: %[[OP_ID_INSERT_UNDEF:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR_TYPE_ID]] %[[UNDEF_FLOAT]] %[[OP_ID]] 3
+// CHECK: OpStore {{.*}} %[[OP_ID_INSERT_UNDEF]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/divide/float3_native_divide_novec3.cl
+++ b/test/MathBuiltins/divide/float3_native_divide_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]] %[[CONSTANT_FLOAT_42_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_FLOAT_42_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: OpReturn
+// CHECK: OpFunctionEnd
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_divide(*b, 42.0f);
+}

--- a/test/MathBuiltins/exp/float3_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_CONSTANT_LN10_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[MUL_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = exp10(*b);
+}

--- a/test/MathBuiltins/exp/float3_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = exp2(*b);
+}

--- a/test/MathBuiltins/exp/float3_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = exp(*b);
+}

--- a/test/MathBuiltins/exp/float3_half_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_CONSTANT_LN10_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[MUL_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_exp10(*b);
+}

--- a/test/MathBuiltins/exp/float3_half_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_exp2(*b);
+}

--- a/test/MathBuiltins/exp/float3_half_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_exp(*b);
+}

--- a/test/MathBuiltins/exp/float3_native_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 2.3025
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]] %[[CONSTANT_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_CONSTANT_LN10_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[MUL_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_exp10(*b);
+}

--- a/test/MathBuiltins/exp/float3_native_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_exp2(*b);
+}

--- a/test/MathBuiltins/exp/float3_native_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Exp %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_exp(*b);
+}

--- a/test/MathBuiltins/fabs/float3_fabs_novec3.cl
+++ b/test/MathBuiltins/fabs/float3_fabs_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fabs(*b);
+}

--- a/test/MathBuiltins/floor/float3_floor_novec3.cl
+++ b/test/MathBuiltins/floor/float3_floor_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Floor %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = floor(*b);
+}

--- a/test/MathBuiltins/fma/float3_fma_novec3.cl
+++ b/test/MathBuiltins/fma/float3_fma_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Fma %[[LOADA_ID]] %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3* c, global float3*o)
+{
+  *o = fma(*a, *b, *c);
+}

--- a/test/MathBuiltins/fmax/float3_fmax_novec3.cl
+++ b/test/MathBuiltins/fmax/float3_fmax_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fmax(*b, 1.0f);
+}

--- a/test/MathBuiltins/fmin/float3_fmin_novec3.cl
+++ b/test/MathBuiltins/fmin/float3_fmin_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fmin(*b, 1.0f);
+}

--- a/test/MathBuiltins/fmod/float3_fmod.cl
+++ b/test/MathBuiltins/fmod/float3_fmod.cl
@@ -8,7 +8,9 @@ kernel void foo(global float3 *A, float3 x, float3 y) {
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v4float]] [[_27]] [[_29]]
-// CHECK: OpStore {{.*}} [[_30]]
+// CHECK: [[_shuffle30:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_30]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} [[_shuffle30]]

--- a/test/MathBuiltins/fmod/float3_fmod.cl
+++ b/test/MathBuiltins/fmod/float3_fmod.cl
@@ -7,8 +7,8 @@ kernel void foo(global float3 *A, float3 x, float3 y) {
   *A = fmod(x,y);
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v3float]] [[_27]] [[_29]]
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v4float]] [[_27]] [[_29]]
 // CHECK: OpStore {{.*}} [[_30]]

--- a/test/MathBuiltins/fract/float3_fract_private.cl
+++ b/test/MathBuiltins/fract/float3_fract_private.cl
@@ -12,13 +12,15 @@ void kernel foo(global float3* A, global float3* B, float3 x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
+// CHECK-DAG: [[_v4undef:%[^ ]+]] = OpUndef [[_v4float]]
 // CHECK-DAG: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] {{1|0.99999}}
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_1]] [[_float_1]] [[_float_1]]
 // CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpAccessChain
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpAccessChain
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_31]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Fract [[_31]]
+// CHECK: [[_shuffle31:%[^ ]+]] = OpVectorShuffle [[_v4float]] [[_31]] [[_v4undef]] 0 1 2 4294967295
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_shuffle31]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Fract [[_shuffle31]]
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore [[_28]] [[_34]]
 // CHECK: OpStore [[_29]] [[_32]]

--- a/test/MathBuiltins/fract/float3_fract_private.cl
+++ b/test/MathBuiltins/fract/float3_fract_private.cl
@@ -11,14 +11,14 @@ void kernel foo(global float3* A, global float3* B, float3 x)
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
+// CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] {{1|0.99999}}
-// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_1]] [[_float_1]] [[_float_1]]
+// CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_1]] [[_float_1]] [[_float_1]]
 // CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpAccessChain
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpAccessChain
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Floor [[_31]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Fract [[_31]]
-// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] NMin [[_33]] [[_17]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_31]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Fract [[_31]]
+// CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore [[_28]] [[_34]]
 // CHECK: OpStore [[_29]] [[_32]]

--- a/test/MathBuiltins/ldexp/float3_ldexp_novec3.cl
+++ b/test/MathBuiltins/ldexp/float3_ldexp_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK: %[[A_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain
+// CHECK: %[[B_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain
+// CHECK: %[[C_ACCESS_CHAIN_ID:[a-zA-Z0-9_]*]] = OpAccessChain
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]] %[[B_ACCESS_CHAIN_ID]]
+// CHECK: %[[LOADC_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]] %[[C_ACCESS_CHAIN_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Ldexp %[[LOADB_ID]] %[[LOADC_ID]]
+// CHECK: OpStore %[[A_ACCESS_CHAIN_ID]] %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global int3* c)
+{
+  *a = ldexp(*b, *c);
+}

--- a/test/MathBuiltins/log/float3_half_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0.434294
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID]]
+// CHECK: OpStore {{.*}} %[[MUL_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_log10(*b);
+}

--- a/test/MathBuiltins/log/float3_half_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_log2(*b);
+}

--- a/test/MathBuiltins/log/float3_half_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_log(*b);
+}

--- a/test/MathBuiltins/log/float3_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_log10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0.434294
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID]]
+// CHECK: OpStore {{.*}} %[[MUL_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = log10(*b);
+}

--- a/test/MathBuiltins/log/float3_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_log2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = log2(*b);
+}

--- a/test/MathBuiltins/log/float3_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_log_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = log(*b);
+}

--- a/test/MathBuiltins/log/float3_native_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log10_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 0.434294
+// CHECK-DAG: %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]] %[[CONSTANT_1_OVER_LN10_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[COMPOSITE_CONSTANT_1_OVER_LN10_ID]]
+// CHECK: OpStore {{.*}} %[[MUL_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_log10(*b);
+}

--- a/test/MathBuiltins/log/float3_native_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log2_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log2 %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_log2(*b);
+}

--- a/test/MathBuiltins/log/float3_native_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Log %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_log(*b);
+}

--- a/test/MathBuiltins/mad/float3_mad_novec3.cl
+++ b/test/MathBuiltins/mad/float3_mad_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: %[[ADD_ID:[a-zA-Z0-9_]*]] = OpFAdd %[[FLOAT_VECTOR_TYPE_ID]] %[[MUL_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[ADD_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = mad(*b, 42.0f, 1.0f);
+}

--- a/test/MathBuiltins/mad/half3_mad_novec3.cl
+++ b/test/MathBuiltins/mad/half3_mad_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-DAG: %[[HALF_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[HALF_TYPE_ID]] 0x1.5p+5
+// CHECK-DAG: %[[COMPOSITE_42_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[HALF_VECTOR_TYPE_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]] %[[CONSTANT_42_ID]]
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[HALF_TYPE_ID]] 0x1p+0
+// CHECK-DAG: %[[COMPOSITE_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[HALF_VECTOR_TYPE_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_VECTOR_TYPE_ID]]
+// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpFMul %[[HALF_VECTOR_TYPE_ID]] %[[LOADB_ID]] %[[COMPOSITE_42_ID]]
+// CHECK: %[[ADD_ID:[a-zA-Z0-9_]*]] = OpFAdd %[[HALF_VECTOR_TYPE_ID]] %[[MUL_ID]] %[[COMPOSITE_1_ID]]
+// CHECK: OpStore {{.*}} %[[ADD_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half3* a, global half3* b)
+{
+  *a = mad(*b, (half3)42.0f, (half3)1.0f);
+}
+

--- a/test/MathBuiltins/pow/float3_half_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_half_powr_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Pow %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_powr(*b, 1.0f);
+}

--- a/test/MathBuiltins/pow/float3_native_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_native_powr_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Pow %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_powr(*b, 1.0f);
+}

--- a/test/MathBuiltins/pow/float3_pow_novec3.cl
+++ b/test/MathBuiltins/pow/float3_pow_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Pow %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = pow(*b, 1.0f);
+}

--- a/test/MathBuiltins/pow/float3_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_powr_novec3.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Pow %[[LOADB_ID]] %[[COMPOSITE_FLOAT_1_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = powr(*b, 1.0f);
+}

--- a/test/MathBuiltins/recip/float3_half_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_half_recip_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %s -o %t.spv -inline-entry-points -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_UNDEF:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_TYPE_ID]]
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT4_UNDEF:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[FLOAT_UNDEF]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[COMPOSITE_FLOAT_1_ID]] %[[LOADB_ID]]
+// CHECK: %[[OP_ID4:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[FLOAT4_UNDEF]] 0 1 2 4294967295
+// CHECK: OpStore {{.*}} %[[OP_ID4]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_recip(*b);
+}

--- a/test/MathBuiltins/recip/float3_half_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_half_recip_novec3.cl
@@ -6,12 +6,11 @@
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_UNDEF:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_TYPE_ID]]
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
-// CHECK-DAG: %[[FLOAT4_UNDEF:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR_TYPE_ID]]
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
 // CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[FLOAT_UNDEF]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[COMPOSITE_FLOAT_1_ID]] %[[LOADB_ID]]
-// CHECK: %[[OP_ID4:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[OP_ID]] %[[FLOAT4_UNDEF]] 0 1 2 4294967295
+// CHECK: %[[OP_ID4:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[FLOAT_VECTOR_TYPE_ID]] %[[FLOAT_UNDEF]] %[[OP_ID]] 3
 // CHECK: OpStore {{.*}} %[[OP_ID4]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/MathBuiltins/recip/float3_native_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_native_recip_novec3.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-DAG: %[[COMPOSITE_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]] %[[CONSTANT_FLOAT_1_ID]]
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_VECTOR_TYPE_ID]] %[[COMPOSITE_FLOAT_1_ID]] %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_recip(*b);
+}

--- a/test/MathBuiltins/rint/float3_rint_novec3.cl
+++ b/test/MathBuiltins/rint/float3_rint_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] RoundEven %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = rint(*b);
+}

--- a/test/MathBuiltins/round/float3_round_novec3.cl
+++ b/test/MathBuiltins/round/float3_round_novec3.cl
@@ -1,0 +1,44 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
+// CHECK-DAG: [[sign_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+// CHECK-DAG: [[sign_mask3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int3]] [[sign_mask]] [[sign_mask]] [[sign_mask]]
+// CHECK-DAG: [[rest_mask:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+// CHECK-DAG: [[rest_mask3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[int3]] [[rest_mask]] [[rest_mask]] [[rest_mask]]
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK-DAG: [[float:%[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[float3:%[a-zA-Z0-9_]*]] = OpTypeVector [[float]] 3
+// CHECK-DAG: [[float4:%[a-zA-Z0-9_]*]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[undef3:%[a-zA-Z0-9_]*]] = OpUndef [[float3]]
+// CHECK-DAG: [[undef4:%[a-zA-Z0-9_]*]] = OpUndef [[float4]]
+// CHECK-DAG: [[halfway:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 0.5
+// CHECK-DAG: [[halfway3:%[a-zA-Z0-9_]+]] = OpConstantComposite [[float4]] [[halfway]] [[halfway]] [[halfway]] [[halfway]]
+// CHECK: [[ld:%[a-zA-Z0-9_]*]] = OpLoad [[float4]]
+// CHECK: [[ld3:%[a-zA-Z0-9_]*]] = OpVectorShuffle [[float3]] [[ld]] [[undef4]] 0 1 2
+// CHECK: [[fabs:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] FAbs [[ld3]]
+// CHECK: [[fabs4:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[float4]] [[fabs]] [[undef3]] 0 1 2 4294967295
+// CHECK: [[ceil:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] Ceil [[fabs]]
+// CHECK: [[ceil4:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[float4]] [[ceil]] [[undef3]] 0 1 2 4294967295
+// CHECK: [[floor:%[a-zA-Z0-9_]+]] = OpExtInst [[float3]] [[ext_inst]] Floor [[fabs]]
+// CHECK: [[floor4:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[float4]] [[floor]] [[undef3]] 0 1 2 4294967295
+// CHECK: [[fract:%[a-zA-Z0-9_]+]] = OpExtInst [[float4]] [[ext_inst]] Fract [[fabs4]]
+// CHECK: [[gte:%[a-zA-Z0-9_]+]] = OpFOrdGreaterThanEqual [[bool4]] [[fract]] [[halfway3]]
+// CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[float4]] [[gte]] [[ceil4]] [[floor4]]
+// CHECK: [[sel3:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[float3]] [[sel]] [[undef4]] 0 1 2
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int3]] [[ld3]]
+// CHECK: [[sign:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int3]] [[cast]] [[sign_mask3]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int3]] [[sel3]]
+// CHECK: [[rest:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int3]] [[cast]] [[rest_mask3]]
+// CHECK: [[combine:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[int3]] [[rest]] [[sign]]
+// CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[float3]] [[combine]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = round(*b);
+}

--- a/test/MathBuiltins/sin/float3_half_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_half_sin_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sin %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_sin(*b);
+}

--- a/test/MathBuiltins/sin/float3_native_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_native_sin_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sin %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_sin(*b);
+}

--- a/test/MathBuiltins/sin/float3_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_sin_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sin %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = sin(*b);
+}

--- a/test/MathBuiltins/sin/float3_sinh_novec3.cl
+++ b/test/MathBuiltins/sin/float3_sinh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sinh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = sinh(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_half_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_half_rsqrt_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_rsqrt(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_half_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_half_sqrt_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_sqrt(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_native_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_native_rsqrt_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_rsqrt(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_native_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_native_sqrt_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_sqrt(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = rsqrt(*b);
+}

--- a/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = sqrt(*b);
+}

--- a/test/MathBuiltins/tan/float3_half_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_half_tan_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Tan %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = half_tan(*b);
+}

--- a/test/MathBuiltins/tan/float3_native_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_native_tan_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Tan %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = native_tan(*b);
+}

--- a/test/MathBuiltins/tan/float3_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_tan_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Tan %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = tan(*b);
+}

--- a/test/MathBuiltins/tan/float3_tanh_novec3.cl
+++ b/test/MathBuiltins/tan/float3_tanh_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Tanh %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = tanh(*b);
+}

--- a/test/MathBuiltins/trunc/float3_trunc_novec3.cl
+++ b/test/MathBuiltins/trunc/float3_trunc_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Trunc %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = trunc(*b);
+}

--- a/test/PointerCasts/load_cast_float3_to_int3.cl
+++ b/test/PointerCasts/load_cast_float3_to_int3.cl
@@ -8,8 +8,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, g
   *a = ((global int3*)b)[i];
 }
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
 // CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[_v3float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 3
-// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_v3float]]
-// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpBitcast [[_v3uint]] [[_28]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_28]]

--- a/test/PointerCasts/load_cast_float3_to_uint3.cl
+++ b/test/PointerCasts/load_cast_float3_to_uint3.cl
@@ -8,8 +8,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, 
   *a = ((global uint3*)b)[i];
 }
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK:  [[_v3uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 3
+// CHECK:  [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
 // CHECK:  [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK:  [[_v3float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 3
-// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_v3float]]
-// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpBitcast [[_v3uint]] [[_28]]
+// CHECK:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
+// CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]]
+// CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_28]]

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -module-constants-in-storage-buffer -vec3-to-vec4
+// RUN: clspv-reflection %t.spv -o %t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Proves ConstantDataVector and ConstantArray work.
+
+__constant uint3 ppp[2] = {(uint3)(1,2,3), (uint3)(5)};
+
+kernel void foo(global uint* A, uint i) { *A = ppp[i].x; }
+
+
+
+// MAP: constant,descriptorSet,1,binding,0,kind,buffer,hexbytes,010000000200000003000000{{........}}050000000500000005000000{{........}}

--- a/test/RelationalBuiltins/all/all_char3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_char3_novec3.cl
@@ -1,0 +1,25 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* a, global char3* b) {
+  *a = all(*b);
+}
+
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool3:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 3
+// CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[null:%[a-zA-Z0-9_]+]] = OpConstantNull [[char4]]
+// CHECK-DAG: [[undefvec4:%[a-zA-Z0-9_]+]] = OpUndef [[bool4]]
+// CHECK:     [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK:     [[less:%[a-zA-Z0-9_]+]] = OpSLessThan [[bool4]] [[ld]] [[null]]
+// CHECK:     [[less3:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[bool3]] [[less]] [[undefvec4]] 0 1 2
+// CHECK:     [[all:%[a-zA-Z0-9_]+]] = OpAll [[bool]] [[less3]]
+// CHECK:     OpSelect [[int]] [[all]] [[int_1]] [[int_0]]
+

--- a/test/RelationalBuiltins/all/all_int3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_int3_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 3
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[UNDEFVEC4:[a-zA-Z0-9_]+]] = OpUndef %[[BOOL4_TYPE_ID]]
+// CHECK: %[[B_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpSLessThan %[[BOOL4_TYPE_ID]] %[[B_LOAD_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: %[[CMP3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[BOOL3_TYPE_ID]] %[[CMP_ID]] %[[UNDEFVEC4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpAll %[[BOOL_TYPE_ID]] %[[CMP3]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[OP_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int3* b)
+{
+  *a = all(b[0]);
+}

--- a/test/RelationalBuiltins/all/all_long3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_long3_novec3.cl
@@ -1,0 +1,27 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v3bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 3
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK-DAG: %[[undefvec4:[a-zA-Z0-9_]+]] = OpUndef %[[v4bool]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_25]] %[[__original_id_18]]
+// CHECK:     %[[less3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[v3bool]] %[[__original_id_26]] %[[undefvec4]] 0 1 2
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpAll %[[bool]] %[[less3]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpSelect %[[uint]] %[[__original_id_27]] %[[uint_1]] %[[uint_0]]
+// CHECK:     OpStore {{.*}} %[[__original_id_28]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global long3* b)
+{
+    *a = all(*b);
+}
+

--- a/test/RelationalBuiltins/all/all_short3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_short3_novec3.cl
@@ -1,0 +1,27 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v3bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 3
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK-DAG: %[[undefvec4:[a-zA-Z0-9_]+]] = OpUndef %[[v4bool]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_25]] %[[__original_id_18]]
+// CHECK:     %[[less3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[v3bool]] %[[__original_id_26]] %[[undefvec4]] 0 1 2
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpAll %[[bool]] %[[less3]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpSelect %[[uint]] %[[__original_id_27]] %[[uint_1]] %[[uint_0]]
+// CHECK:     OpStore {{.*}} %[[__original_id_28]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global short3* b)
+{
+    *a = all(*b);
+}
+

--- a/test/RelationalBuiltins/any/any_char3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_char3_novec3.cl
@@ -1,0 +1,26 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global int* a, global char3* b) {
+  *a = any(*b);
+}
+
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool3:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 3
+// CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[null:%[a-zA-Z0-9_]+]] = OpConstantNull [[char4]]
+// CHECK-DAG: [[undefvec4:%[a-zA-Z0-9_]+]] = OpUndef [[bool4]]
+// CHECK:     [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK:     [[less:%[a-zA-Z0-9_]+]] = OpSLessThan [[bool4]] [[ld]] [[null]]
+// CHECK:     [[less3:%[a-zA-Z0-9_]+]] = OpVectorShuffle [[bool3]] [[less]] [[undefvec4]] 0 1 2
+// CHECK:     [[any:%[a-zA-Z0-9_]+]] = OpAny [[bool]] [[less3]]
+// CHECK:     OpSelect [[int]] [[any]] [[int_1]] [[int_0]]
+
+

--- a/test/RelationalBuiltins/any/any_int3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_int3_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 3
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[UNDEFVEC4:[a-zA-Z0-9_]+]] = OpUndef %[[BOOL4_TYPE_ID]]
+// CHECK: %[[B_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpSLessThan %[[BOOL4_TYPE_ID]] %[[B_LOAD_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: %[[CMP3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[BOOL3_TYPE_ID]] %[[CMP_ID]] %[[UNDEFVEC4]] 0 1 2
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpAny %[[BOOL_TYPE_ID]] %[[CMP3]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[OP_ID]] %[[CONSTANT_1_ID]] %[[CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int3* b)
+{
+  *a = any(b[0]);
+}

--- a/test/RelationalBuiltins/any/any_long3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_long3_novec3.cl
@@ -1,0 +1,27 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v3bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 3
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK-DAG: %[[undefvec4:[a-zA-Z0-9_]+]] = OpUndef %[[v4bool]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_25]] %[[__original_id_18]]
+// CHECK:     %[[less3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[v3bool]] %[[__original_id_26]] %[[undefvec4]] 0 1 2
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpAny %[[bool]] %[[less3]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpSelect %[[uint]] %[[__original_id_27]] %[[uint_1]] %[[uint_0]]
+// CHECK:     OpStore {{.*}} %[[__original_id_28]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global long3* b)
+{
+    *a = any(*b);
+}
+

--- a/test/RelationalBuiltins/any/any_short3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_short3_novec3.cl
@@ -1,0 +1,27 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v3bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 3
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK-DAG: %[[undefvec4:[a-zA-Z0-9_]+]] = OpUndef %[[v4bool]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_25]] %[[__original_id_18]]
+// CHECK:     %[[less3:[a-zA-Z0-9_]+]] = OpVectorShuffle %[[v3bool]] %[[__original_id_26]] %[[undefvec4]] 0 1 2
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpAny %[[bool]] %[[less3]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpSelect %[[uint]] %[[__original_id_27]] %[[uint_1]] %[[uint_0]]
+// CHECK:     OpStore {{.*}} %[[__original_id_28]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global short3* b)
+{
+    *a = any(*b);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_char3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char3_novec3.cl
@@ -1,0 +1,21 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global char3* a, global char3* b, global char3* c) {
+  *a = bitselect(*a, *b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[char_255:%[a-zA-Z0-9_]+]] = OpConstant [[char]] 255
+// CHECK: [[char4_255_255_255:%[a-zA-Z0-9_]+]] = OpConstantComposite [[char4]] [[char_255]] [[char_255]] [[char_255]]
+// CHECK: [[ld_a:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[xor:%[a-zA-Z0-9_]+]] = OpBitwiseXor [[char4]] [[ld_c]] [[char4_255_255_255]]
+// CHECK: [[and1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[char4]] [[ld_a]] [[xor]]
+// CHECK: [[and2:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[char4]] [[ld_c]] [[ld_b]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[char4]] [[and1]] [[and2]]
+

--- a/test/RelationalBuiltins/bitselect/bitselect_float3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_float3_novec3.cl
@@ -1,0 +1,29 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_4294967295:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_4294967295]] %[[uint_4294967295]] %[[uint_4294967295]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpBitcast %[[v4uint]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitcast %[[v4uint]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpBitcast %[[v4uint]] %[[__original_id_26]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpBitwiseXor %[[v4uint]] %[[__original_id_27]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_29:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_23]] %[[__original_id_28]]
+// CHECK:     %[[__original_id_30:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_27]] %[[__original_id_25]]
+// CHECK:     %[[__original_id_31:[0-9]+]] = OpBitwiseOr %[[v4uint]] %[[__original_id_29]] %[[__original_id_30]]
+// CHECK:     %[[__original_id_32:[0-9]+]] = OpBitcast %[[v4float]] %[[__original_id_31]]
+// CHECK:     OpStore {{.*}} %[[__original_id_32]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global float3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_int3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_4294967295:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295
+// CHECK-DAG: %[[__original_id_11:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_4294967295]] %[[uint_4294967295]] %[[uint_4294967295]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpBitwiseXor %[[v4uint]] %[[__original_id_22]] %[[__original_id_11]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_20]] %[[__original_id_23]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseOr %[[v4uint]] %[[__original_id_24]] %[[__original_id_25]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b, global int3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ulong_18446744073709551615:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 18446744073709551615
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_18446744073709551615]] %[[ulong_18446744073709551615]] %[[ulong_18446744073709551615]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseXor %[[v4ulong]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] %[[__original_id_21]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpBitwiseOr %[[v4ulong]] %[[__original_id_25]] %[[__original_id_26]]
+// CHECK:     OpStore {{.*}} %[[__original_id_27]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long3* a, global long3* b, global long3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ushort_65535:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 65535
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_65535]] %[[ushort_65535]] %[[ushort_65535]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseXor %[[v4ushort]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] %[[__original_id_21]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpBitwiseOr %[[v4ushort]] %[[__original_id_25]] %[[__original_id_26]]
+// CHECK:     OpStore {{.*}} %[[__original_id_27]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short3* a, global short3* b, global short3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global uchar3* a, global uchar3* b, global uchar3* c) {
+  *a = bitselect(*a, *b, *c);
+}
+
+// CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[char_255:%[a-zA-Z0-9_]+]] = OpConstant [[char]] 255
+// CHECK: [[char4_255_255_255:%[a-zA-Z0-9_]+]] = OpConstantComposite [[char4]] [[char_255]] [[char_255]] [[char_255]]
+// CHECK: [[ld_a:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[xor:%[a-zA-Z0-9_]+]] = OpBitwiseXor [[char4]] [[ld_c]] [[char4_255_255_255]]
+// CHECK: [[and1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[char4]] [[ld_a]] [[xor]]
+// CHECK: [[and2:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[char4]] [[ld_c]] [[ld_b]]
+// CHECK: [[or:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[char4]] [[and1]] [[and2]]
+
+

--- a/test/RelationalBuiltins/bitselect/bitselect_uint3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[uint_4294967295:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295
+// CHECK-DAG: %[[__original_id_11:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[uint_4294967295]] %[[uint_4294967295]] %[[uint_4294967295]]
+// CHECK:     %[[__original_id_20:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpBitwiseXor %[[v4uint]] %[[__original_id_22]] %[[__original_id_11]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_20]] %[[__original_id_23]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseOr %[[v4uint]] %[[__original_id_24]] %[[__original_id_25]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b, global uint3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[ulong_18446744073709551615:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 18446744073709551615
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[ulong_18446744073709551615]] %[[ulong_18446744073709551615]] %[[ulong_18446744073709551615]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseXor %[[v4ulong]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] %[[__original_id_21]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpBitwiseOr %[[v4ulong]] %[[__original_id_25]] %[[__original_id_26]]
+// CHECK:     OpStore {{.*}} %[[__original_id_27]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global ulong3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[ushort_65535:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 65535
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[ushort_65535]] %[[ushort_65535]] %[[ushort_65535]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpBitwiseXor %[[v4ushort]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] %[[__original_id_21]] %[[__original_id_24]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpBitwiseOr %[[v4ushort]] %[[__original_id_25]] %[[__original_id_26]]
+// CHECK:     OpStore {{.*}} %[[__original_id_27]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global ushort3* c)
+{
+    *a = bitselect(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/isequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isequal_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isequal(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/isgreater_float3_novec3.cl
+++ b/test/RelationalBuiltins/isgreater_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdGreaterThan %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isgreater(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/isgreaterequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isgreaterequal(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/isinf_float3_novec3.cl
+++ b/test/RelationalBuiltins/isinf_float3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpIsInf %[[BOOL4_TYPE_ID]] %[[B_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isinf(b[0]);
+}

--- a/test/RelationalBuiltins/isless_float3_novec3.cl
+++ b/test/RelationalBuiltins/isless_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdLessThan %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isless(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/islessequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/islessequal_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFOrdLessThanEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = islessequal(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/isnan_float3_novec3.cl
+++ b/test/RelationalBuiltins/isnan_float3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpIsNan %[[BOOL4_TYPE_ID]] %[[B_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isnan(b[0]);
+}

--- a/test/RelationalBuiltins/isnotequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isnotequal_float3_novec3.cl
@@ -1,0 +1,23 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
+// CHECK-DAG: %[[BOOL4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[BOOL_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT4_CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstantNull %[[UINT4_TYPE_ID]]
+// CHECK-DAG: %[[CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
+// CHECK-DAG: %[[UINT4_CONSTANT_ALL_BITS_SET_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]] %[[CONSTANT_ALL_BITS_SET_ID]]
+// CHECK: %[[B0_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B1_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[CMP_ID:[a-zA-Z0-9_]*]] = OpFUnordNotEqual %[[BOOL4_TYPE_ID]] %[[B0_LOAD_ID]] %[[B1_LOAD_ID]]
+// CHECK: %[[CAS_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT4_TYPE_ID]] %[[CMP_ID]] %[[UINT4_CONSTANT_ALL_BITS_SET_ID]] %[[UINT4_CONSTANT_0_ID]]
+// CHECK: OpStore {{.*}} %[[CAS_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = isnotequal(b[0], b[1]);
+}

--- a/test/RelationalBuiltins/select/select_char3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_char3_novec3.cl
@@ -1,0 +1,20 @@
+// RUN: clspv  %s -o %t.spv -int8 -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global char3* a, global char3* b, global uchar3* c) {
+  *a = select(*a, *b, *c);
+}
+
+// CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4
+// CHECK: [[null:%[a-zA-Z0-9_]+]] = OpConstantNull [[char4]]
+// CHECK: [[ld_a:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_b:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[ld_c:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
+// CHECK: [[less:%[a-zA-Z0-9_]+]] = OpSLessThan [[bool4]] [[ld_c]] [[null]]
+// CHECK: OpSelect [[char4]] [[less]] [[ld_b]] [[ld_a]]
+

--- a/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_29:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_30:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_29]] %[[__original_id_18]]
+// CHECK:     %[[__original_id_31:[0-9]+]] = OpSelect %[[v4float]] %[[__original_id_30]] %[[__original_id_28]] %[[__original_id_27]]
+// CHECK:     OpStore {{.*}} %[[__original_id_31]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global int3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
@@ -1,0 +1,24 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
+// CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_18:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_27:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_28:[0-9]+]] = OpLoad %[[v4float]]
+// CHECK:     %[[__original_id_29:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_30:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_29]] %[[__original_id_18]]
+// CHECK:     %[[__original_id_31:[0-9]+]] = OpSelect %[[v4float]] %[[__original_id_30]] %[[__original_id_28]] %[[__original_id_27]]
+// CHECK:     OpStore {{.*}} %[[__original_id_31]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b, global uint3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_25]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b, global int3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_25]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global int3* b, global uint3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long3* a, global long3* b, global long3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long3* a, global long3* b, global ulong3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short3* a, global short3* b, global short3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short3* a, global short3* b, global ushort3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_25]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b, global int3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_12:[0-9]+]] = OpConstantNull %[[v4uint]]
+// CHECK:     %[[__original_id_21:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4uint]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_23]] %[[__original_id_12]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSelect %[[v4uint]] %[[__original_id_24]] %[[__original_id_22]] %[[__original_id_21]]
+// CHECK:     OpStore {{.*}} %[[__original_id_25]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint3* a, global uint3* b, global uint3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global long3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
+// CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ulong]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ulong]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ulong]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong3* a, global ulong3* b, global ulong3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global short3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
@@ -1,0 +1,22 @@
+// RUN: clspv  %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
+// CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
+// CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool
+// CHECK-DAG: %[[v4bool:[0-9a-zA-Z_]+]] = OpTypeVector %[[bool]] 4
+// CHECK-DAG: %[[__original_id_13:[0-9]+]] = OpConstantNull %[[v4ushort]]
+// CHECK:     %[[__original_id_22:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_23:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_24:[0-9]+]] = OpLoad %[[v4ushort]]
+// CHECK:     %[[__original_id_25:[0-9]+]] = OpSLessThan %[[v4bool]] %[[__original_id_24]] %[[__original_id_13]]
+// CHECK:     %[[__original_id_26:[0-9]+]] = OpSelect %[[v4ushort]] %[[__original_id_25]] %[[__original_id_23]] %[[__original_id_22]]
+// CHECK:     OpStore {{.*}} %[[__original_id_26]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort3* a, global ushort3* b, global ushort3* c)
+{
+    *a = select(*a, *b, *c);
+}
+

--- a/test/RelationalBuiltins/signbit_float3_novec3.cl
+++ b/test/RelationalBuiltins/signbit_float3_novec3.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[CONSTANT_31_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 31
+// CHECK-DAG: %[[CONSTANT_COMPOSITE_31_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT4_TYPE_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]] %[[CONSTANT_31_ID]]
+// CHECK: %[[B_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT4_TYPE_ID]]
+// CHECK: %[[B_BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT4_TYPE_ID]] %[[B_LOAD_ID]]
+// CHECK: %[[ASHR_ID:[a-zA-Z0-9_]*]] = OpShiftRightArithmetic %[[UINT4_TYPE_ID]] %[[B_BITCAST_ID]] %[[CONSTANT_COMPOSITE_31_ID]]
+// CHECK: OpStore {{.*}} %[[ASHR_ID]]
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int3* a, global float3* b)
+{
+  *a = signbit(b[0]);
+}

--- a/test/UBO/char_ubo_struct_novec3.cl
+++ b/test/UBO/char_ubo_struct_novec3.cl
@@ -1,0 +1,48 @@
+// RUN: clspv -int8 -constant-args-ubo -inline-entry-points %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv-reflection %t.spv -o %t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct {
+  char a;
+  char2 b;
+  char3 c;
+  char4 d;
+  int pad; // necessary to get up to 16 byte size
+} S;
+
+kernel void foo(global S* out, constant S* in) {
+  out->d = in->d;
+}
+
+//      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
+// MAP-NEXT: kernel,foo,arg,in,argOrdinal,1,descriptorSet,0,binding,1,offset,0,argKind,buffer_ubo
+
+// CHECK-DAG: OpMemberDecorate [[s:%[0-9a-zA-Z_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[s]] 1 Offset 2
+// CHECK-DAG: OpMemberDecorate [[s]] 2 Offset 4
+// CHECK-DAG: OpMemberDecorate [[s]] 3 Offset 8
+// CHECK-DAG: OpMemberDecorate [[s]] 4 Offset 12
+// CHECK: OpDecorate [[rta:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK-DAG: OpDecorate [[out:%[0-9a-zA-Z_]+]] Binding 0
+// CHECK-DAG: OpDecorate [[out]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in:%[0-9a-zA-Z_]+]] Binding 1
+// CHECK-DAG: OpDecorate [[in]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[in]] NonWritable
+// CHECK: OpDecorate [[ubo_array:%[0-9a-zA-Z_]+]] ArrayStride 16
+// CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[char:%[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[char2:%[0-9a-zA-Z_]+]] = OpTypeVector [[char]] 2
+// CHECK-DAG: [[char4:%[0-9a-zA-Z_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[s]] = OpTypeStruct [[char]] [[char2]] [[char4]] [[char4]] [[int]]
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[ubo_array]] = OpTypeArray [[s]] [[int_4096]]
+// CHECK-DAG: [[ubo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[ubo_array]]
+// CHECK-DAG: [[ubo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[ubo_block]]
+// CHECK-DAG: [[rta]] = OpTypeRuntimeArray [[s]]
+// CHECK-DAG: [[ssbo_block:%[0-9a-zA-Z_]+]] = OpTypeStruct [[rta]]
+// CHECK-DAG: [[ssbo_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[ssbo_block]]
+// CHECK-DAG: [[out]] = OpVariable [[ssbo_ptr]] StorageBuffer
+// CHECK-DAG: [[in]] = OpVariable [[ubo_ptr]] Uniform

--- a/test/float3_add_novec3.cl
+++ b/test/float3_add_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFAdd %[[VEC_TYPE_ID]] %[[LOADB_ID]] %[[LOADA_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+  *a += *b;
+}

--- a/test/float3_div_novec3.cl
+++ b/test/float3_div_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[VEC_TYPE_ID]] %[[LOADA_ID]] %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+  *a /= *b;
+}

--- a/test/float3_mul_novec3.cl
+++ b/test/float3_mul_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFMul %[[VEC_TYPE_ID]] %[[LOADB_ID]] %[[LOADA_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+  *a *= *b;
+}

--- a/test/float3_sub_novec3.cl
+++ b/test/float3_sub_novec3.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpFSub %[[VEC_TYPE_ID]] %[[LOADA_ID]] %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+  *a -= *b;
+}

--- a/test/issue-679.cl
+++ b/test/issue-679.cl
@@ -1,0 +1,40 @@
+// RUN: clspv %s -o %t2.spv
+// RUN: spirv-dis -o %t2.spvasm %t2.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t2.spv
+
+// CHECK-DAG: [[uint:%[0-9a-zA-Z_]*]] = OpTypeInt 32
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[float:%[0-9a-zA-Z_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[float4:%[0-9a-zA-Z_]*]] = OpTypeVector [[float]] 4
+// CHECK: [[in_mul:%[0-9a-zA-Z_]*]] = OpIMul [[uint]] {{.*}} [[uint_3]]
+// CHECK: [[load0_shift:%[0-9a-zA-Z_]*]] = OpShiftRightLogical [[uint]] [[in_mul]] [[uint_2]]
+// CHECK: [[load0_addr:%[0-9a-zA-Z_]*]] = OpAccessChain {{.*}} [[uint_0]] [[load0_shift]]
+// CHECK: [[load0:%[0-9a-zA-Z_]*]] = OpLoad [[float4]] [[load0_addr]]
+// CHECK: [[load0_idx:%[0-9a-zA-Z_]*]] = OpBitwiseAnd [[uint]] [[in_mul]] [[uint_3]]
+// CHECK: [[x0:%[0-9a-zA-Z_]*]] = OpVectorExtractDynamic [[float]] [[load0]] [[load0_idx]]
+// CHECK: [[load1_offset:%[0-9a-zA-Z_]*]] = OpIAdd [[uint]] [[in_mul]] [[uint_1]]
+// CHECK: [[load1_shift:%[0-9a-zA-Z_]*]] = OpShiftRightLogical [[uint]] [[load1_offset]] [[uint_2]]
+// CHECK: [[load1_addr:%[0-9a-zA-Z_]*]] = OpAccessChain {{.*}} [[uint_0]] [[load1_shift]]
+// CHECK: [[load1:%[0-9a-zA-Z_]*]] = OpLoad [[float4]] [[load1_addr]]
+// CHECK: [[load1_idx:%[0-9a-zA-Z_]*]] = OpBitwiseAnd [[uint]] [[load1_offset]] [[uint_3]]
+// CHECK: [[x1:%[0-9a-zA-Z_]*]] = OpVectorExtractDynamic [[float]] [[load1]] [[load1_idx]]
+// CHECK: [[load2_offset:%[0-9a-zA-Z_]*]] = OpIAdd [[uint]] [[in_mul]] [[uint_2]]
+// CHECK: [[load2_shift:%[0-9a-zA-Z_]*]] = OpShiftRightLogical [[uint]] [[load2_offset]] [[uint_2]]
+// CHECK: [[load2_addr:%[0-9a-zA-Z_]*]] = OpAccessChain {{.*}} [[uint_0]] [[load2_shift]]
+// CHECK: [[load2:%[0-9a-zA-Z_]*]] = OpLoad [[float4]] [[load2_addr]]
+// CHECK: [[load2_idx:%[0-9a-zA-Z_]*]] = OpBitwiseAnd [[uint]] [[load2_offset]] [[uint_3]]
+// CHECK: [[x2:%[0-9a-zA-Z_]*]] = OpVectorExtractDynamic [[float]] [[load2]] [[load2_idx]]
+// CHECK: [[x10:%[0-9a-zA-Z_]*]] = OpFAdd [[float]] [[x0]] [[x1]]
+// CHECK: [[StoreVal:%[0-9a-zA-Z_]*]] = OpFAdd [[float]] [[x2]] [[x10]]
+// CHECK: [[StoreAddr:%[0-9a-zA-Z_]*]] = OpAccessChain
+// CHECK: OpStore [[StoreAddr]] [[StoreVal]]
+
+kernel void test(global float *out, global float3 *in) {
+  uint gid = get_global_id(0);
+  float3 x = vload3(gid, (global float *)in);
+  out[gid] = x[0] + x[1] + x[2];
+}

--- a/test/issue-679.ll
+++ b/test/issue-679.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt --ThreeElementVectorLowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(float addrspace(1)* %out, <3 x float> addrspace(1)* %in, i32 %n) {
+entry:
+    %bitcast = bitcast <3 x float> addrspace(1)* %in to float addrspace(1)*
+    %gep = getelementptr float, float addrspace(1)* %bitcast, i32 %n
+    %load = load float, float addrspace(1)* %gep, align 4
+    store float %load, float addrspace(1)* %out, align 4
+    ret void
+}
+
+; CHECK: define spir_kernel void @test(float addrspace(1)* %out, <4 x float> addrspace(1)* %in, i32 %n) {
+; CHECK: [[bitcast:%[^ ]+]] = bitcast <4 x float> addrspace(1)* %in to float addrspace(1)*
+; CHECK: [[gep:%[^ ]+]] = getelementptr float, float addrspace(1)* [[bitcast]], i32 %n
+; CHECK: [[load:%[^ ]+]] = load float, float addrspace(1)* [[gep]], align 4
+; CHECK: store float [[load]], float addrspace(1)* %out, align 4
+

--- a/test/packed_struct_novec3.cl
+++ b/test/packed_struct_novec3.cl
@@ -1,0 +1,72 @@
+// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+struct S1{
+    int3 x;
+    int y;
+} __attribute__((packed));
+
+struct S2{
+    int3 x;
+    int y;
+};
+
+__kernel void test(__global int *a) {
+    int gid = get_global_id(0);
+    __local struct S1 s1[64];
+    __local struct S2 s2[64];
+    s1[gid].x[0] = a[gid + 0];
+    s1[gid].x[1] = a[gid + 1];
+    s1[gid].x[2] = a[gid + 2];
+    s1[gid].y = a[gid + 3];
+
+    s2[gid].x[0] = a[gid + 4];
+    s2[gid].x[1] = a[gid + 5];
+    s2[gid].x[2] = a[gid + 6];
+    s2[gid].y = a[gid + 7];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    a[gid + 0] = s1[gid].x[0];
+    a[gid + 1] = s1[gid].x[1];
+    a[gid + 2] = s1[gid].x[2];
+    a[gid + 3] = s1[gid].y;
+
+    a[gid + 4] = s2[gid].x[0];
+    a[gid + 5] = s2[gid].x[1];
+    a[gid + 6] = s2[gid].x[2];
+    a[gid + 7] = s2[gid].y;
+}
+
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uintv3:%[^ ]+]] = OpTypeVector [[uint]] 3
+// CHECK-DAG: [[uintv4:%[^ ]+]] = OpTypeVector [[uint]] 4
+// CHECK-DAG: [[uintinput:%[^ ]+]] = OpTypePointer Input [[uint]]
+// CHECK-DAG: [[uintv3input:%[^ ]+]] = OpTypePointer Input [[uintv3]]
+// CHECK-DAG: [[uintworkgroup:%[^ ]+]] = OpTypePointer Workgroup [[uint]]
+// CHECK-DAG: [[uintv3workgroup:%[^ ]+]] = OpTypePointer Workgroup [[uintv3]]
+// CHECK-DAG: [[uintv4workgroup:%[^ ]+]] = OpTypePointer Workgroup [[uintv4]]
+// CHECK-DAG: [[uint12:%[^ ]+]] = OpConstant [[uint]] 12
+// CHECK-DAG: [[uint64:%[^ ]+]] = OpConstant [[uint]] 64
+// CHECK-DAG: [[uchararray12:%[^ ]+]] = OpTypeArray [[uchar]] [[uint12]]
+// CHECK-DAG: [[S1:%[^ ]+]] = OpTypeStruct [[uintv3]] [[uint]]
+// CHECK-DAG: [[S2:%[^ ]+]] = OpTypeStruct [[uintv4]] [[uint]] [[uchararray12]]
+// CHECK-DAG: [[S1array:%[^ ]+]] = OpTypeArray [[S1]] [[uint64]]
+// CHECK-DAG: [[S2array:%[^ ]+]] = OpTypeArray [[S2]] [[uint64]]
+// CHECK-DAG: [[S1arrayptr:%[^ ]+]] = OpTypePointer Workgroup [[S1array]]
+// CHECK-DAG: [[S2arrayptr:%[^ ]+]] = OpTypePointer Workgroup [[S2array]]
+// CHECK-DAG: [[uint0:%[^ ]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint1:%[^ ]+]] = OpConstant [[uint]] 1
+// CHECK: [[s1:%[^ ]+]] = OpVariable [[S1arrayptr]] Workgroup
+// CHECK: [[s2:%[^ ]+]] = OpVariable [[S2arrayptr]] Workgroup
+// CHECK: [[gidptr:%[^ ]+]] = OpVariable [[uintv3input]] Input
+// CHECK: [[gidgep:%[^ ]+]] = OpAccessChain [[uintinput]] [[gidptr]] [[uint0]]
+// CHECK: [[gid:%[^ ]+]] = OpLoad [[uint]] [[gidgep]]
+// CHECK: [[_0:%[^ ]+]] = OpAccessChain [[uintv3workgroup]] [[s1]] [[gid]] [[uint0]]
+// CHECK: [[_1:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s1]] [[gid]] [[uint1]]
+// CHECK: [[_2:%[^ ]+]] = OpAccessChain [[uintv4workgroup]] [[s2]] [[gid]] [[uint0]]
+// CHECK: [[_3:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[gid]] [[uint1]]

--- a/test/packed_struct_novec3.ll
+++ b/test/packed_struct_novec3.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt --ThreeElementVectorLowering -vec3-to-vec4 %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S1 = type <{ <3 x i32>, i32 }>
+%struct.S2 = type { <3 x i32>, i32, [12 x i8] }
+
+@test.s1 = internal addrspace(3) global [64 x %struct.S1] undef, align 1
+@test.s2 = internal addrspace(3) global [64 x %struct.S2] undef, align 16
+
+; CHECK: %struct.S1 = type <{ <3 x i32>, i32 }>
+;
+; CHECK: @test.s1 = internal addrspace(3) global [64 x %struct.S1] undef, align 1
+; CHECK: @test.s2 = internal addrspace(3) global [64 x { <4 x i32>, i32, [12 x i8] }] undef, align 16

--- a/test/vector_shuffle_float3.cl
+++ b/test/vector_shuffle_float3.cl
@@ -4,10 +4,10 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
-// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK: %[[UNDEF_ID:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_VECTOR_TYPE_ID]]
 // CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[SHUFFLE_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_ID]] 2 0 1 
+// CHECK: %[[SHUFFLE_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT_VECTOR_TYPE_ID]] %[[LOADA_ID]] %[[UNDEF_ID]] 2 0 1 4294967295
 // CHECK: OpStore {{.*}} %[[SHUFFLE_ID]] 
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(float3 a, global float3 *b)


### PR DESCRIPTION
This is done only if a bitcast of a vec3 is detected.
It can also be forced using the '-vec3-to-vec4' option.

exceptions:
 - internal spirv global variables are often vec3 corresponding to the
 3 dimensions. Those are not transformed.
 - builtins: some of them are safe to use with vec4 instead of vec3,
 but not all of them (OpCopyMemory, OpAny, OpAll, etc)

No regression on the OpenCL CTS + 27 new tests passed

Fixes #679