### PR TITLE
longvector: Uses Array instead of Struct

### DIFF
--- a/test/AsyncWorkGroupCopy/async_work_group_copy_long_vector_test_gen.py
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_long_vector_test_gen.py
@@ -92,8 +92,7 @@ def get_type(width, vector_size):
     return '<' + str(vector_size) + ' x ' + get_scalar_type(width) + '>'
 
 def get_check_type(width, vector_size):
-    type_array = [ get_scalar_type(width) ] * vector_size
-    return '{ ' + ', '.join(type_array) + ' }'
+    return '[' + str(vector_size) + ' x ' + str(get_scalar_type(width)) + ']'
 
 def get_type_mangling(width, vector_size, signed):
     if vector_size > 1:

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_global_to_local.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_sPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(3)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(3)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(3)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(3)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(3)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(3)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(3)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(3)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_global_to_local_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_sPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(3)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(3)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(3)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(3)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(3)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(3)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(3)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(3)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_local_to_global.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_sPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(1)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(1)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(1)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(1)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(1)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(1)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(1)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(1)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i16_local_to_global_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_sPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(1)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(1)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(1)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(1)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(1)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(1)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(1)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(1)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_global_to_local.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_iPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(3)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(3)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(3)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(3)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(3)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(3)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(3)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(3)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_global_to_local_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_iPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(3)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(3)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(3)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(3)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(3)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(3)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(3)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(3)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_local_to_global.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_iPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(1)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(1)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(1)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(1)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(1)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(1)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(1)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(1)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i32_local_to_global_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_iPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(1)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(1)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(1)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(1)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(1)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(1)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(1)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(1)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_global_to_local.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_lPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(3)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(3)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(3)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(3)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(3)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(3)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(3)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(3)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_global_to_local_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_lPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(3)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(3)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(3)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(3)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(3)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(3)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(3)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(3)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_local_to_global.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_lPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(1)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(1)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(1)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(1)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(1)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(1)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(1)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(1)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i64_local_to_global_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_lPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(1)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(1)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(1)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(1)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(1)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(1)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(1)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(1)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_global_to_local.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_cPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(3)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(3)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(3)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(3)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(3)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(3)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(3)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(3)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_global_to_local_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv16_cPU3AS1K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(3)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(3)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(3)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(3)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(3)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(3)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(3)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(3)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_local_to_global.ll
@@ -40,88 +40,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_cPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(1)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(1)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(1)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(1)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(1)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(1)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(1)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(1)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v16i8_local_to_global_explicit_spirv_variables.ll
@@ -43,88 +43,88 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv16_cPU3AS3K
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(1)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(1)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(1)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(1)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(1)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(1)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(1)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(1)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_global_to_local.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_sPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_global_to_local_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_sPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_local_to_global.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_sPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i16_local_to_global_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_sPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_global_to_local.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_iPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_global_to_local_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_iPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_local_to_global.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_iPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i32_local_to_global_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_iPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_global_to_local.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_lPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_global_to_local_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_lPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_local_to_global.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_lPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i64_local_to_global_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_lPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_global_to_local.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_cPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_global_to_local_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS3Dv8_cPU3AS1KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_local_to_global.ll
@@ -40,48 +40,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_cPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_copy_v8i8_local_to_global_explicit_spirv_variables.ll
@@ -43,48 +43,48 @@ declare spir_func %opencl.event_t* @_Z21async_work_group_copyPU3AS1Dv8_cPU3AS3KS
 ; CHECK: [[icmp:%[a-zA-Z0-9_.]+]] = icmp ult i32 [[phiiterator]], %num_gentypes
 ; CHECK: br i1 [[icmp]], label %[[loop]], label %[[exit:[a-zA-Z0-9_.]+]]
 ; CHECK: [[loop]]:
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_long_vector_test_gen.py
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_long_vector_test_gen.py
@@ -102,8 +102,7 @@ def get_type(width, vector_size):
         return '<' + str(vector_size) + ' x ' + get_scalar_type(width) + '>'
 
 def get_check_type(width, vector_size):
-    type_array = [ get_scalar_type(width) ] * vector_size
-    return '{ ' + ', '.join(type_array) + ' }'
+    return '[' + str(vector_size) + ' x ' + str(get_scalar_type(width)) + ']'
 
 def get_type_mangling(width, vector_size, signed):
     if vector_size > 1:

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_global_to_local.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(3)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(3)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(3)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(3)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(3)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(3)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(3)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(3)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_global_to_local_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(3)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(3)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(3)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(3)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(3)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(3)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(3)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(3)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_local_to_global.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(1)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(1)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(1)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(1)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(1)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(1)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(1)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(1)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i16_local_to_global_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc8]], align 2
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i16 [[loadsrc8]], i16 addrspace(1)* [[gepdst8]], align 2
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc9]], align 2
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i16 [[loadsrc9]], i16 addrspace(1)* [[gepdst9]], align 2
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc10]], align 2
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i16 [[loadsrc10]], i16 addrspace(1)* [[gepdst10]], align 2
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc11]], align 2
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i16 [[loadsrc11]], i16 addrspace(1)* [[gepdst11]], align 2
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc12]], align 2
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i16 [[loadsrc12]], i16 addrspace(1)* [[gepdst12]], align 2
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc13]], align 2
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i16 [[loadsrc13]], i16 addrspace(1)* [[gepdst13]], align 2
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc14]], align 2
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i16 [[loadsrc14]], i16 addrspace(1)* [[gepdst14]], align 2
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc15]], align 2
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i16], [16 x i16] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i16 [[loadsrc15]], i16 addrspace(1)* [[gepdst15]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_global_to_local.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(3)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(3)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(3)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(3)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(3)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(3)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(3)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(3)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_global_to_local_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(3)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(3)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(3)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(3)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(3)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(3)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(3)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(3)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_local_to_global.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(1)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(1)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(1)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(1)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(1)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(1)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(1)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(1)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i32_local_to_global_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc8]], align 4
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i32 [[loadsrc8]], i32 addrspace(1)* [[gepdst8]], align 4
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc9]], align 4
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i32 [[loadsrc9]], i32 addrspace(1)* [[gepdst9]], align 4
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc10]], align 4
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i32 [[loadsrc10]], i32 addrspace(1)* [[gepdst10]], align 4
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc11]], align 4
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i32 [[loadsrc11]], i32 addrspace(1)* [[gepdst11]], align 4
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc12]], align 4
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i32 [[loadsrc12]], i32 addrspace(1)* [[gepdst12]], align 4
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc13]], align 4
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i32 [[loadsrc13]], i32 addrspace(1)* [[gepdst13]], align 4
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc14]], align 4
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i32 [[loadsrc14]], i32 addrspace(1)* [[gepdst14]], align 4
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc15]], align 4
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i32], [16 x i32] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i32 [[loadsrc15]], i32 addrspace(1)* [[gepdst15]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_global_to_local.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(3)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(3)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(3)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(3)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(3)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(3)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(3)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(3)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_global_to_local_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(3)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(3)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(3)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(3)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(3)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(3)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(3)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(3)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_local_to_global.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(1)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(1)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(1)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(1)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(1)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(1)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(1)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(1)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i64_local_to_global_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc8]], align 8
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i64 [[loadsrc8]], i64 addrspace(1)* [[gepdst8]], align 8
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc9]], align 8
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i64 [[loadsrc9]], i64 addrspace(1)* [[gepdst9]], align 8
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc10]], align 8
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i64 [[loadsrc10]], i64 addrspace(1)* [[gepdst10]], align 8
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc11]], align 8
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i64 [[loadsrc11]], i64 addrspace(1)* [[gepdst11]], align 8
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc12]], align 8
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i64 [[loadsrc12]], i64 addrspace(1)* [[gepdst12]], align 8
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc13]], align 8
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i64 [[loadsrc13]], i64 addrspace(1)* [[gepdst13]], align 8
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc14]], align 8
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i64 [[loadsrc14]], i64 addrspace(1)* [[gepdst14]], align 8
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc15]], align 8
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i64], [16 x i64] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i64 [[loadsrc15]], i64 addrspace(1)* [[gepdst15]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_global_to_local.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(3)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(3)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(3)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(3)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(3)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(3)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(3)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(3)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_global_to_local_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(3)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(3)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(3)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(3)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(3)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(3)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(3)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(3)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_local_to_global.ll
@@ -42,89 +42,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(1)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(1)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(1)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(1)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(1)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(1)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(1)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(1)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v16i8_local_to_global_explicit_spirv_variables.ll
@@ -45,89 +45,89 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv16_
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
-;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 8
+;CHECK: [[gepsrc8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 8
 ;CHECK: [[loadsrc8:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc8]], align 1
-;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 8
+;CHECK: [[gepdst8:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 8
 ;CHECK: store i8 [[loadsrc8]], i8 addrspace(1)* [[gepdst8]], align 1
 
-;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 9
+;CHECK: [[gepsrc9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 9
 ;CHECK: [[loadsrc9:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc9]], align 1
-;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 9
+;CHECK: [[gepdst9:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 9
 ;CHECK: store i8 [[loadsrc9]], i8 addrspace(1)* [[gepdst9]], align 1
 
-;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 10
+;CHECK: [[gepsrc10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 10
 ;CHECK: [[loadsrc10:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc10]], align 1
-;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 10
+;CHECK: [[gepdst10:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 10
 ;CHECK: store i8 [[loadsrc10]], i8 addrspace(1)* [[gepdst10]], align 1
 
-;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 11
+;CHECK: [[gepsrc11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 11
 ;CHECK: [[loadsrc11:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc11]], align 1
-;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 11
+;CHECK: [[gepdst11:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 11
 ;CHECK: store i8 [[loadsrc11]], i8 addrspace(1)* [[gepdst11]], align 1
 
-;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 12
+;CHECK: [[gepsrc12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 12
 ;CHECK: [[loadsrc12:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc12]], align 1
-;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 12
+;CHECK: [[gepdst12:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 12
 ;CHECK: store i8 [[loadsrc12]], i8 addrspace(1)* [[gepdst12]], align 1
 
-;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 13
+;CHECK: [[gepsrc13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 13
 ;CHECK: [[loadsrc13:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc13]], align 1
-;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 13
+;CHECK: [[gepdst13:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 13
 ;CHECK: store i8 [[loadsrc13]], i8 addrspace(1)* [[gepdst13]], align 1
 
-;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 14
+;CHECK: [[gepsrc14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 14
 ;CHECK: [[loadsrc14:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc14]], align 1
-;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 14
+;CHECK: [[gepdst14:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 14
 ;CHECK: store i8 [[loadsrc14]], i8 addrspace(1)* [[gepdst14]], align 1
 
-;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 15
+;CHECK: [[gepsrc15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(3)* [[srci]], i32 0, i32 15
 ;CHECK: [[loadsrc15:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc15]], align 1
-;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 15
+;CHECK: [[gepdst15:%[a-zA-Z0-9_.]+]] = getelementptr [16 x i8], [16 x i8] addrspace(1)* [[dsti]], i32 0, i32 15
 ;CHECK: store i8 [[loadsrc15]], i8 addrspace(1)* [[gepdst15]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_global_to_local.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_s
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_global_to_local_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_s
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(3)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(3)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(3)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(3)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(3)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(3)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(3)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(1)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(3)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_local_to_global.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_s
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i16_local_to_global_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_s
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc0]], align 2
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i16 [[loadsrc0]], i16 addrspace(1)* [[gepdst0]], align 2
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc1]], align 2
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i16 [[loadsrc1]], i16 addrspace(1)* [[gepdst1]], align 2
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc2]], align 2
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i16 [[loadsrc2]], i16 addrspace(1)* [[gepdst2]], align 2
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc3]], align 2
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i16 [[loadsrc3]], i16 addrspace(1)* [[gepdst3]], align 2
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc4]], align 2
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i16 [[loadsrc4]], i16 addrspace(1)* [[gepdst4]], align 2
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc5]], align 2
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i16 [[loadsrc5]], i16 addrspace(1)* [[gepdst5]], align 2
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc6]], align 2
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i16 [[loadsrc6]], i16 addrspace(1)* [[gepdst6]], align 2
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i16, i16 addrspace(3)* [[gepsrc7]], align 2
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i16, i16, i16, i16, i16, i16, i16, i16 }, { i16, i16, i16, i16, i16, i16, i16, i16 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i16], [8 x i16] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i16 [[loadsrc7]], i16 addrspace(1)* [[gepdst7]], align 2
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_global_to_local.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_i
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_global_to_local_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_i
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(3)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(3)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(3)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(3)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(3)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(3)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(3)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(1)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(3)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_local_to_global.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_i
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i32_local_to_global_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_i
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc0]], align 4
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i32 [[loadsrc0]], i32 addrspace(1)* [[gepdst0]], align 4
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc1]], align 4
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i32 [[loadsrc1]], i32 addrspace(1)* [[gepdst1]], align 4
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc2]], align 4
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i32 [[loadsrc2]], i32 addrspace(1)* [[gepdst2]], align 4
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc3]], align 4
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i32 [[loadsrc3]], i32 addrspace(1)* [[gepdst3]], align 4
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc4]], align 4
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i32 [[loadsrc4]], i32 addrspace(1)* [[gepdst4]], align 4
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc5]], align 4
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i32 [[loadsrc5]], i32 addrspace(1)* [[gepdst5]], align 4
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc6]], align 4
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i32 [[loadsrc6]], i32 addrspace(1)* [[gepdst6]], align 4
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[gepsrc7]], align 4
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i32, i32, i32, i32, i32, i32, i32, i32 }, { i32, i32, i32, i32, i32, i32, i32, i32 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], [8 x i32] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i32 [[loadsrc7]], i32 addrspace(1)* [[gepdst7]], align 4
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_global_to_local.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_l
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_global_to_local_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_l
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(3)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(3)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(3)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(3)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(3)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(3)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(3)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(1)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(3)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_local_to_global.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_l
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i64_local_to_global_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_l
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc0]], align 8
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i64 [[loadsrc0]], i64 addrspace(1)* [[gepdst0]], align 8
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc1]], align 8
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i64 [[loadsrc1]], i64 addrspace(1)* [[gepdst1]], align 8
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc2]], align 8
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i64 [[loadsrc2]], i64 addrspace(1)* [[gepdst2]], align 8
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc3]], align 8
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i64 [[loadsrc3]], i64 addrspace(1)* [[gepdst3]], align 8
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc4]], align 8
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i64 [[loadsrc4]], i64 addrspace(1)* [[gepdst4]], align 8
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc5]], align 8
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i64 [[loadsrc5]], i64 addrspace(1)* [[gepdst5]], align 8
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc6]], align 8
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i64 [[loadsrc6]], i64 addrspace(1)* [[gepdst6]], align 8
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i64, i64 addrspace(3)* [[gepsrc7]], align 8
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i64], [8 x i64] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i64 [[loadsrc7]], i64 addrspace(1)* [[gepdst7]], align 8
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_global_to_local.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_global_to_local.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_c
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_global_to_local_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_global_to_local_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS3Dv8_c
 ; CHECK: [[loop]]:
 
 ; CHECK: [[srciterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %dst, i32 [[phiiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %src, i32 [[srciterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %dst, i32 [[phiiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %src, i32 [[srciterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(3)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(3)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(3)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(3)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(3)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(3)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(3)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(1)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(3)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_local_to_global.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_local_to_global.ll
@@ -42,49 +42,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_c
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_local_to_global_explicit_spirv_variables.ll
+++ b/test/AsyncWorkGroupCopy/async_work_group_strided_copy_v8i8_local_to_global_explicit_spirv_variables.ll
@@ -45,49 +45,49 @@ declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv8_c
 ; CHECK: [[loop]]:
 
 ; CHECK: [[dstiterator:%[a-zA-Z0-9_.]+]] = mul i32 [[phiiterator]], %stride
-; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* %dst, i32 [[dstiterator]]
-; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* %src, i32 [[phiiterator]]
+; CHECK: [[dsti:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* %dst, i32 [[dstiterator]]
+; CHECK: [[srci:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* %src, i32 [[phiiterator]]
 
 ; CHECK: [[nextiterator]] = add i32 [[phiiterator]], [[incr]]
 
-;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 0
+;CHECK: [[gepsrc0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 0
 ;CHECK: [[loadsrc0:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc0]], align 1
-;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 0
+;CHECK: [[gepdst0:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 0
 ;CHECK: store i8 [[loadsrc0]], i8 addrspace(1)* [[gepdst0]], align 1
 
-;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 1
+;CHECK: [[gepsrc1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 1
 ;CHECK: [[loadsrc1:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc1]], align 1
-;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 1
+;CHECK: [[gepdst1:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 1
 ;CHECK: store i8 [[loadsrc1]], i8 addrspace(1)* [[gepdst1]], align 1
 
-;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 2
+;CHECK: [[gepsrc2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 2
 ;CHECK: [[loadsrc2:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc2]], align 1
-;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 2
+;CHECK: [[gepdst2:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 2
 ;CHECK: store i8 [[loadsrc2]], i8 addrspace(1)* [[gepdst2]], align 1
 
-;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 3
+;CHECK: [[gepsrc3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 3
 ;CHECK: [[loadsrc3:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc3]], align 1
-;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 3
+;CHECK: [[gepdst3:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 3
 ;CHECK: store i8 [[loadsrc3]], i8 addrspace(1)* [[gepdst3]], align 1
 
-;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 4
+;CHECK: [[gepsrc4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 4
 ;CHECK: [[loadsrc4:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc4]], align 1
-;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 4
+;CHECK: [[gepdst4:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 4
 ;CHECK: store i8 [[loadsrc4]], i8 addrspace(1)* [[gepdst4]], align 1
 
-;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 5
+;CHECK: [[gepsrc5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 5
 ;CHECK: [[loadsrc5:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc5]], align 1
-;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 5
+;CHECK: [[gepdst5:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 5
 ;CHECK: store i8 [[loadsrc5]], i8 addrspace(1)* [[gepdst5]], align 1
 
-;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 6
+;CHECK: [[gepsrc6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 6
 ;CHECK: [[loadsrc6:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc6]], align 1
-;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 6
+;CHECK: [[gepdst6:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 6
 ;CHECK: store i8 [[loadsrc6]], i8 addrspace(1)* [[gepdst6]], align 1
 
-;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(3)* [[srci]], i32 0, i32 7
+;CHECK: [[gepsrc7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(3)* [[srci]], i32 0, i32 7
 ;CHECK: [[loadsrc7:%[a-zA-Z0-9_.]+]] = load i8, i8 addrspace(3)* [[gepsrc7]], align 1
-;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr { i8, i8, i8, i8, i8, i8, i8, i8 }, { i8, i8, i8, i8, i8, i8, i8, i8 } addrspace(1)* [[dsti]], i32 0, i32 7
+;CHECK: [[gepdst7:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i8], [8 x i8] addrspace(1)* [[dsti]], i32 0, i32 7
 ;CHECK: store i8 [[loadsrc7]], i8 addrspace(1)* [[gepdst7]], align 1
 
 ; CHECK: br label %[[cmp]]

--- a/test/LongVectorLowering/bitcast.ll
+++ b/test/LongVectorLowering/bitcast.ll
@@ -87,25 +87,25 @@ define spir_func <2 x i32 addrspace(5)*> @pv2pv_C(<2 x float addrspace(5)*> %x) 
 ; process re-orders functions in the module.
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[OUT:{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 } addrspace\(5\)\*]]
+; CHECK-SAME: [[OUT:\[16 x i32\] addrspace\(5\)\*]]
 ; CHECK-SAME: @ps2ps_B(
-; CHECK-SAME: [[IN:{ float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float } addrspace\(5\)\*]]
+; CHECK-SAME: [[IN:\[16 x float\] addrspace\(5\)\*]]
 ; CHECK-SAME: [[X:%[^ ]+]])
 ; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
 ; CHECK-NEXT: ret [[OUT]] [[Y]]
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[OUT:{ i32, i32, i32, i32, i32, i32, i32, i32 }\*]]
+; CHECK-SAME: [[OUT:\[8 x i32\]\*]]
 ; CHECK-SAME: @ps2ps_A(
-; CHECK-SAME: [[IN:{ float, float, float, float, float, float, float, float }\*]]
+; CHECK-SAME: [[IN:\[8 x float\]\*]]
 ; CHECK-SAME: [[X:%[^ ]+]])
 ; CHECK-NEXT: [[Y:%[^ ]+]] = bitcast [[IN]] [[X]] to [[OUT]]
 ; CHECK-NEXT: ret [[OUT]] [[Y]]
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[OUT:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: [[OUT:\[8 x i32\]]]
 ; CHECK-SAME: @v2v_A(
-; CHECK-SAME: [[IN:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[IN:\[8 x float\]]]
 ; CHECK-SAME: [[X:%[^ ]+]])
 ; CHECK-DAG: [[X0:%[^ ]+]] = extractvalue [[IN]] [[X]], 0
 ; CHECK-DAG: [[X1:%[^ ]+]] = extractvalue [[IN]] [[X]], 1

--- a/test/LongVectorLowering/bitselect_float8.cl
+++ b/test/LongVectorLowering/bitselect_float8.cl
@@ -10,7 +10,8 @@ __kernel void bitselect(__global float8 *A, __global float8 *B,
 
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK-DAG: %[[float8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[float]] %[[float]] %[[float]] %[[float]] %[[float]] %[[float]] %[[float]] %[[float]]
+// CHECK-DAG: %[[uint_8:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 8
+// CHECK-DAG: %[[float8:[0-9a-zA-Z_]+]] = OpTypeArray %[[float]] %[[uint_8]]
 // CHECK-DAG: %[[array_float8:[0-9a-zA-Z_]+]] = OpTypeRuntimeArray %[[float8]]
 // CHECK-DAG: %[[struct_float8:[0-9a-zA-Z_]+]] = OpTypeStruct %[[array_float8]]
 // CHECK-DAG: %[[ptr_float8:[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer %[[struct_float8]]

--- a/test/LongVectorLowering/constants.ll
+++ b/test/LongVectorLowering/constants.ll
@@ -31,23 +31,23 @@ define spir_func <8 x i32> @test6() {
 }
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: [[INT8:\[8 x i32\]]]
 ; CHECK-SAME: @test6()
-; CHECK-NEXT: ret [[INT8]] { i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7 }
+; CHECK-NEXT: ret [[INT8]] [i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7]
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test5()
-; CHECK-NEXT: ret [[FLOAT8]] { float 0[[SUFFIX:\.0+e\+0+]], float 1[[SUFFIX]], float 2[[SUFFIX]],
-; CHECK-SAME: float 3[[SUFFIX]], float 4[[SUFFIX]], float 5[[SUFFIX]], float 6[[SUFFIX]], float 7[[SUFFIX]] }
+; CHECK-NEXT: ret [[FLOAT8]] [float 0[[SUFFIX:\.0+e\+0+]], float 1[[SUFFIX]], float 2[[SUFFIX]],
+; CHECK-SAME: float 3[[SUFFIX]], float 4[[SUFFIX]], float 5[[SUFFIX]], float 6[[SUFFIX]], float 7[[SUFFIX]]]
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[INT16:{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: [[INT16:\[16 x i32\]]]
 ; CHECK-SAME: @test4()
 ; CHECK-NEXT: ret [[INT16]] undef
 
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[FLOAT16:{ float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[FLOAT16:\[16 x float\]]]
 ; CHECK-SAME: @test3()
 ; CHECK-NEXT: ret [[FLOAT16]] undef
 

--- a/test/LongVectorLowering/elements.ll
+++ b/test/LongVectorLowering/elements.ll
@@ -13,7 +13,7 @@ define spir_func <8 x i32> @test(<8 x i32> %xs) {
 }
 
 ; CHECK-LABEL: @test
-; CHECK-SAME: ([[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]] [[XS:%[^ ]+]])
+; CHECK-SAME: ([[INT8:\[8 x i32\]]] [[XS:%[^ ]+]])
 ; CHECK-DAG: [[A:%[^ ]+]] = extractvalue [[INT8]] [[XS]], 0
 ; CHECK-DAG: [[B:%[^ ]+]] = extractvalue [[INT8]] [[XS]], 1
 ; CHECK-DAG: insertvalue {{.*}} i32 [[A]], 1

--- a/test/LongVectorLowering/function.ll
+++ b/test/LongVectorLowering/function.ll
@@ -40,13 +40,13 @@ define spir_func <8 x i32> @test2(i32 %a) {
 ; CHECK-NOT: <8 x i32>
 ;
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK-SAME: [[INT8:\[8 x i32\]]]
 ; CHECK-SAME: @test2(i32 {{%[^ ]+}})
 ; CHECK-NEXT: call spir_func i32 @foo()
 ; CHECK: ret [[INT8]] {{%[^ ]+}}
 ;
 ; CHECK-LABEL: define spir_func
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test1([[FLOAT8]] [[X:%[^ ]+]])
 ; CHECK-SAME: !info [[MD:![0-9]+]]
 ; CHECK-NEXT: [[Y:%[^ ]+]] = call spir_func [[FLOAT8]] @id([[FLOAT8]] [[X]])

--- a/test/LongVectorLowering/gep.ll
+++ b/test/LongVectorLowering/gep.ll
@@ -51,7 +51,7 @@ define dso_local spir_kernel void @test6(<8 x float> addrspace(1)* %out) {
 }
 
 ; CHECK: @global = external dso_local addrspace(3) global
-; CHECK-SAME: [1 x [[FLOAT8:{ float, float, float, float, float, float, float, float }]]], align 32
+; CHECK-SAME: [1 x [[FLOAT8:\[8 x float\]]]], align 32
 
 ; CHECK-LABEL: @test6(
 ; CHECK: load [[FLOAT8]], [[FLOAT8]] addrspace(3)*
@@ -69,12 +69,12 @@ define dso_local spir_kernel void @test6(<8 x float> addrspace(1)* %out) {
 ; CHECK-SAME: align 32
 
 ; CHECK-LABEL: @test3(
-; CHECK-SAME: [[TYPE:\[2 x \[3 x { i16, i16, i16, i16, i16, i16, i16, i16 }\]\]]] addrspace(1)* [[IN:%[^,]+]],
+; CHECK-SAME: [[TYPE:\[2 x \[3 x \[8 x i16\]\]\]]] addrspace(1)* [[IN:%[^,]+]],
 ; CHECK: [[PTR:%[^ ]+]] = getelementptr inbounds [[TYPE]], [[TYPE]] addrspace(1)* [[IN]], i32 0, i32 1, i32 undef
-; CHECK: load [[SHORT8:{ i16, i16, i16, i16, i16, i16, i16, i16 }]], [[SHORT8]] addrspace(1)* [[PTR]], align 32
+; CHECK: load [[SHORT8:\[8 x i16\]]], [[SHORT8]] addrspace(1)* [[PTR]], align 32
 
 ; CHECK-LABEL: @test2(
-; CHECK-SAME: [1 x [[HALF8:{ half, half, half, half, half, half, half, half, half, half, half, half, half, half, half, half }]]]
+; CHECK-SAME: [1 x [[HALF8:\[16 x half\]]]]
 ; CHECK-SAME: addrspace(1)* [[IN:%[^,]+]],
 ; CHECK: [[PTR:%[^ ]+]] = getelementptr inbounds [1 x [[HALF8]]], [1 x [[HALF8]]] addrspace(1)* [[IN]], i32 0, i32 undef
 ; CHECK: load [[HALF8]], [[HALF8]] addrspace(1)* [[PTR]], align 32

--- a/test/LongVectorLowering/globals.ll
+++ b/test/LongVectorLowering/globals.ll
@@ -9,10 +9,10 @@ target triple = "spir-unknown-unknown"
 ; NEGATIVE-NOT: <16 x float>
 
 @global_a = external addrspace(2) constant <8 x float>, align 32
-; CHECK: external addrspace(2) constant { float, float, float, float, float, float, float, float }, align 32
+; CHECK: external addrspace(2) constant [8 x float], align 32
 
 @global_b = addrspace(3) global <16 x i16> zeroinitializer, align 16
-; CHECK: addrspace(3) global { i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16 }
+; CHECK: addrspace(3) global [16 x i16]
 ; CHECK-SAME: zeroinitializer, align 16
 
 define spir_func <8 x float> @test_a() {

--- a/test/LongVectorLowering/memory.ll
+++ b/test/LongVectorLowering/memory.ll
@@ -24,7 +24,7 @@ define spir_func void @test2(<8 x i32>* %ptr) {
 }
 
 ; CHECK-LABEL: define spir_func void @test2(
-; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]* [[PTR:%[^ ]+]])
+; CHECK-SAME: [[INT8:\[8 x i32\]]]* [[PTR:%[^ ]+]])
 ; CHECK: [[ALLOCA:%[^ ]+]] = alloca [[INT8]], align 32
 ; CHECK: [[VALUE:%[^ ]+]] = load volatile [[INT8]], [[INT8]]* [[PTR]], align 32
 ; CHECK: store [[INT8]] [[VALUE]], [[INT8]]* [[ALLOCA]], align 32
@@ -33,7 +33,7 @@ define spir_func void @test2(<8 x i32>* %ptr) {
 ; CHECK: ret void
 
 ; CHECK-LABEL: define spir_func void @test1(
-; CHECK-SAME: [[HALF16:{ half, half, half, half, half, half, half, half, half, half, half, half, half, half, half, half }]]* [[PTR:%[^ ]+]])
+; CHECK-SAME: [[HALF16:\[16 x half\]]]* [[PTR:%[^ ]+]])
 ; CHECK: [[ALLOCA:%[^ ]+]] = alloca [[HALF16]], align 16
 ; CHECK: [[VALUE:%[^ ]+]] = load [[HALF16]], [[HALF16]]* [[PTR]], align 16
 ; CHECK: store volatile [[HALF16]] [[VALUE]], [[HALF16]]* [[ALLOCA]], align 16

--- a/test/LongVectorLowering/select1.ll
+++ b/test/LongVectorLowering/select1.ll
@@ -14,9 +14,9 @@ entry:
 }
 
 ; CHECK: define spir_func
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test(
-; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]] [[COND:%[^ ]+]],
+; CHECK-SAME: [[INT8:\[8 x i32\]]] [[COND:%[^ ]+]],
 ; CHECK-SAME: [[FLOAT8]] [[A:%[^ ]+]],
 ; CHECK-SAME: [[FLOAT8]] [[B:%[^ ]+]]) {
 

--- a/test/LongVectorLowering/select2.ll
+++ b/test/LongVectorLowering/select2.ll
@@ -12,7 +12,7 @@ entry:
 }
 
 ; CHECK: define spir_func
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test(
 ; CHECK-SAME: i1 [[COND:%[^ ]+]],
 ; CHECK-SAME: [[FLOAT8]] [[A:%[^ ]+]],

--- a/test/LongVectorLowering/shufflevector/shufflevector2.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector2.ll
@@ -15,7 +15,7 @@ entry:
 }
 
 ; CHECK: @test(
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]] [[A:%[^ ]+]],
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]] [[A:%[^ ]+]],
 ; CHECK-SAME: [[FLOAT8]] [[B:%[^ ]+]])
 ; CHECK-DAG: [[S0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1
 ; CHECK-DAG: [[S1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 4

--- a/test/LongVectorLowering/shufflevector/shufflevector3.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector3.ll
@@ -14,7 +14,7 @@ entry:
   ret <8 x float> %x
 }
 
-; CHECK: define spir_func [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK: define spir_func [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test(<3 x float> [[A:%[^ ]+]], <3 x float> [[B:%[^ ]+]])
 ; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x float> [[A]], i64 0
 ; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x float> [[A]], i64 1

--- a/test/LongVectorLowering/shufflevector/shufflevector4.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector4.ll
@@ -14,7 +14,7 @@ entry:
   ret <8 x float> %x
 }
 
-; CHECK: define spir_func [[FLOAT8:{ float, float, float, float, float, float, float, float }]]
+; CHECK: define spir_func [[FLOAT8:\[8 x float\]]]
 ; CHECK-SAME: @test([[FLOAT8]] [[A:%[^ ]+]])
 ; CHECK-DAG: [[S0:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 0
 ; CHECK-DAG: [[S1:%[^ ]+]] = extractvalue [[FLOAT8]] [[A]], 1

--- a/test/LongVectorLowering/shufflevector/shufflevector5.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector5.ll
@@ -14,7 +14,7 @@ entry:
   ret <8 x i32> %x
 }
 
-; CHECK: define spir_func [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK: define spir_func [[INT8:\[8 x i32\]]]
 ; CHECK-SAME: @test(<3 x i32> [[A:%[^ ]+]])
 ; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 0
 ; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 1

--- a/test/LongVectorLowering/shufflevector/shufflevector6.ll
+++ b/test/LongVectorLowering/shufflevector/shufflevector6.ll
@@ -17,7 +17,7 @@ entry:
   ret <8 x i32> %x
 }
 
-; CHECK: define spir_func [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]]
+; CHECK: define spir_func [[INT8:\[8 x i32\]]]
 ; CHECK-SAME: @test(<3 x i32> [[A:%[^ ]+]])
 ; CHECK-DAG: [[S0:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 0
 ; CHECK-DAG: [[S1:%[^ ]+]] = extractelement <3 x i32> [[A]], i64 1

--- a/test/MathBuiltins/isfinite/isfinite_float8.ll
+++ b/test/MathBuiltins/isfinite/isfinite_float8.ll
@@ -14,8 +14,8 @@ entry:
 }
 
 ; CHECK-LABEL: define spir_kernel void @test(
-; CHECK-SAME: [[FLOAT8:{ float, float, float, float, float, float, float, float }]] [[VAL:%[^ ,]+]],
-; CHECK-SAME: [[INT8:{ i32, i32, i32, i32, i32, i32, i32, i32 }]] addrspace(1)* nocapture [[OUT:%[^ )]+]]
+; CHECK-SAME: [[FLOAT8:\[8 x float\]]] [[VAL:%[^ ,]+]],
+; CHECK-SAME: [[INT8:\[8 x i32\]]] addrspace(1)* nocapture [[OUT:%[^ )]+]]
 ; CHECK-SAME: )
 
 ; CHECK-DAG: [[V0:%[^ ]+]] = extractvalue [[FLOAT8]] [[VAL]], 0
@@ -63,14 +63,14 @@ entry:
 ; CHECK-DAG: [[D6:%[^ ]+]] = sext i1 [[C6]] to i32
 ; CHECK-DAG: [[D7:%[^ ]+]] = sext i1 [[C7]] to i32
 
-; CHECK-DAG: [[E0:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 0
-; CHECK-DAG: [[E1:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 1
-; CHECK-DAG: [[E2:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 2
-; CHECK-DAG: [[E3:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 3
-; CHECK-DAG: [[E4:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 4
-; CHECK-DAG: [[E5:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 5
-; CHECK-DAG: [[E6:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 6
-; CHECK-DAG: [[E7:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i32 7
+; CHECK-DAG: [[E0:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 0
+; CHECK-DAG: [[E1:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 1
+; CHECK-DAG: [[E2:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 2
+; CHECK-DAG: [[E3:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 3
+; CHECK-DAG: [[E4:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 4
+; CHECK-DAG: [[E5:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 5
+; CHECK-DAG: [[E6:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 6
+; CHECK-DAG: [[E7:%[^ ]+]] = getelementptr inbounds [[INT8]], [[INT8]] addrspace(1)* [[OUT]], i64 0, i64 7
 
 ; CHECK-DAG: store i32 [[D0]], i32 addrspace(1)* [[E0]]
 ; CHECK-DAG: store i32 [[D1]], i32 addrspace(1)* [[E1]]

--- a/test/RelationalBuiltins/all/all_char16.cl
+++ b/test/RelationalBuiltins/all/all_char16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global char16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[char0:%[a-zA-Z0-9_]+]] = OpConstant [[char]] 0

--- a/test/RelationalBuiltins/all/all_int16.cl
+++ b/test/RelationalBuiltins/all/all_int16.cl
@@ -9,6 +9,7 @@ kernel void foo(global int* a, global int16* b) {
 
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4

--- a/test/RelationalBuiltins/all/all_long16.cl
+++ b/test/RelationalBuiltins/all/all_long16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global long16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[long0:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 0

--- a/test/RelationalBuiltins/all/all_short16.cl
+++ b/test/RelationalBuiltins/all/all_short16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global short16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[short0:%[a-zA-Z0-9_]+]] = OpConstant [[short]] 0

--- a/test/RelationalBuiltins/any/any_char16.cl
+++ b/test/RelationalBuiltins/any/any_char16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global char16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[char0:%[a-zA-Z0-9_]+]] = OpConstant [[char]] 0

--- a/test/RelationalBuiltins/any/any_int16.cl
+++ b/test/RelationalBuiltins/any/any_int16.cl
@@ -9,6 +9,7 @@ kernel void foo(global int* a, global int16* b) {
 
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[bool4:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 4

--- a/test/RelationalBuiltins/any/any_long16.cl
+++ b/test/RelationalBuiltins/any/any_long16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global long16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[long0:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 0

--- a/test/RelationalBuiltins/any/any_short16.cl
+++ b/test/RelationalBuiltins/any/any_short16.cl
@@ -10,6 +10,7 @@ kernel void foo(global int* a, global short16* b) {
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int_16:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 16
 // CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
 // CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
 // CHECK-DAG: [[short0:%[a-zA-Z0-9_]+]] = OpConstant [[short]] 0


### PR DESCRIPTION
To support long vectors, clspv use to transform them into struct of
the element type of the vector. But it is not ideal because llvm does
not know that all the elements of the structure are the same.
Let's use array instead of struct to help llvm.

No regression on OpenCL CTS + vload_local is now passing

Fixes #780