### PR TITLE
Tidy up handling of image types in SPIR-V Producer pass

### DIFF
--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -22,9 +22,9 @@ using namespace llvm;
 
 bool clspv::IsSamplerType(llvm::StructType *STy) {
   if (STy->isOpaque()) {
-     if (STy->getName().equals("opencl.sampler_t")) {
-        return true;
-     }
+    if (STy->getName().equals("opencl.sampler_t")) {
+      return true;
+    }
   }
   return false;
 }
@@ -34,9 +34,9 @@ bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
     if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
       if (IsSamplerType(STy)) {
-          isSamplerType = true;
-          if (struct_type_ptr)
-            *struct_type_ptr = STy;
+        isSamplerType = true;
+        if (struct_type_ptr)
+          *struct_type_ptr = STy;
       }
     }
   }
@@ -44,26 +44,26 @@ bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
 }
 
 bool clspv::IsImageType(llvm::StructType *STy) {
- if (STy->isOpaque()) {
-   if (STy->getName().startswith("opencl.image1d_ro_t") ||
-       STy->getName().startswith("opencl.image1d_rw_t") ||
-       STy->getName().startswith("opencl.image1d_wo_t") ||
-       STy->getName().startswith("opencl.image1d_array_ro_t") ||
-       STy->getName().startswith("opencl.image1d_array_rw_t") ||
-       STy->getName().startswith("opencl.image1d_array_wo_t") ||
-       STy->getName().startswith("opencl.image2d_ro_t") ||
-       STy->getName().startswith("opencl.image2d_rw_t") ||
-       STy->getName().startswith("opencl.image2d_wo_t") ||
-       STy->getName().startswith("opencl.image2d_array_ro_t") ||
-       STy->getName().startswith("opencl.image2d_array_rw_t") ||
-       STy->getName().startswith("opencl.image2d_array_wo_t") ||
-       STy->getName().startswith("opencl.image3d_ro_t") ||
-       STy->getName().startswith("opencl.image3d_rw_t") ||
-       STy->getName().startswith("opencl.image3d_wo_t")) {
-     return true;
-   }
- }
- return false;
+  if (STy->isOpaque()) {
+    if (STy->getName().startswith("opencl.image1d_ro_t") ||
+        STy->getName().startswith("opencl.image1d_rw_t") ||
+        STy->getName().startswith("opencl.image1d_wo_t") ||
+        STy->getName().startswith("opencl.image1d_array_ro_t") ||
+        STy->getName().startswith("opencl.image1d_array_rw_t") ||
+        STy->getName().startswith("opencl.image1d_array_wo_t") ||
+        STy->getName().startswith("opencl.image2d_ro_t") ||
+        STy->getName().startswith("opencl.image2d_rw_t") ||
+        STy->getName().startswith("opencl.image2d_wo_t") ||
+        STy->getName().startswith("opencl.image2d_array_ro_t") ||
+        STy->getName().startswith("opencl.image2d_array_rw_t") ||
+        STy->getName().startswith("opencl.image2d_array_wo_t") ||
+        STy->getName().startswith("opencl.image3d_ro_t") ||
+        STy->getName().startswith("opencl.image3d_rw_t") ||
+        STy->getName().startswith("opencl.image3d_wo_t")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
@@ -71,9 +71,9 @@ bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
     if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
       if (IsImageType(STy)) {
-          isImageType = true;
-          if (struct_type_ptr)
-            *struct_type_ptr = STy;
+        isImageType = true;
+        if (struct_type_ptr)
+          *struct_type_ptr = STy;
       }
     }
   }
@@ -95,7 +95,8 @@ uint32_t clspv::ImageDimensionality(StructType *STy) {
 
 uint32_t clspv::ImageDimensionality(Type *type) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+    if (auto struct_ty =
+            dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
       return ImageDimensionality(struct_ty);
     }
   }
@@ -130,7 +131,8 @@ bool clspv::IsSampledImageType(StructType *STy) {
 
 bool clspv::IsSampledImageType(Type *type) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+    if (auto struct_ty =
+            dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
       return IsSampledImageType(struct_ty);
     }
   }

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -20,62 +20,83 @@
 using namespace clspv;
 using namespace llvm;
 
+bool clspv::IsSamplerType(llvm::StructType *STy) {
+  if (STy->isOpaque()) {
+     if (STy->getName().equals("opencl.sampler_t")) {
+        return true;
+     }
+  }
+  return false;
+}
+
 bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   bool isSamplerType = false;
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
     if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
-      if (STy->isOpaque()) {
-        if (STy->getName().equals("opencl.sampler_t")) {
+      if (IsSamplerType(STy)) {
           isSamplerType = true;
           if (struct_type_ptr)
             *struct_type_ptr = STy;
-        }
       }
     }
   }
   return isSamplerType;
 }
 
+bool clspv::IsImageType(llvm::StructType *STy) {
+ if (STy->isOpaque()) {
+   if (STy->getName().startswith("opencl.image1d_ro_t") ||
+       STy->getName().startswith("opencl.image1d_rw_t") ||
+       STy->getName().startswith("opencl.image1d_wo_t") ||
+       STy->getName().startswith("opencl.image1d_array_ro_t") ||
+       STy->getName().startswith("opencl.image1d_array_rw_t") ||
+       STy->getName().startswith("opencl.image1d_array_wo_t") ||
+       STy->getName().startswith("opencl.image2d_ro_t") ||
+       STy->getName().startswith("opencl.image2d_rw_t") ||
+       STy->getName().startswith("opencl.image2d_wo_t") ||
+       STy->getName().startswith("opencl.image2d_array_ro_t") ||
+       STy->getName().startswith("opencl.image2d_array_rw_t") ||
+       STy->getName().startswith("opencl.image2d_array_wo_t") ||
+       STy->getName().startswith("opencl.image3d_ro_t") ||
+       STy->getName().startswith("opencl.image3d_rw_t") ||
+       STy->getName().startswith("opencl.image3d_wo_t")) {
+     return true;
+   }
+ }
+ return false;
+}
+
 bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   bool isImageType = false;
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
     if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
-      if (STy->isOpaque()) {
-        if (STy->getName().startswith("opencl.image1d_ro_t") ||
-            STy->getName().startswith("opencl.image1d_rw_t") ||
-            STy->getName().startswith("opencl.image1d_wo_t") ||
-            STy->getName().startswith("opencl.image1d_array_ro_t") ||
-            STy->getName().startswith("opencl.image1d_array_rw_t") ||
-            STy->getName().startswith("opencl.image1d_array_wo_t") ||
-            STy->getName().startswith("opencl.image2d_ro_t") ||
-            STy->getName().startswith("opencl.image2d_rw_t") ||
-            STy->getName().startswith("opencl.image2d_wo_t") ||
-            STy->getName().startswith("opencl.image2d_array_ro_t") ||
-            STy->getName().startswith("opencl.image2d_array_rw_t") ||
-            STy->getName().startswith("opencl.image2d_array_wo_t") ||
-            STy->getName().startswith("opencl.image3d_ro_t") ||
-            STy->getName().startswith("opencl.image3d_rw_t") ||
-            STy->getName().startswith("opencl.image3d_wo_t")) {
+      if (IsImageType(STy)) {
           isImageType = true;
           if (struct_type_ptr)
             *struct_type_ptr = STy;
-        }
       }
     }
   }
   return isImageType;
 }
 
+uint32_t clspv::ImageDimensionality(StructType *STy) {
+  if (IsImageType(STy)) {
+    if (STy->getName().contains("image1d"))
+      return 1;
+    if (STy->getName().contains("image2d"))
+      return 2;
+    if (STy->getName().contains("image3d"))
+      return 3;
+  }
+
+  return 0;
+}
+
 uint32_t clspv::ImageDimensionality(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains("image1d"))
-        return 1;
-      if (struct_ty->getName().contains("image2d"))
-        return 2;
-      if (struct_ty->getName().contains("image3d"))
-        return 3;
+  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+      return ImageDimensionality(struct_ty);
     }
   }
 
@@ -99,12 +120,18 @@ bool clspv::IsArrayImageType(Type *type) {
   return isArrayImageType;
 }
 
+bool clspv::IsSampledImageType(StructType *STy) {
+  if (IsImageType(STy)) {
+    return STy->getName().contains(".sampled");
+  }
+
+  return false;
+}
+
 bool clspv::IsSampledImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains(".sampled"))
-        return true;
+  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+      return IsSampledImageType(struct_ty);
     }
   }
 

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -15,17 +15,28 @@
 #ifndef CLSPV_LIB_TYPES_H
 #define CLSPV_LIB_TYPES_H
 
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Type.h"
 
 namespace clspv {
+
+// Returns true if the given struct type is a sampler type.
+bool IsSamplerType(llvm::StructType *type);
 
 // Returns true if the given type is a sampler type.  If it is, then the
 // struct type is sent back through the ptr argument.
 bool IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
 
+// Returns true if the given struct type is an image type.
+bool IsImageType(llvm::StructType *type);
+
 // Returns true if the given type is a image type.  If it is, then the
 // struct type is sent back through the ptr argument.
 bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
+
+// Returns the dimensionality of the image struct type. If |type| is not an
+// image, returns 0.
+uint32_t ImageDimensionality(llvm::StructType *type);
 
 // Returns the dimensionality of the image type. If |type| is not an image,
 // returns 0.
@@ -33,6 +44,10 @@ uint32_t ImageDimensionality(llvm::Type *type);
 
 // Returns true if the given type is an array image type.
 bool IsArrayImageType(llvm::Type *type);
+
+// Returns true if the given struct type is a sampled image type. Can only
+// return true after image specialization.
+bool IsSampledImageType(llvm::StructType *type);
 
 // Returns true if the given type is a sampled image type. Can only return true
 // after image specialization.


### PR DESCRIPTION
Done as part of looking at what is needed to support 1D buffer images.

- Add variants of functions in type utilities that take a StructType
- Centralise queries based on image type names

Signed-off-by: Kévin Petit <kevin.petit@arm.com>