### PR TITLE
Migrate clspv off deprecated llvm::IRBuilder APIs

### DIFF
--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -128,7 +128,8 @@ bool ClusterModuleScopeConstantVars::runOnModule(Module &M) {
         } else if (auto *inst = dyn_cast<Instruction>(user)) {
           unsigned index = initializers.idFor(GV->getInitializer()) - 1;
           Instruction *gep = GetElementPtrInst::CreateInBounds(
-              clustered_gv, {zero, Builder.getInt32(index)}, "", inst);
+              clustered_gv->getValueType(), clustered_gv,
+              {zero, Builder.getInt32(index)}, "", inst);
           user->replaceUsesOfWith(GV, gep);
         } else {
           errs() << "Don't know how to handle updating user of __constant: "

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -251,7 +251,9 @@ void MultiVersionUBOFunctionsPass::SpecializeCall(
           ++new_arg_iter;
         }
       }
-      ptr = builder.CreateGEP(ptr, indices);
+      ptr = builder.CreateGEP(
+          ptr->getType()->getScalarType()->getPointerElementType(), ptr,
+          indices);
     }
 
     // Now replace the use of the argument with the result GEP.

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -113,7 +113,7 @@ Value *GetPushConstantPointer(BasicBlock *BB, PushConstant pc,
   Indices[1] = Builder.getInt32(idx);
   for (auto idx : extra_indices)
     Indices.push_back(idx);
-  return Builder.CreateInBoundsGEP(GV, Indices);
+  return Builder.CreateInBoundsGEP(GV->getValueType(), GV, Indices);
 }
 
 bool UsesGlobalPushConstants(Module &M) {

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -416,9 +416,12 @@ bool ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
 
             // Avoid the builder for Src in order to prevent the folder from
             // creating constant expressions for constant memcpys.
-            auto SrcElemPtr =
-                GetElementPtrInst::CreateInBounds(Src, SrcIndices, "", CI);
-            auto DstElemPtr = Builder.CreateGEP(Dst, DstIndices);
+            auto SrcElemPtr = GetElementPtrInst::CreateInBounds(
+                Src->getType()->getScalarType()->getPointerElementType(), Src,
+                SrcIndices, "", CI);
+            auto DstElemPtr = Builder.CreateGEP(
+                Dst->getType()->getScalarType()->getPointerElementType(), Dst,
+                DstIndices);
             SmallVector<Type *, 5> param_tys = {
                 DstElemPtr->getType(), SrcElemPtr->getType(), I32Ty, I32Ty};
             SmallVector<Value *, 5> param_values = {DstElemPtr, SrcElemPtr,

--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -196,7 +196,7 @@ bool UndoInstCombinePass::UndoWideVectorExtractCast(Instruction *inst) {
   Value *new_src = nullptr;
   if (load) {
     potentially_dead_.insert(load);
-    new_src = builder.CreateLoad(src);
+    new_src = builder.CreateLoad(src_vec_ty, src);
     src = new_src;
   }
   new_src = builder.CreateExtractElement(src, builder.getInt32(new_idx));
@@ -273,7 +273,7 @@ bool UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
   Value *insert = nullptr;
   if (in1_load) {
     potentially_dead_.insert(in1_load);
-    src = builder.CreateLoad(src);
+    src = builder.CreateLoad(src_vec_ty, src);
   }
 
   int i = 0;


### PR DESCRIPTION
These are being removed in upstream LLVM, breaking the build
https://github.com/llvm/llvm-project/commit/89eb85ac6eab6431ef72ef705d560c72c5ed71f3