### PR TITLE
Make it possible to build with BUILD_SHARED_LIBS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,6 +133,7 @@ target_link_libraries(clspv_core PUBLIC clspv_passes)
 target_link_libraries(clspv_core PRIVATE
   LLVMIRReader
   LLVMLinker
+  ${CLSPV_LLVM_COMPONENTS}
   clangAST
   clangBasic
   clangCodeGen


### PR DESCRIPTION
Using BUILD_SHARED_LIBS forces all libraries to be built as shared
libraries. This can drastically reduce the time spent on linking
and thus iteration time.

Signed-off-by: Kévin Petit <kevin.petit@arm.com>