### PR TITLE
vec3: add option to force disabling of the vec3 pass

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -209,7 +209,7 @@ bool KernelArgInfo();
 
 // Returns true if lowering to vec3 to vec4 should be done whether or not it
 // seems necessary
-bool Vec3ToVec4();
+int Vec3ToVec4();
 
 } // namespace Option
 } // namespace clspv

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -207,8 +207,9 @@ bool UniformWorkgroupSize();
 // Returns true if kernel argument info production is enabled
 bool KernelArgInfo();
 
-// Returns true if lowering to vec3 to vec4 should be done whether or not it
-// seems necessary
+// Returns a positive value to force usage of the pass
+// Returns a negative value to force not to use the vecc3 pass
+// Returns zero if the decision is left to the pass to do anything
 int Vec3ToVec4();
 
 } // namespace Option

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -207,10 +207,17 @@ bool UniformWorkgroupSize();
 // Returns true if kernel argument info production is enabled
 bool KernelArgInfo();
 
+enum class Vec3ToVec4SupportClass : int {
+  vec3ToVec4SupportDefault = 0,
+  vec3ToVec4SupportError,   // -vec3-to-vec4 & -no-vec3-to-vec4
+  vec3ToVec4SupportForce,   // -vec3-to-vec4
+  vec3ToVec4SupportDisable, // -no-vec3-to-vec4
+};
+
 // Returns a positive value to force usage of the pass
 // Returns a negative value to force not to use the vecc3 pass
 // Returns zero if the decision is left to the pass to do anything
-int Vec3ToVec4();
+Vec3ToVec4SupportClass Vec3ToVec4();
 
 } // namespace Option
 } // namespace clspv

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -214,9 +214,6 @@ enum class Vec3ToVec4SupportClass : int {
   vec3ToVec4SupportDisable, // -no-vec3-to-vec4
 };
 
-// Returns a positive value to force usage of the pass
-// Returns a negative value to force not to use the vecc3 pass
-// Returns zero if the decision is left to the pass to do anything
 Vec3ToVec4SupportClass Vec3ToVec4();
 
 } // namespace Option

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -644,13 +644,6 @@ int PopulatePassManager(
     break;
   }
 
-  if (clspv::Option::Vec3ToVec4() ==
-      clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportError) {
-    llvm::errs() << "error: -vec3-to-vec4 and -no-vec3-to-vec4 are exclusive "
-                    "so they cannot be used together!\n";
-    return -1;
-  }
-
   pm->add(clspv::createNativeMathPass());
   pm->add(clspv::createZeroInitializeAllocasPass());
   pm->add(clspv::createAddFunctionAttributesPass());
@@ -893,6 +886,13 @@ int ParseOptions(const int argc, const char *const argv[]) {
       clspv::Option::UniformWorkgroupSize()) {
     llvm::errs() << "cannot enable Arm non-uniform workgroup extension support "
                     "and assume uniform workgroup sizes\n";
+    return -1;
+  }
+
+  if (clspv::Option::Vec3ToVec4() ==
+      clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportError) {
+    llvm::errs() << "error: -vec3-to-vec4 and -no-vec3-to-vec4 are exclusive "
+                    "so they cannot be used together!\n";
     return -1;
   }
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -644,6 +644,13 @@ int PopulatePassManager(
     break;
   }
 
+  if (clspv::Option::Vec3ToVec4() ==
+      clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportError) {
+    llvm::errs() << "error: -vec3-to-vec4 and -no-vec3-to-vec4 are exclusive "
+                    "so they cannot be used together!\n";
+    return -1;
+  }
+
   pm->add(clspv::createNativeMathPass());
   pm->add(clspv::createZeroInitializeAllocasPass());
   pm->add(clspv::createAddFunctionAttributesPass());

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -267,6 +267,10 @@ static llvm::cl::opt<bool>
     force_vec3_to_vec4("vec3-to-vec4", llvm::cl::init(false),
                        llvm::cl::desc("Force lowering vec3 to vec4"));
 
+static llvm::cl::opt<bool>
+    force_no_vec3_to_vec4("no-vec3-to-vec4", llvm::cl::init(false),
+                          llvm::cl::desc("Force NOT lowering vec3 to vec4"));
+
 } // namespace
 
 namespace clspv {
@@ -348,7 +352,9 @@ bool UniformWorkgroupSize() { return uniform_workgroup_size; }
 
 bool KernelArgInfo() { return cl_kernel_arg_info; }
 
-bool Vec3ToVec4() { return force_vec3_to_vec4; }
+int Vec3ToVec4() {
+  return force_no_vec3_to_vec4 ? -1 : (force_vec3_to_vec4 ? 1 : 0);
+}
 
 } // namespace Option
 } // namespace clspv

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -352,8 +352,16 @@ bool UniformWorkgroupSize() { return uniform_workgroup_size; }
 
 bool KernelArgInfo() { return cl_kernel_arg_info; }
 
-int Vec3ToVec4() {
-  return force_no_vec3_to_vec4 ? -1 : (force_vec3_to_vec4 ? 1 : 0);
+Vec3ToVec4SupportClass Vec3ToVec4() {
+  if (force_no_vec3_to_vec4 && force_vec3_to_vec4) {
+    return Vec3ToVec4SupportClass::vec3ToVec4SupportError;
+  } else if (force_vec3_to_vec4) {
+    return Vec3ToVec4SupportClass::vec3ToVec4SupportForce;
+  } else if (force_no_vec3_to_vec4) {
+    return Vec3ToVec4SupportClass::vec3ToVec4SupportDisable;
+  } else {
+    return Vec3ToVec4SupportClass::vec3ToVec4SupportDefault;
+  }
 }
 
 } // namespace Option

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -434,17 +434,18 @@ bool vec3BitcastInFunction(Function &F) {
 
 /// Returns whether the vec3 should be transform into vec4
 bool vec3ShouldBeLowered(Module &M) {
-  int vec3ToVec4 = clspv::Option::Vec3ToVec4();
-  if (vec3ToVec4 > 0)
+  switch (clspv::Option::Vec3ToVec4()) {
+  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportForce:
     return true;
-  if (vec3ToVec4 < 0)
+  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportDisable:
     return false;
-
-  for (auto &F : M.functions()) {
-    if (vec3BitcastInFunction(F))
-      return true;
+  default:
+    for (auto &F : M.functions()) {
+      if (vec3BitcastInFunction(F))
+        return true;
+    }
+    return false;
   }
-  return false;
 }
 
 bool ThreeElementVectorLoweringPass::runOnModule(Module &M) {

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -434,8 +434,11 @@ bool vec3BitcastInFunction(Function &F) {
 
 /// Returns whether the vec3 should be transform into vec4
 bool vec3ShouldBeLowered(Module &M) {
-  if (clspv::Option::Vec3ToVec4())
+  int vec3ToVec4 = clspv::Option::Vec3ToVec4();
+  if (vec3ToVec4 > 0)
     return true;
+  if (vec3ToVec4 < 0)
+    return false;
 
   for (auto &F : M.functions()) {
     if (vec3BitcastInFunction(F))


### PR DESCRIPTION
no-vec3-to-vec4 takes priority over vec3-to-vec4 as it intends to
avoid running into bugs in the vec3 pass implementation.

Ref #795