### PR TITLE
Update LLVM

### DIFF
--- a/cmake/strip_banned_opencl_features.py
+++ b/cmake/strip_banned_opencl_features.py
@@ -30,7 +30,13 @@ def main():
     args = parser.parse_args()
 
     # Strip invalid features.
-    regex = re.compile('(convert_[a-zA-Z0-9]+(_rt[pn]|_sat))|(reserve_id_t)')
+    unsupported_features = '(convert_[a-zA-Z0-9]+(_rt[pn]|_sat))'
+    unsupported_features += '|(reserve_id_t)'
+    unsupported_features += '|(ndrange_t)'
+    unsupported_features += '|(queue_t)'
+    unsupported_features += '|(clk_event_t)'
+    unsupported_features += '|(clk_profiling_info)'
+    regex = re.compile(unsupported_features)
     with open(args.input_file, "r") as input:
         with open(args.output_file, "w") as output:
             for line in input:

--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "d7630b37ceb8d7032f133e0257724997e4cc76ec"
+      "commit" : "c26729251588cb6e9e20c3edf67d14ac9b549f9b"
     },
     {
       "name" : "SPIRV-Headers",


### PR DESCRIPTION
Also, strip device-enque features from the header file.
A recent change to Clang accidentally removes the predeclaration
of the queue_t and clk_event_t types for OpenCL 2.0 flows.
A compile error results in opencl-c.h if we don't strip the offending
declarations of the enqueue-related builtins.