### PR TITLE
popcount: manage non 32-bit types explicitly

### DIFF
--- a/test/IntegerBuiltins/popcount/char2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/char2_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global char2* a, global char2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char2:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char2]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char2]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/char3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/char3_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global char3* a, global char3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char3:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 3
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char3]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char3]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
@@ -7,8 +7,12 @@ kernel void foo(global char3* a, global char3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/char4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/char4_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global char4* a, global char4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/char_popcount.cl
+++ b/test/IntegerBuiltins/popcount/char_popcount.cl
@@ -7,7 +7,10 @@ kernel void foo(global char* a, global char* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/long2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/long2_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global long2* a, global long2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long2:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long2_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long2]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long2]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long2]] [[ld]] [[long2_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int2]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long2]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/long3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/long3_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global long3* a, global long3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long3:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 3
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long3_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long3]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long3]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long3]] [[ld]] [[long3_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int3]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long3]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
@@ -7,8 +7,18 @@ kernel void foo(global long3* a, global long3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long4_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long4]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long4]] [[ld]] [[long4_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int4]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long4]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/long4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/long4_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global long4* a, global long4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long4_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long4]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long4]] [[ld]] [[long4_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int4]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long4]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/long_popcount.cl
+++ b/test/IntegerBuiltins/popcount/long_popcount.cl
@@ -7,7 +7,15 @@ kernel void foo(global long* a, global long* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long]] [[ld]] [[long32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/short2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/short2_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global short2* a, global short2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short2:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short2]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short2]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/short3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/short3_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global short3* a, global short3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short3:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 3
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short3]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short3]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
@@ -7,8 +7,12 @@ kernel void foo(global short3* a, global short3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/short4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/short4_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global short4* a, global short4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/short_popcount.cl
+++ b/test/IntegerBuiltins/popcount/short_popcount.cl
@@ -7,7 +7,10 @@ kernel void foo(global short* a, global short* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/uchar2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uchar2_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global uchar2* a, global uchar2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char2:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char2]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char2]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/uchar3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uchar3_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global uchar3* a, global uchar3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char3:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 3
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char3]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char3]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
@@ -7,8 +7,12 @@ kernel void foo(global uchar3* a, global uchar3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/uchar4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uchar4_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global uchar4* a, global uchar4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/uchar_popcount.cl
+++ b/test/IntegerBuiltins/popcount/uchar_popcount.cl
@@ -7,7 +7,10 @@ kernel void foo(global uchar* a, global uchar* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[char]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[char]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[char]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/ulong2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ulong2_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global ulong2* a, global ulong2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long2:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long2_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long2]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long2]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long2]] [[ld]] [[long2_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int2]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long2]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ulong3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ulong3_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global ulong3* a, global ulong3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long3:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 3
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long3_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long3]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long3]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long3]] [[ld]] [[long3_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int3]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long3]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
@@ -7,8 +7,18 @@ kernel void foo(global ulong3* a, global ulong3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long4_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long4]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long4]] [[ld]] [[long4_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int4]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long4]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ulong4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ulong4_popcount.cl
@@ -7,8 +7,18 @@ kernel void foo(global ulong4* a, global ulong4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
 // CHECK: [[long4:%[a-zA-Z0-9_]+]] = OpTypeVector [[long]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
+// CHECK: [[long4_32:%[a-zA-Z0-9_]+]] = OpConstantComposite [[long4]] [[long32]] [[long32]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long4]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long4]] [[ld]] [[long4_32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int4]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long4]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ulong_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ulong_popcount.cl
@@ -7,7 +7,15 @@ kernel void foo(global ulong* a, global ulong* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[long:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[long32:%[a-zA-Z0-9_]+]] = OpConstant [[long]] 32
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[long]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[long]] [[ld]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[lowerbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[upperld:%[a-zA-Z0-9_]+]] = OpShiftRightLogical [[long]] [[ld]] [[long32]]
+// CHECK: [[convert2:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[upperld]]
+// CHECK: [[upperbitcount:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert2]]
+// CHECK: [[bitcount:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[lowerbitcount]] [[upperbitcount]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpUConvert [[long]] [[bitcount]]
 // CHECK: OpStore {{.*}} [[cnt]]

--- a/test/IntegerBuiltins/popcount/ushort2_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ushort2_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global ushort2* a, global ushort2* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short2:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 2
+// CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short2]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short2]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int2]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int2]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short2]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/ushort3_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ushort3_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global ushort3* a, global ushort3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short3:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 3
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short3]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short3]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int3]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int3]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short3]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
@@ -7,8 +7,12 @@ kernel void foo(global ushort3* a, global ushort3* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/ushort4_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ushort4_popcount.cl
@@ -7,8 +7,12 @@ kernel void foo(global ushort4* a, global ushort4* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[short4:%[a-zA-Z0-9_]+]] = OpTypeVector [[short]] 4
+// CHECK: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short4]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short4]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int4]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int4]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short4]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]

--- a/test/IntegerBuiltins/popcount/ushort_popcount.cl
+++ b/test/IntegerBuiltins/popcount/ushort_popcount.cl
@@ -7,7 +7,10 @@ kernel void foo(global ushort* a, global ushort* b) {
   *a = popcount(*b);
 }
 
+// CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[short:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[short]]
-// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[short]] [[ld]]
-// CHECK: OpStore {{.*}} [[cnt]]
+// CHECK: [[convert:%[a-zA-Z0-9_]+]] = OpUConvert [[int]] [[ld]]
+// CHECK: [[cnt:%[a-zA-Z0-9_]+]] = OpBitCount [[int]] [[convert]]
+// CHECK: [[res:%[a-zA-Z0-9_]+]] = OpUConvert [[short]] [[cnt]]
+// CHECK: OpStore {{.*}} [[res]]


### PR DESCRIPTION
The Base operand of any OpBitCount, OpBitReverse, OpBitFieldInsert,
OpBitFieldSExtract, or OpBitFieldUExtract instruction must be a 32-bit
integer scalar or a vector of 32-bit integers.
https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap46.html#VUID-StandaloneSpirv-Base-04781