### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "4631cba10b31078b601684e32d0bac83e6aeed84"
+      "commit" : "88b9d1a49aba54171804da355f00c8fe0483f428"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1371,7 +1371,7 @@ Type *LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   }
 
   if (auto *PointerTy = dyn_cast<PointerType>(Ty)) {
-    if (auto *ElementTy = getEquivalentType(PointerTy->getElementType())) {
+    if (auto *ElementTy = getEquivalentType(PointerTy->getNonOpaquePointerElementType())) {
       return ElementTy->getPointerTo(PointerTy->getAddressSpace());
     }
 

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1371,7 +1371,8 @@ Type *LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   }
 
   if (auto *PointerTy = dyn_cast<PointerType>(Ty)) {
-    if (auto *ElementTy = getEquivalentType(PointerTy->getNonOpaquePointerElementType())) {
+    if (auto *ElementTy =
+            getEquivalentType(PointerTy->getNonOpaquePointerElementType())) {
       return ElementTy->getPointerTo(PointerTy->getAddressSpace());
     }
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1565,8 +1565,7 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
     // Ops[1] = Element Type ID
     SPIRVOperandVec Ops;
 
-    Ops << GetStorageClass(AddrSpace)
-        << getSPIRVType(PointeeTy, needs_layout);
+    Ops << GetStorageClass(AddrSpace) << getSPIRVType(PointeeTy, needs_layout);
 
     RID = addSPIRVInst<kTypes>(spv::OpTypePointer, Ops);
     break;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1547,8 +1547,8 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
     PointerType *PTy = cast<PointerType>(Canonical);
     unsigned AddrSpace = PTy->getAddressSpace();
 
+    auto PointeeTy = PTy->getNonOpaquePointerElementType();
     if (AddrSpace != AddressSpace::UniformConstant) {
-      auto PointeeTy = PTy->getElementType();
       if (PointeeTy->isStructTy() &&
           dyn_cast<StructType>(PointeeTy)->isOpaque()) {
         RID = getSPIRVType(PointeeTy, needs_layout);
@@ -1566,7 +1566,7 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
     SPIRVOperandVec Ops;
 
     Ops << GetStorageClass(AddrSpace)
-        << getSPIRVType(PTy->getElementType(), needs_layout);
+        << getSPIRVType(PointeeTy, needs_layout);
 
     RID = addSPIRVInst<kTypes>(spv::OpTypePointer, Ops);
     break;
@@ -5019,7 +5019,7 @@ void SPIRVProducerPass::HandleDeferredDecorations() {
 
     Type *elemTy = nullptr;
     if (auto *ptrTy = dyn_cast<PointerType>(type)) {
-      elemTy = ptrTy->getElementType();
+      elemTy = ptrTy->getNonOpaquePointerElementType();
     } else if (auto *arrayTy = dyn_cast<ArrayType>(type)) {
       elemTy = arrayTy->getElementType();
     } else if (auto *vecTy = dyn_cast<VectorType>(type)) {

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -1033,7 +1033,8 @@ Type *ThreeElementVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   }
 
   if (auto *PointerTy = dyn_cast<PointerType>(Ty)) {
-    if (auto *ElementTy = getEquivalentType(PointerTy->getElementType())) {
+    if (auto *ElementTy =
+            getEquivalentType(PointerTy->getNonOpaquePointerElementType())) {
       return ElementTy->getPointerTo(PointerTy->getAddressSpace());
     }
 

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -33,7 +33,8 @@ bool clspv::IsSamplerType(llvm::StructType *STy) {
 bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   bool isSamplerType = false;
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
+    if (StructType *STy =
+            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
       if (IsSamplerType(STy)) {
         isSamplerType = true;
         if (struct_type_ptr)
@@ -73,7 +74,8 @@ bool clspv::IsImageType(llvm::StructType *STy) {
 bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
   bool isImageType = false;
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
+    if (StructType *STy =
+            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
       if (IsImageType(STy)) {
         isImageType = true;
         if (struct_type_ptr)
@@ -101,8 +103,8 @@ spv::Dim clspv::ImageDimensionality(StructType *STy) {
 
 spv::Dim clspv::ImageDimensionality(Type *type) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty =
-            dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(
+            TmpArgPTy->getNonOpaquePointerElementType())) {
       return ImageDimensionality(struct_ty);
     }
   }
@@ -126,8 +128,8 @@ uint32_t clspv::ImageNumDimensions(StructType *STy) {
 
 uint32_t clspv::ImageNumDimensions(Type *type) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty =
-            dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(
+            TmpArgPTy->getNonOpaquePointerElementType())) {
       return ImageNumDimensions(struct_ty);
     }
   }
@@ -138,7 +140,8 @@ uint32_t clspv::ImageNumDimensions(Type *type) {
 bool clspv::IsArrayImageType(Type *type) {
   bool isArrayImageType = false;
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy = dyn_cast<StructType>(TmpArgPTy->getElementType())) {
+    if (StructType *STy =
+            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
       if (STy->isOpaque()) {
         if (STy->getName().startswith("opencl.image1d_array_ro_t") ||
             STy->getName().startswith("opencl.image1d_array_wo_t") ||
@@ -162,8 +165,8 @@ bool clspv::IsSampledImageType(StructType *STy) {
 
 bool clspv::IsSampledImageType(Type *type) {
   if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty =
-            dyn_cast_or_null<StructType>(TmpArgPTy->getElementType())) {
+    if (auto struct_ty = dyn_cast_or_null<StructType>(
+            TmpArgPTy->getNonOpaquePointerElementType())) {
       return IsSampledImageType(struct_ty);
     }
   }

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -173,7 +173,8 @@ Type *UBOTypeTransformPass::MapType(Type *type, Module &M, bool rewrite) {
   switch (type->getTypeID()) {
   case Type::PointerTyID: {
     PointerType *pointer = cast<PointerType>(type);
-    Type *pointee = MapType(pointer->getElementType(), M, rewrite);
+    Type *pointee =
+        MapType(pointer->getNonOpaquePointerElementType(), M, rewrite);
     remapped = PointerType::get(pointee, pointer->getAddressSpace());
     break;
   }
@@ -380,8 +381,8 @@ bool UBOTypeTransformPass::RemapGlobalVariables(
   bool changed = false;
   for (auto &GV : M.globals()) {
     if (auto *ptr_ty = dyn_cast<PointerType>(GV.getType())) {
-      auto *remapped = RebuildType(ptr_ty->getElementType(), M);
-      if (ptr_ty->getElementType() != remapped) {
+      auto *remapped = RebuildType(ptr_ty->getNonOpaquePointerElementType(), M);
+      if (ptr_ty->getNonOpaquePointerElementType() != remapped) {
         changed = true;
         variables_to_modify->push_back(&GV);
       }

--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -69,7 +69,7 @@ bool UndoByvalPass::runOnModule(Module &M) {
       // Check byval attribute and build new function's parameter type.
       if (Arg.hasByValAttr()) {
         PointerType *PTy = cast<PointerType>(Arg.getType());
-        Type *ArgTy = PTy->getElementType();
+        Type *ArgTy = PTy->getNonOpaquePointerElementType();
         NewFuncParamTys.push_back(ArgTy);
 
         ByValList.push_back(&Arg);
@@ -104,7 +104,7 @@ bool UndoByvalPass::runOnModule(Module &M) {
       ValueToValueMapTy ArgVMap;
       for (Argument *Arg : ByValList) {
         PointerType *PTy = cast<PointerType>(Arg->getType());
-        Type *ArgTy = PTy->getElementType();
+        Type *ArgTy = PTy->getNonOpaquePointerElementType();
         AllocaInst *ArgAddr = new AllocaInst(
             ArgTy, 0, nullptr, Arg->getName() + ".addr", InsertPoint);
 

--- a/lib/UndoSRetPass.cpp
+++ b/lib/UndoSRetPass.cpp
@@ -70,7 +70,7 @@ bool UndoSRetPass::runOnModule(Module &M) {
       // Check sret attribute.
       if (Arg.hasStructRetAttr()) {
         PointerType *PTy = cast<PointerType>(Arg.getType());
-        Type *RetTy = PTy->getElementType();
+        Type *RetTy = PTy->getNonOpaquePointerElementType();
         // Create alloca instruction for return value on function's entry
         // block.
         AllocaInst *RetVal =

--- a/test/emit_ir.cl
+++ b/test/emit_ir.cl
@@ -9,4 +9,6 @@ void kernel foo(global double *out, int in)
 // CHECK: target triple = "spir-unknown-unknown"
 // CHECK: define
 // CHECK-SAME: spir_kernel
-// CHECK-SAME: void @foo(double addrspace(1)* noundef align 8 %out, i32 noundef %in)
+// CHECK-SAME: void @foo
+// CHECK-SAME: double addrspace(1)* {{[^%]+}}%out
+// CHECK-SAME: i32 {{[^%]+}}%in


### PR DESCRIPTION
* Switch to use `getNonOpaquePointerElementType()`
* Temporary solution for #816
* Improve robustness of emit_ir.cl test