### PR TITLE
OpMulExtended: workaround Intel GPU issue

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -70,6 +70,10 @@ bool HackBlockOrder();
 // operations. Works around a driver bug.
 bool HackClampWidth();
 
+// Returns true if OpSMulExtended and OpUMulExtended should be avoided. Works
+// around a driver bug.
+bool HackMulExtended();
+
 // Returns true if module-scope constants are to be collected into a single
 // storage buffer.  The binding for that buffer, and its intialization data
 // are given in the descriptor map file.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -103,6 +103,10 @@ llvm::cl::opt<bool> hack_clamp_width(
     llvm::cl::desc("Force clamp to be on 32bit elements at least when "
                    "performing staturating operations"));
 
+llvm::cl::opt<bool> hack_mul_extended(
+    "hack-mul-extended", llvm::cl::init(false),
+    llvm::cl::desc("Avoid usage of OpSMulExtended and OpUMulExtended"));
+
 llvm::cl::opt<bool>
     pod_ubo("pod-ubo", llvm::cl::init(false),
             llvm::cl::desc("POD kernel arguments are in uniform buffers"));
@@ -298,6 +302,7 @@ bool HackUndef() { return hack_undef; }
 bool HackPhis() { return hack_phis; }
 bool HackBlockOrder() { return hack_block_order; }
 bool HackClampWidth() { return hack_clamp_width; }
+bool HackMulExtended() { return hack_mul_extended; }
 bool ModuleConstantsInStorageBuffer() {
   return module_constants_in_storage_buffer;
 }

--- a/test/hack_mul_extended/mad_hi_char_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_char_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ushort]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ushort]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort]] [[mul]] [[ushort_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uchar]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char *a, global char *b, global char *c, global char *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_int_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_int_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *a, global int *b, global int *c, global int *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_int_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_int_hack_mul_extended.cl
@@ -3,18 +3,53 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
-// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint_65535:%[^ ]+]] = OpConstant [[uint]] 65535
+// CHECK-DAG: [[uint_2147418112:%[^ ]+]] = OpConstant [[uint]] 2147418112
+// CHECK-DAG: [[uint_4294967295:%[^ ]+]] = OpConstant [[uint]] 4294967295
+// CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
 // CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
 // CHECK:     [[c:%[^ ]+]] = OpLoad [[uint]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
-// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[c]] [[trunc]]
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool]] [[xor]] [[uint_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[uint]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[uint]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a_pos]] [[uint_16]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[b_pos]] [[uint_16]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a_pos]] [[uint_65535]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[b_pos]] [[uint_65535]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b0]] [[uint_16]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a1b0]] [[uint_16]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b1]] [[uint_16]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_2147418112]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a0b0]] [[uint_65535]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b0]] [[uint_65535]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a0b1]] [[uint_65535]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_65535]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[uint]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul_lo_add2]] [[uint_16]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[uint]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[uint]] [[mul_lo_add2]] [[uint_16]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[uint]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[mul_lo]] [[uint_4294967295]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[uint_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[uint]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[mul_hi]] [[uint_4294967295]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[uint]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[uint]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[select]] [[c]]
 // CHECK:     OpStore {{.*}} [[add]]
 
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *a, global int *b, global int *c, global int *d)

--- a/test/hack_mul_extended/mad_hi_long_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_long_hack_mul_extended.cl
@@ -1,0 +1,59 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_0:%[^ ]+]] = OpConstant [[ulong]] 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong_9223372032559808512:%[^ ]+]] = OpConstant [[ulong]] 9223372032559808512
+// CHECK-DAG: [[ulong_18446744073709551615:%[^ ]+]] = OpConstant [[ulong]] 18446744073709551615
+// CHECK-DAG: [[ulong_1:%[^ ]+]] = OpConstant [[ulong]] 1
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool]] [[xor]] [[ulong_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[ulong]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[ulong]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a_pos]] [[ulong_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[b_pos]] [[ulong_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a_pos]] [[ulong_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[b_pos]] [[ulong_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b0]] [[ulong_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a1b0]] [[ulong_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b1]] [[ulong_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_9223372032559808512]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b0]] [[ulong_4294967295]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b0]] [[ulong_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b1]] [[ulong_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[ulong]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[mul_lo]] [[ulong_18446744073709551615]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[ulong_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[ulong]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[mul_hi]] [[ulong_18446744073709551615]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[ulong]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[ulong]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[ulong]] [[select]] [[c]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long *a, global long *b, global long *c, global long *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_short_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_short_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[uint]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[uint]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul]] [[uint_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[ushort]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short *a, global short *b, global short *c, global short *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_uchar_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_uchar_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ushort]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ushort]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort]] [[mul]] [[ushort_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uchar]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar *a, global uchar *b, global uchar *c, global uchar *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_uint_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_uint_hack_mul_extended.cl
@@ -4,18 +4,36 @@
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
-// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint_65535:%[^ ]+]] = OpConstant [[uint]] 65535
+// CHECK-DAG: [[uint_4294901760:%[^ ]+]] = OpConstant [[uint]] 4294901760
 // CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
 // CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
 // CHECK:     [[c:%[^ ]+]] = OpLoad [[uint]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
-// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[c]] [[trunc]]
-// CHECK:     OpStore {{.*}} [[add]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a]] [[uint_16]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[b]] [[uint_16]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a]] [[uint_65535]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[b]] [[uint_65535]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b0]] [[uint_16]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a1b0]] [[uint_16]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b1]] [[uint_16]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_4294901760]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b0]] [[uint_65535]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a0b1]] [[uint_65535]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_65535]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[uint]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul_lo_add2]] [[uint_16]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[a1b0_1]] [[c]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[uint]] [[add]] [[a1b1_0]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
 
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint *a, global uint *b, global uint *c, global uint *d)
 {

--- a/test/hack_mul_extended/mad_hi_uint_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_uint_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[uint]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint *a, global uint *b, global uint *c, global uint *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_ulong_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_ulong_hack_mul_extended.cl
@@ -1,0 +1,42 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a]] [[ulong_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[b]] [[ulong_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a]] [[ulong_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[b]] [[ulong_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b0]] [[ulong_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a1b0]] [[ulong_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b1]] [[ulong_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_18446744069414584320]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b0]] [[ulong_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b1]] [[ulong_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[ulong]] [[a1b0_1]] [[c]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong]] [[add]] [[a1b1_0]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong *a, global ulong *b, global ulong *c, global ulong *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mad_hi_ushort_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mad_hi_ushort_hack_mul_extended.cl
@@ -1,0 +1,24 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[c:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[uint]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[uint]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul]] [[uint_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort]] [[shift]]
+// CHECK:     [[add:%[^ ]+]] = OpIAdd [[ushort]] [[c]] [[trunc]]
+// CHECK:     OpStore {{.*}} [[add]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort *a, global ushort *b, global ushort *c, global ushort *d)
+{
+    *d = mad_hi(*a, *b, *c);
+}
+

--- a/test/hack_mul_extended/mul_hi_char2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_char2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[uchar2:%[^ ]+]] = OpTypeVector [[uchar]] 2
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort2:%[^ ]+]] = OpTypeVector [[ushort]] 2
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK-DAG: [[ushort2_8:%[^ ]+]] = OpConstantComposite [[ushort2]] [[ushort_8]] [[ushort_8]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ushort2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ushort2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort2]] [[mul]] [[ushort2_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char2 *a, global char2 *b, global char2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_char_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_char_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ushort]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ushort]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort]] [[mul]] [[ushort_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char *a, global char *b, global char *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_int2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_int2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul]] [[ulong2_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2 *a, global int2 *b, global int2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_int2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_int2_hack_mul_extended.cl
@@ -3,20 +3,59 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
+// CHECK-DAG: [[bool2:%[^ ]+]] = OpTypeVector [[bool]] 2
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
-// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
-// CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
-// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
-// CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
+// CHECK-DAG: [[uint2_0:%[^ ]+]] = OpConstantNull [[uint2]]
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint2_16:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_16]] [[uint_16]]
+// CHECK-DAG: [[uint_65535:%[^ ]+]] = OpConstant [[uint]] 65535
+// CHECK-DAG: [[uint2_65535:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_65535]] [[uint_65535]]
+// CHECK-DAG: [[uint_4294901760:%[^ ]+]] = OpConstant [[uint]] 4294901760
+// CHECK-DAG: [[uint2_4294901760:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_4294901760]] [[uint_4294901760]]
+// CHECK-DAG: [[uint_4294967295:%[^ ]+]] = OpConstant [[uint]] 4294967295
+// CHECK-DAG: [[uint2_4294967295:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_4294967295]] [[uint_4294967295]]
+// CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint2_1:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_1]] [[uint_1]]
 // CHECK:     [[a:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
 // CHECK:     [[b:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong2]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong2]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong2]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul]] [[ulong2_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint2]] [[shift]]
-// CHECK:     OpStore {{.*}} [[trunc]]
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[uint2]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool2]] [[xor]] [[uint2_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[uint2]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[uint2]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[a_pos]] [[uint2_16]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[b_pos]] [[uint2_16]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a_pos]] [[uint2_65535]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[b_pos]] [[uint2_65535]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[uint2]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[a0b0]] [[uint2_16]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[uint2]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[a1b0]] [[uint2_16]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[uint2]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[a0b1]] [[uint2_16]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[uint2]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a1b1]] [[uint2_4294901760]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a0b0]] [[uint2_65535]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a1b0]] [[uint2_65535]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a0b1]] [[uint2_65535]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[uint2]] [[a1b1]] [[uint2_65535]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[uint2]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[uint2]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[mul_lo_add2]] [[uint2_16]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[uint2]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[uint2]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[uint2]] [[mul_lo_add2]] [[uint2_16]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[uint2]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[uint2]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[uint2]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[uint2]] [[mul_lo]] [[uint2_4294967295]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[uint2_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[uint2]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[uint2]] [[mul_hi]] [[uint2_4294967295]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[uint2]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[uint2]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     OpStore {{.*}} [[select]]
 
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int2 *a, global int2 *b, global int2 *c)
 {

--- a/test/hack_mul_extended/mul_hi_int_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_int_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *a, global int *b, global int *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_int_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_int_hack_mul_extended.cl
@@ -3,17 +3,52 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
-// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint_65535:%[^ ]+]] = OpConstant [[uint]] 65535
+// CHECK-DAG: [[uint_2147418112:%[^ ]+]] = OpConstant [[uint]] 2147418112
+// CHECK-DAG: [[uint_4294967295:%[^ ]+]] = OpConstant [[uint]] 4294967295
+// CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
 // CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[ulong]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
-// CHECK:     OpStore {{.*}} [[trunc]]
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool]] [[xor]] [[uint_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[uint]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[uint]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a_pos]] [[uint_16]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[b_pos]] [[uint_16]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a_pos]] [[uint_65535]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[b_pos]] [[uint_65535]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b0]] [[uint_16]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[uint]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a1b0]] [[uint_16]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[uint]] [[a0b1]] [[uint_16]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[uint]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_2147418112]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a0b0]] [[uint_65535]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b0]] [[uint_65535]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a0b1]] [[uint_65535]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[uint]] [[a1b1]] [[uint_65535]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[uint]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul_lo_add2]] [[uint_16]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[uint]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[uint]] [[mul_lo_add2]] [[uint_16]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[uint]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[uint]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[mul_lo]] [[uint_4294967295]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[uint_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[uint]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[uint]] [[mul_hi]] [[uint_4294967295]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[uint]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[uint]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     OpStore {{.*}} [[select]]
 
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int *a, global int *b, global int *c)
 {

--- a/test/hack_mul_extended/mul_hi_long2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_long2_hack_mul_extended.cl
@@ -1,0 +1,64 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
+// CHECK-DAG: [[bool2:%[^ ]+]] = OpTypeVector [[bool]] 2
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
+// CHECK-DAG: [[ulong2_0:%[^ ]+]] = OpConstantNull [[ulong2]]
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong2_4294967295:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_4294967295]] [[ulong_4294967295]]
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK-DAG: [[ulong2_18446744069414584320:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_18446744069414584320]] [[ulong_18446744069414584320]]
+// CHECK-DAG: [[ulong_18446744073709551615:%[^ ]+]] = OpConstant [[ulong]] 18446744073709551615
+// CHECK-DAG: [[ulong2_18446744073709551615:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_18446744073709551615]] [[ulong_18446744073709551615]]
+// CHECK-DAG: [[ulong_1:%[^ ]+]] = OpConstant [[ulong]] 1
+// CHECK-DAG: [[ulong2_1:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_1]] [[ulong_1]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[ulong2]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool2]] [[xor]] [[ulong2_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[ulong2]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[ulong2]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a_pos]] [[ulong2_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[b_pos]] [[ulong2_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a_pos]] [[ulong2_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[b_pos]] [[ulong2_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b0]] [[ulong2_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a1b0]] [[ulong2_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b1]] [[ulong2_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_18446744069414584320]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a0b0]] [[ulong2_4294967295]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b0]] [[ulong2_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a0b1]] [[ulong2_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul_lo_add2]] [[ulong2_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[ulong2]] [[mul_lo_add2]] [[ulong2_32]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[ulong2]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[ulong2]] [[mul_lo]] [[ulong2_18446744073709551615]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[ulong2_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[ulong2]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[ulong2]] [[mul_hi]] [[ulong2_18446744073709551615]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[ulong2]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[ulong2]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     OpStore {{.*}} [[select]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long2 *a, global long2 *b, global long2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_long_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_long_hack_mul_extended.cl
@@ -1,0 +1,57 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_0:%[^ ]+]] = OpConstant [[ulong]] 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong_9223372032559808512:%[^ ]+]] = OpConstant [[ulong]] 9223372032559808512
+// CHECK-DAG: [[ulong_18446744073709551615:%[^ ]+]] = OpConstant [[ulong]] 18446744073709551615
+// CHECK-DAG: [[ulong_1:%[^ ]+]] = OpConstant [[ulong]] 1
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[b]] [[a]]
+// CHECK:     [[res_neg:%[^ ]+]] = OpSLessThan [[bool]] [[xor]] [[ulong_0]]
+// CHECK:     [[a_pos:%[^ ]+]] = OpExtInst [[ulong]] {{.*}} SAbs [[a]]
+// CHECK:     [[b_pos:%[^ ]+]] = OpExtInst [[ulong]] {{.*}} SAbs [[b]]
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a_pos]] [[ulong_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[b_pos]] [[ulong_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a_pos]] [[ulong_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[b_pos]] [[ulong_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b0]] [[ulong_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a1b0]] [[ulong_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b1]] [[ulong_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_9223372032559808512]]
+// CHECK:     [[a0b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b0]] [[ulong_4294967295]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b0]] [[ulong_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b1]] [[ulong_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_lo_hi:%[^ ]+]] = OpShiftLeftLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_lo:%[^ ]+]] = OpBitwiseOr [[ulong]] [[mul_lo_hi]] [[a0b0_0]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     [[mul_lo_xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[mul_lo]] [[ulong_18446744073709551615]]
+// CHECK:     [[add_carry:%[^ ]+]] = OpIAddCarry {{.*}} [[mul_lo_xor]] [[ulong_1]]
+// CHECK:     [[carry:%[^ ]+]] = OpCompositeExtract [[ulong]] [[add_carry]] 1
+// CHECK:     [[mul_hi_xor:%[^ ]+]] = OpBitwiseXor [[ulong]] [[mul_hi]] [[ulong_18446744073709551615]]
+// CHECK:     [[mul_hi_inv:%[^ ]+]] = OpIAdd [[ulong]] [[carry]] [[mul_hi_xor]]
+// CHECK:     [[select:%[^ ]+]] = OpSelect [[ulong]] [[res_neg]] [[mul_hi_inv]] [[mul_hi]]
+// CHECK:     OpStore {{.*}} [[select]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global long *a, global long *b, global long *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_short2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_short2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort2:%[^ ]+]] = OpTypeVector [[ushort]] 2
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint2_16:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_16]] [[uint_16]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[uint2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[uint2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[mul]] [[uint2_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short2 *a, global short2 *b, global short2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_short_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_short_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpSConvert [[uint]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpSConvert [[uint]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul]] [[uint_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global short *a, global short *b, global short *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_uchar2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uchar2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[uchar2:%[^ ]+]] = OpTypeVector [[uchar]] 2
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort2:%[^ ]+]] = OpTypeVector [[ushort]] 2
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK-DAG: [[ushort2_8:%[^ ]+]] = OpConstantComposite [[ushort2]] [[ushort_8]] [[ushort_8]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ushort2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ushort2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort2]] [[mul]] [[ushort2_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar2 *a, global uchar2 *b, global uchar2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_uchar_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uchar_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort_8:%[^ ]+]] = OpConstant [[ushort]] 8
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uchar]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ushort]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ushort]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ushort]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ushort]] [[mul]] [[ushort_8]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uchar]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar *a, global uchar *b, global uchar *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_uint2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uint2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul]] [[ulong2_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint2 *a, global uint2 *b, global uint2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_uint2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uint2_hack_mul_extended.cl
@@ -3,22 +3,41 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
 // CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
 // CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
 // CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
 // CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
-// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
-// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint2]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong2]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong2]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong2]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul]] [[ulong2_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint2]] [[shift]]
-// CHECK:     OpStore {{.*}} [[trunc]]
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong2_4294967295:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_4294967295]] [[ulong_4294967295]]
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK-DAG: [[ulong2_18446744069414584320:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_18446744069414584320]] [[ulong_18446744069414584320]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a]] [[ulong2_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[b]] [[ulong2_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a]] [[ulong2_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[b]] [[ulong2_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b0]] [[ulong2_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a1b0]] [[ulong2_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b1]] [[ulong2_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_18446744069414584320]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b0]] [[ulong2_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a0b1]] [[ulong2_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul_lo_add2]] [[ulong2_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
 
-kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint2 *a, global uint2 *b, global uint2 *c)
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong2 *a, global ulong2 *b, global ulong2 *c)
 {
     *c = mul_hi(*a, *b);
 }

--- a/test/hack_mul_extended/mul_hi_uint_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uint_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint *a, global uint *b, global uint *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_uint_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_uint_hack_mul_extended.cl
@@ -3,19 +3,37 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
 // CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
-// CHECK:     [[a:%[^ ]+]] = OpLoad [[uint]] {{.*}}
-// CHECK:     [[b:%[^ ]+]] = OpLoad [[uint]] {{.*}}
-// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[ulong]] [[a]]
-// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[ulong]] [[b]]
-// CHECK:     [[mul:%[^ ]+]] = OpIMul [[ulong]] [[b_ext]] [[a_ext]]
-// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul]] [[ulong_32]]
-// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[uint]] [[shift]]
-// CHECK:     OpStore {{.*}} [[trunc]]
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a]] [[ulong_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[b]] [[ulong_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a]] [[ulong_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[b]] [[ulong_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b0]] [[ulong_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a1b0]] [[ulong_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b1]] [[ulong_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_18446744069414584320]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b0]] [[ulong_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b1]] [[ulong_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
 
-kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint *a, global uint *b, global uint *c)
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong *a, global ulong *b, global ulong *c)
 {
     *c = mul_hi(*a, *b);
 }

--- a/test/hack_mul_extended/mul_hi_ulong2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_ulong2_hack_mul_extended.cl
@@ -1,0 +1,44 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong2:%[^ ]+]] = OpTypeVector [[ulong]] 2
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong2_32:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_32]] [[ulong_32]]
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong2_4294967295:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_4294967295]] [[ulong_4294967295]]
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK-DAG: [[ulong2_18446744069414584320:%[^ ]+]] = OpConstantComposite [[ulong2]] [[ulong_18446744069414584320]] [[ulong_18446744069414584320]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong2]] {{.*}}
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a]] [[ulong2_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[b]] [[ulong2_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a]] [[ulong2_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[b]] [[ulong2_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b0]] [[ulong2_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong2]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a1b0]] [[ulong2_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[a0b1]] [[ulong2_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong2]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_18446744069414584320]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b0]] [[ulong2_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a0b1]] [[ulong2_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong2]] [[a1b1]] [[ulong2_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong2]] [[mul_lo_add2]] [[ulong2_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong2]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong2]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong2 *a, global ulong2 *b, global ulong2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_ulong_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_ulong_hack_mul_extended.cl
@@ -1,0 +1,40 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ulong:%[^ ]+]] = OpTypeInt 64 0
+// CHECK-DAG: [[ulong_32:%[^ ]+]] = OpConstant [[ulong]] 32
+// CHECK-DAG: [[ulong_4294967295:%[^ ]+]] = OpConstant [[ulong]] 4294967295
+// CHECK-DAG: [[ulong_18446744069414584320:%[^ ]+]] = OpConstant [[ulong]] 18446744069414584320
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ulong]] {{.*}}
+// CHECK:     [[a1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a]] [[ulong_32]]
+// CHECK:     [[b1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[b]] [[ulong_32]]
+// CHECK:     [[a0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a]] [[ulong_4294967295]]
+// CHECK:     [[b0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[b]] [[ulong_4294967295]]
+// CHECK:     [[a0b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a0]]
+// CHECK:     [[a0b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b0]] [[ulong_32]]
+// CHECK:     [[a1b0:%[^ ]+]] = OpIMul [[ulong]] [[b0]] [[a1]]
+// CHECK:     [[a1b0_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a1b0]] [[ulong_32]]
+// CHECK:     [[a0b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a0]]
+// CHECK:     [[a0b1_1:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[a0b1]] [[ulong_32]]
+// CHECK:     [[a1b1:%[^ ]+]] = OpIMul [[ulong]] [[b1]] [[a1]]
+// CHECK:     [[a1b1_1:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_18446744069414584320]]
+// CHECK:     [[a1b0_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b0]] [[ulong_4294967295]]
+// CHECK:     [[a0b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a0b1]] [[ulong_4294967295]]
+// CHECK:     [[a1b1_0:%[^ ]+]] = OpBitwiseAnd [[ulong]] [[a1b1]] [[ulong_4294967295]]
+// CHECK:     [[mul_lo_add:%[^ ]+]] = OpIAdd [[ulong]] [[a0b0_1]] [[a1b0_0]]
+// CHECK:     [[mul_lo_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_lo_add]] [[a0b1_0]]
+// CHECK:     [[low_carry:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[mul_lo_add2]] [[ulong_32]]
+// CHECK:     [[mul_hi_add:%[^ ]+]] = OpIAdd [[ulong]] [[a1b1_0]] [[a1b0_1]]
+// CHECK:     [[mul_hi_add2:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add]] [[a0b1_1]]
+// CHECK:     [[mul_hi_no_carry:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_add2]] [[a1b1_1]]
+// CHECK:     [[mul_hi:%[^ ]+]] = OpIAdd [[ulong]] [[mul_hi_no_carry]] [[low_carry]]
+// CHECK:     OpStore {{.*}} [[mul_hi]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ulong *a, global ulong *b, global ulong *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_ushort2_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_ushort2_hack_mul_extended.cl
@@ -1,0 +1,25 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[ushort2:%[^ ]+]] = OpTypeVector [[ushort]] 2
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint2_16:%[^ ]+]] = OpConstantComposite [[uint2]] [[uint_16]] [[uint_16]]
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort2]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort2]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[uint2]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[uint2]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint2]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint2]] [[mul]] [[uint2_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort2]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort2 *a, global ushort2 *b, global ushort2 *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/hack_mul_extended/mul_hi_ushort_hack_mul_extended.cl
+++ b/test/hack_mul_extended/mul_hi_ushort_hack_mul_extended.cl
@@ -1,0 +1,22 @@
+// RUN: clspv -int8 %s -o %t.spv -hack-mul-extended
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: [[ushort:%[^ ]+]] = OpTypeInt 16 0
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK:     [[a:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[b:%[^ ]+]] = OpLoad [[ushort]] {{.*}}
+// CHECK:     [[a_ext:%[^ ]+]] = OpUConvert [[uint]] [[a]]
+// CHECK:     [[b_ext:%[^ ]+]] = OpUConvert [[uint]] [[b]]
+// CHECK:     [[mul:%[^ ]+]] = OpIMul [[uint]] [[b_ext]] [[a_ext]]
+// CHECK:     [[shift:%[^ ]+]] = OpShiftRightLogical [[uint]] [[mul]] [[uint_16]]
+// CHECK:     [[trunc:%[^ ]+]] = OpUConvert [[ushort]] [[shift]]
+// CHECK:     OpStore {{.*}} [[trunc]]
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global ushort *a, global ushort *b, global ushort *c)
+{
+    *c = mul_hi(*a, *b);
+}
+

--- a/test/int_mod.cl
+++ b/test/int_mod.cl
@@ -6,7 +6,6 @@
 // CHECK-DAG: %[[GLSL:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool
-// CHECK-DAG: %[[MUL_STRUCT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeStruct %[[UINT_TYPE_ID]] %[[UINT_TYPE_ID]]
 // CHECK-DAG: %[[UINT0:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 // CHECK-DAG: %[[UINT1:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 // CHECK-DAG: %[[UINTM1:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 4294967295
@@ -18,9 +17,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK: %[[ABSB_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_TYPE_ID]] %[[GLSL]] SAbs %[[LOADB_ID]]
 // CHECK: %[[SREM_ID:[a-zA-Z0-9_]*]] = OpUMod %[[UINT_TYPE_ID]] %[[ABSA_ID]] %[[ABSB_ID]]
 // CHECK: %[[A_POS_ID:[a-zA-Z0-9_]*]] = OpSGreaterThan %[[BOOL_TYPE_ID]] %[[LOADA_ID]] %[[UINT0]]
-// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[A_POS_ID]] %[[UINT1]] %[[UINTM1]]
-// CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpSMulExtended %[[MUL_STRUCT_TYPE_ID]] %[[SREM_ID]] %[[SELECT_ID]]
-// CHECK: %[[EXTRACT_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] %[[MUL_ID]] 0
-// CHECK: OpStore {{.*}} %[[EXTRACT_ID]]
+// CHECK: %[[XOR:[a-zA-Z0-9_]*]] = OpBitwiseXor %[[UINT_TYPE_ID]] %[[SREM_ID]] %[[UINTM1]]
+// CHECK: %[[ADD:[a-zA-Z0-9_]*]] = OpIAdd %[[UINT_TYPE_ID]] %[[XOR]] %[[UINT1]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[A_POS_ID]] %[[SREM_ID]] %[[ADD]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
   *a %= *b;
 }


### PR DESCRIPTION
OpMulExtended only works on Intel GPU with 32bit types.
Workaround it with a new option 'hack-mul-extended' which prevents
clspv from using OpMulExtended.

Also change the SRem implementation not to use OpMulExtended all the
time.