### PR TITLE
fix signed modulo implementation

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4208,7 +4208,7 @@ void SPIRVProducerPass::GenerateInstruction(Instruction &I) {
         // abs(x) % abs(y)
         Ops.clear();
         Ops << Ty << AbsX << AbsY;
-        auto Mod = addSPIRVInst(spv::OpSRem, Ops);
+        auto Mod = addSPIRVInst(spv::OpUMod, Ops);
 
         // x > 0
         Ops.clear();

--- a/test/int_mod.cl
+++ b/test/int_mod.cl
@@ -16,7 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, gl
 // CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_TYPE_ID]]
 // CHECK: %[[ABSA_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_TYPE_ID]] %[[GLSL]] SAbs %[[LOADA_ID]]
 // CHECK: %[[ABSB_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[UINT_TYPE_ID]] %[[GLSL]] SAbs %[[LOADB_ID]]
-// CHECK: %[[SREM_ID:[a-zA-Z0-9_]*]] = OpSRem %[[UINT_TYPE_ID]] %[[ABSA_ID]] %[[ABSB_ID]]
+// CHECK: %[[SREM_ID:[a-zA-Z0-9_]*]] = OpUMod %[[UINT_TYPE_ID]] %[[ABSA_ID]] %[[ABSB_ID]]
 // CHECK: %[[A_POS_ID:[a-zA-Z0-9_]*]] = OpSGreaterThan %[[BOOL_TYPE_ID]] %[[LOADA_ID]] %[[UINT0]]
 // CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[UINT_TYPE_ID]] %[[A_POS_ID]] %[[UINT1]] %[[UINTM1]]
 // CHECK: %[[MUL_ID:[a-zA-Z0-9_]*]] = OpSMulExtended %[[MUL_STRUCT_TYPE_ID]] %[[SREM_ID]] %[[SELECT_ID]]


### PR DESCRIPTION
at the moment signed modulo are transform in clspv:
a % b = (abs(a) % abs(b)) * (a>0 ? 1 : -1)

Using OpSRem to perform the modulo creates a bug when 'a' is TYPE_MIN.
abs((signed)TYPE_MIN) => (unsigned)UTYPE_MAX => (signed)TYPE_MIN.
It leds to wrong output on some GPUs.
Let's use OpUMod instead of OpSRem to avoid this issue, as we use abs
before doing the modulo