### PR TITLE
fix replaceFshl to avoid spirv undefined behavior

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -151,15 +151,16 @@ bool ReplaceLLVMIntrinsicsPass::replaceFshl(Function &F) {
     auto scalar_size = ConstantInt::get(type, type->getScalarSizeInBits());
     auto down_amount = builder.CreateSub(scalar_size, shift_amount);
 
-    // Shift the two arguments and OR the results together.
-    auto hi_bits = builder.CreateShl(arg_hi, shift_amount);
-    auto lo_bits = builder.CreateLShr(arg_lo, down_amount);
-
     // "The resulting value is undefined if Shift is greater than or equal to
     // the bit width of the components of Base."
     // https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#Bit
-    auto cmp = builder.CreateICmpUGE(down_amount, scalar_size);
-    lo_bits = builder.CreateSelect(cmp, ConstantInt::get(type, 0), lo_bits);
+    if (!dyn_cast<ConstantInt>(arg_shift)) {
+      down_amount = builder.CreateAnd(down_amount, mod_mask);
+    }
+
+    // Shift the two arguments and OR the results together.
+    auto hi_bits = builder.CreateShl(arg_hi, shift_amount);
+    auto lo_bits = builder.CreateLShr(arg_lo, down_amount);
 
     return builder.CreateOr(lo_bits, hi_bits);
   });

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -154,6 +154,13 @@ bool ReplaceLLVMIntrinsicsPass::replaceFshl(Function &F) {
     // Shift the two arguments and OR the results together.
     auto hi_bits = builder.CreateShl(arg_hi, shift_amount);
     auto lo_bits = builder.CreateLShr(arg_lo, down_amount);
+
+    // "The resulting value is undefined if Shift is greater than or equal to
+    // the bit width of the components of Base."
+    // https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#Bit
+    auto cmp = builder.CreateICmpUGE(down_amount, scalar_size);
+    lo_bits = builder.CreateSelect(cmp, ConstantInt::get(type, 0), lo_bits);
+
     return builder.CreateOr(lo_bits, hi_bits);
   });
 }

--- a/test/IntegerBuiltins/rotate/rotate_uchar.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar.cl
@@ -7,7 +7,8 @@
 // CHECK-DAG: %[[modmask:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 7
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 8
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[uchar]] {{.*}} %[[modmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[uchar]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[uchar]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[uchar]] %[[downamountraw]] %[[modmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[uchar]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[uchar]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[uchar]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uchar2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar2.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 8
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v2uchar]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v2uchar]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v2uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v2uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v2uchar]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v2uchar]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v2uchar]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v2uchar]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uchar3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar3.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 8
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v3uchar]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v3uchar]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v3uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v3uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v3uchar]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v3uchar]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v3uchar]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v3uchar]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uchar4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar4.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 8
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v4uchar]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v4uchar]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v4uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v4uchar]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v4uchar]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v4uchar]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v4uchar]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v4uchar]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uchar_0.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar_0.cl
@@ -1,0 +1,16 @@
+// RUN: clspv  %s -o %t.spv -int8
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK:     %[[a_struct:[0-9a-zA-Z_]+]] = OpLoad {{.*}} {{.*}}
+// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[a_struct]] 0
+// CHECK:     OpStore {{.*}} %[[a]]
+
+kernel void test_rotate(global uchar* out, uchar a)
+{
+    *out = rotate(a, (uchar)0);
+}
+
+

--- a/test/IntegerBuiltins/rotate/rotate_uchar_2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar_2.cl
@@ -1,0 +1,18 @@
+// RUN: clspv  %s -o %t.spv -int8
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK-DAG: %[[uchar_2:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 2
+// CHECK-DAG: %[[uchar_6:[0-9a-zA-Z_]+]] = OpConstant %[[uchar]] 6
+// CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[uchar]] {{.*}} %[[uchar_2]]
+// CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[uchar]] {{.*}} %[[uchar_6]]
+// CHECK:     OpBitwiseOr %[[uchar]] %[[lobits]] %[[hibits]]
+
+kernel void test_rotate(global uchar* out, uchar a)
+{
+    *out = rotate(a, (uchar)2);
+}
+
+

--- a/test/IntegerBuiltins/rotate/rotate_uchar_64.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar_64.cl
@@ -1,0 +1,16 @@
+// RUN: clspv  %s -o %t.spv -int8
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
+// CHECK:     %[[a_struct:[0-9a-zA-Z_]+]] = OpLoad {{.*}} {{.*}}
+// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[a_struct]] 0
+// CHECK:     OpStore {{.*}} %[[a]]
+
+kernel void test_rotate(global uchar* out, uchar a)
+{
+    *out = rotate(a, (uchar)64);
+}
+
+

--- a/test/IntegerBuiltins/rotate/rotate_uint.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint.cl
@@ -7,7 +7,8 @@
 // CHECK-DAG: %[[modmask:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 31
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 32
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[uint]] {{.*}} %[[modmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[uint]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[uint]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[uint]] %[[downamountraw]] %[[modmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[uint]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[uint]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[uint]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uint2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint2.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 32
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v2uint]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v2uint]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v2uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v2uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v2uint]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v2uint]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v2uint]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v2uint]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uint3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint3.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 32
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v3uint]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v3uint]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v3uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v3uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v3uint]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v3uint]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v3uint]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v3uint]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_uint4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uint4.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 32
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v4uint]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v4uint]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v4uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v4uint]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v4uint]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v4uint]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v4uint]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v4uint]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ulong.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong.cl
@@ -7,7 +7,8 @@
 // CHECK-DAG: %[[modmask:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 63
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 64
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[ulong]] {{.*}} %[[modmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[ulong]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[ulong]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[ulong]] %[[downamountraw]] %[[modmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[ulong]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[ulong]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[ulong]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ulong2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong2.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 64
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v2ulong]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v2ulong]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v2ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v2ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v2ulong]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v2ulong]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v2ulong]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v2ulong]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ulong3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong3.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 64
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v3ulong]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v3ulong]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v3ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v3ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v3ulong]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v3ulong]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v3ulong]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v3ulong]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ulong4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ulong4.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 64
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v4ulong]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v4ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v4ulong]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v4ulong]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v4ulong]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v4ulong]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v4ulong]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ushort.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort.cl
@@ -7,7 +7,8 @@
 // CHECK-DAG: %[[modmask:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 15
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 16
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[ushort]] {{.*}} %[[modmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[ushort]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[ushort]] %[[scalarsize]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[ushort]] %[[downamountraw]] %[[modmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[ushort]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[ushort]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[ushort]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ushort2.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort2.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 16
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v2ushort]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v2ushort]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v2ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v2ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v2ushort]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v2ushort]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v2ushort]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v2ushort]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ushort3.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort3.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 16
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v3ushort]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v3ushort]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v3ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v3ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v3ushort]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v3ushort]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v3ushort]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v3ushort]] %[[lobits]] %[[hibits]]

--- a/test/IntegerBuiltins/rotate/rotate_ushort4.cl
+++ b/test/IntegerBuiltins/rotate/rotate_ushort4.cl
@@ -10,7 +10,8 @@
 // CHECK-DAG: %[[scalarsize:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 16
 // CHECK-DAG: %[[vecscalarbits:[0-9]+]] = OpConstantComposite %[[v4ushort]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]] %[[scalarsize]]
 // CHECK:     %[[rotamount:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] {{.*}} %[[vecmodmask]]
-// CHECK:     %[[downamount:[0-9]+]] = OpISub %[[v4ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamountraw:[0-9]+]] = OpISub %[[v4ushort]] %[[vecscalarbits]] %[[rotamount]]
+// CHECK:     %[[downamount:[0-9]+]] = OpBitwiseAnd %[[v4ushort]] %[[downamountraw]] %[[vecmodmask]]
 // CHECK:     %[[hibits:[0-9]+]] = OpShiftLeftLogical %[[v4ushort]] {{.*}} %[[rotamount]]
 // CHECK:     %[[lobits:[0-9]+]] = OpShiftRightLogical %[[v4ushort]] {{.*}} %[[downamount]]
 // CHECK:     OpBitwiseOr %[[v4ushort]] %[[lobits]] %[[hibits]]

--- a/test/LLVMIntrinsics/fshl.ll
+++ b/test/LLVMIntrinsics/fshl.ll
@@ -16,8 +16,9 @@ declare i8 @llvm.fshl.i8(i8, i8, i8)
 ; CHECK-NOT: llvm.fshl
 ; CHECK: [[and:%[0-9a-zA-Z_.]+]] = and i8 %c, 7
 ; CHECK: [[sub:%[0-9a-zA-Z_.]+]] = sub i8 8, [[and]]
+; CHECK: [[and2:%[0-9a-zA-Z_.]+]] = and i8 [[sub]], 7
 ; CHECK: [[shl:%[0-9a-zA-Z_.]+]] = shl i8 %a, [[and]]
-; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i8 %b, [[sub]]
+; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i8 %b, [[and2]]
 ; CHECK: [[or:%[0-9a-zA-Z_.]+]] = or i8 [[lshr]], [[shl]]
 ; CHECK: store i8 [[or]], i8 addrspace(1)* %out
 
@@ -35,8 +36,9 @@ declare i16 @llvm.fshl.i16(i16, i16, i16)
 ; CHECK-NOT: llvm.fshl
 ; CHECK: [[and:%[0-9a-zA-Z_.]+]] = and i16 %c, 15
 ; CHECK: [[sub:%[0-9a-zA-Z_.]+]] = sub i16 16, [[and]]
+; CHECK: [[and2:%[0-9a-zA-Z_.]+]] = and i16 [[sub]], 15
 ; CHECK: [[shl:%[0-9a-zA-Z_.]+]] = shl i16 %a, [[and]]
-; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i16 %b, [[sub]]
+; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i16 %b, [[and2]]
 ; CHECK: [[or:%[0-9a-zA-Z_.]+]] = or i16 [[lshr]], [[shl]]
 ; CHECK: store i16 [[or]], i16 addrspace(1)* %out
 
@@ -54,8 +56,9 @@ declare i32 @llvm.fshl.i32(i32, i32, i32)
 ; CHECK-NOT: llvm.fshl
 ; CHECK: [[and:%[0-9a-zA-Z_.]+]] = and i32 %c, 31
 ; CHECK: [[sub:%[0-9a-zA-Z_.]+]] = sub i32 32, [[and]]
+; CHECK: [[and2:%[0-9a-zA-Z_.]+]] = and i32 [[sub]], 31
 ; CHECK: [[shl:%[0-9a-zA-Z_.]+]] = shl i32 %a, [[and]]
-; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i32 %b, [[sub]]
+; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i32 %b, [[and2]]
 ; CHECK: [[or:%[0-9a-zA-Z_.]+]] = or i32 [[lshr]], [[shl]]
 ; CHECK: store i32 [[or]], i32 addrspace(1)* %out
 
@@ -73,7 +76,8 @@ declare i64 @llvm.fshl.i64(i64, i64, i64)
 ; CHECK-NOT: llvm.fshl
 ; CHECK: [[and:%[0-9a-zA-Z_.]+]] = and i64 %c, 63
 ; CHECK: [[sub:%[0-9a-zA-Z_.]+]] = sub i64 64, [[and]]
+; CHECK: [[and2:%[0-9a-zA-Z_.]+]] = and i64 [[sub]], 63
 ; CHECK: [[shl:%[0-9a-zA-Z_.]+]] = shl i64 %a, [[and]]
-; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i64 %b, [[sub]]
+; CHECK: [[lshr:%[0-9a-zA-Z_.]+]] = lshr i64 %b, [[and2]]
 ; CHECK: [[or:%[0-9a-zA-Z_.]+]] = or i64 [[lshr]], [[shl]]
 ; CHECK: store i64 [[or]], i64 addrspace(1)* %out


### PR DESCRIPTION
Some CTS tests fail on some platforms when doing rotate of 0.
This is because rotate ends up to combination of shifts. One of them
being of type size in bits when rotating of 0.

But spirv says that shifting of the type size in bits results in an
undefined behavior.