### PR TITLE
Use python3 as the executable name.

### DIFF
--- a/utils/fetch_sources.py
+++ b/utils/fetch_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 The Clspv Authors. All rights reserved.
 #


### PR DESCRIPTION
Starting from recent macOS releases, python(2) is no longer shipped
with the operating system at all. The script can already fetch LLVM
fine when using python3, so switching to that.