### PR TITLE
Enable universal binaries on Apple platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@
 
 cmake_minimum_required(VERSION 3.13.4)
 
+# Enable universal binaries on modern Apple platforms.
+IF(APPLE)
+  SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
+ENDIF(APPLE)
+
 if(NOT COMMAND find_host_package)
   macro(find_host_package)
     find_package(${ARGN})

--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "5910150140cd5e781e7827d160ddce0a146cddd4"
+      "commit" : "308ca349cbc5fa891b08c525084fc86017bdc498"
     },
     {
       "name" : "SPIRV-Headers",


### PR DESCRIPTION
- I know this may not be desirable for development, but for releases we have a mixture of architectures in our fleet and would like to avoid Rosetta when possible.
- Updates LLVM for:

```
commit 578d85e924fcb172ff9b2eaa7da6cdd6df42b020
Author: Martin Storsjö <martin@martin.st>
Date:   Fri Apr 1 11:50:25 2022 +0300

    [Support] [BLAKE3] Fix compilation with CMAKE_OSX_ARCHITECTURES

    With CMake, one can build for multiple macOS architectures
    at the same time by setting CMAKE_OSX_ARCHITECTURES to multiple
    architectures (avoiding needing to do two separate builds and
    gluing the binaries together after the build).

    In this case, while targeting x86_64 and arm64, neither IS_X64
    nor IS_ARM64 is set, while compilation of the individual source
    files will hit those cases (in either architecture mode).

    Therefore, if we on the CMake level decide not to include the
    architecture specific SIMD implementation files, also tell the
    source this explicitly by passing the defines indicating that we
    don't expect to use them.

    Such a build clearly is less ideal than explicitly targeting one
    architecture at a time if it won't include all the SIMD optimizations,
    but that's a tradeoff that is up to the one deciding to do such an
    universal build.

    This also fixes builds for i386. The blake3 source code automatically
    enables the SIMD implementations when building for i386, but we don't
    provide the sources for that build configuration.

    Differential Revision: https://reviews.llvm.org/D122884
```