### PR TITLE
enable support of non uniform workgroup size by default

### DIFF
--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -264,7 +264,8 @@ static llvm::cl::opt<bool>
 
 static llvm::cl::opt<bool> uniform_workgroup_size(
     "uniform-workgroup-size", llvm::cl::init(false),
-    llvm::cl::desc("Assume all workgroups are uniformly sized."));
+    llvm::cl::desc("Assume all workgroups are uniformly sized and the "
+                   "size will not exceed device limits"));
 
 static llvm::cl::opt<bool>
     cl_kernel_arg_info("cl-kernel-arg-info", llvm::cl::init(false),
@@ -322,11 +323,7 @@ bool WorkDim() { return work_dim; }
 bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool NonUniformNDRangeSupported() {
-  return ((Language() == SourceLanguage::OpenCL_CPP) ||
-          (Language() == SourceLanguage::OpenCL_C_20) ||
-          (Language() == SourceLanguage::OpenCL_C_30) ||
-          ArmNonUniformWorkGroupSize()) &&
-         !UniformWorkgroupSize();
+  return !UniformWorkgroupSize();
 }
 bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 

--- a/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
+++ b/test/HalfStorage/vstore_half_without_16bit_storage_uses_atomic_xor.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-16bit-storage=ssbo
+// RUN: clspv %s -o %t.spv -no-16bit-storage=ssbo -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerAccessChains/pointer_index_is_constant_1.cl
+++ b/test/PointerAccessChains/pointer_index_is_constant_1.cl
@@ -1,9 +1,9 @@
-// RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments
+// RUN: clspv %s -o %t.spv -no-inline-single -keep-unused-arguments -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %s -o %t.spv -no-dra -no-inline-single -keep-unused-arguments
+// RUN: clspv %s -o %t.spv -no-dra -no-inline-single -keep-unused-arguments -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerCasts/deref_load_cast_float2_to_int4.cl
+++ b/test/PointerCasts/deref_load_cast_float2_to_int4.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerCasts/deref_store_cast_int4_to_float2.cl
+++ b/test/PointerCasts/deref_store_cast_int4_to_float2.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerCasts/load_cast_float_to_int.cl
+++ b/test/PointerCasts/load_cast_float_to_int.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerCasts/store_cast_float2_to_int2.cl
+++ b/test/PointerCasts/store_cast_float2_to_int2.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/PointerCasts/store_cast_float_to_int.cl
+++ b/test/PointerCasts/store_cast_float_to_int.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/LocalInclude.cl
+++ b/test/Preprocessor/LocalInclude.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/SystemInclude.cl
+++ b/test/Preprocessor/SystemInclude.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -I %S/SomeIncludeDirectory %s -o %t.spv
+// RUN: clspv -I %S/SomeIncludeDirectory %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/TwoSystemIncludes.cl
+++ b/test/Preprocessor/TwoSystemIncludes.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -I %S/SomeIncludeDirectory -I %S/AnotherIncludeDirectory %s -o %t.spv
+// RUN: clspv -I %S/SomeIncludeDirectory -I %S/AnotherIncludeDirectory %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/UserDefine.cl
+++ b/test/Preprocessor/UserDefine.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -DUSER_SPECIFIED %s -o %t.spv
+// RUN: clspv -DUSER_SPECIFIED %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/UserDefineValue.cl
+++ b/test/Preprocessor/UserDefineValue.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -DUSER_SPECIFIED=42 %s -o %t.spv
+// RUN: clspv -DUSER_SPECIFIED=42 %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/VULKAN.cl
+++ b/test/Preprocessor/VULKAN.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/__FAST_RELAXED_MATH__.cl
+++ b/test/Preprocessor/__FAST_RELAXED_MATH__.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -cl-fast-relaxed-math %s -o %t.spv
+// RUN: clspv -cl-fast-relaxed-math %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/__OPENCL_C_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_C_VERSION__.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Preprocessor/__OPENCL_VERSION__.cl
+++ b/test/Preprocessor/__OPENCL_VERSION__.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Reflection/global_offset_spec_constant.cl
+++ b/test/Reflection/global_offset_spec_constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -global-offset
+// RUN: clspv %s -o %t.spv -global-offset -uniform-workgroup-size
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Spv1p4/interface_global_push_constant.ll
+++ b/test/Spv1p4/interface_global_push_constant.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -uniform-workgroup-size
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Spv1p4/interface_global_workgroup.ll
+++ b/test/Spv1p4/interface_global_workgroup.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -uniform-workgroup-size
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Spv1p4/interface_pod_pushconstant.ll
+++ b/test/Spv1p4/interface_pod_pushconstant.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -uniform-workgroup-size
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Spv1p4/interface_ssbo_resource.ll
+++ b/test/Spv1p4/interface_ssbo_resource.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -uniform-workgroup-size
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Spv1p4/interface_workgroup_resource.ll
+++ b/test/Spv1p4/interface_workgroup_resource.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; RUN: clspv-opt -SPIRVProducerPass %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -uniform-workgroup-size
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Structs/byval.cl
+++ b/test/Structs/byval.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/Structs/sret.cl
+++ b/test/Structs/sret.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/VaryingLocalSizes/reqd_work_group_size.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_one_kernel.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
+++ b/test/VaryingLocalSizes/reqd_work_group_size_two_kernels.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
+++ b/test/WorkItemBuiltins/get_global_id-with-global-offset-push-constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset-push-constant %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size -global-offset-push-constant %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_id-with-global-offset-spec-constant.cl
+++ b/test/WorkItemBuiltins/get_global_id-with-global-offset-spec-constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size -global-offset %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_id.cl
+++ b/test/WorkItemBuiltins/get_global_id.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-inline-single
+// RUN: clspv %s -o %t.spv -no-inline-single -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.cl
+++ b/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size -global-offset %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_offset-spec-constant.cl
+++ b/test/WorkItemBuiltins/get_global_offset-spec-constant.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -global-offset %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size -global-offset %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: clspv-reflection %t.spv -o %t.dmap

--- a/test/WorkItemBuiltins/get_global_size.cl
+++ b/test/WorkItemBuiltins/get_global_size.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-inline-single
+// RUN: clspv %s -o %t.spv -no-inline-single -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_global_size_hack_initializers.cl
+++ b/test/WorkItemBuiltins/get_global_size_hack_initializers.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -hack-initializers -no-inline-single
+// RUN: clspv %s -o %t.spv -hack-initializers -no-inline-single -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_group_id.cl
+++ b/test/WorkItemBuiltins/get_group_id.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-inline-single
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_local_size.cl
+++ b/test/WorkItemBuiltins/get_local_size.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-inline-single
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/WorkItemBuiltins/get_num_groups.cl
+++ b/test/WorkItemBuiltins/get_num_groups.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -no-inline-single
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv -no-inline-single
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/cluster_pod_args_attibutes_on_pod.cl
+++ b/test/cluster_pod_args_attibutes_on_pod.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -int8 -cluster-pod-kernel-args %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size -int8 -cluster-pod-kernel-args %s -o %t.spv
 // RUN: clspv-reflection %t.spv -o %t.map
 // RUN: FileCheck %s < %t.map -check-prefix=MAP
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/different_reqd_work_group_sizes.cl
+++ b/test/different_reqd_work_group_sizes.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/explicit_stdin.cl
+++ b/test/explicit_stdin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv - -o %t.spv < %s
+// RUN: clspv -uniform-workgroup-size - -o %t.spv < %s
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/for.cl
+++ b/test/for.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/global_buffer_arg_dynamic_store.cl
+++ b/test/global_buffer_arg_dynamic_store.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/nop.cl
+++ b/test/nop.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/packed_struct_novec3.cl
+++ b/test/packed_struct_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv -vec3-to-vec4
+// RUN: clspv -uniform-workgroup-size %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/reqd_work_group_size.cl
+++ b/test/reqd_work_group_size.cl
@@ -1,4 +1,4 @@
-// RUN: clspv  %s -o %t.spv
+// RUN: clspv -uniform-workgroup-size  %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/stdin.cl
+++ b/test/stdin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -o %t.spv < %s
+// RUN: clspv -uniform-workgroup-size -o %t.spv < %s
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/stdout.cl
+++ b/test/stdout.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o - > %t.spv
+// RUN: clspv -uniform-workgroup-size %s -o - > %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/two_nop_kernels.cl
+++ b/test/two_nop_kernels.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv -uniform-workgroup-size
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv


### PR DESCRIPTION
Support of non uniform workgroup size also allow to split a NDRange in
several smaller regions.
We need that feature available by default to run the CTS on small
embedded GPUs even in CL1.2.
Allow to disable to feature with '-uniform-group-size'.

This is related to the work in kpet/clvk#367