### PR TITLE
Fix image1d buffer support

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1488,23 +1488,6 @@ SPIRVID SPIRVProducerPass::getSPIRVType(Type *Ty, bool needs_layout) {
   // stores a laid out and non-laid out version of the type.
   const unsigned layout = needs_layout ? 1 : 0;
 
-  if (dyn_cast<StructType>(Ty) && IsImageType(dyn_cast<StructType>(Ty))) {
-    // %opencl.image1d_buffer_ro.t, %opencl.image1d_buffer_wo.t and
-    // %opencl.image1d_buffer_rw.t needs to be rework as they will map on the
-    // same SPIRV type.
-    const char *bufferString = "_buffer_";
-    StringRef CanonicalName = Ty->getStructName();
-    size_t bufferPos = CanonicalName.find(bufferString);
-    if (bufferPos != std::string::npos) {
-      std::string NewName = CanonicalName.str().replace(
-          bufferPos + strlen(bufferString), 2, "rw");
-      Ty = StructType::getTypeByName(module->getContext(), NewName);
-      if (!Ty) {
-        Ty = StructType::create(module->getContext(), NewName);
-      }
-    }
-  }
-
   auto TI = TypeMap.find(Ty);
   if (TI != TypeMap.end()) {
     assert(layout < TI->second.size());
@@ -3461,11 +3444,12 @@ SPIRVProducerPass::GenerateImageInstruction(CallInst *Call,
       } else {
         result_type = getSPIRVType(Call->getType());
       }
-
-      uint32_t mask = spv::ImageOperandsLodMask |
-                      GetExtendMask(Call->getType(), is_int_image);
-      Ops << result_type << Image << Coordinate << mask
-          << getSPIRVInt32Constant(0);
+      Ops << result_type << Image << Coordinate;
+      if (ImageDimensionality(image_ty) != spv::DimBuffer) {
+        uint32_t mask = spv::ImageOperandsLodMask |
+                        GetExtendMask(Call->getType(), is_int_image);
+        Ops << mask << getSPIRVInt32Constant(0);
+      }
 
       RID = addSPIRVInst(spv::OpImageFetch, Ops);
 
@@ -3553,7 +3537,8 @@ SPIRVProducerPass::GenerateImageInstruction(CallInst *Call,
     }
     Ops << SizesTypeID << Image;
     spv::Op query_opcode = spv::OpImageQuerySize;
-    if (IsSampledImageType(Image->getType())) {
+    if (IsSampledImageType(Image->getType()) &&
+        ImageDimensionality(Image->getType()) != spv::DimBuffer) {
       query_opcode = spv::OpImageQuerySizeLod;
       // Need explicit 0 for Lod operand.
       Ops << getSPIRVInt32Constant(0);

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -179,8 +179,7 @@ bool clspv::IsStorageImageType(Type *type) {
   if (IsImageType(type, &ty)) {
     if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
       if (struct_ty->getName().contains("_wo_t") ||
-          struct_ty->getName().contains("_rw_t") ||
-          struct_ty->getName().contains("image1d_buffer")) {
+          struct_ty->getName().contains("_rw_t")) {
         return true;
       }
     }

--- a/test/ImageBuiltins/get_image_width_image1d_buffer_readonly.cl
+++ b/test/ImageBuiltins/get_image_width_image1d_buffer_readonly.cl
@@ -11,7 +11,7 @@ foo(global int* out, read_only image1d_buffer_t im)
 
 // CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[_float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
-// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] Buffer 0 0 0 2 Unknown
+// CHECK-DAG: [[_8:%[0-9a-zA-Z_]+]] = OpTypeImage [[_float]] Buffer 0 0 0 1 Unknown
 // CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[_uint]] 0
 // CHECK: [[_18:%[0-9a-zA-Z_]+]] = OpLoad [[_8]]
 // CHECK: [[_19:%[0-9a-zA-Z_]+]] = OpImageQuerySize [[_uint]] [[_18]]

--- a/test/ImageBuiltins/image_1d_buffer.cl
+++ b/test/ImageBuiltins/image_1d_buffer.cl
@@ -25,48 +25,51 @@
 
 // CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
 
-// CHECK-DAG: [[f_image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] Buffer 0 0 0 2 Unknown
-// CHECK-DAG: [[u_image:%[a-zA-Z0-9_]+]] = OpTypeImage [[uint]] Buffer 0 0 0 2 Unknown
-// CHECK-DAG: [[i_image:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] Buffer 0 0 0 2 Unknown
+// CHECK-DAG: [[f_image_ro:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] Buffer 0 0 0 1 Unknown
+// CHECK-DAG: [[u_image_ro:%[a-zA-Z0-9_]+]] = OpTypeImage [[uint]] Buffer 0 0 0 1 Unknown
+// CHECK-DAG: [[i_image_ro:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] Buffer 0 0 0 1 Unknown
+// CHECK-DAG: [[f_image_wo:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] Buffer 0 0 0 2 Unknown
+// CHECK-DAG: [[u_image_wo:%[a-zA-Z0-9_]+]] = OpTypeImage [[uint]] Buffer 0 0 0 2 Unknown
+// CHECK-DAG: [[i_image_wo:%[a-zA-Z0-9_]+]] = OpTypeImage [[int]] Buffer 0 0 0 2 Unknown
 
 // CHECK: [[read_float]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
-// CHECK: OpImageRead [[float4]] [[image]] [[uint_0]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_ro]]
+// CHECK: OpImageFetch [[float4]] [[image]] [[uint_0]]
 kernel void read_float(read_only image1d_buffer_t image, global float4* out) {
   out[0] = read_imagef(image, 0);
 }
 
 // CHECK: [[write_float]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_wo]]
 // CHECK: OpImageWrite [[image]]
 kernel void write_float(write_only image1d_buffer_t image) {
   write_imagef(image, 0, (float4)(0));
 }
 
 // CHECK: [[read_uint]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[u_image]]
-// CHECK: OpImageRead [[uint4]] [[image]] [[uint_0]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[u_image_ro]]
+// CHECK: OpImageFetch [[uint4]] [[image]] [[uint_0]]
 kernel void read_uint(read_only image1d_buffer_t image, global uint4* out) {
   out[0] = read_imageui(image, 0);
 }
 
 // CHECK: [[write_uint]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[u_image]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[u_image_wo]]
 // CHECK: OpImageWrite [[image]]
 kernel void write_uint(write_only image1d_buffer_t image) {
   write_imageui(image, 0, (uint4)(0));
 }
 
 // CHECK: [[read_int]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[i_image]]
-// CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageRead [[int4]] [[image]] [[uint_0]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[i_image_ro]]
+// CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageFetch [[int4]] [[image]] [[uint_0]]
 // CHECK: OpBitcast [[uint4]] [[read]]
 kernel void read_int(read_only image1d_buffer_t image, global int4* out) {
   out[0] = read_imagei(image, 0);
 }
 
 // CHECK: [[write_int]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[i_image]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[i_image_wo]]
 // CHECK: [[cast:%[a-zA-Z0-9_]+]] = OpBitcast [[int4]]
 // CHECK: OpImageWrite [[image]] {{.*}} [[cast]]
 kernel void write_int(write_only image1d_buffer_t image) {
@@ -74,23 +77,23 @@ kernel void write_int(write_only image1d_buffer_t image) {
 }
 
 // CHECK: [[read_half]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
-// CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageRead [[float4]] [[image]] [[uint_0]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_ro]]
+// CHECK: [[read:%[a-zA-Z0-9_]+]] = OpImageFetch [[float4]] [[image]] [[uint_0]]
 // CHECK: OpFConvert [[half4]] [[read]]
 kernel void read_half(read_only image1d_buffer_t image, global half4* out) {
   out[0] = read_imageh(image, 0);
 }
 
 // CHECK: [[write_half]] = OpFunction
-// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
+// CHECK: [[image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_wo]]
 // CHECK: OpImageWrite [[image]]
 kernel void write_half(write_only image1d_buffer_t image) {
   write_imageh(image, 0, (half4)(0));
 }
 
 // CHECK: [[image_width]] = OpFunction
-// CHECK: [[ro_image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
-// CHECK: [[wo_image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image]]
+// CHECK: [[ro_image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_ro]]
+// CHECK: [[wo_image:%[a-zA-Z0-9_]+]] = OpLoad [[f_image_wo]]
 // CHECK: [[query:%[a-zA-Z0-9_]+]] = OpImageQuerySize [[uint]] [[ro_image]]
 // CHECK: [[query:%[a-zA-Z0-9_]+]] = OpImageQuerySize [[uint]] [[wo_image]]
 kernel void image_width(image1d_buffer_t ri, write_only image1d_buffer_t wi, global int* out) {

--- a/test/SpecializeImageTypes/read_image1d_buffer_float.ll
+++ b/test/SpecializeImageTypes/read_image1d_buffer_float.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
 ; RUN: FileCheck %s < %t
 
-; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.float]] = type opaque
+; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.float.sampled]] = type opaque
 ; CHECK: declare spir_func <4 x float> @_Z11read_imagef21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)*, i32) [[ATTRS:#[0-9]+]]
 ; CHECK: define spir_kernel void @read_float
 ; CHECK: call spir_func <4 x float> @_Z11read_imagef21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image

--- a/test/SpecializeImageTypes/read_image1d_buffer_int.ll
+++ b/test/SpecializeImageTypes/read_image1d_buffer_int.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
 ; RUN: FileCheck %s < %t
 
-; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.int]] = type opaque
+; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.int.sampled]] = type opaque
 ; CHECK: declare spir_func <4 x i32> @_Z11read_imagei21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)*, i32) [[ATTRS:#[0-9]+]]
 ; CHECK: define spir_kernel void @read_int
 ; CHECK: call spir_func <4 x i32> @_Z11read_imagei21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image

--- a/test/SpecializeImageTypes/read_image1d_buffer_uint.ll
+++ b/test/SpecializeImageTypes/read_image1d_buffer_uint.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt -SpecializeImageTypesPass %s -o %t
 ; RUN: FileCheck %s < %t
 
-; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.uint]] = type opaque
+; CHECK: %[[IMAGE:opencl.image1d_buffer_ro_t.uint.sampled]] = type opaque
 ; CHECK: declare spir_func <4 x i32> @_Z12read_imageui21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)*, i32) [[ATTRS:#[0-9]+]]
 ; CHECK: define spir_kernel void @read_uint
 ; CHECK: call spir_func <4 x i32> @_Z12read_imageui21ocl_image1d_buffer_roi.[[IMAGE]](%[[IMAGE]] addrspace(1)* %image


### PR DESCRIPTION
reading a image1d buffer needs to go through OpImageFetch and not
OpImageRead.
This is because OpImageRead requires the capability ReadWithoutFormat
which is not necessarily implemented on all vulkan compliant driver.