### PR TITLE
Prevent contraction of OpFMul in more cases

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -198,6 +198,26 @@ bool Supports16BitStorageClass(StorageClass sc);
 // Returns true if |sc| supports 8-bit storage.
 bool Supports8BitStorageClass(StorageClass sc);
 
+// Returns true if unsafe math optimizations are allowed.
+// The following options imply this flag:
+// * -cl-unsafe-math-optimizations
+// * -cl-fast-relaxed-math
+// * -cl-native-math
+bool UnsafeMath();
+
+// Returns true if finite math is assumed.
+// The following options imply this flag:
+// * -cl-finite-math-only
+// * -cl-fast-relaxed-math
+// * -cl-native-math
+bool FiniteMath();
+
+// Returns true if fast relaxed math is enabled.
+// The following options imply this flag:
+// * -cl-fast-relaxed-math
+// * -cl-native-math
+bool FastRelaxedMath();
+
 // Returns true if -cl-native-math is enabled.
 bool NativeMath();
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -251,6 +251,26 @@ static llvm::cl::list<clspv::Option::StorageClass> no_8bit_storage(
         clEnumValN(clspv::Option::StorageClass::kPushConstant, "pushconstant",
                    "Disallow 8-bit types in push constant interfaces")));
 
+static llvm::cl::opt<bool> cl_unsafe_math_optimizations(
+    "cl-unsafe-math-optimizations", llvm::cl::init(false),
+    llvm::cl::desc("Allow optimizations for floating-point arithmetic that (a) "
+                   "assume that arguments and results are valid, (b) may "
+                   "violate IEEE 754 standard and (c) may violate the OpenCL "
+                   "numerical compliance requirements. This option includes "
+                   "the -cl-no-signed-zeros and -cl-mad-enable options."));
+
+static llvm::cl::opt<bool> cl_finite_math_only(
+    "cl-finite-math-only", llvm::cl::init(false),
+    llvm::cl::desc("Allow optimizations for floating-point arithmetic that "
+                   "assume that arguments and results are not NaNs or INFs."));
+
+static llvm::cl::opt<bool> cl_fast_relaxed_math(
+    "cl-fast-relaxed-math", llvm::cl::init(false),
+    llvm::cl::desc("This option causes the preprocessor macro "
+                   "__FAST_RELAXED_MATH__ to be defined. Sets the optimization "
+                   "options -cl-finite-math-only and "
+                   "-cl-unsafe-math-optimizations."));
+
 static llvm::cl::opt<bool> cl_native_math(
     "cl-native-math", llvm::cl::init(false),
     llvm::cl::desc("Perform all math as fast as possible. This option does not "
@@ -355,6 +375,13 @@ bool Supports8BitStorageClass(StorageClass sc) {
   return true;
 }
 
+bool UnsafeMath() {
+  return cl_unsafe_math_optimizations || FastRelaxedMath() || NativeMath();
+}
+bool FiniteMath() {
+  return cl_finite_math_only || FastRelaxedMath() || NativeMath();
+}
+bool FastRelaxedMath() { return cl_fast_relaxed_math || NativeMath(); }
 bool NativeMath() { return cl_native_math; }
 
 bool FP16() { return fp16; }

--- a/test/Contraction/contract.cl
+++ b/test/Contraction/contract.cl
@@ -1,0 +1,10 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// CHECK: OpExtInst %{{.*}} %{{.*}} Fma
+
+#pragma OPENCL FP_CONTRACT ON
+kernel void test(global float *out, global float *a, global float *b, global float *c) {
+  int i = get_global_id(0);
+  out[i] = a[i] * b[i] + c[i];
+}

--- a/test/Contraction/no_contract.cl
+++ b/test/Contraction/no_contract.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// CHECK: OpDecorate [[mul:%[a-zA-Z0-9_]+]] NoContraction
+// CHECK-NOT: OpExtInst %{{.*}} %{{.*}} Fma
+// CHECK: [[mul]] = OpFMul
+// CHECK: OpFAdd %{{.*}} [[mul]]
+
+// RUN: clspv %s -o %t2.spv -cl-unsafe-math-optimizations
+// RUN: spirv-dis %t2.spv -o %t2.spvasm
+// RUN: FileCheck --check-prefix=FAST %s < %t2.spvasm
+// FAST-NOT: OpDecorate [[mul:%[a-zA-Z0-9_]+]] NoContraction
+// FAST-NOT: OpExtInst %{{.*}} %{{.*}} Fma
+// FAST: [[mul:%[a-zA-Z0-9_]+]] = OpFMul
+// FAST: OpFAdd %{{.*}} [[mul]]
+
+#pragma OPENCL FP_CONTRACT OFF
+kernel void test(global float *out, global float *a, global float *b, global float *c) {
+  int i = get_global_id(0);
+  out[i] = a[i] * b[i] + c[i];
+}
+


### PR DESCRIPTION
* Refactor some math options into Options
  * move -cl-unsafe-math-optimziations, -cl-finite-math-only and
    -cl-fast-relaxed-math
  * add accessors that handle implications
* Change the SPIRVProducer to emit the NoContraction decoration on
  OpFMul unless unsafe math is enabled
  * this is more in line with where contractions should be allowed in
    OpenCL C
  * Clang will emit llvm.fmuladd (translated as fma) if contractions are
    enabled, otherwise clspv assumes contractions shouldn't be allowed
    generally