### PR TITLE
Remove some uses of pointer element types

### DIFF
--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -61,7 +61,7 @@ void clspv::AutoPodArgsPass::runOnFunction(Function &F) {
     auto arg_type = Arg.getType();
     if (Arg.hasByValAttr()) {
       // Byval arguments end up as POD arguments.
-      arg_type = arg_type->getPointerElementType();
+      arg_type = Arg.getParamByValType();
     }
 
     if (isa<PointerType>(arg_type))

--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -268,6 +268,37 @@ bool Builtins::ParamTypeInfo::isSampler() const {
          (name == "ocl_sampler" || name == "opencl.sampler_t");
 }
 
+llvm::Type *Builtins::ParamTypeInfo::DataType(LLVMContext &context) const {
+  if (isSampler()) {
+    llvm_unreachable("sampler is unhandled");
+  }
+
+  Type *ty = nullptr;
+  switch (type_id) {
+    case llvm::Type::IntegerTyID:
+      ty = llvm::IntegerType::get(context, byte_len * 8);
+      break;
+    case llvm::Type::HalfTyID:
+      ty = llvm::Type::getHalfTy(context);
+      break;
+    case llvm::Type::FloatTyID:
+      ty = llvm::Type::getFloatTy(context);
+      break;
+    case llvm::Type::DoubleTyID:
+      ty = llvm::Type::getDoubleTy(context);
+      break;
+    default:
+      llvm_unreachable("unsupported type");
+      break;
+  }
+
+  if (vector_size > 0) {
+    ty = FixedVectorType::get(ty, vector_size);
+  }
+
+  return ty;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ////  Lookup interface
 ////   - only demangle once for any name encountered

--- a/lib/Builtins.h
+++ b/lib/Builtins.h
@@ -38,6 +38,10 @@ struct ParamTypeInfo {
   std::string name;    // struct name
 
   bool isSampler() const;
+
+  // Returns the LLVM type conveyed by mangling.
+  // Currently only supports gentypes from the OpenCL C spec.
+  llvm::Type *DataType(llvm::LLVMContext &context) const;
 };
 
 class FunctionInfo {

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -168,8 +168,7 @@ bool ShouldDeclareRegionGroupOffsetPushConstant(Module &M) {
 uint64_t GlobalPushConstantsSize(Module &M) {
   const auto &DL = M.getDataLayout();
   if (auto GV = M.getGlobalVariable(clspv::PushConstantsVariableName())) {
-    auto ptr_ty = GV->getType();
-    auto block_ty = ptr_ty->getPointerElementType();
+    auto block_ty = GV->getValueType();
     return DL.getTypeStoreSize(block_ty).getKnownMinSize();
   } else {
     SmallVector<Type *, 8> types;

--- a/lib/ReplaceOpenCLBuiltinPass.h
+++ b/lib/ReplaceOpenCLBuiltinPass.h
@@ -111,11 +111,12 @@ private:
                             AddressSpace::Type VariableAddressSpace);
   llvm::Value *replaceAsyncWorkGroupCopies(llvm::Module &M, llvm::CallInst *CI,
                                            llvm::Value *Dst, llvm::Value *Src,
+                                           llvm::Type *GenType,
                                            llvm::Value *NumGentypes,
                                            llvm::Value *Stride,
                                            llvm::Value *Event);
-  bool replaceAsyncWorkGroupCopy(llvm::Function &F);
-  bool replaceAsyncWorkGroupStridedCopy(llvm::Function &F);
+  bool replaceAsyncWorkGroupCopy(llvm::Function &F, llvm::Type *ty);
+  bool replaceAsyncWorkGroupStridedCopy(llvm::Function &F, llvm::Type *ty);
 
   // Caches struct types for { |type|, |type| }. This prevents
   // getOrInsertllvm::Function from introducing a bitcasts between structs with

--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -137,8 +137,8 @@ PreservedAnalyses clspv::UndoByvalPass::run(Module &M,
           auto param = Call->getArgOperand(i);
 
           if (Arg->hasByValAttr()) {
-            Args.push_back(new LoadInst(Arg->getType()->getPointerElementType(),
-                                        param, "", Call));
+            Args.push_back(
+                new LoadInst(Arg->getParamByValType(), param, "", Call));
           } else {
             Args.push_back(param);
           }

--- a/lib/UndoSRetPass.cpp
+++ b/lib/UndoSRetPass.cpp
@@ -50,8 +50,7 @@ PreservedAnalyses clspv::UndoSRetPass::run(Module &M, ModuleAnalysisManager &) {
     for (Argument &Arg : F->args()) {
       // Check sret attribute.
       if (Arg.hasStructRetAttr()) {
-        PointerType *PTy = cast<PointerType>(Arg.getType());
-        Type *RetTy = PTy->getNonOpaquePointerElementType();
+        Type *RetTy = Arg.getParamStructRetType();
         // Create alloca instruction for return value on function's entry
         // block.
         AllocaInst *RetVal =

--- a/lib/ZeroInitializeAllocasPass.cpp
+++ b/lib/ZeroInitializeAllocasPass.cpp
@@ -55,7 +55,7 @@ clspv::ZeroInitializeAllocasPass::run(Module &M, ModuleAnalysisManager &) {
   }
 
   for (AllocaInst *alloca : WorkList) {
-    auto *valueTy = alloca->getType()->getPointerElementType();
+    auto *valueTy = alloca->getAllocatedType();
     auto *store = new StoreInst(Constant::getNullValue(valueTy), alloca, false,
                                 Align(alloca->getAlignment()));
     store->insertAfter(alloca);


### PR DESCRIPTION
Contributes to #816

* Remove uses of pointer element type from:
  * UndoSRet
  * UndoByval
  * AutoPodArgs
  * DefineOpenCLWorkItemBuiltins
  * ReplaceOpenCLBuiltin
  * ZeroInitiailizeAllocas
* Add a new method to parameter info for builtins to rebuild the
  described llvm type
  * currently only support gentypes