### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "c6ad6901734f8fa7c1ecd3aeb7de651b07ab21a6"
+      "commit" : "2ba5d820e2b0e5016ec706e324060a329f9a83a3"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -834,21 +834,26 @@ int ParseOptions(const int argc, const char *const argv[]) {
   // ParseCommandLineOptions with the specific options.
   bool has_pre = false;
   bool has_load_pre = false;
+  bool has_opaque_pointers = false;
   const std::string pre = "-enable-pre";
   const std::string load_pre = "-enable-load-pre";
+  const std::string opaque = "-opaque-pointers";
   for (int i = 1; i < argc; ++i) {
     std::string option(argv[i]);
     auto pre_pos = option.find(pre);
     auto load_pos = option.find(load_pre);
+    auto opaque_pos = option.find(opaque);
     if (pre_pos == 0 || (pre_pos == 1 && option[0] == '-')) {
       has_pre = true;
     } else if (load_pos == 0 || (load_pos == 1 && option[0] == '-')) {
       has_load_pre = true;
+    } else if (opaque_pos == 0 || (opaque_pos == 1 && option[0] == '-')) {
+      has_opaque_pointers = true;
     }
   }
 
   int llvmArgc = 3;
-  const char *llvmArgv[5];
+  const char *llvmArgv[6];
   llvmArgv[0] = argv[0];
   llvmArgv[1] = "-simplifycfg-sink-common=false";
   // TODO(#738): find a better solution to this.
@@ -858,6 +863,10 @@ int ParseOptions(const int argc, const char *const argv[]) {
   }
   if (!has_load_pre) {
     llvmArgv[llvmArgc++] = "-enable-load-pre=0";
+  }
+  // TODO(#816): remove this after final transition.
+  if (!has_opaque_pointers) {
+    llvmArgv[llvmArgc++] = "-opaque-pointers=0";
   }
 
   llvm::cl::ResetAllOptionOccurrences();

--- a/test/LongVectorLowering/function.ll
+++ b/test/LongVectorLowering/function.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt --passes=long-vector-lowering,early-cse,instcombine %s -o %t
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt --passes=long-vector-lowering,early-cse,instcombine %s -o %t -opaque-pointers=0
 ; RUN: FileCheck %s < %t
 
 ; Test that function arguments and return types can be lowered;

--- a/test/PushConstant/cluster_global_pod_args-arrays.ll
+++ b/test/PushConstant/cluster_global_pod_args-arrays.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass -opaque-pointers=0
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/PushConstant/cluster_global_pod_args-short_array.ll
+++ b/test/PushConstant/cluster_global_pod_args-short_array.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass -opaque-pointers=0
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/PushConstant/cluster_global_pod_args-structs.ll
+++ b/test/PushConstant/cluster_global_pod_args-structs.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass -opaque-pointers=0
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/PushConstant/cluster_global_pod_args-vectors.ll
+++ b/test/PushConstant/cluster_global_pod_args-vectors.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass -opaque-pointers=0
 ; RUN: FileCheck %s < %t.ll
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/Spv1p4/interface_global_push_constant.ll
+++ b/test/Spv1p4/interface_global_push_constant.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -opaque-pointers=0
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/Spv1p4/interface_private_builtin.ll
+++ b/test/Spv1p4/interface_private_builtin.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.4 -opaque-pointers=0
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val --target-env vulkan1.1spv1.4 %t.spv

--- a/test/longvector-metadata.ll
+++ b/test/longvector-metadata.ll
@@ -1,4 +1,5 @@
-; RUN: clspv-opt --passes=long-vector-lowering %s
+; TODO(#816): remove opaque pointers disable
+; RUN: clspv-opt --passes=long-vector-lowering %s -opaque-pointers=0
 ; RUN: clspv -x ir %s -o %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"


### PR DESCRIPTION
Contributes to #816

* LLVM switched opaque pointers option default value
* Disable opaque pointers temporarily
* Update tests that had no pointers to avoid opaque pointers