### PR TITLE
Transition SPIRVProducer to opaque pointers P1

### DIFF
--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -23,6 +23,27 @@ namespace clspv {
 // Name for module level metadata storing workgroup argument spec ids.
 const std::string &LocalSpecIdMetadataName();
 
+enum ClspvOperand {
+  // Operands for workgroup variables.
+  kWorkgroupSpecId = 0,
+  kWorkgroupDataType = 1,
+
+  // Operands for resource variables.
+  kResourceDescriptorSet = 0,
+  kResourceBinding = 1,
+  kResourceArgKind = 2,
+  kResourceArgIndex = 3,
+  kResourceDiscriminantIndex = 4,
+  kResourceCoherent = 5,
+  kResourceDataType = 6,
+
+  // Operands for literal samplers.
+  kSamplerDescriptorSet = 0,
+  kSamplerBinding = 1,
+  kSamplerParams = 2,
+  kSamplerDataType = 3,
+};
+
 // Base name for workgroup variable accessor function.
 const std::string &WorkgroupAccessorFunction();
 

--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -188,17 +188,27 @@ bool clspv::DirectResourceAccessPass::RewriteAccessesForArg(Function *fn,
         auto &func_info = clspv::Builtins::Lookup(callee);
         if (func_info.getType() == clspv::Builtins::kClspvResource) {
           const auto set = uint32_t(
-              dyn_cast<ConstantInt>(call->getOperand(0))->getZExtValue());
+              dyn_cast<ConstantInt>(
+                  call->getOperand(clspv::ClspvOperand::kResourceDescriptorSet))
+                  ->getZExtValue());
           const auto binding = uint32_t(
-              dyn_cast<ConstantInt>(call->getOperand(1))->getZExtValue());
-          auto *resource_type = call->getOperand(6)->getType();
+              dyn_cast<ConstantInt>(
+                  call->getOperand(clspv::ClspvOperand::kResourceBinding))
+                  ->getZExtValue());
+          auto *resource_type =
+              call->getOperand(clspv::ClspvOperand::kResourceDataType)
+                  ->getType();
           if (!merge_param_info(
                   {callee, set, binding, resource_type, num_gep_zeroes, call}))
             return false;
         } else if (func_info.getType() == clspv::Builtins::kClspvLocal) {
           const uint32_t spec_id = uint32_t(
-              dyn_cast<ConstantInt>(call->getOperand(0))->getZExtValue());
-          auto *array_ty = call->getOperand(1)->getType();
+              dyn_cast<ConstantInt>(
+                  call->getOperand(clspv::ClspvOperand::kWorkgroupSpecId))
+                  ->getZExtValue());
+          auto *array_ty =
+              call->getOperand(clspv::ClspvOperand::kWorkgroupDataType)
+                  ->getType();
           if (!merge_param_info(
                   {callee, spec_id, 0, array_ty, num_gep_zeroes, call}))
             return false;

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "Builtins.h"
+#include "Constants.h"
 #include "Types.h"
 #include "spirv/unified1/spirv.hpp"
 
@@ -57,9 +58,17 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
     auto &info = clspv::Builtins::Lookup(call->getCalledFunction());
     switch (info.getType()) {
     case clspv::Builtins::kClspvSamplerVarLiteral:
+      return CacheType(
+          call->getArgOperand(clspv::ClspvOperand::kSamplerDataType)
+              ->getType());
     case clspv::Builtins::kClspvResource:
+      return CacheType(
+          call->getArgOperand(clspv::ClspvOperand::kResourceDataType)
+              ->getType());
     case clspv::Builtins::kClspvLocal:
-      return CacheType(call->getArgOperand(call->arg_size() - 1)->getType());
+      return CacheType(
+          call->getArgOperand(clspv::ClspvOperand::kWorkgroupDataType)
+              ->getType());
     default:
       break;
     }

--- a/test/Spv1p4/copy.ll
+++ b/test/Spv1p4/copy.ll
@@ -27,14 +27,14 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
 entry:
-  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
   %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
   %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
   call void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)* %gep_out, %struct.S addrspace(3)* %gep_mem, i32 16, i32 16, i32 0)
   ret void
 }
 
-declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
 
 declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32, i32)
 

--- a/test/Spv1p4/copy_two_operands.ll
+++ b/test/Spv1p4/copy_two_operands.ll
@@ -14,9 +14,9 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @foo(%struct.S addrspace(1)* nocapture %out, %struct.S addrspace(1)* nocapture readonly %in)!clspv.pod_args_impl !9 {
 entry:
-  %0 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x %struct.S] } zeroinitializer)
   %1 = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %2 = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x %struct.S] } zeroinitializer)
   %3 = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %2, i32 0, i32 0, i32 0
   call void @_Z17spirv.copy_memory(%struct.S addrspace(1)* %1, %struct.S addrspace(1)* %3, i32 16, i32 16, i32 0)
   ret void
@@ -26,9 +26,9 @@ declare void @llvm.memcpy.p1i8.p1i8.i32(i8 addrspace(1)* noalias nocapture write
 
 declare void @_Z17spirv.copy_memory(%struct.S addrspace(1)*, %struct.S addrspace(1)*, i32, i32, i32)
 
-declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
 
-declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
 
 !9 = !{i32 2}
 

--- a/test/Spv1p4/function-pointer-parameter-that-needs-layout.ll
+++ b/test/Spv1p4/function-pointer-parameter-that-needs-layout.ll
@@ -19,13 +19,13 @@ entry:
 
 define dso_local spir_kernel void @test(i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !8 {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 3
   tail call spir_func void @func(i32 addrspace(1)* %1)
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/int_fetch.ll
+++ b/test/Spv1p4/int_fetch.ll
@@ -12,21 +12,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)*, <2 x i32>)
+declare spir_func <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampledDv2_i(%opencl.image2d_ro_t.int.sampled addrspace(1)*, <2 x i32>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.int.sampled addrspace(1)* %i)!clspv.pod_args_impl !10 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
-  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_roDv2_i.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
+  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, %opencl.image2d_ro_t.int.sampled zeroinitializer)
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampledDv2_i(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.int.sampled)
 
 !10 = !{i32 2}
 

--- a/test/Spv1p4/int_read.ll
+++ b/test/Spv1p4/int_read.ll
@@ -12,21 +12,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.int(%opencl.image2d_rw_t.int addrspace(1)*, <2 x i32>)
+declare spir_func <4 x i32> @_Z11read_imagei23opencl.image2d_rw_t.intDv2_i(%opencl.image2d_rw_t.int addrspace(1)*, <2 x i32>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_rw_t.int addrspace(1)* %i) !clspv.pod_args_impl !11 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0)
-  %call = tail call spir_func <4 x i32> @_Z11read_imagei14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.int(%opencl.image2d_rw_t.int addrspace(1)* %2, <2 x i32> zeroinitializer)
+  %2 = call %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, %opencl.image2d_rw_t.int zeroinitializer)
+  %call = tail call spir_func <4 x i32> @_Z11read_imagei23opencl.image2d_rw_t.intDv2_i(%opencl.image2d_rw_t.int addrspace(1)* %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_rw_t.int addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_rw_t.int)
 
 !11 = !{i32 2}
 

--- a/test/Spv1p4/int_sample.ll
+++ b/test/Spv1p4/int_sample.ll
@@ -13,24 +13,24 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+declare <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.int.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.int.sampled addrspace(1)* %i, %opencl.sampler_t addrspace(2)* %s)!clspv.pod_args_impl !10 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
-  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0)
-  %4 = tail call <4 x i32> @_Z11read_imagei14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.int.sampled(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
+  %2 = call %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, %opencl.image2d_ro_t.int.sampled zeroinitializer)
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0, %opencl.sampler_t zeroinitializer)
+  %4 = tail call <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.int.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
   store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32> ] })
 
-declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.int.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.int.sampled)
 
-declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, %opencl.sampler_t)
 
 !10 = !{i32 2}
 

--- a/test/Spv1p4/int_write.ll
+++ b/test/Spv1p4/int_write.ll
@@ -12,16 +12,16 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.int(%opencl.image2d_wo_t.int addrspace(1)*, <2 x i32>, <4 x i32>)
+declare spir_func void @_Z12write_imagei23opencl.image2d_wo_t.intDv2_iDv4_j(%opencl.image2d_wo_t.int addrspace(1)*, <2 x i32>, <4 x i32>)
 
 define spir_kernel void @foo(%opencl.image2d_wo_t.int addrspace(1)* %i)!clspv.pod_args_impl !8 {
 entry:
-  %0 = call %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0)
-  tail call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.int(%opencl.image2d_wo_t.int addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  %0 = call %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, %opencl.image2d_wo_t.int zeroinitializer)
+  tail call spir_func void @_Z12write_imagei23opencl.image2d_wo_t.intDv2_iDv4_j(%opencl.image2d_wo_t.int addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
   ret void
 }
 
-declare %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_wo_t.int addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %opencl.image2d_wo_t.int)
 
 !8 = !{i32 2}
 

--- a/test/Spv1p4/interface_literal_sampler_in_helper.ll
+++ b/test/Spv1p4/interface_literal_sampler_in_helper.ll
@@ -17,25 +17,25 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+declare <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.float.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
 
 define void @bar(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img) {
 entry:
-  %0 = call %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 18)
-  %1 = tail call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, %opencl.sampler_t addrspace(2)* %0, <2 x float> <float 1.000000e+00, float 2.000000e+00>)
+  %0 = call %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 18, %opencl.sampler_t zeroinitializer)
+  %1 = tail call <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, %opencl.sampler_t addrspace(2)* %0, <2 x float> <float 1.000000e+00, float 2.000000e+00>)
   ret void
 }
 
 define spir_kernel void @foo(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img) !clspv.pod_args_impl !0 {
 entry:
-  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0)
+  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, %opencl.image2d_ro_t.float.sampled zeroinitializer)
   call void @bar(%opencl.image2d_ro_t.float.sampled addrspace(1)* %0)
   ret void
 }
 
-declare %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32, i32, i32)
+declare %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32, i32, i32, %opencl.sampler_t)
 
-declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.float.sampled)
 
 !0 = !{i32 2}
 

--- a/test/Spv1p4/interface_module_constants_in_storage_buffer.ll
+++ b/test/Spv1p4/interface_module_constants_in_storage_buffer.ll
@@ -20,9 +20,9 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* nocapture %out, { i32 } %podargs) local_unnamed_addr !clspv.pod_args_impl !9 !kernel_arg_map !10 {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32 -1, i32 1, i32 5, i32 1, i32 1, i32 0)
+  %2 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32 -1, i32 1, i32 5, i32 1, i32 1, i32 0, { { i32 } } zeroinitializer)
   %3 = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %2, i32 0, i32 0
   %4 = load { i32 }, { i32 } addrspace(9)* %3, align 4
   %idx = extractvalue { i32 } %4, 0
@@ -32,9 +32,9 @@ entry:
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { { i32 } })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/interface_pod_pushconstant.ll
+++ b/test/Spv1p4/interface_pod_pushconstant.ll
@@ -11,13 +11,13 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo({ float, float } %podargs)!reqd_work_group_size !8 !clspv.pod_args_impl !9 !kernel_arg_map !10 {
 entry:
-  %0 = call { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32 -1, i32 0, i32 5, i32 0, i32 0, i32 0)
+  %0 = call { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32 -1, i32 0, i32 5, i32 0, i32 0, i32 0, { { float, float } } zeroinitializer)
   %1 = getelementptr { { float, float } }, { { float, float } } addrspace(9)* %0, i32 0, i32 0
   %2 = load { float, float }, { float, float } addrspace(9)* %1, align 4
   ret void
 }
 
-declare { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { { float, float } } addrspace(9)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { { float, float } })
 
 !8 = !{i32 1, i32 1, i32 1}
 !9 = !{i32 2}

--- a/test/Spv1p4/interface_sampler.ll
+++ b/test/Spv1p4/interface_sampler.ll
@@ -16,24 +16,24 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+declare <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.float.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
 
 define spir_kernel void @test(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, <4 x float> addrspace(1)* nocapture %out) !clspv.pod_args_impl !4 {
 entry:
-  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0)
-  %1 = call { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, %opencl.image2d_ro_t.float.sampled zeroinitializer)
+  %1 = call { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <4 x float>] } zeroinitializer)
   %2 = getelementptr { [0 x <4 x float>] }, { [0 x <4 x float>] } addrspace(1)* %1, i32 0, i32 0, i32 0
-  %3 = call %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 16)
-  %4 = tail call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)* %0, %opencl.sampler_t addrspace(2)* %3, <2 x float> <float 1.000000e+00, float 2.000000e+00>)
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 16, %opencl.sampler_t zeroinitializer)
+  %4 = tail call <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.float.sampled addrspace(1)* %0, %opencl.sampler_t addrspace(2)* %3, <2 x float> <float 1.000000e+00, float 2.000000e+00>)
   store <4 x float> %4, <4 x float> addrspace(1)* %2, align 16
   ret void
 }
 
-declare %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32, i32, i32)
+declare %opencl.sampler_t addrspace(2)* @_Z25clspv.sampler_var_literal(i32, i32, i32, %opencl.sampler_t)
 
-declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.float.sampled)
 
-declare { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x <4 x float>] })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/interface_ssbo_resource.ll
+++ b/test/Spv1p4/interface_ssbo_resource.ll
@@ -11,11 +11,11 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo(i32 addrspace(1)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x i32] } zeroinitializer)
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
 !1 = !{i32 2}
 !2 = !{i32 1, i32 1, i32 1}

--- a/test/Spv1p4/interface_workgroup_resource.ll
+++ b/test/Spv1p4/interface_workgroup_resource.ll
@@ -13,20 +13,20 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo(i32 addrspace(3)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
 entry:
-  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3)
+  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3, [0 x i32] zeroinitializer)
   %gep = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 0
   ret void
 }
 
 define spir_kernel void @bar(float addrspace(3)* %data) !clspv.pod_args_impl !1 !reqd_work_group_size !2 {
 entry:
-  %0 = call [0 x float] addrspace(3)* @_Z11clspv.local.4(i32 4)
+  %0 = call [0 x float] addrspace(3)* @_Z11clspv.local.4(i32 4, [0 x float] zeroinitializer)
   %gep = getelementptr [0 x float], [0 x float] addrspace(3)* %0, i32 0, i32 0
   ret void
 }
 
-declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32)
-declare [0 x float] addrspace(3)* @_Z11clspv.local.4(i32)
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32, [0 x i32])
+declare [0 x float] addrspace(3)* @_Z11clspv.local.4(i32, [0 x float])
 
 !_Z20clspv.local_spec_ids = !{!3, !4}
 !clspv.next_spec_constant_id = !{!5}

--- a/test/Spv1p4/load.ll
+++ b/test/Spv1p4/load.ll
@@ -25,13 +25,13 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo(%struct.S addrspace(1)* %in) !clspv.pod_args_impl !1 {
 entry:
-  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
   %gep = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
   %ld = load %struct.S, %struct.S addrspace(1)* %gep
   ret void
 }
 
-declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
 
 !1 = !{i32 2}
 

--- a/test/Spv1p4/opaque_structs.ll
+++ b/test/Spv1p4/opaque_structs.ll
@@ -15,21 +15,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)*, <2 x i32>)
+declare <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampledDv2_i(%opencl.image2d_ro_t.float.sampled addrspace(1)*, <2 x i32>)
 
 define void @bar(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img) {
 entry:
-  %0 = tail call <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i.opencl.image2d_ro_t.float.sampled(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, <2 x i32> zeroinitializer)
+  %0 = tail call <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampledDv2_i(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img, <2 x i32> zeroinitializer)
   ret void
 }
 
 define spir_kernel void @foo(%opencl.image2d_ro_t.float.sampled addrspace(1)* %img) !clspv.pod_args_impl !0 {
 entry:
-  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0)
+  %0 = call %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, %opencl.image2d_ro_t.float.sampled zeroinitializer)
   call void @bar(%opencl.image2d_ro_t.float.sampled addrspace(1)* %0)
   ret void
 }
 
-declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.float.sampled addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.float.sampled)
 
 !0 = !{i32 2}

--- a/test/Spv1p4/pod-in-ubo.ll
+++ b/test/Spv1p4/pod-in-ubo.ll
@@ -18,9 +18,9 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @sample_test(i64 addrspace(1)* nocapture %result, { i64, i64 } %podargs) !clspv.pod_args_impl !4 !kernel_arg_map !9 {
 entry:
-  %0 = call { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i64] } zeroinitializer)
   %1 = getelementptr { [0 x i64] }, { [0 x i64] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32 0, i32 1, i32 4, i32 1, i32 1, i32 0)
+  %2 = call { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32 0, i32 1, i32 4, i32 1, i32 1, i32 0, { { i64, i64 } } zeroinitializer)
   %3 = getelementptr { { i64, i64 } }, { { i64, i64 } } addrspace(6)* %2, i32 0, i32 0
   %4 = load { i64, i64 }, { i64, i64 } addrspace(6)* %3, align 8
   %arg0 = extractvalue { i64, i64 } %4, 0
@@ -30,9 +30,9 @@ entry:
   ret void
 }
 
-declare { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i64] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i64] })
 
-declare { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { { i64, i64 } } addrspace(6)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { { i64, i64 } })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/pointer_comparisons.ll
+++ b/test/Spv1p4/pointer_comparisons.ll
@@ -32,12 +32,12 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @test(i32 addrspace(1)* readnone %ptr0, i32 addrspace(1)* readnone %ptr1, i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !9 {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %arg0ptr = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 0
   %arg0ptr2 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 13
-  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
   %arg1ptr = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 0
-  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0)
+  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i32] } zeroinitializer)
   %3 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 0
   %cmp = icmp eq i32 addrspace(1)* %arg0ptr, %arg1ptr
   %conv = zext i1 %cmp to i32
@@ -65,11 +65,11 @@ entry:
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/pointer_comparisons_with_null.ll
+++ b/test/Spv1p4/pointer_comparisons_with_null.ll
@@ -19,10 +19,10 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(i32 addrspace(1)* nocapture readnone %ptr0, i32 addrspace(1)* nocapture %out, { i32 } %podargs) local_unnamed_addr !clspv.pod_args_impl !9 !kernel_arg_map !10 {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
-  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
   %2 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 0
-  %3 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0)
+  %3 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { i32 } } zeroinitializer)
   %4 = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %3, i32 0, i32 0
   %5 = load { i32 }, { i32 } addrspace(9)* %4, align 4
   %val = extractvalue { i32 } %5, 0
@@ -40,11 +40,11 @@ test.inner.exit:                                  ; preds = %if.then2.i, %entry
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
 
 !clspv.descriptor.index = !{!4}
 

--- a/test/Spv1p4/pointer_comparisons_workgroup.ll
+++ b/test/Spv1p4/pointer_comparisons_workgroup.ll
@@ -32,12 +32,12 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @test(i32 addrspace(3)* readnone %ptr0, i32 addrspace(3)* readnone %ptr1, i32 addrspace(1)* nocapture %out) local_unnamed_addr !clspv.pod_args_impl !17 {
 entry:
-  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3)
+  %0 = call [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32 3, [0 x i32] zeroinitializer)
   %arg0ptr = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 0
   %arg0ptr2 = getelementptr [0 x i32], [0 x i32] addrspace(3)* %0, i32 0, i32 13
-  %1 = call [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32 4)
+  %1 = call [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32 4, [0 x i32] zeroinitializer)
   %arg1ptr = getelementptr [0 x i32], [0 x i32] addrspace(3)* %1, i32 0, i32 0
-  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 2, i32 0, i32 0)
+  %2 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 2, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %3 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %2, i32 0, i32 0, i32 0
   %cmp = icmp ne i32 addrspace(3)* %arg0ptr, %arg1ptr
   %conv = zext i1 %cmp to i32
@@ -65,11 +65,11 @@ entry:
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
 
-declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32)
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.3(i32, [0 x i32])
 
-declare [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32)
+declare [0 x i32] addrspace(3)* @_Z11clspv.local.4(i32, [0 x i32])
 
 !clspv.descriptor.index = !{!4}
 !clspv.next_spec_constant_id = !{!5}

--- a/test/Spv1p4/scalar_cond_vector_data.ll
+++ b/test/Spv1p4/scalar_cond_vector_data.ll
@@ -18,11 +18,11 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @copy(i32 addrspace(1)* nocapture readonly %in, i32 addrspace(1)* nocapture %out) !clspv.pod_args_impl !9 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0)
+  %2 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %3 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %2, i32 0, i32 0, i32 0
-  %4 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %4 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %5 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 1
   %6 = load <4 x i32>, <4 x i32> addrspace(1)* %1, align 4
   %7 = load <4 x i32>, <4 x i32> addrspace(1)* %5, align 4
@@ -31,9 +31,9 @@ entry:
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
 !9 = !{i32 2}
 

--- a/test/Spv1p4/store.ll
+++ b/test/Spv1p4/store.ll
@@ -27,7 +27,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
 entry:
-  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
   %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
   %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
   %ld = load %struct.S, %struct.S addrspace(3)* %gep_mem
@@ -35,6 +35,6 @@ entry:
   ret void
 }
 
-declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
 
 !1 = !{i32 2}

--- a/test/Spv1p4/uint_fetch.ll
+++ b/test/Spv1p4/uint_fetch.ll
@@ -12,21 +12,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, <2 x i32>)
+declare spir_func <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampledDv2_i(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, <2 x i32>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.uint.sampled addrspace(1)* %i)!clspv.pod_args_impl !10 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
-  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_roDv2_i.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
+  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, %opencl.image2d_ro_t.uint.sampled zeroinitializer)
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampledDv2_i(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.uint.sampled)
 
 !10 = !{i32 2}
 

--- a/test/Spv1p4/uint_read.ll
+++ b/test/Spv1p4/uint_read.ll
@@ -12,21 +12,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.uint(%opencl.image2d_rw_t.uint addrspace(1)*, <2 x i32>)
+declare spir_func <4 x i32> @_Z12read_imageui24opencl.image2d_rw_t.uintDv2_i(%opencl.image2d_rw_t.uint addrspace(1)*, <2 x i32>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_rw_t.uint addrspace(1)* %i) !clspv.pod_args_impl !11 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0)
-  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image2d_rwDv2_i.opencl.image2d_rw_t.uint(%opencl.image2d_rw_t.uint addrspace(1)* %2, <2 x i32> zeroinitializer)
+  %2 = call %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, %opencl.image2d_rw_t.uint zeroinitializer)
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui24opencl.image2d_rw_t.uintDv2_i(%opencl.image2d_rw_t.uint addrspace(1)* %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_rw_t.uint addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_rw_t.uint)
 
 !11 = !{i32 2}
 

--- a/test/Spv1p4/uint_sample.ll
+++ b/test/Spv1p4/uint_sample.ll
@@ -13,24 +13,24 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
+declare <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.uint.sampled addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
 
 define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, %opencl.image2d_ro_t.uint.sampled addrspace(1)* %i, %opencl.sampler_t addrspace(2)* %s)!clspv.pod_args_impl !10 {
 entry:
-  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0)
-  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0)
-  %4 = tail call <4 x i32> @_Z12read_imageui14ocl_image2d_ro11ocl_samplerDv2_f.opencl.image2d_ro_t.uint.sampled(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
+  %2 = call %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, %opencl.image2d_ro_t.uint.sampled zeroinitializer)
+  %3 = call %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0, %opencl.sampler_t zeroinitializer)
+  %4 = tail call <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampled11ocl_samplerDv2_f(%opencl.image2d_ro_t.uint.sampled addrspace(1)* %2, %opencl.sampler_t addrspace(2)* %3, <2 x float> zeroinitializer)
   store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16
   ret void
 }
 
-declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
 
-declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_ro_t.uint.sampled addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %opencl.image2d_ro_t.uint.sampled)
 
-declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32)
+declare %opencl.sampler_t addrspace(2)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, %opencl.sampler_t)
 
 !10 = !{i32 2}
 

--- a/test/Spv1p4/uint_write.ll
+++ b/test/Spv1p4/uint_write.ll
@@ -12,16 +12,16 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
-declare spir_func void @_Z13write_imageui14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.uint(%opencl.image2d_wo_t.uint addrspace(1)*, <2 x i32>, <4 x i32>)
+declare spir_func void @_Z13write_imageui24opencl.image2d_wo_t.uintDv2_iDv4_j(%opencl.image2d_wo_t.uint addrspace(1)*, <2 x i32>, <4 x i32>)
 
 define spir_kernel void @foo(%opencl.image2d_wo_t.uint addrspace(1)* %i)!clspv.pod_args_impl !8 {
 entry:
-  %0 = call %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0)
-  tail call spir_func void @_Z13write_imageui14ocl_image2d_woDv2_iDv4_j.opencl.image2d_wo_t.uint(%opencl.image2d_wo_t.uint addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  %0 = call %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, %opencl.image2d_wo_t.uint zeroinitializer)
+  tail call spir_func void @_Z13write_imageui24opencl.image2d_wo_t.uintDv2_iDv4_j(%opencl.image2d_wo_t.uint addrspace(1)* %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
   ret void
 }
 
-declare %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32)
+declare %opencl.image2d_wo_t.uint addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %opencl.image2d_wo_t.uint)
 
 !8 = !{i32 2}
 


### PR DESCRIPTION
Contributes to #816

* Convert simple cases of getPointerElementType() in SPIRVProducerPass
  to finding the type in other ways
  * generally uses the data type in the resource functions
* Added an enum for resource function operands
* Fixed a bug in UBOTypeTransformPass that was not properly visiting
  constant operands
  * This is now frequently covered by resource variable functions