### PR TITLE
fix README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ your system, CMake, and (optionally) Ninja.
 
 To rebuild the library run the following commands:
 
-  cmake -GNinja <libclc dir> -DLIBCLC\_TARGETS\_TO\_BUILD="clspv--" -DLLVM\_CONFIG=<path to llvm-config>
-  ninja
+    cmake -GNinja <libclc dir> -DLIBCLC\_TARGETS\_TO\_BUILD="clspv--" -DLLVM\_CONFIG=<path to llvm-config>
+    ninja
 
 Copy the resulting `clspv--.bc` into the cmake/ directory and rebuild clspv.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ your system, CMake, and (optionally) Ninja.
 
 To rebuild the library run the following commands:
 
-    cmake -GNinja <libclc dir> -DLIBCLC\_TARGETS\_TO\_BUILD="clspv--" -DLLVM\_CONFIG=<path to llvm-config>
+    cmake -GNinja <libclc dir> -DLIBCLC_TARGETS_TO_BUILD="clspv--" -DLLVM_CONFIG=<path to llvm-config>
     ninja
 
 Copy the resulting `clspv--.bc` into the cmake/ directory and rebuild clspv.


### PR DESCRIPTION
The instructions to rebuild the "clspv--.bc" did not produce the
expected out because of missing whitespace.