### PR TITLE
Prevent infinite loop in image specialization

### DIFF
--- a/lib/SpecializeImageTypes.h
+++ b/lib/SpecializeImageTypes.h
@@ -59,6 +59,8 @@ private:
 
   // Tracks which functions need rewritten due to modified arguments.
   llvm::DenseSet<llvm::Function *> functions_to_modify_;
+
+  llvm::DenseSet<llvm::Value *> visited_;
 };
 } // namespace clspv
 

--- a/test/SpecializeImageTypes/pointer_loop.ll
+++ b/test/SpecializeImageTypes/pointer_loop.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t.ll --passes=specialize-image-types
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  br label %loop
+
+loop:
+  %phi = phi ptr addrspace(1) [ %in, %entry ], [ %p1, %next ]
+  %cmp = icmp eq i32 %n, 0
+  br i1 %cmp, label %next, label %exit
+
+next:
+  %p1 = getelementptr i32, ptr addrspace(1) %phi, i32 1
+  br label %loop
+
+exit:
+  ret void
+}
+

--- a/test/SpecializeImageTypes/pointer_loop_simple.ll
+++ b/test/SpecializeImageTypes/pointer_loop_simple.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt %s -o %t.ll --passes=specialize-image-types
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  br label %loop
+
+loop:
+  %phi = phi ptr addrspace(1) [ %in, %entry ], [ %phi, %loop ]
+  %cmp = icmp eq i32 %n, 0
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
Fixes #868

* Prevent infinite loop during instruction traversal for image
  specialization
  * Can return not an image because images can't be used in phis or
    selects so if one exists it needs to be addressed earlier in the
    flow