### PR TITLE
Transition SPIRVProducer to opaque pointers P2

### DIFF
--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -3236,9 +3236,10 @@ bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(
     // The coordinate (integer type that we can't handle).
     auto Arg2 = CI->getOperand(2);
 
-    uint32_t dim = clspv::ImageNumDimensions(Arg0->getType());
-    uint32_t components =
-        dim + (clspv::IsArrayImageType(Arg0->getType()) ? 1 : 0);
+    auto *image_ty =
+        cast<StructType>(InferType(Arg0, M.getContext(), &InferredTypeCache));
+    uint32_t dim = clspv::ImageNumDimensions(image_ty);
+    uint32_t components = dim + (clspv::IsArrayImageType(image_ty) ? 1 : 0);
     Type *float_ty = nullptr;
     if (components == 1) {
       float_ty = Type::getFloatTy(M.getContext());

--- a/lib/ReplaceOpenCLBuiltinPass.h
+++ b/lib/ReplaceOpenCLBuiltinPass.h
@@ -128,6 +128,8 @@ private:
                                    bool IsSigned, bool Int64 = false);
 
   llvm::DenseMap<llvm::Type *, llvm::Type *> PairStructMap;
+
+  llvm::DenseMap<llvm::Value *, llvm::Type *> InferredTypeCache;
 };
 } // namespace clspv
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5421,7 +5421,7 @@ void SPIRVProducerPassImpl::HandleDeferredDecorations() {
       continue;
 
     Type *elemTy = nullptr;
-    if (auto *ptrTy = dyn_cast<PointerType>(type)) {
+    if (isa<PointerType>(type)) {
       if (stride == 0) {
         llvm_unreachable("missing stride for pointer");
       }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4537,7 +4537,8 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
             {GEP->getPointerOperandType(),
              static_cast<uint32_t>(GetTypeAllocSize(GEP->getSourceElementType(),
                                                     module->getDataLayout())),
-             getSPIRVPointerType(GEP->getType(), GEP->getSourceElementType())});
+             getSPIRVPointerType(GEP->getPointerOperand()->getType(),
+                                 GEP->getSourceElementType())});
         break;
       case spv::StorageClassWorkgroup:
         break;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3324,9 +3324,6 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVBuiltin(spv::BuiltIn BID,
   } else {
     addCapability(Cap);
 
-    //Type *type = PointerType::get(IntegerType::get(module->getContext(), 32),
-    //                              AddressSpace::Input);
-
     auto *data_ty = IntegerType::get(module->getContext(), 32);
     auto *ptr_ty = data_ty->getPointerTo(AddressSpace::Input);
     auto ptr_id = getSPIRVPointerType(ptr_ty, data_ty);

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -202,21 +202,6 @@ bool clspv::IsSamplerType(llvm::StructType *STy) {
   return false;
 }
 
-bool clspv::IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr) {
-  bool isSamplerType = false;
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy =
-            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
-      if (IsSamplerType(STy)) {
-        isSamplerType = true;
-        if (struct_type_ptr)
-          *struct_type_ptr = STy;
-      }
-    }
-  }
-  return isSamplerType;
-}
-
 bool clspv::IsImageType(llvm::StructType *STy) {
   if (!STy) return false;
   if (STy->isOpaque()) {
@@ -260,21 +245,6 @@ bool clspv::IsImageType(llvm::StructType *STy) {
     }
   }
   return false;
-}
-
-bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
-  bool isImageType = false;
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy =
-            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
-      if (IsImageType(STy)) {
-        isImageType = true;
-        if (struct_type_ptr)
-          *struct_type_ptr = STy;
-      }
-    }
-  }
-  return isImageType;
 }
 
 spv::Dim clspv::ImageDimensionality(StructType *STy) {

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -273,6 +273,9 @@ bool clspv::IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr) {
 }
 
 spv::Dim clspv::ImageDimensionality(StructType *STy) {
+  if (!STy->isOpaque())
+    return spv::DimMax;
+
   if (IsImageType(STy)) {
     if (STy->getName().contains("image1d_buffer"))
       return spv::DimBuffer;
@@ -282,17 +285,6 @@ spv::Dim clspv::ImageDimensionality(StructType *STy) {
       return spv::Dim2D;
     if (STy->getName().contains("image3d"))
       return spv::Dim3D;
-  }
-
-  return spv::DimMax;
-}
-
-spv::Dim clspv::ImageDimensionality(Type *type) {
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(
-            TmpArgPTy->getNonOpaquePointerElementType())) {
-      return ImageDimensionality(struct_ty);
-    }
   }
 
   return spv::DimMax;
@@ -312,96 +304,64 @@ uint32_t clspv::ImageNumDimensions(StructType *STy) {
   }
 }
 
-uint32_t clspv::ImageNumDimensions(Type *type) {
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(
-            TmpArgPTy->getNonOpaquePointerElementType())) {
-      return ImageNumDimensions(struct_ty);
-    }
+bool clspv::IsArrayImageType(StructType *type) {
+  if (!type->isOpaque())
+    return false;
+  if (!IsImageType(type))
+    return false;
+  if (type->getName().startswith("opencl.image1d_array_ro_t") ||
+      type->getName().startswith("opencl.image1d_array_wo_t") ||
+      type->getName().startswith("opencl.image2d_array_ro_t") ||
+      type->getName().startswith("opencl.image2d_array_wo_t") ||
+      type->getName().startswith("ocl_image1d_array_ro") ||
+      type->getName().startswith("ocl_image1d_array_wo") ||
+      type->getName().startswith("ocl_image2d_array_ro") ||
+      type->getName().startswith("ocl_image2d_array_wo")) {
+    return true;
   }
-
-  return 0;
-}
-
-bool clspv::IsArrayImageType(Type *type) {
-  bool isArrayImageType = false;
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (StructType *STy =
-            dyn_cast<StructType>(TmpArgPTy->getNonOpaquePointerElementType())) {
-      if (STy->isOpaque()) {
-        if (STy->getName().startswith("opencl.image1d_array_ro_t") ||
-            STy->getName().startswith("opencl.image1d_array_wo_t") ||
-            STy->getName().startswith("opencl.image2d_array_ro_t") ||
-            STy->getName().startswith("opencl.image2d_array_wo_t") ||
-            STy->getName().startswith("ocl_image1d_array_ro") ||
-            STy->getName().startswith("ocl_image1d_array_wo") ||
-            STy->getName().startswith("ocl_image2d_array_ro") ||
-            STy->getName().startswith("ocl_image2d_array_wo")) {
-          isArrayImageType = true;
-        }
-      }
-    }
-  }
-  return isArrayImageType;
+  return false;
 }
 
 bool clspv::IsSampledImageType(StructType *STy) {
-  if (IsImageType(STy)) {
-    return STy->getName().contains(".sampled");
-  }
+  if (!STy->isOpaque())
+    return false;
+  if (!IsImageType(STy))
+    return false;
+  return STy->getName().contains(".sampled");
+}
 
+bool clspv::IsStorageImageType(StructType *type) {
+  if (!type->isOpaque())
+    return false;
+  if (!IsImageType(type))
+    return false;
+  if (type->getName().contains("_wo") ||
+      type->getName().contains("_rw")) {
+    return true;
+  }
   return false;
 }
 
-bool clspv::IsSampledImageType(Type *type) {
-  if (PointerType *TmpArgPTy = dyn_cast<PointerType>(type)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(
-            TmpArgPTy->getNonOpaquePointerElementType())) {
-      return IsSampledImageType(struct_ty);
-    }
-  }
-
-  return false;
-}
-
-bool clspv::IsStorageImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains("_wo") ||
-          struct_ty->getName().contains("_rw")) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-bool clspv::IsFloatImageType(Type *type) {
+bool clspv::IsFloatImageType(StructType *type) {
   return IsImageType(type) && !IsIntImageType(type) && !IsUintImageType(type);
 }
 
-bool clspv::IsIntImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains(".int"))
-        return true;
-    }
-  }
-
+bool clspv::IsIntImageType(StructType *type) {
+  if (!type->isOpaque())
+    return false;
+  if (!IsImageType(type))
+    return false;
+  if (type->getName().contains(".int"))
+    return true;
   return false;
 }
 
-bool clspv::IsUintImageType(Type *type) {
-  Type *ty = nullptr;
-  if (IsImageType(type, &ty)) {
-    if (auto struct_ty = dyn_cast_or_null<StructType>(ty)) {
-      if (struct_ty->getName().contains(".uint"))
-        return true;
-    }
-  }
-
+bool clspv::IsUintImageType(StructType *type) {
+  if (!type->isOpaque())
+    return false;
+  if (!IsImageType(type))
+    return false;
+  if (type->getName().contains(".uint"))
+    return true;
   return false;
 }

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -79,10 +79,15 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
     worklist.push_back(std::make_pair(use.getUser(), use.getOperandNo()));
   }
 
+  DenseSet<Value *> seen;
   while (!worklist.empty()) {
     User *user = worklist.back().first;
     unsigned operand = worklist.back().second;
     worklist.pop_back();
+
+    if (!seen.insert(user).second) {
+      continue;
+    }
 
     if (auto *GEP = dyn_cast<GEPOperator>(user)) {
       return CacheType(GEP->getSourceElementType());

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -49,44 +49,32 @@ bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
 // image, returns spv::DimMax.
 spv::Dim ImageDimensionality(llvm::StructType *type);
 
-// Returns the dimensionality of the image type. If |type| is not an image,
-// returns spv::DimMax.
-spv::Dim ImageDimensionality(llvm::Type *type);
-
 // Returns the dimensionality of the image struct type. If |type| is not an
 // image, returns 0.
 uint32_t ImageNumDimensions(llvm::StructType *type);
 
-// Returns the dimensionality of the image type. If |type| is not an image,
-// returns 0.
-uint32_t ImageNumDimensions(llvm::Type *type);
-
 // Returns true if the given type is an array image type.
-bool IsArrayImageType(llvm::Type *type);
+bool IsArrayImageType(llvm::StructType *type);
 
 // Returns true if the given struct type is a sampled image type. Can only
 // return true after image specialization.
 bool IsSampledImageType(llvm::StructType *type);
 
-// Returns true if the given type is a sampled image type. Can only return true
-// after image specialization.
-bool IsSampledImageType(llvm::Type *type);
-
 // Returns true if the given type is a storage image type. This is the case
 // for read_write and write_only images.
-bool IsStorageImageType(llvm::Type *type);
+bool IsStorageImageType(llvm::StructType *type);
 
 // Returns true if the given type is a float image type.
 // Before image specialization, all images are considered float images.
-bool IsFloatImageType(llvm::Type *type);
+bool IsFloatImageType(llvm::StructType *type);
 
 // Returns true if the given type is an int image type.
 // Can only return true after image specialization.
-bool IsIntImageType(llvm::Type *type);
+bool IsIntImageType(llvm::StructType *type);
 
 // Returns true if the given type is an uint image type.
 // Can only return true after image specialization.
-bool IsUintImageType(llvm::Type *type);
+bool IsUintImageType(llvm::StructType *type);
 
 } // namespace clspv
 

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -34,16 +34,8 @@ llvm::Type *InferType(llvm::Value *v, llvm::LLVMContext &context,
 // Returns true if the given struct type is a sampler type.
 bool IsSamplerType(llvm::StructType *type);
 
-// Returns true if the given type is a sampler type.  If it is, then the
-// struct type is sent back through the ptr argument.
-bool IsSamplerType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
-
 // Returns true if the given struct type is an image type.
 bool IsImageType(llvm::StructType *type);
-
-// Returns true if the given type is a image type.  If it is, then the
-// struct type is sent back through the ptr argument.
-bool IsImageType(llvm::Type *type, llvm::Type **struct_type_ptr = nullptr);
 
 // Returns the dimensionality of the image struct type. If |type| is not an
 // image, returns spv::DimMax.

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -356,6 +356,13 @@ bool clspv::UBOTypeTransformPass::RemapValue(Value *value, Module &M) {
   if (remapped == value->getType())
     return false;
 
+  if (auto *gep = dyn_cast<GetElementPtrInst>(value)) {
+    auto *remapped_ele_ty = RebuildType(gep->getResultElementType(), M);
+    if (remapped_ele_ty != gep->getResultElementType()) {
+      gep->setResultElementType(remapped->getNonOpaquePointerElementType());
+    }
+  }
+
   value->mutateType(remapped);
   return true;
 }

--- a/test/SPIRVProducer/opaque_buffer_write_zero.ll
+++ b/test/SPIRVProducer/opaque_buffer_write_zero.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[int]]
+; CHECK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[int]]
+; CHECK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+; CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK: OpStore [[gep]] [[zero]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+  %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  store i32 0, ptr addrspace(1) %1, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+
+!8 = !{i32 2}
+

--- a/test/SPIRVProducer/opaque_literal_sampler.ll
+++ b/test/SPIRVProducer/opaque_literal_sampler.ll
@@ -1,0 +1,43 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK-DAG: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[sampler]]
+; CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[ptr]] UniformConstant
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%ocl_image2d_ro.float.sampled = type opaque
+%opencl.sampler_t = type opaque
+
+define spir_kernel void @test(ptr addrspace(1) %t, ptr addrspace(1) nocapture writeonly align 16 %out, { <2 x float> } %podargs) !clspv.pod_args_impl !4 !kernel_arg_map !10 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, %ocl_image2d_ro.float.sampled zeroinitializer)
+  %1 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <4 x float>] } zeroinitializer)
+  %2 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %1, i32 0, i32 0, i32 0
+  %3 = call ptr addrspace(9) @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { <2 x float> } } zeroinitializer)
+  %4 = getelementptr { { <2 x float> } }, ptr addrspace(9) %3, i32 0, i32 0
+  %5 = load { <2 x float> }, ptr addrspace(9) %4, align 8
+  %coords = extractvalue { <2 x float> } %5, 0
+  %6 = call ptr addrspace(2) @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 21, %opencl.sampler_t zeroinitializer)
+  %call.i = tail call spir_func <4 x float> @_Z11read_imagef28ocl_image2d_ro.float.sampled11ocl_samplerDv2_f(ptr addrspace(1) %0, ptr addrspace(2) %6, <2 x float> %coords)
+  store <4 x float> %call.i, ptr addrspace(1) %2, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef28ocl_image2d_ro.float.sampled11ocl_samplerDv2_f(ptr addrspace(1), ptr addrspace(2), <2 x float>)
+declare ptr addrspace(2) @_Z25clspv.sampler_var_literal(i32, i32, i32, %opencl.sampler_t)
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %ocl_image2d_ro.float.sampled)
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x <4 x float>] })
+declare ptr addrspace(9) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { <2 x float> } })
+
+!clspv.descriptor.index = !{!4}
+
+!4 = !{i32 2}
+!10 = !{!11, !12, !13}
+!11 = !{!"t", i32 0, i32 0, i32 0, i32 0, !"buffer"}
+!12 = !{!"out", i32 2, i32 1, i32 0, i32 0, !"buffer"}
+!13 = !{!"coords", i32 1, i32 2, i32 0, i32 8, !"pod_pushconstant"}

--- a/test/SPIRVProducer/opaque_local_arg.ll
+++ b/test/SPIRVProducer/opaque_local_arg.ll
@@ -1,0 +1,64 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK: OpDecorate [[size:%[a-zA-Z0-9_]+]] SpecId 3
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+; CHECK-DAG: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int4]] [[float4]]
+; CHECK-DAG: [[size]] = OpSpecConstant [[int]]
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[struct]] [[size]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[array]]
+; CHECK: OpVariable [[ptr]] Workgroup
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { <4 x i32>, <4 x float> }
+
+@__spirv_LocalInvocationId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @test(ptr addrspace(3) nocapture align 16 %wg, ptr addrspace(1) nocapture readonly align 16 %in1, ptr addrspace(1) nocapture readonly align 16 %in2, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !13 {
+entry:
+  %0 = call ptr addrspace(3) @_Z11clspv.local.3(i32 3, [0 x %struct.S] zeroinitializer)
+  %1 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 1, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 2, i32 1, i32 0, { [0 x <4 x float>] } zeroinitializer)
+  %3 = call ptr addrspace(1) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 3, i32 2, i32 0, { [0 x %struct.S] } zeroinitializer)
+  %gep = getelementptr <3 x i32>, ptr addrspace(5) @__spirv_LocalInvocationId, i32 0, i32 0
+  %4 = load i32, ptr addrspace(5) %gep, align 4
+  %5 = getelementptr { [0 x <4 x i32>] }, ptr addrspace(1) %1, i32 0, i32 0, i32 %4
+  %6 = load <4 x i32>, ptr addrspace(1) %5, align 16
+  %7 = getelementptr [0 x %struct.S], ptr addrspace(3) %0, i32 0, i32 %4, i32 0
+  store <4 x i32> %6, ptr addrspace(3) %7, align 16
+  %8 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %2, i32 0, i32 0, i32 %4
+  %9 = load <4 x float>, ptr addrspace(1) %8, align 16
+  %10 = getelementptr [0 x %struct.S], ptr addrspace(3) %0, i32 0, i32 %4, i32 1
+  store <4 x float> %9, ptr addrspace(3) %10, align 16
+  tail call void @_Z8spirv.op.224.jjj(i32 224, i32 2, i32 2, i32 264)
+  %11 = load <4 x i32>, ptr addrspace(3) %7, align 16
+  %12 = getelementptr { [0 x %struct.S] }, ptr addrspace(1) %3, i32 0, i32 0, i32 %4, i32 0
+  store <4 x i32> %11, ptr addrspace(1) %12, align 16
+  ret void
+}
+
+declare void @_Z8spirv.op.224.jjj(i32, i32, i32, i32) local_unnamed_addr
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x <4 x float>] })
+declare ptr addrspace(1) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
+declare ptr addrspace(3) @_Z11clspv.local.3(i32, [0 x %struct.S])
+
+!clspv.descriptor.index = !{!4}
+!clspv.next_spec_constant_id = !{!5}
+!clspv.spec_constant_list = !{!6}
+!_Z20clspv.local_spec_ids = !{!7}
+
+!4 = !{i32 1}
+!5 = distinct !{i32 4}
+!6 = !{i32 3, i32 3}
+!7 = !{ptr @test, i32 0, i32 3}
+!13 = !{i32 2}
+

--- a/test/SPIRVProducer/opaque_pointer_loop.ll
+++ b/test/SPIRVProducer/opaque_pointer_loop.ll
@@ -1,0 +1,34 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[int]]
+; CHECK: OpPhi [[ptr]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in) {
+entry:
+  %res = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x i32] } zeroinitializer)
+  %gep = getelementptr { [0 x i32] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  br label %loop
+
+loop:
+  %phi = phi ptr addrspace(1) [ %gep, %entry ], [ %p1, %next ]
+  %n = phi i32 [ 0, %entry ], [ %add, %next ]
+  %cmp = icmp eq i32 %n, 0
+  br i1 %cmp, label %next, label %exit
+
+next:
+  %p1 = getelementptr i32, ptr addrspace(1) %phi, i32 1
+  %add = add i32 %n, 1
+  br label %loop
+
+exit:
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })

--- a/test/SPIRVProducer/opaque_pointer_parameter.ll
+++ b/test/SPIRVProducer/opaque_pointer_parameter.ll
@@ -1,0 +1,38 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[int]]
+; CHECK-DAG: [[func_ty:%[a-zA-Z0-9_]+]] = OpTypeFunction [[int]] [[ptr]]
+; CHECK: OpFunction [[int]] None [[func_ty]]
+; CHECK: [[param:%[a-zA-Z0-9_]+]] = OpFunctionParameter [[ptr]]
+; CHECK: OpLoad [[int]] [[param]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_func i32 @foo(ptr addrspace(1) nocapture readonly %x) {
+entry:
+  %0 = load i32, ptr addrspace(1) %x, align 4
+  %add = add nsw i32 %0, 1
+  ret i32 %add
+}
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture readonly align 4 %in, ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !9 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+  %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
+  %3 = getelementptr { [0 x i32] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
+  %call = tail call spir_func i32 @foo(ptr addrspace(1) %1)
+  store i32 %call, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+!9 = !{i32 2}
+

--- a/test/SPIRVProducer/opaque_pointer_return.ll
+++ b/test/SPIRVProducer/opaque_pointer_return.ll
@@ -1,0 +1,35 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK: [[int2:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 2
+; CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[int2]]
+; CHECK: [[func_ty:%[a-zA-Z0-9_]+]] = OpTypeFunction [[ptr]] [[ptr]]
+; CHECK: OpFunction [[ptr]] None [[func_ty]]
+; CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr]]
+; CHECK: OpReturnValue [[gep]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_func ptr addrspace(1) @foo(ptr addrspace(1) readnone %x) {
+entry:
+  %arrayidx = getelementptr inbounds <2 x i32>, ptr addrspace(1) %x, i32 2
+  ret ptr addrspace(1) %arrayidx
+}
+
+define dso_local spir_kernel void @test(ptr addrspace(1) writeonly align 8 %data) !clspv.pod_args_impl !9 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <2 x i32>] } zeroinitializer)
+  %1 = getelementptr { [0 x <2 x i32>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %call = tail call spir_func ptr addrspace(1) @foo(ptr addrspace(1) %1) #2
+  store <2 x i32> <i32 42, i32 42>, ptr addrspace(1) %call, align 8
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <2 x i32>] })
+
+!9 = !{i32 2}
+

--- a/test/SPIRVProducer/opaque_pointer_select.ll
+++ b/test/SPIRVProducer/opaque_pointer_select.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK: [[float3:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 3
+; CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float3]]
+; CHECK: [[sel:%[a-zA-Z0-9_]+]] = OpSelect [[ptr]]
+; CHECK: OpStore [[sel]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 16 %a, ptr addrspace(1) nocapture writeonly align 16 %b, { i32 } %podargs) !clspv.pod_args_impl !10 !kernel_arg_map !11 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <3 x float>] } zeroinitializer)
+  %1 = getelementptr { [0 x <3 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <3 x float>] } zeroinitializer)
+  %3 = getelementptr { [0 x <3 x float>] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
+  %4 = call ptr addrspace(9) @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { i32 } } zeroinitializer)
+  %5 = getelementptr { { i32 } }, ptr addrspace(9) %4, i32 0, i32 0
+  %6 = load { i32 }, ptr addrspace(9) %5, align 4
+  %n = extractvalue { i32 } %6, 0
+  %cmp.i = icmp sgt i32 %n, 10
+  %a.b = select i1 %cmp.i, ptr addrspace(1) %1, ptr addrspace(1) %3
+  store <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, ptr addrspace(1) %a.b, align 16
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <3 x float>] })
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x <3 x float>] })
+declare ptr addrspace(9) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
+
+!10 = !{i32 2}
+!11 = !{!12, !13, !14}
+!12 = !{!"a", i32 0, i32 0, i32 0, i32 0, !"buffer"}
+!13 = !{!"b", i32 1, i32 1, i32 0, i32 0, !"buffer"}
+!14 = !{!"n", i32 2, i32 2, i32 0, i32 4, !"pod_pushconstant"}
+

--- a/test/SPIRVProducer/opaque_sample_image2d_float.ll
+++ b/test/SPIRVProducer/opaque_sample_image2d_float.ll
@@ -1,0 +1,43 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
+; CHECK-DAG: [[sampler:%[a-zA-Z0-9_]+]] = OpTypeSampler
+; CHECK-DAG: [[image:%[a-zA-Z0-9_]+]] = OpTypeImage [[float]] 2D 0 0 0 1
+; CHECK-DAG: [[sampled_image:%[a-zA-Z0-9_]+]] = OpTypeSampledImage [[image]]
+; CHECK-DAG: [[image_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[image]]
+; CHECK-DAG: [[sampler_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer UniformConstant [[sampler]]
+; CHECK-DAG: [[image_var:%[a-zA-Z0-9_]+]] = OpVariable [[image_ptr]] UniformConstant
+; CHECK-DAG: [[sampler_var:%[a-zA-Z0-9_]+]] = OpVariable [[sampler_ptr]] UniformConstant
+; CHECK-DAG: [[ld_image:%[a-zA-Z0-9_]+]] = OpLoad [[image]] [[image_var]]
+; CHECK-DAG: [[ld_sampler:%[a-zA-Z0-9_]+]] = OpLoad [[sampler]] [[sampler_var]]
+; CHECK: [[combined:%[a-zA-Z0-9_]+]] = OpSampledImage [[sampled_image]] [[ld_image]] [[ld_sampler]]
+; CHECK: OpImageSampleExplicitLod [[float4]] [[combined]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%ocl_image2d_ro.float.sampled = type opaque
+%ocl_sampler = type opaque
+
+define dso_local spir_kernel void @test(ptr addrspace(1) %t, ptr addrspace(2) %s, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, %ocl_image2d_ro.float.sampled zeroinitializer)
+  %1 = call ptr addrspace(2) @_Z14clspv.resource.1(i32 0, i32 1, i32 8, i32 1, i32 1, i32 0, %ocl_sampler zeroinitializer)
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x <4 x float>] } zeroinitializer)
+  %3 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
+  %call = tail call spir_func <4 x float> @_Z11read_imagef28ocl_image2d_ro.float.sampled11ocl_samplerDv2_f(ptr addrspace(1) %0, ptr addrspace(2) %1, <2 x float> zeroinitializer)
+  store <4 x float> %call, ptr addrspace(1) %3, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef28ocl_image2d_ro.float.sampled11ocl_samplerDv2_f(ptr addrspace(1), ptr addrspace(2), <2 x float>)
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %ocl_image2d_ro.float.sampled)
+declare ptr addrspace(2) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %ocl_sampler)
+declare ptr addrspace(1) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { [0 x <4 x float>] })
+
+!10 = !{i32 2}
+


### PR DESCRIPTION
Contributes to #816 

More changes to support opaque pointers in SPIRVProducer:
* Change image type queries to only accept a StructType
  * remove the need to get the pointer element
* New tracking in SPIRVProducer for pointer and function types
  * both require type inference to correctly generate a typed SPIR-V pointer
  * Pointers are mapped aspace -> {element type -> [ids]}
  * Functions generate a representative type used to create unique types for type caching
* Fix code generation to handle opaque pointers in
  * geps
  * functions calls
  * function definitions
  * select
  * phi
  * image instructions
* Fixed an issue where we generated a stronger capability than necessary
* Fixed a bug that caused infinite loops in type inference
* Changed how workgroup variable info is gathered to avoid the need for pointer elements
* Fixed an issue in DRA that required non-opaque pointers
* Removed the need for pointer element types in POD argument clustering
* Fixed a bug where invalid IR was being generated by the UBO type transform for GEPs

After this change many basic programs can be supported using opaque pointers. 

Known unsupported cases:
* arrays and structures containing pointers
* loading/storing pointers
* pointer casting (unfortunately including accessing component zero of compute builtins)