### PR TITLE
Create the combined static library and install correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,11 @@ if(NOT IS_DIRECTORY ${path})
 endif()
 endmacro()
 
+option(SKIP_CLSPV_INSTALL "Skip installation" ${SKIP_CLSPV_INSTALL})
+if(NOT ${SKIP_CLSPV_INSTALL})
+  set(ENABLE_CLSPV_INSTALL ON)
+endif()
+
 option(SKIP_CLSPV_TOOLS_INSTALL "Skip installation" ${SKIP_CLSPV_TOOLS_INSTALL})
 if(NOT ${SKIP_CLSPV_TOOLS_INSTALL})
   set(ENABLE_CLSPV_TOOLS_INSTALL ON)
@@ -182,19 +187,3 @@ if (CLSPV_BUILD_TESTS)
   # Bring in our test folder
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
 endif()
-
-
-if(ENABLE_CLSPV_TOOLS_INSTALL)
-  install(
-    FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/AddressSpace.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/ArgKind.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/Compiler.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/Option.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/Passes.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/PushConstant.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/Sampler.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/clspv/SpecConstant.h
-    DESTINATION
-      ${CMAKE_INSTALL_INCLUDEDIR}/clspv/)
-endif(ENABLE_CLSPV_TOOLS_INSTALL)

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -1,0 +1,84 @@
+# Finds all transitive static library dependencies of a given target
+# including possibly the target itself.
+# This will skip libraries that were statically linked that were not
+# built by CMake, for example -lpthread.
+macro(clspv_get_transitive_libs target out_list)
+  if (TARGET ${target})
+    get_target_property(libtype ${target} TYPE)
+    # If this target is a static library, get anything it depends on.
+    if ("${libtype}" STREQUAL "STATIC_LIBRARY")
+      # Get the original library if this is an alias library. This is
+      # to avoid putting both the original library and the alias library
+      # in the list (given we are deduplicating according to target names).
+      # Otherwise, we may pack the same library twice, resulting in
+      # duplicated symbols.
+      get_target_property(aliased_target ${target} ALIASED_TARGET)
+      if (aliased_target)
+        list(INSERT ${out_list} 0 "${aliased_target}")
+      else()
+        list(INSERT ${out_list} 0 "${target}")
+      endif()
+
+      get_target_property(libs ${target} LINK_LIBRARIES)
+      if (libs)
+        foreach(lib ${libs})
+          clspv_get_transitive_libs(${lib} ${out_list})
+        endforeach()
+      endif()
+    endif()
+  endif()
+  # If we know the location (i.e. if it was made with CMake) then we
+  # can add it to our list.
+  LIST(REMOVE_DUPLICATES ${out_list})
+endmacro()
+
+# Combines the static library "target" with all of its transitive static
+# library dependencies into a single static library "new_target".
+function(clspv_combine_static_lib new_target target)
+
+  set(all_libs "")
+  clspv_get_transitive_libs(${target} all_libs)
+
+  set(libname
+      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${new_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+  if (MSVC)
+    string(REPLACE ";" ">;$<TARGET_FILE:" temp_string "${all_libs}")
+    set(lib_target_list "$<TARGET_FILE:${temp_string}>")
+
+    add_custom_command(OUTPUT ${libname}
+      DEPENDS ${all_libs}
+      COMMAND lib.exe ${lib_target_list} /OUT:${libname} /NOLOGO)
+  elseif(APPLE)
+    string(REPLACE ";" ">;$<TARGET_FILE:" temp_string "${all_libs}")
+    set(lib_target_list "$<TARGET_FILE:${temp_string}>")
+
+    add_custom_command(OUTPUT ${libname}
+      DEPENDS ${all_libs}
+      COMMAND libtool -static -o ${libname} ${lib_target_list})
+  else()
+    string(REPLACE ";" "> \naddlib $<TARGET_FILE:" temp_string "${all_libs}")
+    set(start_of_file
+      "create ${libname}\naddlib $<TARGET_FILE:${temp_string}>")
+    set(build_script_file "${start_of_file}\nsave\nend\n")
+
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${new_target}.ar"
+        CONTENT ${build_script_file}
+        CONDITION 1)
+
+    add_custom_command(OUTPUT  ${libname}
+      DEPENDS ${all_libs}
+      COMMAND ${CMAKE_AR} -M < ${new_target}.ar)
+  endif()
+
+  add_custom_target(${new_target}_genfile ALL
+    DEPENDS ${libname})
+
+  # CMake needs to be able to see this as another normal library,
+  # so import the newly created library as an imported library,
+  # and set up the dependencies on the custom target.
+  add_library(${new_target} STATIC IMPORTED)
+  set_target_properties(${new_target}
+    PROPERTIES IMPORTED_LOCATION ${libname})
+  add_dependencies(${new_target} ${new_target}_genfile)
+endfunction() 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -150,10 +150,41 @@ if (MSVC)
   )
 endif()
 
-if(ENABLE_CLSPV_TOOLS_INSTALL)
+if (ENABLE_CLSPV_INSTALL)
+  include(../cmake/util.cmake)
+  clspv_combine_static_lib(clspv_combined clspv_core)
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/AddressSpace.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/ArgKind.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Compiler.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Option.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Passes.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/PushConstant.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Sampler.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/SpecConstant.h
+    DESTINATION
+      ${CMAKE_INSTALL_INCLUDEDIR}/clspv/)
+
   install(
     TARGETS clspv_core clspv_passes
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
-endif(ENABLE_CLSPV_TOOLS_INSTALL)
+
+  # Since clspv_combined is defined as an imported library, we cannot use the
+  # install() directive to install it. Install it like a normal file.
+  get_target_property(generated_location clspv_combined LOCATION)
+  string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
+  if (NOT "${vs_generator}" STREQUAL "")
+    # With Visual Studio generators, the LOCATION property is not properly
+    # expanded according to the current build configuration. We need to work
+    # around this problem by manually substitution.
+    string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
+      install_location "${generated_location}")
+    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  else()
+    install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endif()
+endif()


### PR DESCRIPTION
- It's not make sense installing headers and libraries when the tools installation is needed. So installing headers and libraries will be proper regardless tools installation.
- Supporting the combined static library will be very helpful for people who want to link clspv_core. Because without the combined static library, they need to handle linking llvm and clang.