### PR TITLE
roundup integer type to be a multiple of 8

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1468,7 +1468,14 @@ SPIRVID SPIRVProducerPassImpl::addSPIRVGlobalVariable(const SPIRVID &TypeID,
 }
 
 Type *SPIRVProducerPassImpl::CanonicalType(Type *type) {
-  if (type->getNumContainedTypes() != 0) {
+  if (type->isIntegerTy()) {
+    auto bit_width = static_cast<uint32_t>(type->getPrimitiveSizeInBits());
+    if (bit_width > 1) {
+      // round up bit_width to a multiple of 8
+      bit_width = ((bit_width + 7) / 8) * 8;
+    }
+    return IntegerType::get(type->getContext(), bit_width);
+  } else if (type->getNumContainedTypes() != 0) {
     switch (type->getTypeID()) {
     case Type::PointerTyID: {
       // For the purposes of our Vulkan SPIR-V type system, constant and global
@@ -1926,11 +1933,6 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
   case Type::IntegerTyID: {
     uint32_t bit_width =
         static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
-
-    if (bit_width > 1) {
-      // round up bit_width to a multiple of 8
-      bit_width = ((bit_width + 7) / 8) * 8;
-    }
 
     if (clspv::Option::Int8Support() && bit_width == 8) {
       addCapability(spv::CapabilityInt8);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1927,6 +1927,11 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
     uint32_t bit_width =
         static_cast<uint32_t>(Canonical->getPrimitiveSizeInBits());
 
+    if (bit_width > 1) {
+      // round up bit_width to a multiple of 8
+      bit_width = ((bit_width + 7) / 8) * 8;
+    }
+
     if (clspv::Option::Int8Support() && bit_width == 8) {
       addCapability(spv::CapabilityInt8);
     } else if (bit_width == 16) {

--- a/test/no_int2.cl
+++ b/test/no_int2.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void foo( __global int* dst, __global int * src, const int n )
+{
+   size_t gid = get_global_id(0);
+   int cond = 0;
+   cond = n ? 1 : cond;
+   cond = src[n] ? 2 : cond;
+
+   switch(cond) {
+   case 0:
+      dst[gid] = src[gid];
+   case 1:
+      dst[gid + 7] = src[gid - 2];
+   case 2:
+      dst[gid + 3] = src[gid + 2];
+   }
+}
+
+// CHECK-NOT: OpTypeInt 2 0
+// CHECK: OpTypeInt 8 0

--- a/test/no_int2.cl
+++ b/test/no_int2.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-__kernel void foo( __global int* dst, __global int * src, const int n )
+__kernel void foo( __global char* dst, __global char * src, const int n )
 {
    size_t gid = get_global_id(0);
    int cond = 0;
@@ -22,3 +22,5 @@ __kernel void foo( __global int* dst, __global int * src, const int n )
 
 // CHECK-NOT: OpTypeInt 2 0
 // CHECK: OpTypeInt 8 0
+// CHECK-NOT: OpTypeInt 8 0
+// CHECK-NOT: OpTypeInt 2 0

--- a/test/no_int2.ll
+++ b/test/no_int2.ll
@@ -1,0 +1,92 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32>, %1 }
+%1 = type { i32 }
+
+@__spirv_GlobalInvocationId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+@__push_constants = local_unnamed_addr addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define spir_kernel void @foo(i32 addrspace(1)* nocapture writeonly align 4 %dst, i32 addrspace(1)* nocapture readonly align 4 %src) {
+entry:
+  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
+  %2 = getelementptr inbounds %0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0
+  %n = load i32, i32 addrspace(9)* %2, align 16
+  %3 = getelementptr <3 x i32>, <3 x i32> addrspace(5)* @__spirv_GlobalInvocationId, i32 0, i32 0
+  %4 = load i32, i32 addrspace(5)* %3, align 16
+  %5 = getelementptr inbounds %0, %0 addrspace(9)* @__push_constants, i32 0, i32 1, i32 0
+  %6 = load i32, i32 addrspace(9)* %5, align 16
+  %7 = add i32 %6, %4
+  %tobool.i.not = icmp ne i32 %n, 0
+  %8 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %n
+  %9 = load i32, i32 addrspace(1)* %8, align 4
+  %tobool2.i.not = icmp eq i32 %9, 0
+  %10 = zext i1 %tobool.i.not to i2
+  %trunc = select i1 %tobool2.i.not, i2 %10, i2 -2
+  br label %NodeBlock1
+
+NodeBlock1:
+  %Pivot2 = icmp sge i2 %trunc, 0
+  br i1 %Pivot2, label %NodeBlock, label %Flow
+
+NodeBlock:
+  %Pivot = icmp slt i2 %trunc, 1
+  br i1 %Pivot, label %sw.bb.i, label %sw.bb9.i
+
+sw.bb.i:
+  %11 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %7
+  %12 = load i32, i32 addrspace(1)* %11, align 4
+  %13 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %7
+  store i32 %12, i32 addrspace(1)* %13, align 4
+  br label %sw.bb9.i
+
+sw.bb9.i:
+  %sub.i = add i32 %7, -2
+  %14 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %sub.i
+  %15 = load i32, i32 addrspace(1)* %14, align 4
+  %add.i = add i32 %7, 7
+  %16 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %add.i
+  store i32 %15, i32 addrspace(1)* %16, align 4
+  br label %Flow
+
+Flow:
+  %17 = phi i1 [ true, %sw.bb9.i ], [ false, %NodeBlock1 ]
+  %18 = phi i1 [ false, %sw.bb9.i ], [ true, %NodeBlock1 ]
+  br i1 %18, label %LeafBlock, label %Flow3
+
+LeafBlock:
+  %SwitchLeaf = icmp eq i2 %trunc, -2
+  br label %Flow3
+
+Flow3:
+  %19 = phi i1 [ %SwitchLeaf, %LeafBlock ], [ %17, %Flow ]
+  br i1 %19, label %sw.bb12.i, label %math_kernel.inner.exit
+
+sw.bb12.i:
+  %add13.i = add i32 %7, 2
+  %20 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %add13.i
+  %21 = load i32, i32 addrspace(1)* %20, align 4
+  %add15.i = add i32 %7, 3
+  %22 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %add15.i
+  store i32 %21, i32 addrspace(1)* %22, align 4
+  br label %math_kernel.inner.exit
+
+math_kernel.inner.exit:
+  ret void
+}
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+!0 = !{i32 1, i32 4, i32 7}
+
+; CHECK-NOT: OpTypeInt 2 0
+; CHECK: OpTypeInt 8 0

--- a/test/no_int2.ll
+++ b/test/no_int2.ll
@@ -13,80 +13,83 @@ target triple = "spir-unknown-unknown"
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 @__push_constants = local_unnamed_addr addrspace(9) global %0 zeroinitializer, !push_constants !0
 
-define spir_kernel void @foo(i32 addrspace(1)* nocapture writeonly align 4 %dst, i32 addrspace(1)* nocapture readonly align 4 %src) {
+define spir_kernel void @foo(i8 addrspace(1)* nocapture writeonly align 1 %dst, i8 addrspace(1)* nocapture readonly align 1 %src, { i32 } %podargs) {
 entry:
-  %0 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
-  %1 = call { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
-  %2 = getelementptr inbounds %0, %0 addrspace(9)* @__push_constants, i32 0, i32 2, i32 0
-  %n = load i32, i32 addrspace(9)* %2, align 16
-  %3 = getelementptr <3 x i32>, <3 x i32> addrspace(5)* @__spirv_GlobalInvocationId, i32 0, i32 0
-  %4 = load i32, i32 addrspace(5)* %3, align 16
-  %5 = getelementptr inbounds %0, %0 addrspace(9)* @__push_constants, i32 0, i32 1, i32 0
-  %6 = load i32, i32 addrspace(9)* %5, align 16
-  %7 = add i32 %6, %4
+  %0 = call { [0 x i8] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i8] } zeroinitializer)
+  %1 = call { [0 x i8] } addrspace(1)* @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i8] } zeroinitializer)
+  %2 = call { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { i32 } } zeroinitializer)
+  %3 = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %2, i32 0, i32 0
+  %4 = load { i32 }, { i32 } addrspace(9)* %3, align 4
+  %n = extractvalue { i32 } %4, 0
+  %5 = getelementptr <3 x i32>, <3 x i32> addrspace(5)* @__spirv_GlobalInvocationId, i32 0, i32 0
+  %6 = load i32, i32 addrspace(5)* %5, align 16
   %tobool.i.not = icmp ne i32 %n, 0
-  %8 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %n
-  %9 = load i32, i32 addrspace(1)* %8, align 4
-  %tobool2.i.not = icmp eq i32 %9, 0
-  %10 = zext i1 %tobool.i.not to i2
-  %trunc = select i1 %tobool2.i.not, i2 %10, i2 -2
+  %7 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %1, i32 0, i32 0, i32 %n
+  %8 = load i8, i8 addrspace(1)* %7, align 1
+  %tobool2.i.not = icmp eq i8 %8, 0
+  %9 = zext i1 %tobool.i.not to i2
+  %trunc = select i1 %tobool2.i.not, i2 %9, i2 -2
   br label %NodeBlock1
 
-NodeBlock1:
+NodeBlock1:                                       ; preds = %entry
   %Pivot2 = icmp sge i2 %trunc, 0
   br i1 %Pivot2, label %NodeBlock, label %Flow
 
-NodeBlock:
+NodeBlock:                                        ; preds = %NodeBlock1
   %Pivot = icmp slt i2 %trunc, 1
   br i1 %Pivot, label %sw.bb.i, label %sw.bb9.i
 
-sw.bb.i:
-  %11 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %7
-  %12 = load i32, i32 addrspace(1)* %11, align 4
-  %13 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %7
-  store i32 %12, i32 addrspace(1)* %13, align 4
+sw.bb.i:                                          ; preds = %NodeBlock
+  %10 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %1, i32 0, i32 0, i32 %6
+  %11 = load i8, i8 addrspace(1)* %10, align 1
+  %12 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %0, i32 0, i32 0, i32 %6
+  store i8 %11, i8 addrspace(1)* %12, align 1
   br label %sw.bb9.i
 
-sw.bb9.i:
-  %sub.i = add i32 %7, -2
-  %14 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %sub.i
-  %15 = load i32, i32 addrspace(1)* %14, align 4
-  %add.i = add i32 %7, 7
-  %16 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %add.i
-  store i32 %15, i32 addrspace(1)* %16, align 4
+sw.bb9.i:                                         ; preds = %sw.bb.i, %NodeBlock
+  %sub.i = add i32 %6, -2
+  %13 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %1, i32 0, i32 0, i32 %sub.i
+  %14 = load i8, i8 addrspace(1)* %13, align 1
+  %add.i = add i32 %6, 7
+  %15 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %0, i32 0, i32 0, i32 %add.i
+  store i8 %14, i8 addrspace(1)* %15, align 1
   br label %Flow
 
-Flow:
-  %17 = phi i1 [ true, %sw.bb9.i ], [ false, %NodeBlock1 ]
-  %18 = phi i1 [ false, %sw.bb9.i ], [ true, %NodeBlock1 ]
-  br i1 %18, label %LeafBlock, label %Flow3
+Flow:                                             ; preds = %sw.bb9.i, %NodeBlock1
+  %16 = phi i1 [ true, %sw.bb9.i ], [ false, %NodeBlock1 ]
+  %17 = phi i1 [ false, %sw.bb9.i ], [ true, %NodeBlock1 ]
+  br i1 %17, label %LeafBlock, label %Flow3
 
-LeafBlock:
+LeafBlock:                                        ; preds = %Flow
   %SwitchLeaf = icmp eq i2 %trunc, -2
   br label %Flow3
 
-Flow3:
-  %19 = phi i1 [ %SwitchLeaf, %LeafBlock ], [ %17, %Flow ]
-  br i1 %19, label %sw.bb12.i, label %math_kernel.inner.exit
+Flow3:                                            ; preds = %LeafBlock, %Flow
+  %18 = phi i1 [ %SwitchLeaf, %LeafBlock ], [ %16, %Flow ]
+  br i1 %18, label %sw.bb12.i, label %foo.inner.exit
 
-sw.bb12.i:
-  %add13.i = add i32 %7, 2
-  %20 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %1, i32 0, i32 0, i32 %add13.i
-  %21 = load i32, i32 addrspace(1)* %20, align 4
-  %add15.i = add i32 %7, 3
-  %22 = getelementptr { [0 x i32] }, { [0 x i32] } addrspace(1)* %0, i32 0, i32 0, i32 %add15.i
-  store i32 %21, i32 addrspace(1)* %22, align 4
-  br label %math_kernel.inner.exit
+sw.bb12.i:                                        ; preds = %Flow3
+  %add13.i = add i32 %6, 2
+  %19 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %1, i32 0, i32 0, i32 %add13.i
+  %20 = load i8, i8 addrspace(1)* %19, align 1
+  %add15.i = add i32 %6, 3
+  %21 = getelementptr { [0 x i8] }, { [0 x i8] } addrspace(1)* %0, i32 0, i32 0, i32 %add15.i
+  store i8 %20, i8 addrspace(1)* %21, align 1
+  br label %foo.inner.exit
 
-math_kernel.inner.exit:
+foo.inner.exit:                                   ; preds = %sw.bb12.i, %Flow3
   ret void
 }
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+declare { [0 x i8] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i8] })
 
-declare { [0 x i32] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+declare { [0 x i8] } addrspace(1)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i8] })
+
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
 
 !0 = !{i32 1, i32 4, i32 7}
 
 ; CHECK-NOT: OpTypeInt 2 0
 ; CHECK: OpTypeInt 8 0
+; CHECK-NOT: OpTypeInt 8 0
+; CHECK-NOT: OpTypeInt 2 0


### PR DESCRIPTION
Most vulkan drivers do not support integer type not being a multiple
of 8.
Make sure we always produce integer type with a size multiple of 8.

This will fix a compilation issue with libclc lgamma and lgamma_r
functions.