### PR TITLE
Fix incorrect POD arg struct layout for kernels with long-vector POD args

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -437,6 +437,49 @@ Value *convertVectorOperation(Instruction &I, Type *EquivalentReturnTy,
   return ReturnValue;
 }
 
+/// Create module level metadata that maps a new remapped struct type to the
+/// layout information for the original struct type. Ensures UBO struct types
+/// with long vector members still match previously generated reflection
+/// metadata.
+void createStructLayoutRemapMetadata(StructType *OldStructTy,
+                                     StructType *NewStructTy, Module *Module) {
+  auto &DL = Module->getDataLayout();
+  auto &Ctx = Module->getContext();
+  const auto *Layout = Module->getDataLayout().getStructLayout(OldStructTy);
+  auto *Int32Ty = Type::getInt32Ty(Ctx);
+
+  // Record the correct offsets for use when generating the SPIR-V binary.
+  NamedMDNode *OffsetsMD =
+      Module->getOrInsertNamedMetadata(clspv::RemappedTypeOffsetMetadataName());
+  SmallVector<Metadata *, 8> OffsetValues;
+  for (unsigned i = 0; i < OldStructTy->getNumElements(); ++i) {
+    uint64_t Offset = Layout->getElementOffset(i);
+    OffsetValues.push_back(
+        ConstantAsMetadata::get(ConstantInt::get(Int32Ty, Offset)));
+  }
+  MDTuple *OffsetValuesMD = MDTuple::get(Ctx, OffsetValues);
+  MDTuple *OffsetEntry = MDTuple::get(
+      Ctx, {ConstantAsMetadata::get(Constant::getNullValue(NewStructTy)),
+            OffsetValuesMD});
+  OffsetsMD->addOperand(OffsetEntry);
+
+  // Record the correct sizes for use when generating the SPIR-V binary.
+  NamedMDNode *SizesMD =
+      Module->getOrInsertNamedMetadata(clspv::RemappedTypeSizesMetadataName());
+  Metadata *SizeValues[3];
+  SizeValues[0] = ConstantAsMetadata::get(
+      ConstantInt::get(Int32Ty, DL.getTypeSizeInBits(OldStructTy)));
+  SizeValues[1] = ConstantAsMetadata::get(
+      ConstantInt::get(Int32Ty, DL.getTypeStoreSize(OldStructTy)));
+  SizeValues[2] = ConstantAsMetadata::get(
+      ConstantInt::get(Int32Ty, DL.getTypeAllocSize(OldStructTy)));
+  MDTuple *SizeValuesMD = MDTuple::get(Ctx, SizeValues);
+  MDTuple *SizeEntry = MDTuple::get(
+      Ctx, {ConstantAsMetadata::get(Constant::getNullValue(NewStructTy)),
+            SizeValuesMD});
+  SizesMD->addOperand(SizeEntry);
+}
+
 /// Map the arguments of the wrapper function (which are either not long-vectors
 /// or aggregates of scalars) to the original arguments of the user-defined
 /// function (which can be long-vectors). Handle pointers as well.
@@ -444,16 +487,27 @@ SmallVector<Value *, 16> mapWrapperArgsToWrappeeArgs(IRBuilder<> &B,
                                                      Function &Wrappee,
                                                      Function &Wrapper) {
   SmallVector<Value *, 16> Args;
+  auto *Module = Wrappee.getParent();
 
   std::size_t ArgumentCount = Wrapper.arg_size();
   Args.reserve(ArgumentCount);
 
   for (std::size_t i = 0; i < ArgumentCount; ++i) {
+    auto *Arg = Wrappee.getArg(i);
     auto *NewArg = Wrapper.getArg(i);
-    NewArg->takeName(Wrappee.getArg(i));
+    NewArg->takeName(Arg);
     auto *OldArgTy = Wrappee.getFunctionType()->getParamType(i);
     auto *EquivalentArg = convertEquivalentValue(B, NewArg, OldArgTy);
     Args.push_back(EquivalentArg);
+
+    // Converting struct members from vectors to arrays can result in changes to
+    // the struct layout. Record the correct layout information for use when
+    // generating the SPIR-V binary.
+    if (auto *StructTy = dyn_cast<StructType>(Arg->getType())) {
+      if (auto *NewStructTy = dyn_cast<StructType>(NewArg->getType())) {
+        createStructLayoutRemapMetadata(StructTy, NewStructTy, Module);
+      }
+    }
   }
 
   return Args;

--- a/test/LongVectorLowering/cluster_pod_args_offsets.cl
+++ b/test/LongVectorLowering/cluster_pod_args_offsets.cl
@@ -1,0 +1,37 @@
+// RUN: clspv %s -long-vector -o %t.spv -int8 -cluster-pod-kernel-args -std430-ubo-layout
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: clspv-reflection %t.spv -o %t.map -d
+// RUN: FileCheck %s < %t.map -check-prefix=MAP
+// RUN: spirv-val --target-env vulkan1.0 --uniform-buffer-standard-layout %t.spv
+
+// Checks that the lowering of long-vector arguments doesn't invalidate the
+// clustered POD arg struct's layout and the reflection data matches
+
+__kernel void test(char8 c, uchar8 uc, short8 s, ushort8 us, int8 i, uint8 ui,
+float8 f, __global float8 *result) {
+    result[0] = convert_float8(c);
+    result[1] = convert_float8(uc);
+    result[2] = convert_float8(s);
+    result[3] = convert_float8(us);
+    result[4] = convert_float8(i);
+    result[5] = convert_float8(ui);
+    result[6] = f;
+}
+
+// CHECK: OpMemberDecorate [[struct_ssbo:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK: OpMemberDecorate [[struct]] 1 Offset 8
+// CHECK: OpMemberDecorate [[struct]] 2 Offset 16
+// CHECK: OpMemberDecorate [[struct]] 3 Offset 32
+// CHECK: OpMemberDecorate [[struct]] 4 Offset 64
+// CHECK: OpMemberDecorate [[struct]] 5 Offset 96
+// CHECK: OpMemberDecorate [[struct]] 6 Offset 128
+
+// MAP: kernel,test,arg,c,argOrdinal,0,descriptorSet,0,binding,1,offset,0,argKind,pod_ubo,argSize,8
+// MAP: kernel,test,arg,uc,argOrdinal,1,descriptorSet,0,binding,1,offset,8,argKind,pod_ubo,argSize,8
+// MAP: kernel,test,arg,s,argOrdinal,2,descriptorSet,0,binding,1,offset,16,argKind,pod_ubo,argSize,16
+// MAP: kernel,test,arg,us,argOrdinal,3,descriptorSet,0,binding,1,offset,32,argKind,pod_ubo,argSize,16
+// MAP: kernel,test,arg,i,argOrdinal,4,descriptorSet,0,binding,1,offset,64,argKind,pod_ubo,argSize,32
+// MAP: kernel,test,arg,ui,argOrdinal,5,descriptorSet,0,binding,1,offset,96,argKind,pod_ubo,argSize,32
+// MAP: kernel,test,arg,f,argOrdinal,6,descriptorSet,0,binding,1,offset,128,argKind,pod_ubo,argSize,32


### PR DESCRIPTION
This contribution is being made by Codeplay on behalf of Samsung.

Long-vector POD args are lowered to arrays. When these args are clustered in a struct, changing these member types can change the layout of the struct. This can result in the clustered POD arg struct not having the same layout as the corresponding reflection metadata.

Fix this behavior by using the same remapped type offset/size metadata as the UBO Type Transform Pass to preserve the original layout.

The test case here comes from the basic/parameter_types test from the OpenCL CTS.