### PR TITLE
longvector: add support for missing builtins

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -87,6 +87,7 @@ Function *getIntrinsicScalarVersion(Function &Intrinsic) {
   case Intrinsic::ctlz:
   case Intrinsic::exp:
   case Intrinsic::fabs:
+  case Intrinsic::floor:
   case Intrinsic::fmuladd:
   case Intrinsic::fshl:
   case Intrinsic::log:
@@ -193,6 +194,7 @@ Function *getBIFScalarVersion(Function &Builtin) {
   case clspv::Builtins::kAtanh:
   case clspv::Builtins::kCeil:
   case clspv::Builtins::kClamp:
+  case clspv::Builtins::kClspvFract:
   case clspv::Builtins::kCos:
   case clspv::Builtins::kCosh:
   case clspv::Builtins::kCospi:

--- a/test/LongVectorLowering/clspv_fract.ll
+++ b/test/LongVectorLowering/clspv_fract.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+; CHECK: call float @_Z11clspv.fractf(float 0.000000e+00)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test() {
+entry:
+  %call = call <16 x float> @_Z11clspv.fractDv16_f(<16 x float> zeroinitializer)
+  ret void
+}
+
+declare <16 x float> @_Z11clspv.fractDv16_f(<16 x float>)
+

--- a/test/LongVectorLowering/floor.ll
+++ b/test/LongVectorLowering/floor.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+; CHECK: call float @llvm.floor.f32(float 0.000000e+00)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test() {
+entry:
+  %call = call <16 x float> @llvm.floor.v16f32(<16 x float> zeroinitializer)
+  ret void
+}
+
+declare <16 x float> @llvm.floor.v16f32(<16 x float>)
+


### PR DESCRIPTION
clspv.fract and floor