### PR TITLE
Support opaque pointers in ReplacePointerBitcast and InlineFuncWithPointerBitCastArg

### DIFF
--- a/lib/InlineFuncWithPointerBitCastArgPass.cpp
+++ b/lib/InlineFuncWithPointerBitCastArgPass.cpp
@@ -157,8 +157,8 @@ bool clspv::InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
               auto *next_gep = cast<GetElementPtrInst>(user);
               if (result_ele_ty &&
                   next_gep->getResultElementType() != result_ele_ty) {
-                // TODO: this is an over-approximation, but it's easier to not
-                // worry about phis.
+                // TODO: this is an over-approximation, but it is necessary
+                // unless we want to traverse phis multiple times.
                 add_all = true;
               }
               for (auto &use : user->uses()) {

--- a/lib/InlineFuncWithPointerBitCastArgPass.cpp
+++ b/lib/InlineFuncWithPointerBitCastArgPass.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 
 #include "InlineFuncWithPointerBitCastArgPass.h"
+#include "Types.h"
 
 using namespace llvm;
 
@@ -86,6 +87,86 @@ bool clspv::InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
                   ToChecks.append(Inst->user_begin(), Inst->user_end());
                 }
               }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Check if any calls need inlined due to implicit pointer casts from opaque
+  // pointers.
+  DenseMap<Value *, Type *> type_cache;
+  for (auto &F : M) {
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        // All implicit casts of interest will be based on GEPs. There are two
+        // scenarios:
+        // 1. The GEP itself is the cast (e.g. source type doesn't
+        //    match the inferred input type).
+        // 2. The cast occurs through the call instruction (e.g. the inferred
+        //    argument type doesn't match the GEP result element type).
+        auto *gep = dyn_cast<GetElementPtrInst>(&I);
+        if (!gep)
+          continue;
+
+        const auto *source_inferred_ty = clspv::InferType(
+            gep->getPointerOperand(), M.getContext(), &type_cache);
+        const auto *source_ele_ty = gep->getSourceElementType();
+        const auto *result_ele_ty = gep->getResultElementType();
+        bool add_all = source_inferred_ty && source_ele_ty &&
+                       source_inferred_ty != source_ele_ty;
+        SmallVector<std::pair<User *, unsigned>, 8> to_check;
+        for (auto &use : gep->uses()) {
+          to_check.push_back(std::make_pair(use.getUser(), use.getOperandNo()));
+        }
+        SmallSet<User *, 8> checked_phis;
+        while (!to_check.empty()) {
+          auto *user = to_check.back().first;
+          auto operand = to_check.back().second;
+          to_check.pop_back();
+
+          if (auto *inst = dyn_cast<Instruction>(user)) {
+            switch (inst->getOpcode()) {
+            default:
+              break;
+            case Instruction::Call: {
+              auto *call = cast<CallInst>(inst);
+              if (add_all) {
+                WorkList.insert(call);
+              } else {
+                const auto *arg_ty =
+                    clspv::InferType(call->getCalledFunction()->getArg(operand),
+                                     M.getContext(), &type_cache);
+                if (arg_ty != result_ele_ty) {
+                  WorkList.insert(call);
+                }
+              }
+              break;
+            }
+            case Instruction::PHI:
+              if (checked_phis.count(user))
+                break;
+              checked_phis.insert(user);
+              for (auto &use : user->uses()) {
+                to_check.push_back(
+                    std::make_pair(use.getUser(), use.getOperandNo()));
+              }
+              break;
+            case Instruction::GetElementPtr: {
+              auto *next_gep = cast<GetElementPtrInst>(user);
+              if (result_ele_ty &&
+                  next_gep->getResultElementType() != result_ele_ty) {
+                // TODO: this is an over-approximation, but it's easier to not
+                // worry about phis.
+                add_all = true;
+              }
+              for (auto &use : user->uses()) {
+                to_check.push_back(
+                    std::make_pair(use.getUser(), use.getOperandNo()));
+              }
+              break;
+            }
             }
           }
         }

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -2045,7 +2045,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F) {
           PointerType::get(ShortTy, Arg1->getType()->getPointerAddressSpace());
 
       // Cast the half* pointer to short*.
-      auto Cast = CastInst::CreatePointerCast(Arg1, ShortPointerTy, "", CI);
+      // TODO(#816): remove after final transition.
+      Value *Cast = Arg1;
+      if (Arg1->getType() != ShortPointerTy) {
+        Cast = CastInst::CreatePointerCast(Arg1, ShortPointerTy, "", CI);
+      }
 
       // Index into the correct address of the casted pointer.
       auto Index = GetElementPtrInst::Create(ShortTy, Cast, Arg0, "", CI);
@@ -2083,7 +2087,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F) {
       // Cast the base pointer to int*.
       // In a valid call (according to assumptions), this should get
       // optimized away in the simplify GEP pass.
-      auto Cast = CastInst::CreatePointerCast(Arg1, IntPointerTy, "", CI);
+      // TODO(#816): remove after final transition.
+      Value *Cast = Arg1;
+      if (Arg1->getType() != IntPointerTy) {
+        Cast = CastInst::CreatePointerCast(Arg1, IntPointerTy, "", CI);
+      }
 
       auto One = ConstantInt::get(IntTy, 1);
       auto IndexIsOdd = BinaryOperator::CreateAnd(Arg0, One, "", CI);
@@ -2122,7 +2130,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf2(Function &F) {
     auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     // Cast the half* pointer to int*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(IntTy, Cast, Arg0, "", CI);
@@ -2163,7 +2175,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf3(Function &F) {
     auto Int2 = ConstantInt::get(IntTy, 2);
 
     // Cast the half* pointer to short*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Load the first element
     auto Index0 = BinaryOperator::Create(
@@ -2230,7 +2246,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadaHalf3(Function &F) {
     auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     // Cast the half* pointer to int2*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(Int2Ty, Cast, Arg0, "", CI);
@@ -2282,7 +2302,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf4(Function &F) {
     auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     // Cast the half* pointer to int2*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(Int2Ty, Cast, Arg0, "", CI);
@@ -2334,7 +2358,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf8(Function &F) {
     auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     // Cast the half* pointer to int4*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(Int4Ty, Cast, Arg0, "", CI);
@@ -2402,7 +2430,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf16(Function &F) {
     auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     // Cast the half* pointer to int4*.
-    auto Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg1;
+    if (Arg1->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg1, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Arg0x2 = BinaryOperator::Create(Instruction::Shl, Arg0, ConstantInt::get(IntTy, 1), "", CI);
@@ -2645,7 +2677,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F) {
       auto Trunc = CastInst::CreateTruncOrBitCast(X, ShortTy, "", CI);
 
       // Cast the half* pointer to short*.
-      auto Cast = CastInst::CreatePointerCast(Arg2, ShortPointerTy, "", CI);
+      // TODO(#816): remove after final transition.
+      Value *Cast = Arg2;
+      if (Arg2->getType() != ShortPointerTy) {
+        Cast = CastInst::CreatePointerCast(Arg2, ShortPointerTy, "", CI);
+      }
 
       // Index into the correct address of the casted pointer.
       auto Index = GetElementPtrInst::Create(ShortTy, Cast, Arg1, "", CI);
@@ -2683,8 +2719,12 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F) {
       // Compute index / 2
       auto IndexIntoI32 =
           BinaryOperator::CreateLShr(Arg1, One, "index_into_i32", CI);
-      auto BaseI32Ptr =
+      // TODO(#816): remove after final transition.
+      Value *BaseI32Ptr = Arg2;
+      if (Arg2->getType() != IntPointerTy) {
+        BaseI32Ptr =
           CastInst::CreatePointerCast(Arg2, IntPointerTy, "base_i32_ptr", CI);
+      }
       auto OutPtr = GetElementPtrInst::Create(IntTy, BaseI32Ptr, IndexIntoI32,
                                               "base_i32_ptr", CI);
       auto CurrentValue = new LoadInst(IntTy, OutPtr, "current_value", CI);
@@ -2766,7 +2806,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf2(Function &F) {
     auto X = CallInst::Create(NewF, Arg0, "", CI);
 
     // Cast the half* pointer to int*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(IntTy, Cast, Arg1, "", CI);
@@ -2828,7 +2872,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf3(Function &F) {
                          ShortTy, "", CI);
 
     // Cast the half* pointer to short*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     auto Index0 = BinaryOperator::Create(
         Instruction::Add,
@@ -2901,7 +2949,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreaHalf3(Function &F) {
                          ShortTy, "", CI);
 
     // Cast the half* pointer to short*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     auto Index0 = BinaryOperator::Create(Instruction::Shl, Arg1, Int2, "", CI);
     auto GEP0 = GetElementPtrInst::Create(ShortTy, Cast, Index0, "", CI);
@@ -2969,7 +3021,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf4(Function &F) {
                                         "", CI);
 
     // Cast the half* pointer to int2*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(Int2Ty, Cast, Arg1, "", CI);
@@ -3039,7 +3095,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf8(Function &F) {
                                         ConstantInt::get(IntTy, 3), "", CI);
 
     // Cast the half* pointer to int4*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Index = GetElementPtrInst::Create(Int4Ty, Cast, Arg1, "", CI);
@@ -3134,7 +3194,11 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf16(Function &F) {
                                          ConstantInt::get(IntTy, 3), "", CI);
 
     // Cast the half* pointer to int4*.
-    auto Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    // TODO(#816): remove after final transition.
+    Value *Cast = Arg2;
+    if (Arg2->getType() != NewPointerTy) {
+      Cast = CastInst::CreatePointerCast(Arg2, NewPointerTy, "", CI);
+    }
 
     // Index into the correct address of the casted pointer.
     auto Arg1x2 = BinaryOperator::Create(Instruction::Shl, Arg1,

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -454,7 +454,6 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
       for (auto &I : BB) {
         Value *source = nullptr;
         Type *source_ty = nullptr;
-        Value *dest = &I;
         Type *dest_ty = nullptr;
         // The following checks use InferType to distinguish when a pointer's
         // interpretation changes between instructions. This requires the input

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -603,7 +603,7 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
         continue;
       }
 
-     LLVM_DEBUG(dbgs() << "#### BitCastUser: "; BitCastUser->dump());
+      LLVM_DEBUG(dbgs() << "#### BitCastUser: "; BitCastUser->dump());
       SmallVector<Value *, 4> NewAddrIdxs;
 
       // It consist of User* and bool whether user is gep or not.

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -50,6 +50,10 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
   // Return the source data interpretation type.
   if (auto *gep = dyn_cast<GEPOperator>(v)) {
     return CacheType(gep->getResultElementType());
+  } else if (auto *alloca = dyn_cast<AllocaInst>(v)) {
+    return CacheType(alloca->getAllocatedType());
+  } else if (auto *gv = dyn_cast<GlobalVariable>(v)) {
+    return CacheType(gv->getValueType());
   }
 
   // Special resource-related functions. The last parameter of each function is

--- a/test/PointerCasts/opaque_canonical_pointer.ll
+++ b/test/PointerCasts/opaque_canonical_pointer.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo(ptr addrspace(1) nocapture readonly %input, ptr addrspace(1) nocapture %output)  {
+entry:
+  %in = alloca [4 x [4 x float]], align 16
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr [4 x [4 x float]], ptr %in, i32 0, i32 0
+  ; CHECK: [[load4:%[a-zA-Z0-9_.]+]] = load [4 x float], ptr [[base]]
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 1
+  ; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 2
+  ; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 3
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[ex0]], i32 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in0]], float [[ex1]], i32 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in1]], float [[ex2]], i32 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in2]], float [[ex3]], i32 3
+  %ld0 = load <4 x float>, <4 x float>* %in
+
+  %gep1 = getelementptr [4 x [4 x float]], ptr %in
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr [4 x [4 x float]], ptr %gep1, i32 0, i32 0
+  ; CHECK: [[load4:%[a-zA-Z0-9_.]+]] = load [4 x float], ptr [[base]]
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 1
+  ; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 2
+  ; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 3
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[ex0]], i32 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in0]], float [[ex1]], i32 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in1]], float [[ex2]], i32 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in2]], float [[ex3]], i32 3
+  %ld1 = load <4 x float>, ptr %gep1
+
+  %gep2 = getelementptr [4 x [4 x float]], ptr %in, i32 0
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr [4 x [4 x float]], ptr %gep2, i32 0, i32 0
+  ; CHECK: [[load4:%[a-zA-Z0-9_.]+]] = load [4 x float], ptr [[base]]
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 1
+  ; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 2
+  ; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 3
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[ex0]], i32 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in0]], float [[ex1]], i32 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in1]], float [[ex2]], i32 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in2]], float [[ex3]], i32 3
+  %ld2 = load <4 x float>, ptr %gep2
+
+  %gep3 = getelementptr [4 x [4 x float]], ptr %in, i32 0, i32 0
+  ; CHECK: [[base:%[a-zA-Z0-9_.]+]] = getelementptr [4 x float], ptr %gep3, i32 0
+  ; CHECK: [[load4:%[a-zA-Z0-9_.]+]] = load [4 x float], ptr [[base]]
+  ; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 0
+  ; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 1
+  ; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 2
+  ; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractvalue [4 x float] [[load4]], 3
+  ; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[ex0]], i32 0
+  ; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in0]], float [[ex1]], i32 1
+  ; CHECK: [[in2:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in1]], float [[ex2]], i32 2
+  ; CHECK: [[in3:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[in2]], float [[ex3]], i32 3
+  %ld3 = load <4 x float>, ptr %gep3
+
+  %gep4 = getelementptr [4 x [4 x float]], ptr %in, i32 0, i32 0, i32 0
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr %gep4, i32 0
+  ; CHECK: load float, ptr [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr %gep4, i32 1
+  ; CHECK: load float, ptr [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr %gep4, i32 2
+  ; CHECK: load float, ptr [[gep]]
+  ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr %gep4, i32 3
+  ; CHECK: load float, ptr [[gep]]
+  %ld4 = load <4 x float>, ptr %gep4
+
+  ret void
+}

--- a/test/PointerCasts/opaque_clspv_vloada_half4_global.ll
+++ b/test/PointerCasts/opaque_clspv_vloada_half4_global.ll
@@ -1,0 +1,37 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i32 %n, 1
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[shl]], 2
+; CHECK: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[shl]], 3
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 [[shr]], i32 [[and]]
+; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep]]
+; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[and]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 [[shr]], i32 [[add]]
+; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep]]
+; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> undef, float [[ld0]], i32 0
+; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> [[in0]], float [[ld1]], i32 1
+; CHECK: [[cast:%[a-zA-Z0-9_]+]] = bitcast <2 x float> [[in1]] to <2 x i32>
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i32 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i32 1
+; CHECK: call <2 x float> @spirv.unpack.v2f16(i32 [[ex0]])
+; CHECK: call <2 x float> @spirv.unpack.v2f16(i32 [[ex1]])
+define void @foo(ptr addrspace(1) %a, i32 %n) {
+entry:
+  %res = call ptr addrspace(1) @clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x float>] } zeroinitializer)
+  %b = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  %gep = getelementptr <2 x i32>, ptr addrspace(1) %b, i32 %n
+  %ld = load <2 x i32>, ptr addrspace(1) %gep
+  %ex0 = extractelement <2 x i32> %ld, i32 0
+  %ex1 = extractelement <2 x i32> %ld, i32 1
+  %unpack0 = call <2 x float> @spirv.unpack.v2f16(i32 %ex0)
+  %unpack1 = call <2 x float> @spirv.unpack.v2f16(i32 %ex1)
+  %shuffle = shufflevector <2 x float> %unpack0, <2 x float> %unpack1, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret void
+}
+
+declare <2 x float> @spirv.unpack.v2f16(i32)
+declare ptr addrspace(1) @clspv.resource.0(i32, i32, i32, i32, i32, i32, { [ 0 x <4 x float>] })

--- a/test/PointerCasts/opaque_clspv_vloada_half4_local.ll
+++ b/test/PointerCasts/opaque_clspv_vloada_half4_local.ll
@@ -1,0 +1,38 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i32 %n, 1
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i32 [[shl]], 2
+; CHECK: [[and:%[a-zA-Z0-9_.]+]] = and i32 [[shl]], 3
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(3) %b, i32 [[shr]], i32 [[and]]
+; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(3) [[gep]]
+; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[and]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(3) %b, i32 [[shr]], i32 [[add]]
+; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(3) [[gep]]
+; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> undef, float [[ld0]], i32 0
+; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x float> [[in0]], float [[ld1]], i32 1
+; CHECK: [[cast:%[a-zA-Z0-9_]+]] = bitcast <2 x float> [[in1]] to <2 x i32>
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i32 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i32 1
+; CHECK: call <2 x float> @spirv.unpack.v2f16(i32 [[ex0]])
+; CHECK: call <2 x float> @spirv.unpack.v2f16(i32 [[ex1]])
+define void @foo(ptr addrspace(1) %a, i32 %n) {
+entry:
+  %res = call ptr addrspace(3) @clspv.local.3(i32 3, [0 x <4 x float>] zeroinitializer)
+  %b = getelementptr [0 x <4 x float>], ptr addrspace(3) %res, i32 0, i32 0
+  %gep = getelementptr <2 x i32>, ptr addrspace(3) %b, i32 %n
+  %ld = load <2 x i32>, ptr addrspace(3) %gep
+  %ex0 = extractelement <2 x i32> %ld, i32 0
+  %ex1 = extractelement <2 x i32> %ld, i32 1
+  %unpack0 = call <2 x float> @spirv.unpack.v2f16(i32 %ex0)
+  %unpack1 = call <2 x float> @spirv.unpack.v2f16(i32 %ex1)
+  %shuffle = shufflevector <2 x float> %unpack0, <2 x float> %unpack1, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret void
+}
+
+declare <2 x float> @spirv.unpack.v2f16(i32)
+declare ptr addrspace(3) @clspv.local.3(i32, [0 x <4 x float>])
+

--- a/test/PointerCasts/opaque_deref_load_cast_float2_to_int4.ll
+++ b/test/PointerCasts/opaque_deref_load_cast_float2_to_int4.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0
+; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load <2 x float>, ptr addrspace(1) [[gep]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 1
+; CHECK: [[ld1:%[a-zA-Z0-9_.]+]] = load <2 x float>, ptr addrspace(1) [[gep]]
+; CHECK: [[shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x float> [[ld0]], <2 x float> [[ld1]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK: bitcast <4 x float> [[shuffle]] to <4 x i32>
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 16 %a) {
+entry:
+  %res = call ptr addrspace(1) @clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <2 x float>] } zeroinitializer)
+  %b = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  %0 = load <4 x i32>, ptr addrspace(1) %b, align 16
+  store <4 x i32> %0,  ptr addrspace(1) %a, align 16
+  ret void
+}
+
+declare ptr addrspace(1) @clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <2 x float>] })

--- a/test/PointerCasts/opaque_deref_load_cast_float4_to_int2.ll
+++ b/test/PointerCasts/opaque_deref_load_cast_float4_to_int2.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr addrspace(1) [[gep]]
+; CHECK: [[shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x float> [[ld]], <4 x float> poison, <2 x i32> <i32 0, i32 1>
+; CHECK: bitcast <2 x float> [[shuffle]] to <2 x i32>
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 16 %a) {
+entry:
+  %res = call ptr addrspace(1) @clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x float>] } zeroinitializer)
+  %b = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  %0 = load <2 x i32>, ptr addrspace(1) %b, align 16
+  store <2 x i32> %0,  ptr addrspace(1) %a, align 16
+  ret void
+}
+
+declare ptr addrspace(1) @clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x float>] })
+

--- a/test/PointerCasts/opaque_deref_store_cast_int2_to_float4.ll
+++ b/test/PointerCasts/opaque_deref_store_cast_int2_to_float4.ll
@@ -1,0 +1,24 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast <4 x float> %ld to <4 x i32>
+; CHECK: [[shuffle0:%[a-zA-Z0-9_.]+]] = shufflevector <4 x i32> [[cast]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK: [[shuffle1:%[a-zA-Z0-9_.]+]] = shufflevector <4 x i32> [[cast]], <4 x i32> poison, <2 x i32> <i32 2, i32 3>
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x i32>, ptr addrspace(1) %a, i32 0
+; CHECK: store <2 x i32> [[shuffle0]], ptr addrspace(1) [[gep]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x i32>, ptr addrspace(1) %a, i32 1
+; CHECK: store <2 x i32> [[shuffle1]], ptr addrspace(1) [[gep]]
+
+define spir_kernel void @foo(ptr addrspace(1) %b) {
+entry:
+  %ld = load <4 x float>, ptr addrspace(1) %b, align 16
+  %res = call ptr addrspace(1) @clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <2 x i32>] } zeroinitializer)
+  %a = getelementptr { [0 x <2 x i32>] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  store <4 x float> %ld, ptr addrspace(1) %a, align 16
+  ret void
+}
+
+declare ptr addrspace(1) @clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <2 x i32>] })

--- a/test/PointerCasts/opaque_deref_store_cast_int4_to_float2.ll
+++ b/test/PointerCasts/opaque_deref_store_cast_int4_to_float2.ll
@@ -1,0 +1,24 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast <2 x float> %0 to <2 x i32>
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i64 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i32> [[cast]], i64 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 0, i32 0
+; CHECK: store i32 [[ex0]], ptr addrspace(1) [[gep]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 0, i32 1
+; CHECK: store i32 [[ex1]], ptr addrspace(1) [[gep]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 8 %b) {
+entry:
+  %0 = load <2 x float>, ptr addrspace(1) %b, align 8
+  %res = call ptr addrspace(1) @clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
+  %a = getelementptr { [0 x <4 x i32>] }, ptr addrspace(1) %res, i32 0, i32 0, i32 0
+  store <2 x float> %0, ptr addrspace(1) %a, align 8
+  ret void
+}
+
+declare ptr addrspace(1) @clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })

--- a/test/PointerCasts/opaque_inline_func_with_pointer_cast_as_argument.ll
+++ b/test/PointerCasts/opaque_inline_func_with_pointer_cast_as_argument.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt %s -o %t.ll --passes=inline-func-with-pointer-cast-arg
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-LABEL: @foo
+; CHECK-NOT call void @bar
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @bar(ptr addrspace(1) %p) {
+entry:
+  store i32 1, ptr addrspace(1) %p
+  ret void
+}
+
+define void @foo(ptr addrspace(1) %p, i32 %n) {
+entry:
+  %gep = getelementptr float, ptr addrspace(1) %p, i32 %n
+  call void @bar(ptr addrspace(1) %gep)
+  ret void
+}

--- a/test/PointerCasts/opaque_issue-551.ll
+++ b/test/PointerCasts/opaque_issue-551.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt --passes=replace-pointer-bitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: [[gep1:%[a-zA-Z0-9_]+]] = getelementptr i8, ptr addrspace(1) %0, i32 0
+; CHECK: [[val1:%[a-zA-Z0-9_]+]] = load i8, ptr addrspace(1) [[gep1]]
+; CHECK: [[gep2:%[a-zA-Z0-9_]+]] = getelementptr i8, ptr addrspace(1) %0, i32 1
+; CHECK: [[val2:%[a-zA-Z0-9_]+]] = load i8, ptr addrspace(1) [[gep2]]
+; CHECK: [[insert1:%[^ ]+]] = insertelement <2 x i8> undef, i8 [[val1]], i32 0
+; CHECK: [[insert2:%[^ ]+]] = insertelement <2 x i8> [[insert1]], i8 [[val2]], i32 1
+; CHECK: [[bitcast:%[^ ]+]] = bitcast <2 x i8> [[insert2]] to i16
+; CHECK: store i16 [[bitcast]], ptr addrspace(1) %out, align 2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+entry:
+  %0 = getelementptr i8, ptr addrspace(1) %in, i32 0
+  %1 = load i16, ptr addrspace(1) %0, align 2
+  store i16 %1, ptr addrspace(1) %out, align 2
+  ret void
+}
+

--- a/test/PointerCasts/opaque_load_cast_array_of_array_int_to_long.ll
+++ b/test/PointerCasts/opaque_load_cast_array_of_array_int_to_long.ll
@@ -1,0 +1,30 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, ptr addrspace(3) %b, i32 %n) {
+entry:
+  %cast = getelementptr [4 x [8 x i32]], ptr addrspace(3) %b, i32 0
+  %gep = getelementptr i64, ptr addrspace(3) %cast, i32 %n
+  %ld = load i64, ptr addrspace(3) %gep
+  store i64 %ld, ptr addrspace(1) %a, align 8
+  ret void
+}
+
+; CHECK: [[mul_n:%[^ ]+]] = shl i32 %n, 1
+; CHECK: [[div32:%[^ ]+]] = lshr i32 [[mul_n]], 5
+; CHECK: [[rem32:%[^ ]+]] = and i32 [[mul_n]], 31
+; CHECK: [[div8:%[^ ]+]] = lshr i32 [[rem32]], 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 [[rem32]], 7
+; CHECK: [[gep1:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8]]
+; CHECK: [[ld1:%[^ ]+]] = load i32, ptr addrspace(3) [[gep1]], align 4
+; CHECK: [[rem8p:%[^ ]+]] = add i32 [[rem8]], 1
+; CHECK: [[gep2:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8p]]
+; CHECK: [[ld2:%[^ ]+]] = load i32, ptr addrspace(3) [[gep2]], align 4
+; CHECK: [[ins0:%[^ ]+]] = insertelement <2 x i32> undef, i32 [[ld1]], i32 0
+; CHECK: [[ins1:%[^ ]+]] = insertelement <2 x i32> [[ins0]], i32 [[ld2]], i32 1
+; CHECK: [[bitcast:%[^ ]+]] = bitcast <2 x i32> [[ins1]] to i64
+; CHECK: store i64 [[bitcast]], ptr addrspace(1) %a, align 8
+

--- a/test/PointerCasts/opaque_load_cast_array_of_array_local.ll
+++ b/test/PointerCasts/opaque_load_cast_array_of_array_local.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, i32 %n) {
+entry:
+  %local = alloca [4 x [8 x i32]], align 32
+  %gep = getelementptr i32, ptr %local, i32 %n
+  %ld = load i32, ptr %gep
+  store i32 %ld, ptr addrspace(1) %a, align 4
+  ret void
+}
+
+; CHECK: [[div8:%[^ ]+]] = lshr i32 %n, 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 %n, 7
+; CHECK: [[gep:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr %local, i32 0, i32 [[div8]], i32 [[rem8]]
+; CHECK: [[ld:%[^ ]+]] = load i32, ptr [[gep]], align 4
+; CHECK: store i32 [[ld]], ptr addrspace(1) %a, align 4
+

--- a/test/PointerCasts/opaque_load_cast_of_array.ll
+++ b/test/PointerCasts/opaque_load_cast_of_array.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, ptr addrspace(3) %b, i32 %n) {
+entry:
+  %cast = getelementptr [4 x [8 x i32]], ptr addrspace(3) %b, i32 0
+  %gep = getelementptr i32, ptr addrspace(3) %cast, i32 %n
+  %ld = load i32, ptr addrspace(3) %gep
+  store i32 %ld, ptr addrspace(1) %a, align 4
+  ret void
+}
+
+; CHECK: [[div32:%[^ ]+]] = lshr i32 %n, 5
+; CHECK: [[rem32:%[^ ]+]] = and i32 %n, 31
+; CHECK: [[div8:%[^ ]+]] = lshr i32 [[rem32]], 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 [[rem32]], 7
+; CHECK: [[gep:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8]]
+; CHECK: [[ld:%[^ ]+]] = load i32, ptr addrspace(3) [[gep]], align 4
+; CHECK: store i32 [[ld]], ptr addrspace(1) %a, align 4
+

--- a/test/PointerCasts/opaque_load_store_struct_i64_1.ll
+++ b/test/PointerCasts/opaque_load_store_struct_i64_1.ll
@@ -1,0 +1,36 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+; CHECK: [[struct:%[a-zA-Z0-9_.]+]] = type { [2 x i32] }
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr [[struct]], ptr addrspace(1) %0, i32 0
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load [[struct]], ptr addrspace(1) [[gep]]
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[struct]] [[ld]], 0
+; CHECK-DAG: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [2 x i32] [[ex]], 0
+; CHECK-DAG: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ex0]] to i64
+; CHECK-DAG: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [2 x i32] [[ex]], 1
+; CHECK-DAG: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ex1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl]]
+; CHECK-DAG: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i64 [[or]] to i32
+; CHECK-DAG: [[insert0:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i32] undef, i32 [[trunc0]], 0
+; CHECK-DAG: [[lshr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 32
+; CHECK-DAG: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr]] to i32
+; CHECK-DAG: [[insert1:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i32] [[insert0]], i32 [[trunc1]], 1
+; CHECK: [[insert:%[a-zA-Z0-9_.]+]] = insertvalue [[struct]] undef, [2 x i32] [[insert1]], 0
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr [[struct]], ptr addrspace(1) %1, i32 0
+; CHECK: store [[struct]] [[insert]], ptr addrspace(1) [[gep]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.__InstanceTest = type { [2 x i32] }
+
+define spir_kernel void @testCopyInstance1(ptr addrspace(1) %src, ptr addrspace(1) %dst) {
+entry:
+  %0 = getelementptr %struct.__InstanceTest, ptr addrspace(1) %src, i32 0
+  %1 = getelementptr %struct.__InstanceTest, ptr addrspace(1) %dst, i32 0
+  %2 = load i64, ptr addrspace(1) %0, align 4
+  store i64 %2, ptr addrspace(1) %1, align 4
+  ret void
+}
+

--- a/test/PointerCasts/opaque_load_store_struct_i64_2.ll
+++ b/test/PointerCasts/opaque_load_store_struct_i64_2.ll
@@ -1,0 +1,50 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+; CHECK: [[struct:%[a-zA-Z0-9_.]+]] = type { [4 x i16] }
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr [[struct]], ptr addrspace(1) %0, i32 0
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load [[struct]], ptr addrspace(1) [[gep]]
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[struct]] [[ld]], 0
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue [4 x i16] [[ex]], 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue [4 x i16] [[ex]], 1
+; CHECK: [[ex2:%[a-zA-Z0-9_.]+]] = extractvalue [4 x i16] [[ex]], 2
+; CHECK: [[ex3:%[a-zA-Z0-9_.]+]] = extractvalue [4 x i16] [[ex]], 3
+; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i16 [[ex0]] to i64
+; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i16 [[ex1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 16
+; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl]]
+; CHECK: [[zext2:%[a-zA-Z0-9_.]+]] = zext i16 [[ex2]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext2]], 32
+; CHECK: [[or2:%[a-zA-Z0-9_.]+]] = or i64 [[or1]], [[shl]]
+; CHECK: [[zext3:%[a-zA-Z0-9_.]+]] = zext i16 [[ex3]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext3]], 48
+; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[or2]], [[shl]]
+; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i64 [[or3]] to i16
+; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i16] undef, i16 [[trunc0]], 0
+; CHECK: [[lshr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or3]], 16
+; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr]] to i16
+; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i16] [[insert0]], i16 [[trunc1]], 1
+; CHECK: [[lshr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or3]], 32
+; CHECK: [[trunc2:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr]] to i16
+; CHECK: [[insert2:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i16] [[insert1]], i16 [[trunc2]], 2
+; CHECK: [[lshr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or3]], 48
+; CHECK: [[trunc3:%[a-zA-Z0-9_.]+]] = trunc i64 [[lshr]] to i16
+; CHECK: [[insert3:%[a-zA-Z0-9_.]+]] = insertvalue [4 x i16] [[insert2]], i16 [[trunc3]], 3
+; CHECK: [[insert:%[a-zA-Z0-9_.]+]] = insertvalue [[struct]] undef, [4 x i16] [[insert3]], 0
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr [[struct]], ptr addrspace(1) %1, i32 0
+; CHECK: store [[struct]] [[insert]], ptr addrspace(1) [[gep]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.__InstanceTest = type { [4 x i16] }
+
+define spir_kernel void @testCopyInstance1(ptr addrspace(1) %src, ptr addrspace(1) %dst) {
+entry:
+  %0 = getelementptr %struct.__InstanceTest, ptr addrspace(1) %src, i32 0
+  %1 = getelementptr %struct.__InstanceTest, ptr addrspace(1) %dst, i32 0
+  %2 = load i64, ptr addrspace(1) %0, align 4
+  store i64 %2, ptr addrspace(1) %1, align 4
+  ret void
+}
+

--- a/test/PointerCasts/opaque_load_store_struct_i64_3.ll
+++ b/test/PointerCasts/opaque_load_store_struct_i64_3.ll
@@ -1,0 +1,55 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+; CHECK-DAG: [[in:%[a-zA-Z0-9_.]+]] = type { { i32 }, { i32 } }
+; CHECK-DAG: [[out:%[a-zA-Z0-9_.]+]] = type { { [2 x i16] }, { <4 x i8> } }
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load [[in]], ptr addrspace(1)
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[in]] [[ld]], 0
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue { i32 } [[ex]], 0
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[in]] [[ld]], 1
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue { i32 } [[ex]], 0
+; CHECK: [[zext0:%[a-zA-Z0-9_.]+]] = zext i32 [[ex0]] to i64
+; CHECK: [[zext1:%[a-zA-Z0-9_.]+]] = zext i32 [[ex1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1]], 32
+; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[zext0]], [[shl]]
+
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[or]] to i16
+; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i16] undef, i16 [[trunc]], 0
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 16
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i16
+; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertvalue [2 x i16] [[insert0]], i16 [[trunc]], 1
+; CHECK: [[insert00:%[a-zA-Z0-9_.]+]] = insertvalue { [2 x i16] } undef, [2 x i16] [[insert1]], 0
+; CHECK: [[insert000:%[a-zA-Z0-9_.]+]] = insertvalue [[out]] undef, { [2 x i16] } [[insert00]], 0
+
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 32
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i8
+; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> undef, i8 [[trunc]], i64 0
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 40
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i8
+; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert0]], i8 [[trunc]], i64 1
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 48
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i8
+; CHECK: [[insert2:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert1]], i8 [[trunc]], i64 2
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 56
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i8
+; CHECK: [[insert3:%[a-zA-Z0-9_.]+]] = insertelement <4 x i8> [[insert2]], i8 [[trunc]], i64 3
+; CHECK: [[insert11:%[a-zA-Z0-9_.]+]] = insertvalue { <4 x i8> } undef, <4 x i8> [[insert3]], 0
+; CHECK: [[insert111:%[a-zA-Z0-9_.]+]] = insertvalue [[out]] [[insert000]], { <4 x i8> } [[insert11]], 1
+; CHECK: store [[out]] [[insert111]], ptr addrspace(1)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.__in = type { { i32 }, { i32 } }
+%struct.__out = type { { [2 x i16] }, { <4 x i8> } }
+
+define spir_kernel void @testCopyInstance1(ptr addrspace(1) %src, ptr addrspace(1) %dst) {
+entry:
+  %0 = getelementptr %struct.__in, ptr addrspace(1) %src, i32 0
+  %1 = getelementptr %struct.__out, ptr addrspace(1) %dst, i32 0
+  %2 = load i64, ptr addrspace(1) %0, align 4
+  store i64 %2, ptr addrspace(1) %1, align 4
+  ret void
+}
+

--- a/test/PointerCasts/opaque_load_store_struct_i64_4.ll
+++ b/test/PointerCasts/opaque_load_store_struct_i64_4.ll
@@ -1,0 +1,59 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+; CHECK-DAG: [[out:%[a-zA-Z0-9_.]+]] = type { { i32 }, { i32 } }
+; CHECK-DAG: [[in:%[a-zA-Z0-9_.]+]] = type { { [2 x i16] }, { <4 x i8> } }
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load [[in]], ptr addrspace(1)
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[in]] [[ld]], 0
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractvalue { [2 x i16] } [[ex]], 0
+; CHECK: [[ex0_0:%[a-zA-Z0-9_.]+]] = extractvalue [2 x i16] [[ex0]], 0
+; CHECK: [[ex0_1:%[a-zA-Z0-9_.]+]] = extractvalue [2 x i16] [[ex0]], 1
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractvalue [[in]] [[ld]], 1
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractvalue { <4 x i8> } [[ex]], 0
+; CHECK: [[ex1_0:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[ex1]], i64 0
+; CHECK: [[ex1_1:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[ex1]], i64 1
+; CHECK: [[ex1_2:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[ex1]], i64 2
+; CHECK: [[ex1_3:%[a-zA-Z0-9_.]+]] = extractelement <4 x i8> [[ex1]], i64 3
+
+; CHECK: [[zext0_0:%[a-zA-Z0-9_.]+]] = zext i16 [[ex0_0]] to i64
+; CHECK: [[zext0_1:%[a-zA-Z0-9_.]+]] = zext i16 [[ex0_1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext0_1]], 16
+; CHECK: [[or1:%[a-zA-Z0-9_.]+]] = or i64 [[zext0_0]], [[shl]]
+; CHECK: [[zext1_0:%[a-zA-Z0-9_.]+]] = zext i8 [[ex1_0]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1_0]], 32
+; CHECK: [[or2:%[a-zA-Z0-9_.]+]] = or i64 [[or1]], [[shl]]
+; CHECK: [[zext1_1:%[a-zA-Z0-9_.]+]] = zext i8 [[ex1_1]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1_1]], 40
+; CHECK: [[or3:%[a-zA-Z0-9_.]+]] = or i64 [[or2]], [[shl]]
+; CHECK: [[zext1_2:%[a-zA-Z0-9_.]+]] = zext i8 [[ex1_2]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1_2]], 48
+; CHECK: [[or4:%[a-zA-Z0-9_.]+]] = or i64 [[or3]], [[shl]]
+; CHECK: [[zext1_3:%[a-zA-Z0-9_.]+]] = zext i8 [[ex1_3]] to i64
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i64 [[zext1_3]], 56
+; CHECK: [[or:%[a-zA-Z0-9_.]+]] = or i64 [[or4]], [[shl]]
+
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[or]] to i32
+; CHECK: [[insert:%[a-zA-Z0-9_.]+]] = insertvalue { i32 } undef, i32 [[trunc]], 0
+; CHECK: [[insert0:%[a-zA-Z0-9_.]+]] = insertvalue [[out]] undef, { i32 } [[insert]], 0
+; CHECK: [[shr:%[a-zA-Z0-9_.]+]] = lshr i64 [[or]], 32
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i64 [[shr]] to i32
+; CHECK: [[insert:%[a-zA-Z0-9_.]+]] = insertvalue { i32 } undef, i32 [[trunc]], 0
+; CHECK: [[insert1:%[a-zA-Z0-9_.]+]] = insertvalue [[out]] [[insert0]], { i32 } [[insert]], 1
+; CHECK: store [[out]] [[insert1]], ptr addrspace(1)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.__in = type { { [2 x i16] }, { <4 x i8> } }
+%struct.__out = type { { i32 }, { i32 } }
+
+define spir_kernel void @testCopyInstance1(ptr addrspace(1) %src, ptr addrspace(1) %dst) {
+entry:
+  %0 = getelementptr %struct.__in, ptr addrspace(1) %src, i32 0
+  %1 = getelementptr %struct.__out, ptr addrspace(1) %dst, i32 0
+  %2 = load i64, ptr addrspace(1) %0, align 4
+  store i64 %2, ptr addrspace(1) %1, align 4
+  ret void
+}
+

--- a/test/PointerCasts/opaque_store_cast_array_of_array.ll
+++ b/test/PointerCasts/opaque_store_cast_array_of_array.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, ptr addrspace(3) %b, i32 %n) {
+entry:
+  %cast = getelementptr [4 x [8 x i32]], ptr addrspace(3) %b, i32 0
+  %gep = getelementptr i32, i32 addrspace(3)* %cast, i32 %n
+  %ld = load i32, i32 addrspace(1)* %a
+  store i32 %ld, i32 addrspace(3)* %gep, align 4
+  ret void
+}
+
+; CHECK: [[div32:%[^ ]+]] = lshr i32 %n, 5
+; CHECK: [[rem32:%[^ ]+]] = and i32 %n, 31
+; CHECK: [[div8:%[^ ]+]] = lshr i32 [[rem32]], 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 [[rem32]], 7
+; CHECK: [[ld:%[^ ]+]] = load i32, ptr addrspace(1) %a, align 4
+; CHECK: [[gep:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8]]
+; CHECK: store i32 [[ld]], ptr addrspace(3) [[gep]], align 4
+

--- a/test/PointerCasts/opaque_store_cast_array_of_array_int_to_long.ll
+++ b/test/PointerCasts/opaque_store_cast_array_of_array_int_to_long.ll
@@ -1,0 +1,30 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, ptr addrspace(3) %b, i32 %n) {
+entry:
+  %cast = getelementptr [4 x [8 x i32]], ptr addrspace(3) %b, i32 0
+  %gep = getelementptr i64, ptr addrspace(3) %cast, i32 %n
+  %ld = load i64, ptr addrspace(1) %a
+  store i64 %ld, ptr addrspace(3) %gep, align 8
+  ret void
+}
+
+; CHECK: [[mul_n:%[^ ]+]] = shl i32 %n, 1
+; CHECK: [[div32:%[^ ]+]] = lshr i32 [[mul_n]], 5
+; CHECK: [[rem32:%[^ ]+]] = and i32 [[mul_n]], 31
+; CHECK: [[div8:%[^ ]+]] = lshr i32 [[rem32]], 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 [[rem32]], 7
+; CHECK: [[ld:%[^ ]+]] = load i64, ptr addrspace(1) %a, align 8
+; CHECK: [[bitcast:%[^ ]+]] = bitcast i64 [[ld]] to <2 x i32>
+; CHECK: [[val1:%[^ ]+]] = extractelement <2 x i32> [[bitcast]], i64 0
+; CHECK: [[val2:%[^ ]+]] = extractelement <2 x i32> [[bitcast]], i64 1
+; CHECK: [[gep1:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8]]
+; CHECK: store i32 [[val1]], ptr addrspace(3) [[gep1]], align 4
+; CHECK: [[rem8p:%[^ ]+]] = add i32 [[rem8]], 1
+; CHECK: [[gep2:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr addrspace(3) %cast, i32 [[div32]], i32 [[div8]], i32 [[rem8p]]
+; CHECK: store i32 [[val2]], ptr addrspace(3) [[gep2]], align 4
+

--- a/test/PointerCasts/opaque_store_cast_array_of_array_local.ll
+++ b/test/PointerCasts/opaque_store_cast_array_of_array_local.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, i32 %n) {
+entry:
+  %local = alloca [4 x [8 x i32]], align 32
+  %gep = getelementptr i32, i32* %local, i32 %n
+  %ld = load i32, ptr addrspace(1) %a
+  store i32 %ld, ptr %gep, align 4
+  ret void
+}
+
+; CHECK: [[div8:%[^ ]+]] = lshr i32 %n, 3
+; CHECK: [[rem8:%[^ ]+]] = and i32 %n, 7
+; CHECK: [[ld:%[^ ]+]] = load i32, ptr addrspace(1) %a, align 4
+; CHECK: [[gep:%[^ ]+]] = getelementptr [4 x [8 x i32]], ptr %local, i32 0, i32 [[div8]], i32 [[rem8]]
+; CHECK: store i32 [[ld]], ptr [[gep]], align 4
+

--- a/test/PointerCasts/opaque_vload_half2_pointer_cast_from_float4.ll
+++ b/test/PointerCasts/opaque_vload_half2_pointer_cast_from_float4.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %cast, i32 0, i32
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep]]
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float [[ld]] to i32
+; CHECK: call <2 x float> @spirv.unpack.v2f16(i32 [[cast]])
+define void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
+entry:
+  %cast = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0
+  %gep = getelementptr i32, ptr addrspace(1) %cast, i32 0
+  %ld = load i32, ptr addrspace(1) %gep
+  %unpack = call <2 x float> @spirv.unpack.v2f16(i32 %ld)
+  ret void
+}
+
+declare <2 x float> @spirv.unpack.v2f16(i32)
+

--- a/test/PointerCasts/opaque_vstore_half4_pointer_cast_to_float4.ll
+++ b/test/PointerCasts/opaque_vstore_half4_pointer_cast_to_float4.ll
@@ -1,0 +1,21 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast <2 x i32> %b to <2 x float>
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <2 x float> [[cast]], i64 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <2 x float> [[cast]], i64 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %cast, i32 0, i32 0
+; CHECK: store float [[ex0]], ptr addrspace(1) [[gep]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %cast, i32 0, i32 1
+; CHECK: store float [[ex1]], ptr addrspace(1) [[gep]]
+define void @foo(ptr addrspace(1) %a, <2 x i32> %b) {
+entry:
+  %cast = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0
+  %gep = getelementptr <2 x i32>, ptr addrspace(1) %cast, i32 0
+  store <2 x i32> %b, ptr addrspace(1) %gep
+  ret void
+}
+


### PR DESCRIPTION
Contributes to #816

* Inline functions where there is an implicit pointer cast in the
  arguments
* Support implicit pointer casts in replace pointer bitcasts
* Cover alloca and global variables for inferring types from the result
* Remove some unnecessary pointer casts in ReplaceOpenCLBuiltin when
  using opaque pointers