### PR TITLE
fix generation of image metadata reflection

### DIFF
--- a/test/ImageBuiltins/get_image_channel_multiple_kernel.cl
+++ b/test/ImageBuiltins/get_image_channel_multiple_kernel.cl
@@ -49,7 +49,7 @@ void kernel fct2(global int *dst, image1d_t read_only image1, image1d_t read_onl
 // CHECK-DAG:  OpAccessChain [[ptr_pc_int]] [[pc_var]] %uint_1 %uint_3
 
 // CHECK:  [[kernel0:%[^ ]+]] = OpExtInst %void {{.*}} Kernel [[fct0]] [[fct0_str]]
-// CHECK:  ImageArgumentInfoChannelOrderPushConstant [[kernel0]] %uint_1 %uint_4 %uint_4
+// CHECK:  ImageArgumentInfoChannelOrderPushConstant [[kernel0]] %uint_2 %uint_4 %uint_4
 // CHECK:  [[kernel1:%[^ ]+]] = OpExtInst %void {{.*}} Kernel [[fct1]] [[fct1_str]]
 // CHECK:  ImageArgumentInfoChannelDataTypePushConstant [[kernel1]] %uint_1 %uint_4 %uint_4
 // CHECK:  [[kernel2:%[^ ]+]] = OpExtInst %void {{.*}} Kernel [[fct2]] [[fct2_str]]

--- a/test/ImageBuiltins/get_image_channel_with_pod_arg.cl
+++ b/test/ImageBuiltins/get_image_channel_with_pod_arg.cl
@@ -1,0 +1,12 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+
+void kernel fct(global int *dst, int off, image1d_t read_only image)
+{
+    *dst = get_image_channel_order(image) + off;
+}
+
+// CHECK:  ImageArgumentInfoChannelOrderPushConstant {{.*}} %uint_2 %uint_4 %uint_4


### PR DESCRIPTION
ordinal could changed when we have pod arguments before the image arg.