### PR TITLE
delete llvm.assume calls 

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.h
+++ b/lib/ReplaceLLVMIntrinsicsPass.h
@@ -28,7 +28,7 @@ struct ReplaceLLVMIntrinsicsPass
   bool runOnFunction(llvm::Function &F);
   bool replaceMemset(llvm::Module &M);
   bool replaceMemcpy(llvm::Module &M);
-  bool removeLifetimeDeclarations(llvm::Module &M);
+  bool removeIntrinsicDeclaration(llvm::Function &F);
   bool replaceFshl(llvm::Function &F);
   bool replaceCountZeroes(llvm::Function &F, bool leading);
   bool replaceCopysign(llvm::Function &F);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2282,6 +2282,13 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVConstant(Constant *C) {
     }
   } else if (Cst->isNullValue()) {
     Opcode = spv::OpConstantNull;
+  } else if(const Function *Fn = dyn_cast<Function>(Cst)) {
+    if (Fn->isIntrinsic()) {
+      Fn->print(errs());
+      llvm_unreachable("Unsupported llvm intrinsic");
+    }
+    Fn->print(errs());
+    llvm_unreachable("Unhandled function declaration/definition");
   } else {
     Cst->print(errs());
     llvm_unreachable("Unsupported Constant???");
@@ -6899,6 +6906,11 @@ void SPIRVProducerPassImpl::AddArgumentReflection(
   Ops << void_id << import_id << reflection::ExtInstArgumentInfo << arg_name;
 
   if (clspv::Option::KernelArgInfo()) {
+    assert(kernelFn.getMetadata("kernel_arg_type") &&
+            kernelFn.getMetadata("kernel_arg_addr_space") &&
+            kernelFn.getMetadata("kernel_arg_access_qual") &&
+            kernelFn.getMetadata("kernel_arg_type_qual")
+          );
     auto const &type_op =
         kernelFn.getMetadata("kernel_arg_type")->getOperand(ordinal);
     auto const &type_name_str = dyn_cast<MDString>(type_op)->getString();
@@ -6956,6 +6968,7 @@ void SPIRVProducerPassImpl::AddArgumentReflection(
     }
     auto type_qual_enum = getSPIRVInt32Constant(type_qual_enum_value);
     Ops << type_qual_enum;
+  
   }
 
   auto arg_info = addSPIRVInst<kReflection>(spv::OpExtInst, Ops);

--- a/test/LLVMIntrinsics/assume.ll
+++ b/test/LLVMIntrinsics/assume.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @call_assume_kernel(i16 %in, i1 addrspace(1)* %out) {
+entry:
+  %x = add i16 %in, 0
+  %cmp.i = icmp slt i16 %x, 10
+  tail call void @llvm.assume(i1 %cmp.i)
+  store i1 %cmp.i, i1 addrspace(1)* %out
+  ret void
+}
+
+declare void @llvm.assume(i1 noundef)
+
+; CHECK-NOT: llvm.assume

--- a/utils/make_test.py
+++ b/utils/make_test.py
@@ -208,7 +208,7 @@ def generate_test_case(args):
     if inputext == '.cl':
         tc = generate_test_case_from_source(args)
     else:
-        tc = disassemble_and_post_process(args.spirv_module_or_cl_source)
+        tc = disassemble_and_post_process(args, args.spirv_module_or_cl_source)
 
     return tc
 


### PR DESCRIPTION
# PR changes:
* **Delete llvm.assume declaration and its calls**: as llvm.assume will require SPV_KHR_expect_assume extension which is not supported by Vulkan at the moment. So, we delete it for now. llvm.assume is a compiler hint so should be safe to ignore. One of the CTS tests that was affected: basic/test_basic kernel_call_kernel_function.
* **Print a meaningful error when there is unsupported llvm intrinsic call or unhandled function declaration/definition**: the current code will handle unsupported llvm intrinsic calls or unlinked function declarations by treating them as llvm::Constants and eventually will fail with ("unsupported Constant???") error. That should be handled so any future call for llvm intrinsic that is not supported or unlinked function declarations is identified.
* **Fix make_test.py for passing ir module to it**
* **Catch the error when kernel argument have no meta data**: This is to prevent segmentation fault when we use `-cl-kernel-info` option and kernel argument have no meta data.

## Related issues
* https://github.com/google/clspv/issues/712 : Not an example for llvm.assume but the failed function declaration in the issue example should give a more concise error message with this PR.

**This contribution is being made by Codeplay on behalf of Samsung.**