### PR TITLE
fix alignment of structure when lowering long vectors

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -48,9 +48,9 @@ namespace {
 using PartitionCallback = std::function<void(Instruction *)>;
 
 Type *getPaddingArray(LLVMContext &Ctx, uint64_t Size) {
-  if (Size % sizeof(uint64_t)) {
+  if (Size % sizeof(uint32_t) == 0) {
     return ArrayType::get(Type::getInt32Ty(Ctx), Size / sizeof(uint32_t));
-  } else if (Size % sizeof(uint16_t)) {
+  } else if (Size % sizeof(uint16_t) == 0) {
     return ArrayType::get(Type::getInt16Ty(Ctx), Size / sizeof(uint16_t));
   } else {
     return ArrayType::get(Type::getInt8Ty(Ctx), Size / sizeof(uint8_t));

--- a/lib/LongVectorLoweringPass.h
+++ b/lib/LongVectorLoweringPass.h
@@ -100,6 +100,12 @@ private:
     return EquivalentTy ? EquivalentTy : Ty;
   }
 
+  /// Rework Indices for GEP
+  void reworkIndices(llvm::SmallVector<llvm::Value *, 4> &Indices,
+                     llvm::Type *Ty);
+  /// Rework Indices for extractvalue and insertvalue
+  void reworkIndices(llvm::SmallVector<unsigned, 4> &Indices, llvm::Type *Ty);
+
 private:
   // Hight-level implementation details of runOnModule.
 
@@ -180,6 +186,8 @@ private:
   /// all functions have been visited.
   llvm::DenseMap<llvm::GlobalVariable *, llvm::GlobalVariable *>
       GlobalVariableMap;
+
+  const llvm::DataLayout *DL;
 };
 } // namespace clspv
 

--- a/test/HalfStorage/vstore_half16.cl
+++ b/test/HalfStorage/vstore_half16.cl
@@ -14,6 +14,7 @@ __kernel void test(__global half *a, float16 b, int c) {
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
 // CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
+// CHECK-DAG: [[uint_60:%[^ ]+]] = OpConstant [[uint]] 60
 // CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
 // CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK-DAG: [[uint_2:%[^ ]+]] = OpConstant [[uint]] 2

--- a/test/HalfStorage/vstore_half16.cl
+++ b/test/HalfStorage/vstore_half16.cl
@@ -14,7 +14,7 @@ __kernel void test(__global half *a, float16 b, int c) {
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
 // CHECK-DAG: [[uint_16:%[^ ]+]] = OpConstant [[uint]] 16
-// CHECK-DAG: [[uint_60:%[^ ]+]] = OpConstant [[uint]] 60
+// CHECK-DAG: [[uint_15:%[^ ]+]] = OpConstant [[uint]] 15
 // CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
 // CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK-DAG: [[uint_2:%[^ ]+]] = OpConstant [[uint]] 2
@@ -30,7 +30,6 @@ __kernel void test(__global half *a, float16 b, int c) {
 // CHECK-DAG: [[uint_12:%[^ ]+]] = OpConstant [[uint]] 12
 // CHECK-DAG: [[uint_13:%[^ ]+]] = OpConstant [[uint]] 13
 // CHECK-DAG: [[uint_14:%[^ ]+]] = OpConstant [[uint]] 14
-// CHECK-DAG: [[uint_15:%[^ ]+]] = OpConstant [[uint]] 15
 
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract {{.*}} {{.*}} 0
 

--- a/test/HalfStorage/vstore_half8.cl
+++ b/test/HalfStorage/vstore_half8.cl
@@ -13,7 +13,7 @@ __kernel void test(__global half *a, float8 b, int c) {
 // CHECK-DAG: [[float2:%[^ ]+]] = OpTypeVector [[float]] 2
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
-// CHECK-DAG: [[uint_28:%[^ ]+]] = OpConstant [[uint]] 28
+// CHECK-DAG: [[uint_7:%[^ ]+]] = OpConstant [[uint]] 7
 // CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
 // CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK-DAG: [[uint_2:%[^ ]+]] = OpConstant [[uint]] 2
@@ -21,7 +21,6 @@ __kernel void test(__global half *a, float8 b, int c) {
 // CHECK-DAG: [[uint_4:%[^ ]+]] = OpConstant [[uint]] 4
 // CHECK-DAG: [[uint_5:%[^ ]+]] = OpConstant [[uint]] 5
 // CHECK-DAG: [[uint_6:%[^ ]+]] = OpConstant [[uint]] 6
-// CHECK-DAG: [[uint_7:%[^ ]+]] = OpConstant [[uint]] 7
 
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract {{.*}} {{.*}} 0
 

--- a/test/HalfStorage/vstore_half8.cl
+++ b/test/HalfStorage/vstore_half8.cl
@@ -13,6 +13,7 @@ __kernel void test(__global half *a, float8 b, int c) {
 // CHECK-DAG: [[float2:%[^ ]+]] = OpTypeVector [[float]] 2
 // CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
+// CHECK-DAG: [[uint_28:%[^ ]+]] = OpConstant [[uint]] 28
 // CHECK-DAG: [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
 // CHECK-DAG: [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
 // CHECK-DAG: [[uint_2:%[^ ]+]] = OpConstant [[uint]] 2

--- a/test/LongVectorLowering/char_struct_ssbo.cl
+++ b/test/LongVectorLowering/char_struct_ssbo.cl
@@ -28,15 +28,18 @@ kernel void foo(global S* data) { }
 // CHECK: OpDecorate [[rta:%[a-zA-Z0-9_]+]] ArrayStride 32
 // CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet
 // CHECK: OpDecorate [[array:%[a-zA-Z0-9_]+]] ArrayStride 1
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char2:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 2
 // CHECK: [[char3:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 3
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
-// CHECK: [[four:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 4
-// CHECK: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[four]]
+// CHECK: [[one:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 1
+// CHECK: [[padding:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[one]]
 // CHECK: [[eight:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 8
 // CHECK: [[char8:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[eight]]
-// CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]] [[char]] [[char2]] [[char3]] [[char4]] [[array]] [[char8]] [[array]] [[array]]
+// CHECK: [[four:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 4
+// CHECK: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[four]]
+// CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]] [[char]] [[char2]] [[char3]] [[char4]] [[padding]] [[char8]] [[array]] [[padding]]
 // CHECK: [[rta:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[struct]]
 // CHECK: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[rta]]
 // CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]

--- a/test/LongVectorLowering/char_struct_ssbo.cl
+++ b/test/LongVectorLowering/char_struct_ssbo.cl
@@ -22,19 +22,21 @@ kernel void foo(global S* data) { }
 // CHECK: OpMemberDecorate [[struct]] 3 Offset 4
 // CHECK: OpMemberDecorate [[struct]] 4 Offset 8
 // CHECK: OpMemberDecorate [[struct]] 5 Offset 12
-// CHECK: OpMemberDecorate [[struct]] 6 Offset 20
-// CHECK: OpDecorate [[rta:%[a-zA-Z0-9_]+]] ArrayStride 24
+// CHECK: OpMemberDecorate [[struct]] 6 Offset 16
+// CHECK: OpMemberDecorate [[struct]] 7 Offset 24
+// CHECK: OpMemberDecorate [[struct]] 8 Offset 28
+// CHECK: OpDecorate [[rta:%[a-zA-Z0-9_]+]] ArrayStride 32
 // CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] DescriptorSet
 // CHECK: OpDecorate [[array:%[a-zA-Z0-9_]+]] ArrayStride 1
 // CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 // CHECK: [[char2:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 2
 // CHECK: [[char3:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 3
 // CHECK: [[char4:%[a-zA-Z0-9_]+]] = OpTypeVector [[char]] 4
-// CHECK: [[eight:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 8
-// CHECK: [[char8:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[eight]]
 // CHECK: [[four:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 4
 // CHECK: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[four]]
-// CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]] [[char]] [[char2]] [[char3]] [[char4]] [[char8]] [[array]]
+// CHECK: [[eight:%[a-zA-Z0-9_]+]] = OpConstant {{.*}} 8
+// CHECK: [[char8:%[a-zA-Z0-9_]+]] = OpTypeArray [[char]] [[eight]]
+// CHECK: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[char]] [[char]] [[char2]] [[char3]] [[char4]] [[array]] [[char8]] [[array]] [[array]]
 // CHECK: [[rta:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[struct]]
 // CHECK: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[rta]]
 // CHECK: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]

--- a/test/LongVectorLowering/cluster_pod_args_offsets.cl
+++ b/test/LongVectorLowering/cluster_pod_args_offsets.cl
@@ -24,9 +24,10 @@ float8 f, __global float8 *result) {
 // CHECK: OpMemberDecorate [[struct]] 1 Offset 8
 // CHECK: OpMemberDecorate [[struct]] 2 Offset 16
 // CHECK: OpMemberDecorate [[struct]] 3 Offset 32
-// CHECK: OpMemberDecorate [[struct]] 4 Offset 64
-// CHECK: OpMemberDecorate [[struct]] 5 Offset 96
-// CHECK: OpMemberDecorate [[struct]] 6 Offset 128
+// CHECK: OpMemberDecorate [[struct]] 4 Offset 48
+// CHECK: OpMemberDecorate [[struct]] 5 Offset 64
+// CHECK: OpMemberDecorate [[struct]] 6 Offset 96
+// CHECK: OpMemberDecorate [[struct]] 7 Offset 128
 
 // MAP: kernel,test,arg,c,argOrdinal,0,descriptorSet,0,binding,1,offset,0,argKind,pod_ubo,argSize,8
 // MAP: kernel,test,arg,uc,argOrdinal,1,descriptorSet,0,binding,1,offset,8,argKind,pod_ubo,argSize,8

--- a/test/LongVectorLowering/padded_struct.ll
+++ b/test/LongVectorLowering/padded_struct.ll
@@ -25,16 +25,16 @@ entry:
 }
 
 ; CHECK-LABEL: @test3(
-; CHECK:  extractvalue { i8, [28 x i8], [8 x i32] } %s, 0
-; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } undef, i8 {{.*}}, 0
-; CHECK:  extractvalue { i8, [28 x i8], [8 x i32] } %s, 2
-; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
-; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
+; CHECK:  extractvalue { i8, [7 x i32], [8 x i32] } %s, 0
+; CHECK:  insertvalue { i8, [7 x i32], [8 x i32] } undef, i8 {{.*}}, 0
+; CHECK:  extractvalue { i8, [7 x i32], [8 x i32] } %s, 2
+; CHECK:  insertvalue { i8, [7 x i32], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
+; CHECK:  insertvalue { i8, [7 x i32], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
 
 ; CHECK-LABEL: @test2(
-; CHECK: extractvalue { i8, [28 x i8], [8 x i32] } %s, 0
-; CHECK: insertvalue { i8, [28 x i8], [8 x i32] } undef, i8 {{.*}}, 0
-; CHECK: extractvalue { i8, [28 x i8], [8 x i32] } %s, 2
+; CHECK: extractvalue { i8, [7 x i32], [8 x i32] } %s, 0
+; CHECK: insertvalue { i8, [7 x i32], [8 x i32] } undef, i8 {{.*}}, 0
+; CHECK: extractvalue { i8, [7 x i32], [8 x i32] } %s, 2
 
 ; CHECK-LABEL: @test1(
-; CHECK: getelementptr { i8, [28 x i8], [8 x i32] }, { i8, [28 x i8], [8 x i32] } addrspace(1)* %ptr, i32 0, i32 2
+; CHECK: getelementptr { i8, [7 x i32], [8 x i32] }, { i8, [7 x i32], [8 x i32] } addrspace(1)* %ptr, i32 0, i32 2

--- a/test/LongVectorLowering/padded_struct.ll
+++ b/test/LongVectorLowering/padded_struct.ll
@@ -1,0 +1,40 @@
+; RUN: clspv-opt %s -o %t --passes=long-vector-lowering
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct = type { i8, <8 x i32> }
+
+define void @test1(%struct addrspace(1)* %ptr) {
+entry:
+    %0 = getelementptr %struct, %struct addrspace(1)* %ptr, i32 0, i32 1
+    ret void
+}
+
+define <8 x i32> @test2(%struct %s) {
+entry:
+    %0 = extractvalue %struct %s, 1
+    ret <8 x i32> %0
+}
+
+define void @test3(%struct %s, <8 x i32> %val) {
+entry:
+    %0 = insertvalue %struct %s, <8 x i32> %val, 1
+    ret void
+}
+
+; CHECK-LABEL: @test3(
+; CHECK:  extractvalue { i8, [28 x i8], [8 x i32] } %s, 0
+; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } undef, i8 {{.*}}, 0
+; CHECK:  extractvalue { i8, [28 x i8], [8 x i32] } %s, 2
+; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
+; CHECK:  insertvalue { i8, [28 x i8], [8 x i32] } {{.*}}, [8 x i32] {{.*}}, 2
+
+; CHECK-LABEL: @test2(
+; CHECK: extractvalue { i8, [28 x i8], [8 x i32] } %s, 0
+; CHECK: insertvalue { i8, [28 x i8], [8 x i32] } undef, i8 {{.*}}, 0
+; CHECK: extractvalue { i8, [28 x i8], [8 x i32] } %s, 2
+
+; CHECK-LABEL: @test1(
+; CHECK: getelementptr { i8, [28 x i8], [8 x i32] }, { i8, [28 x i8], [8 x i32] } addrspace(1)* %ptr, i32 0, i32 2

--- a/test/LongVectorLowering/struct.ll
+++ b/test/LongVectorLowering/struct.ll
@@ -8,4 +8,4 @@ target triple = "spir-unknown-unknown"
 
 @test.s = internal addrspace(3) global [64 x %struct.S] undef, align 1
 
-; CHECK: @test.s = internal addrspace(3) global [64 x { [8 x i32], i32 }] undef, align 1
+; CHECK: @test.s = internal addrspace(3) global [64 x <{ [8 x i32], i32 }>] undef, align 1


### PR DESCRIPTION
vectors are aligned on their size. But when lowering them to arrays,
it changes their alignment to be on the alignment of the element.

When lowering a structure make sure that we are keeping the offset
right. If not add a padding element.

Also make sure that the structure has the same size before and after
the lowering. If not add a padding element at the end.

As the lowered type might have more element than the original one,
rework the indices when lowering gep extractvalue or insertvalue