### PR TITLE
fix cluster constants to keep the proper alignment of each element

### DIFF
--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -45,12 +45,14 @@ PreservedAnalyses
 clspv::ClusterModuleScopeConstantVars::run(Module &M, ModuleAnalysisManager &) {
   PreservedAnalyses PA;
   LLVMContext &Context = M.getContext();
+  const DataLayout &DL = M.getDataLayout();
 
   clspv::NormalizeGlobalVariables(M);
 
   SmallVector<GlobalVariable *, 8> global_constants;
   UniqueVector<Constant *> initializers;
   SmallVector<GlobalVariable *, 8> dead_global_constants;
+  std::map<Constant *, uint64_t> initializers_alignment;
   for (GlobalVariable &GV : M.globals()) {
     if (GV.hasInitializer() && GV.getType()->getPointerAddressSpace() ==
                                    clspv::AddressSpace::Constant) {
@@ -60,6 +62,7 @@ clspv::ClusterModuleScopeConstantVars::run(Module &M, ModuleAnalysisManager &) {
       } else {
         global_constants.push_back(&GV);
         initializers.insert(GV.getInitializer());
+        initializers_alignment[GV.getInitializer()] = GV.getAlignment();
       }
     }
   }
@@ -73,16 +76,45 @@ clspv::ClusterModuleScopeConstantVars::run(Module &M, ModuleAnalysisManager &) {
        !global_constants[0]->getType()->isStructTy())) {
     // Make the struct type.
     SmallVector<Type *, 8> types;
-    types.reserve(initializers.size());
-    for (Value *init : initializers) {
-      Type *ty = init->getType();
-      types.push_back(ty);
-    }
-    StructType *type = StructType::get(Context, types);
 
     // Make the global variable.
-    SmallVector<Constant *, 8> initializers_as_vec(initializers.begin(),
-                                                   initializers.end());
+    SmallVector<Constant *, 8> initializers_as_vec;
+
+    uint64_t max_alignment = 0;
+
+    // Make sure that every element is at the proper offset regarding its
+    // alignment (which might not be the one of its type due to the lowering of
+    // long vectors).
+    {
+      UniqueVector<Constant *> new_initializers;
+      for (Constant *init : initializers) {
+        Type *ty = init->getType();
+        types.push_back(ty);
+        auto align = initializers_alignment[init];
+        max_alignment = std::max(max_alignment, align);
+        auto offset = DL.getStructLayout(StructType::get(Context, types))
+                          ->getElementOffset(types.size() - 1);
+        auto padding = align != 0 ? (align - (offset % align)) % align : 0;
+        if (padding) {
+          types.pop_back();
+          ArrayType *pad_ty = ArrayType::get(ty->getInt8Ty(Context), padding);
+          SmallVector<Constant *, 4> data;
+          for (unsigned i = 0; i < padding; i++) {
+            data.push_back(ConstantInt::get(ty->getInt8Ty(Context), 0));
+          }
+          types.push_back(pad_ty);
+          types.push_back(ty);
+          initializers_as_vec.push_back(ConstantArray::get(pad_ty, data));
+          new_initializers.insert(nullptr);
+        }
+        initializers_as_vec.push_back(init);
+        new_initializers.insert(init);
+      }
+      initializers = std::move(new_initializers);
+    }
+
+    StructType *type = StructType::get(Context, types);
+
     Constant *clustered_initializer =
         ConstantStruct::get(type, initializers_as_vec);
     GlobalVariable *clustered_gv = new GlobalVariable(
@@ -91,6 +123,7 @@ clspv::ClusterModuleScopeConstantVars::run(Module &M, ModuleAnalysisManager &) {
         GlobalValue::ThreadLocalMode::NotThreadLocal,
         clspv::AddressSpace::Constant);
     assert(clustered_gv);
+    clustered_gv->setAlignment(MaybeAlign(max_alignment));
 
     // Replace uses of the other globals with references to the members of the
     // clustered constant.

--- a/test/NormalizeGlobalVariables/cluster_constants_alignment.ll
+++ b/test/NormalizeGlobalVariables/cluster_constants_alignment.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t --passes=cluster-constants
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@mem0 = addrspace(2) constant [3 x i8] zeroinitializer, align 1
+@mem8 = addrspace(2) constant [3 x [8 x i8]] zeroinitializer, align 8
+
+define spir_kernel void @foo() {
+entry:
+  %0 = getelementptr [3 x i8], [3 x i8] addrspace(2)* @mem0, i32 0
+  %1 = getelementptr [3 x [8 x i8]], [3 x [8 x i8]] addrspace(2)* @mem8, i32 0
+  ret void
+}
+
+; CHECK: [[clustered_constants:@[^ ]+]] = internal addrspace(2) constant { [3 x i8], [5 x i8], [3 x [8 x i8]] } zeroinitializer, align 8
+
+; CHECK: [[mem0:%[^ ]+]] = getelementptr inbounds { [3 x i8], [5 x i8], [3 x [8 x i8]] }, { [3 x i8], [5 x i8], [3 x [8 x i8]] } addrspace(2)* [[clustered_constants]], i32 0, i32 0
+; CHECK: getelementptr [3 x i8], [3 x i8] addrspace(2)* [[mem0]], i32 0
+
+; CHECK: [[mem8:%[^ ]+]] = getelementptr inbounds { [3 x i8], [5 x i8], [3 x [8 x i8]] }, { [3 x i8], [5 x i8], [3 x [8 x i8]] } addrspace(2)* [[clustered_constants]], i32 0, i32 2
+; CHECK: getelementptr [3 x [8 x i8]], [3 x [8 x i8]] addrspace(2)* [[mem8]], i32 0


### PR DESCRIPTION
The alignment of each element might not be the alignment of their size
due to the lowering of long vectors.
But the global variable still holds the required alignment.
Use it to make sure that the alignment is correct. If not add a
padding element.