### PR TITLE
add support for memcpy/memset with opaque pointers

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -28,10 +28,38 @@
 #include "Constants.h"
 #include "ReplaceLLVMIntrinsicsPass.h"
 #include "SPIRVOp.h"
+#include "Types.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "ReplaceLLVMIntrinsics"
+
+namespace {
+Type *UpdateTy(LLVMContext &Ctx, uint64_t Size) {
+  if (__builtin_popcount(Size) != 1) {
+    return Type::getInt8Ty(Ctx);
+  } else if (Size > sizeof(uint64_t)) {
+    return FixedVectorType::get(Type::getInt64Ty(Ctx),
+                                std::min(Size / sizeof(uint64_t), 4UL));
+  } else {
+    return Type::getIntNTy(Ctx, Size * CHAR_BIT);
+  }
+}
+Type *descend_type(Type *InType) {
+  Type *OutType = InType;
+  if (OutType->isStructTy()) {
+    OutType = OutType->getStructElementType(0);
+  } else if (OutType->isArrayTy()) {
+    OutType = OutType->getArrayElementType();
+  } else if (auto vec_type = dyn_cast<VectorType>(OutType)) {
+    OutType = vec_type->getElementType();
+  } else {
+    assert(false && "Don't know how to descend into type");
+  }
+
+  return OutType;
+};
+} // namespace
 
 PreservedAnalyses
 clspv::ReplaceLLVMIntrinsicsPass::run(Module &M, ModuleAnalysisManager &) {
@@ -154,6 +182,18 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {
   bool Changed = false;
   auto Layout = M.getDataLayout();
 
+  DenseMap<Value *, Type *> type_cache;
+
+  auto unpack = [&Layout](CallInst &CI, uint64_t Size, Type **Ty,
+                          unsigned *NumUnpackings) {
+    auto ElemSize = Layout.getTypeSizeInBits(*Ty) / 8;
+    while (Size < ElemSize) {
+      *Ty = descend_type(*Ty);
+      (*NumUnpackings)++;
+      ElemSize = Layout.getTypeSizeInBits(*Ty) / 8;
+    }
+  };
+
   for (auto &F : M) {
     if (F.getName().startswith("llvm.memset")) {
       SmallVector<CallInst *, 8> CallsToReplace;
@@ -181,28 +221,37 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {
           NewArg = Bitcast->getOperand(0);
         }
 
+        auto I32Ty = Type::getInt32Ty(M.getContext());
         auto NumBytes = cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
-        auto Ty = NewArg->getType();
-        auto PointeeTy = Ty->getPointerElementType();
-        auto Zero = Constant::getNullValue(PointeeTy);
+        auto PointeeTy = clspv::InferType(NewArg, M.getContext(), &type_cache);
+        if (PointeeTy == nullptr) {
+          PointeeTy = UpdateTy(M.getContext(), NumBytes);
+          NewArg = GetElementPtrInst::Create(
+              PointeeTy, NewArg, {ConstantInt::get(I32Ty, 0)}, "", CI);
+        }
+        unsigned Unpacking = 0;
+        unpack(*CI, NumBytes, &PointeeTy, &Unpacking);
+
+        auto NullValue = Constant::getNullValue(PointeeTy);
+        auto Zero = ConstantInt::get(I32Ty, 0);
+
+        SmallVector<Value *, 3> Indices;
+        for (unsigned i = 0; i < Unpacking; i++) {
+          Indices.push_back(Zero);
+        }
+        // Add a placeholder for the final index.
+        Indices.push_back(Zero);
 
         const auto num_stores = NumBytes / Layout.getTypeAllocSize(PointeeTy);
         assert((NumBytes == num_stores * Layout.getTypeAllocSize(PointeeTy)) &&
                "Null memset can't be divided evenly across multiple stores.");
         assert((num_stores & 0xFFFFFFFF) == num_stores);
 
-        // Generate the first store.
-        new StoreInst(Zero, NewArg, CI);
-
-        // Generate subsequent stores, but only if needed.
-        if (num_stores) {
-          auto I32Ty = Type::getInt32Ty(M.getContext());
-          auto One = ConstantInt::get(I32Ty, 1);
-          auto Ptr = NewArg;
-          for (uint32_t i = 1; i < num_stores; i++) {
-            Ptr = GetElementPtrInst::Create(PointeeTy, Ptr, {One}, "", CI);
-            new StoreInst(Zero, Ptr, CI);
-          }
+        for (uint32_t i = 0; i < num_stores; i++) {
+          Indices.back() = ConstantInt::get(I32Ty, i);
+          auto Ptr =
+              GetElementPtrInst::Create(PointeeTy, NewArg, Indices, "", CI);
+          new StoreInst(NullValue, Ptr, CI);
         }
 
         CI->eraseFromParent();
@@ -221,6 +270,8 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
   bool Changed = false;
   auto Layout = M.getDataLayout();
 
+  DenseMap<Value *, Type *> type_cache;
+
   // Unpack source and destination types until we find a matching
   // element type.  Count the number of levels we unpack for the
   // source and destination types.  So far this only works for
@@ -229,21 +280,6 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
   auto match_types = [&Layout](CallInst &CI, uint64_t Size, Type **DstElemTy,
                                Type **SrcElemTy, unsigned *NumDstUnpackings,
                                unsigned *NumSrcUnpackings) {
-    auto descend_type = [](Type *InType) {
-      Type *OutType = InType;
-      if (OutType->isStructTy()) {
-        OutType = OutType->getStructElementType(0);
-      } else if (OutType->isArrayTy()) {
-        OutType = OutType->getArrayElementType();
-      } else if (auto vec_type = dyn_cast<VectorType>(OutType)) {
-        OutType = vec_type->getElementType();
-      } else {
-        assert(false && "Don't know how to descend into type");
-      }
-
-      return OutType;
-    };
-
     while (*SrcElemTy != *DstElemTy) {
       auto SrcElemSize = Layout.getTypeSizeInBits(*SrcElemTy);
       auto DstElemSize = Layout.getTypeSizeInBits(*DstElemTy);
@@ -277,60 +313,62 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
 
       for (auto U : F.users()) {
         if (auto CI = dyn_cast<CallInst>(U)) {
-          assert(isa<BitCastOperator>(CI->getArgOperand(0)));
-          auto Dst =
-              dyn_cast<BitCastOperator>(CI->getArgOperand(0))->getOperand(0);
+          auto DstBc =
+              dyn_cast<BitCastOperator>(CI->getArgOperand(0));
+          auto SrcBc =
+              dyn_cast<BitCastOperator>(CI->getArgOperand(1));
 
-          assert(isa<BitCastOperator>(CI->getArgOperand(1)));
-          auto Src =
-              dyn_cast<BitCastOperator>(CI->getArgOperand(1))->getOperand(0);
+          if (SrcBc && DstBc) {
+            auto Dst = DstBc->getOperand(0);
+            auto Src = SrcBc->getOperand(0);
+            // The original type of Dst we get from the argument to the bitcast
+            // instruction.
+            auto DstTy = Dst->getType();
+            assert(DstTy->isPointerTy());
 
-          // The original type of Dst we get from the argument to the bitcast
-          // instruction.
-          auto DstTy = Dst->getType();
-          assert(DstTy->isPointerTy());
+            // The original type of Src we get from the argument to the bitcast
+            // instruction.
+            auto SrcTy = Src->getType();
+            assert(SrcTy->isPointerTy());
 
-          // The original type of Src we get from the argument to the bitcast
-          // instruction.
-          auto SrcTy = Src->getType();
-          assert(SrcTy->isPointerTy());
+            // Check that the size is a constant integer.
+            assert(isa<ConstantInt>(CI->getArgOperand(2)));
+            auto Size =
+                dyn_cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
 
-          // Check that the size is a constant integer.
-          assert(isa<ConstantInt>(CI->getArgOperand(2)));
-          auto Size =
-              dyn_cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
+            auto DstElemTy = DstTy->getPointerElementType();
+            auto SrcElemTy = SrcTy->getPointerElementType();
+            unsigned NumDstUnpackings = 0;
+            unsigned NumSrcUnpackings = 0;
+            match_types(*CI, Size, &DstElemTy, &SrcElemTy, &NumDstUnpackings,
+                        &NumSrcUnpackings);
 
-          auto DstElemTy = DstTy->getPointerElementType();
-          auto SrcElemTy = SrcTy->getPointerElementType();
-          unsigned NumDstUnpackings = 0;
-          unsigned NumSrcUnpackings = 0;
-          match_types(*CI, Size, &DstElemTy, &SrcElemTy, &NumDstUnpackings,
-                      &NumSrcUnpackings);
+            // Check that the pointee types match.
+            assert(DstElemTy == SrcElemTy);
 
-          // Check that the pointee types match.
-          assert(DstElemTy == SrcElemTy);
+            auto DstElemSize = Layout.getTypeSizeInBits(DstElemTy) / 8;
+            (void)DstElemSize;
 
-          auto DstElemSize = Layout.getTypeSizeInBits(DstElemTy) / 8;
-          (void)DstElemSize;
+            // Check that the size is a multiple of the size of the pointee
+            // type.
+            assert(Size % DstElemSize == 0);
 
-          // Check that the size is a multiple of the size of the pointee type.
-          assert(Size % DstElemSize == 0);
+            auto Alignment = cast<MemIntrinsic>(CI)->getDestAlignment();
+            auto TypeAlignment = Layout.getABITypeAlignment(DstElemTy);
+            (void)Alignment;
+            (void)TypeAlignment;
 
-          auto Alignment = cast<MemIntrinsic>(CI)->getDestAlignment();
-          auto TypeAlignment = Layout.getABITypeAlignment(DstElemTy);
-          (void)Alignment;
-          (void)TypeAlignment;
+            // Check that the alignment is at least the alignment of the pointee
+            // type.
+            assert(Alignment >= TypeAlignment);
 
-          // Check that the alignment is at least the alignment of the pointee
-          // type.
-          assert(Alignment >= TypeAlignment);
+            // Check that the alignment is a multiple of the alignment of the
+            // pointee type.
+            assert(0 == (Alignment % TypeAlignment));
 
-          // Check that the alignment is a multiple of the alignment of the
-          // pointee type.
-          assert(0 == (Alignment % TypeAlignment));
-
-          // Check that volatile is a constant.
-          assert(isa<ConstantInt>(CI->getArgOperand(3)));
+            // Check that volatile is a constant.
+            assert(isa<ConstantInt>(CI->getArgOperand(3)));
+          }
 
           CallsToReplaceWithSpirvCopyMemory.push_back(CI);
         }
@@ -342,97 +380,89 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         auto Arg3 = dyn_cast<ConstantInt>(CI->getArgOperand(3));
 
         auto I32Ty = Type::getInt32Ty(M.getContext());
-        auto DstAlignment =
-            ConstantInt::get(I32Ty, cast<MemCpyInst>(CI)->getDestAlignment());
-        auto SrcAlignment =
-            ConstantInt::get(I32Ty, cast<MemCpyInst>(CI)->getSourceAlignment());
+        auto DstAlignment = cast<MemCpyInst>(CI)->getDestAlignment();
+        auto SrcAlignment = cast<MemCpyInst>(CI)->getSourceAlignment();
         auto Volatile = ConstantInt::get(I32Ty, Arg3->getZExtValue());
 
-        auto Dst = Arg0->getOperand(0);
-        auto Src = Arg1->getOperand(0);
+        auto Dst = !Arg0 ? CI->getArgOperand(0) : Arg0->getOperand(0);
+        auto Src = !Arg1 ? CI->getArgOperand(1) : Arg1->getOperand(0);
 
-        auto DstElemTy = Dst->getType()->getPointerElementType();
-        auto SrcElemTy = Src->getType()->getPointerElementType();
+        auto Size = dyn_cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
+        Type *DstElemTy = clspv::InferType(Dst, M.getContext(), &type_cache);
+        Type *SrcElemTy = clspv::InferType(Src, M.getContext(), &type_cache);
+
+        IRBuilder<> Builder(CI);
+        if (DstElemTy == nullptr || SrcElemTy == nullptr) {
+          assert(DstElemTy == SrcElemTy);
+          DstElemTy = SrcElemTy = UpdateTy(M.getContext(), Size);
+          Dst = Builder.CreateGEP(DstElemTy, Dst, {ConstantInt::get(I32Ty, 0)});
+          Src = Builder.CreateGEP(SrcElemTy, Src, {ConstantInt::get(I32Ty, 0)});
+        }
+
         unsigned NumDstUnpackings = 0;
         unsigned NumSrcUnpackings = 0;
-        auto Size = dyn_cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
         match_types(*CI, Size, &DstElemTy, &SrcElemTy, &NumDstUnpackings,
                     &NumSrcUnpackings);
         auto SPIRVIntrinsic = clspv::CopyMemoryFunction();
 
         auto DstElemSize = Layout.getTypeSizeInBits(DstElemTy) / 8;
+        auto SrcElemSize = Layout.getTypeSizeInBits(SrcElemTy) / 8;
 
-        IRBuilder<> Builder(CI);
+        auto Zero = ConstantInt::get(I32Ty, 0);
+        SmallVector<Value *, 3> SrcIndices;
+        SmallVector<Value *, 3> DstIndices;
+        // Make unpacking indices.
+        for (unsigned unpacking = 0; unpacking < NumSrcUnpackings;
+             ++unpacking) {
+          SrcIndices.push_back(Zero);
+        }
+        for (unsigned unpacking = 0; unpacking < NumDstUnpackings;
+             ++unpacking) {
+          DstIndices.push_back(Zero);
+        }
+        // Add a placeholder for the final index.
+        SrcIndices.push_back(Zero);
+        DstIndices.push_back(Zero);
 
-        if (NumSrcUnpackings == 0 && NumDstUnpackings == 0) {
-          SmallVector<Type *, 5> param_tys = {Dst->getType(), Src->getType(),
-                                              I32Ty, I32Ty};
-          SmallVector<Value *, 5> param_values = {Dst, Src, DstAlignment};
+        // Build the function and function type only once.
+        FunctionType *NewFType = nullptr;
+        Function *NewF = nullptr;
+
+        for (unsigned i = 0; i < Size / DstElemSize; ++i) {
+          auto Index = ConstantInt::get(I32Ty, i);
+          SrcIndices.back() = Index;
+          DstIndices.back() = Index;
+
+          // Avoid the builder for Src in order to prevent the folder from
+          // creating constant expressions for constant memcpys.
+          auto SrcElemPtr = GetElementPtrInst::CreateInBounds(
+              clspv::InferType(Src, M.getContext(), &type_cache), Src,
+              SrcIndices, "", CI);
+          auto DstElemPtr = Builder.CreateGEP(
+              clspv::InferType(Dst, M.getContext(), &type_cache), Dst,
+              DstIndices);
+          SmallVector<Type *, 5> param_tys = {
+              DstElemPtr->getType(), SrcElemPtr->getType(), I32Ty, I32Ty};
+          SmallVector<Value *, 5> param_values = {
+              DstElemPtr, SrcElemPtr,
+              ConstantInt::get(
+                  I32Ty,
+                  ((DstAlignment + i * DstElemSize - 1) % DstAlignment) + 1)};
           if (clspv::Option::SpvVersion() >=
               clspv::Option::SPIRVVersion::SPIRV_1_4) {
             param_tys.push_back(I32Ty);
-            param_values.push_back(SrcAlignment);
+            param_values.push_back(ConstantInt::get(
+                I32Ty,
+                ((SrcAlignment + i * SrcElemSize - 1) % SrcElemSize) + 1));
           }
           param_values.push_back(Volatile);
-          auto NewFType =
-              FunctionType::get(F.getReturnType(), param_tys, false);
-          auto NewF =
-              Function::Create(NewFType, F.getLinkage(), SPIRVIntrinsic, &M);
+          NewFType = NewFType != nullptr ? NewFType
+                                         : FunctionType::get(F.getReturnType(),
+                                                             param_tys, false);
+          NewF = NewF != nullptr ? NewF
+                                 : Function::Create(NewFType, F.getLinkage(),
+                                                    SPIRVIntrinsic, &M);
           Builder.CreateCall(NewF, param_values, "");
-        } else {
-          auto Zero = ConstantInt::get(I32Ty, 0);
-          SmallVector<Value *, 3> SrcIndices;
-          SmallVector<Value *, 3> DstIndices;
-          // Make unpacking indices.
-          for (unsigned unpacking = 0; unpacking < NumSrcUnpackings;
-               ++unpacking) {
-            SrcIndices.push_back(Zero);
-          }
-          for (unsigned unpacking = 0; unpacking < NumDstUnpackings;
-               ++unpacking) {
-            DstIndices.push_back(Zero);
-          }
-          // Add a placeholder for the final index.
-          SrcIndices.push_back(Zero);
-          DstIndices.push_back(Zero);
-
-          // Build the function and function type only once.
-          FunctionType *NewFType = nullptr;
-          Function *NewF = nullptr;
-
-          IRBuilder<> Builder(CI);
-          for (unsigned i = 0; i < Size / DstElemSize; ++i) {
-            auto Index = ConstantInt::get(I32Ty, i);
-            SrcIndices.back() = Index;
-            DstIndices.back() = Index;
-
-            // Avoid the builder for Src in order to prevent the folder from
-            // creating constant expressions for constant memcpys.
-            auto SrcElemPtr = GetElementPtrInst::CreateInBounds(
-                Src->getType()->getScalarType()->getPointerElementType(), Src,
-                SrcIndices, "", CI);
-            auto DstElemPtr = Builder.CreateGEP(
-                Dst->getType()->getScalarType()->getPointerElementType(), Dst,
-                DstIndices);
-            SmallVector<Type *, 5> param_tys = {
-                DstElemPtr->getType(), SrcElemPtr->getType(), I32Ty, I32Ty};
-            SmallVector<Value *, 5> param_values = {DstElemPtr, SrcElemPtr,
-                                                    DstAlignment};
-            if (clspv::Option::SpvVersion() >=
-                clspv::Option::SPIRVVersion::SPIRV_1_4) {
-              param_tys.push_back(I32Ty);
-              param_values.push_back(SrcAlignment);
-            }
-            param_values.push_back(Volatile);
-            NewFType =
-                NewFType != nullptr
-                    ? NewFType
-                    : FunctionType::get(F.getReturnType(), param_tys, false);
-            NewF = NewF != nullptr ? NewF
-                                   : Function::Create(NewFType, F.getLinkage(),
-                                                      SPIRVIntrinsic, &M);
-            Builder.CreateCall(NewF, param_values, "");
-          }
         }
 
         // Erase the call.
@@ -440,9 +470,9 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
 
         // Erase the bitcasts.  A particular bitcast might be used
         // in more than one memcpy, so defer actual deleting until later.
-        if (isa<BitCastInst>(Arg0))
+        if (Arg0 && isa<BitCastInst>(Arg0))
           BitCastsToForget.insert(dyn_cast<BitCastInst>(Arg0));
-        if (isa<BitCastInst>(Arg1))
+        if (Arg1 && isa<BitCastInst>(Arg1))
           BitCastsToForget.insert(dyn_cast<BitCastInst>(Arg1));
       }
     }

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -336,8 +336,8 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
             auto Size =
                 dyn_cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
 
-            auto DstElemTy = DstTy->getPointerElementType();
-            auto SrcElemTy = SrcTy->getPointerElementType();
+            auto DstElemTy = DstTy->getNonOpaquePointerElementType();
+            auto SrcElemTy = SrcTy->getNonOpaquePointerElementType();
             unsigned NumDstUnpackings = 0;
             unsigned NumSrcUnpackings = 0;
             match_types(*CI, Size, &DstElemTy, &SrcElemTy, &NumDstUnpackings,

--- a/test/LLVMIntrinsics/memcpy_opaque.ll
+++ b/test/LLVMIntrinsics/memcpy_opaque.ll
@@ -9,13 +9,13 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @fct1(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
 entry:
-  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 128, i1 false)
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 64, i1 false)
   ret void
 }
 
 define dso_local spir_kernel void @fct2(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
 entry:
-  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 16, i1 false)
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 8, i1 false)
   ret void
 }
 
@@ -39,32 +39,39 @@ entry:
   ret void
 }
 
+define dso_local spir_kernel void @fct6(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  %0 = getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %0, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 64, i1 false)
+  ret void
+}
+
 declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly %0, ptr addrspace(1) noalias nocapture readonly %1, i32 %2, i1 immarg %3)
 
 ; CHECK-DAG: [[inner:%[^ ]+]] = type { <4 x i32>, <4 x i64> }
 ; CHECK-DAG: [[outer:%[^ ]+]] = type { [2 x [[inner]]] }
 
 ; CHECK-LABEL: @fct1
-; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %dst, i32 0
-; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %src, i32 0
-; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 0
-; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep_dst]], i32 0
 ; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
-; CHECK:  [[gep_src1:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 1
-; CHECK:  [[gep_dst1:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 1
+; CHECK:  [[gep_src1:%[^ ]+]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) [[gep_src]], i32 1
+; CHECK:  [[gep_dst1:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep_dst]], i32 1
 ; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst1]], ptr addrspace(1) [[gep_src1]], i32 16, i32 0)
-; CHECK:  [[gep_src2:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 2
-; CHECK:  [[gep_dst2:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 2
+; CHECK:  [[gep_src2:%[^ ]+]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) [[gep_src]], i32 2
+; CHECK:  [[gep_dst2:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep_dst]], i32 2
 ; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst2]], ptr addrspace(1) [[gep_src2]], i32 16, i32 0)
-; CHECK:  [[gep_src3:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 3
-; CHECK:  [[gep_dst3:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 3
+; CHECK:  [[gep_src3:%[^ ]+]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) [[gep_src]], i32 3
+; CHECK:  [[gep_dst3:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep_dst]], i32 3
 ; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst3]], ptr addrspace(1) [[gep_src3]], i32 16, i32 0)
 
 ; CHECK-LABEL: @fct2
-; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %dst, i32 0
-; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %src, i32 0
-; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <2 x i64>, ptr addrspace(1) [[gep_src]], i32 0
-; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <2 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <2 x i32>, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <2 x i32>, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <2 x i32>, ptr addrspace(1) [[gep_dst]], i32 0
 ; CHECK:  call void @_Z17spirv.copy_memory.1(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
 
 ; CHECK-LABEL: @fct3
@@ -93,3 +100,10 @@ declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly
 ; CHECK:  call void @_Z17spirv.copy_memory.4(ptr addrspace(1) [[gep_dst]], ptr addrspace(1) [[gep_src]], i32 16, i32 0)
 ; CHECK:  getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1, i32 0
 ; CHECK:  getelementptr inbounds %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 1, i32 0
+
+; CHECK-LABEL: @fct6
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr %struct.inner, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_inner_src:%[^ ]+]] = getelementptr inbounds %struct.inner, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_inner_dst:%[^ ]+]] = getelementptr %struct.inner, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.5(ptr addrspace(1) [[gep_inner_dst]], ptr addrspace(1) [[gep_inner_src]], i32 16, i32 0)

--- a/test/LLVMIntrinsics/memcpy_opaque.ll
+++ b/test/LLVMIntrinsics/memcpy_opaque.ll
@@ -1,0 +1,95 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics -opaque-pointers
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.outer = type { [2 x %struct.inner] }
+%struct.inner = type { <4 x i32>, <4 x i64> }
+
+define dso_local spir_kernel void @fct1(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 128, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct2(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 16, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct3(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 4, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct4(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 3, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct5(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src) {
+entry:
+  tail call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noundef align 16 dereferenceable(16) %dst, ptr addrspace(1) noundef align 16 dereferenceable(16) %src, i32 64, i1 false)
+  %0 = getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1, i32 0
+  %1 = getelementptr inbounds %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 1, i32 0
+  ret void
+}
+
+declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly %0, ptr addrspace(1) noalias nocapture readonly %1, i32 %2, i1 immarg %3)
+
+; CHECK-DAG: [[inner:%[^ ]+]] = type { <4 x i32>, <4 x i64> }
+; CHECK-DAG: [[outer:%[^ ]+]] = type { [2 x [[inner]]] }
+
+; CHECK-LABEL: @fct1
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
+; CHECK:  [[gep_src1:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 1
+; CHECK:  [[gep_dst1:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 1
+; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst1]], ptr addrspace(1) [[gep_src1]], i32 16, i32 0)
+; CHECK:  [[gep_src2:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 2
+; CHECK:  [[gep_dst2:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 2
+; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst2]], ptr addrspace(1) [[gep_src2]], i32 16, i32 0)
+; CHECK:  [[gep_src3:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 3
+; CHECK:  [[gep_dst3:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 3
+; CHECK:  call void @_Z17spirv.copy_memory(ptr addrspace(1) [[gep_dst3]], ptr addrspace(1) [[gep_src3]], i32 16, i32 0)
+
+; CHECK-LABEL: @fct2
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <2 x i64>, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.1(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
+
+; CHECK-LABEL: @fct3
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds i32, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr i32, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.2(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
+
+; CHECK-LABEL: @fct4
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %src, i32 0
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds i8, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep_dst]], i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.3(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 16, i32 0)
+; CHECK:  [[gep_src1:%[^ ]+]] = getelementptr inbounds i8, ptr addrspace(1) [[gep_src]], i32 1
+; CHECK:  [[gep_dst1:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep_dst]], i32 1
+; CHECK:  call void @_Z17spirv.copy_memory.3(ptr addrspace(1) [[gep_dst1]], ptr addrspace(1) [[gep_src1]], i32 1, i32 0)
+; CHECK:  [[gep_src2:%[^ ]+]] = getelementptr inbounds i8, ptr addrspace(1) [[gep_src]], i32 2
+; CHECK:  [[gep_dst2:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep_dst]], i32 2
+; CHECK:  call void @_Z17spirv.copy_memory.3(ptr addrspace(1) [[gep_dst2]], ptr addrspace(1) [[gep_src2]], i32 2, i32 0)
+
+; CHECK-LABEL: @fct5
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr inbounds %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 0
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.4(ptr addrspace(1) [[gep_dst]], ptr addrspace(1) [[gep_src]], i32 16, i32 0)
+; CHECK:  getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1, i32 0
+; CHECK:  getelementptr inbounds %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 1, i32 0

--- a/test/LLVMIntrinsics/memcpy_opaque.ll
+++ b/test/LLVMIntrinsics/memcpy_opaque.ll
@@ -46,6 +46,14 @@ entry:
   ret void
 }
 
+define dso_local spir_kernel void @fct7(ptr addrspace(1) nocapture writeonly align 16 %dst, ptr addrspace(1) nocapture readonly align 16 %src, i32 %n) {
+entry:
+  %0 = getelementptr %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 %n, i32 1
+  %1 = getelementptr %struct.inner, ptr addrspace(1) %dst, i32 0, i32 1
+  call void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) %1, ptr addrspace(1) %0, i32 16, i1 false)
+  ret void
+}
+
 declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly %0, ptr addrspace(1) noalias nocapture readonly %1, i32 %2, i1 immarg %3)
 
 ; CHECK-DAG: [[inner:%[^ ]+]] = type { <4 x i32>, <4 x i64> }
@@ -107,3 +115,13 @@ declare void @llvm.memcpy.p1.p1.i32(ptr addrspace(1) noalias nocapture writeonly
 ; CHECK:  [[gep_inner_src:%[^ ]+]] = getelementptr inbounds %struct.inner, ptr addrspace(1) [[gep_src]], i32 0
 ; CHECK:  [[gep_inner_dst:%[^ ]+]] = getelementptr %struct.inner, ptr addrspace(1) [[gep_dst]], i32 0
 ; CHECK:  call void @_Z17spirv.copy_memory.5(ptr addrspace(1) [[gep_inner_dst]], ptr addrspace(1) [[gep_inner_src]], i32 16, i32 0)
+
+; CHECK-LABEL: @fct7
+; CHECK:  [[gep_src:%[^ ]+]] = getelementptr %struct.outer, ptr addrspace(1) %src, i32 0, i32 0, i32 %n, i32 1
+; CHECK:  [[gep_dst:%[^ ]+]] = getelementptr %struct.inner, ptr addrspace(1) %dst, i32 0, i32 1
+; CHECK:  [[gep_src0:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 0, i32 0
+; CHECK:  [[gep_dst0:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 0, i32 0
+; CHECK:  call void @_Z17spirv.copy_memory.6(ptr addrspace(1) [[gep_dst0]], ptr addrspace(1) [[gep_src0]], i32 0, i32 0)
+; CHECK:  [[gep_src1:%[^ ]+]] = getelementptr inbounds <4 x i64>, ptr addrspace(1) [[gep_src]], i32 0, i32 1
+; CHECK:  [[gep_dst1:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep_dst]], i32 0, i32 1
+; CHECK:  call void @_Z17spirv.copy_memory.6(ptr addrspace(1) [[gep_dst1]], ptr addrspace(1) [[gep_src1]], i32 0, i32 0)

--- a/test/LLVMIntrinsics/memset_null_many_copies.ll
+++ b/test/LLVMIntrinsics/memset_null_many_copies.ll
@@ -14,10 +14,11 @@ entry:
 declare void @llvm.memset.p1i8.i32(i8 addrspace(1)*, i8, i32, i1)
 
 ; CHECK-NOT: bitcast
-; CHECK: store float 0.000000e+00, float addrspace(1)* %data
-; CHECK: [[gep0:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* %data, i32 1
+; CHECK: [[gep0:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* %data, i32 0
 ; CHECK: store float 0.000000e+00, float addrspace(1)* [[gep0]]
-; CHECK: [[gep1:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* [[gep0]], i32 1
+; CHECK: [[gep1:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* %data, i32 1
 ; CHECK: store float 0.000000e+00, float addrspace(1)* [[gep1]]
-; CHECK: [[gep2:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* [[gep1]], i32 1
+; CHECK: [[gep2:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* %data, i32 2
 ; CHECK: store float 0.000000e+00, float addrspace(1)* [[gep2]]
+; CHECK: [[gep3:%[0-9a-zA-Z_.]+]] = getelementptr float, float addrspace(1)* %data, i32 3
+; CHECK: store float 0.000000e+00, float addrspace(1)* [[gep3]]

--- a/test/LLVMIntrinsics/memset_opaque.ll
+++ b/test/LLVMIntrinsics/memset_opaque.ll
@@ -9,13 +9,13 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @fct1(ptr addrspace(1) %dst) {
 entry:
-  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 128, i1 false)
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 64, i1 false)
   ret void
 }
 
 define dso_local spir_kernel void @fct2(ptr addrspace(1) %dst) {
 entry:
-  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 16, i1 false)
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 8, i1 false)
   ret void
 }
 
@@ -41,20 +41,20 @@ entry:
 declare void @llvm.memset.p1.i32(ptr addrspace(1), i8, i32, i1)
 
 ; CHECK-LABEL: @fct1
-; CHECK:  [[gep:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %dst, i32 0
-; CHECK:  [[gep0:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 0
-; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep0]]
-; CHECK:  [[gep1:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 1
-; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep1]]
-; CHECK:  [[gep2:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 2
-; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep2]]
-; CHECK:  [[gep3:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 3
-; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep3]]
+; CHECK:  [[gep:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store <4 x i32> zeroinitializer, ptr addrspace(1) [[gep0]]
+; CHECK:  [[gep1:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep]], i32 1
+; CHECK:  store <4 x i32> zeroinitializer, ptr addrspace(1) [[gep1]]
+; CHECK:  [[gep2:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep]], i32 2
+; CHECK:  store <4 x i32> zeroinitializer, ptr addrspace(1) [[gep2]]
+; CHECK:  [[gep3:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) [[gep]], i32 3
+; CHECK:  store <4 x i32> zeroinitializer, ptr addrspace(1) [[gep3]]
 
 ; CHECK-LABEL: @fct2
-; CHECK:  [[gep:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %dst, i32 0
-; CHECK:  [[gep0:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) [[gep]], i32 0
-; CHECK:  store <2 x i64> zeroinitializer, ptr addrspace(1) [[gep0]]
+; CHECK:  [[gep:%[^ ]+]] = getelementptr <2 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr <2 x i32>, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store <2 x i32> zeroinitializer, ptr addrspace(1) [[gep0]]
 
 ; CHECK-LABEL: @fct3
 ; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %dst, i32 0

--- a/test/LLVMIntrinsics/memset_opaque.ll
+++ b/test/LLVMIntrinsics/memset_opaque.ll
@@ -1,0 +1,76 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics -opaque-pointers
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.outer = type { [2 x %struct.inner] }
+%struct.inner = type { <4 x i32>, <4 x i64> }
+
+define dso_local spir_kernel void @fct1(ptr addrspace(1) %dst) {
+entry:
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 128, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct2(ptr addrspace(1) %dst) {
+entry:
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 16, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct3(ptr addrspace(1) %dst) {
+entry:
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 4, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct4(ptr addrspace(1) %dst) {
+entry:
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 3, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @fct5(ptr addrspace(1) %dst) {
+entry:
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 64, i1 false)
+  %0 = getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1, i32 0
+  ret void
+}
+
+declare void @llvm.memset.p1.i32(ptr addrspace(1), i8, i32, i1)
+
+; CHECK-LABEL: @fct1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep0]]
+; CHECK:  [[gep1:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 1
+; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep1]]
+; CHECK:  [[gep2:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 2
+; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep2]]
+; CHECK:  [[gep3:%[^ ]+]] = getelementptr <4 x i64>, ptr addrspace(1) [[gep]], i32 3
+; CHECK:  store <4 x i64> zeroinitializer, ptr addrspace(1) [[gep3]]
+
+; CHECK-LABEL: @fct2
+; CHECK:  [[gep:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr <2 x i64>, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store <2 x i64> zeroinitializer, ptr addrspace(1) [[gep0]]
+
+; CHECK-LABEL: @fct3
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr i32, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store i32 0, ptr addrspace(1) [[gep0]]
+
+; CHECK-LABEL: @fct4
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %dst, i32 0
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store i8 0, ptr addrspace(1) [[gep0]]
+; CHECK:  [[gep1:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 1
+; CHECK:  store i8 0, ptr addrspace(1) [[gep1]]
+; CHECK:  [[gep2:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 2
+; CHECK:  store i8 0, ptr addrspace(1) [[gep2]]
+
+; CHECK-LABEL: @fct5
+; CHECK:  [[gep:%[^ ]+]] = getelementptr %struct.inner, ptr addrspace(1) %dst, i32 0, i32 0, i32 0
+; CHECK:  store %struct.inner zeroinitializer, ptr addrspace(1) [[gep]], align 32
+; CHECK:  getelementptr inbounds %struct.outer, ptr addrspace(1) %dst, i32 0, i32 0, i32 1, i32 0


### PR DESCRIPTION
Use InferType to get the type. If InferType returns null, it means
that we are not capable of inferring the type. In that case, choose an
appropriate type and add a gep so that future pass can infer the type
we choose. ReplacePointerBitcast might rework what we did in this pass
to have something coherent at a function level.

Fix memcpy, which did not work as expected when having no unpacking
but a type smaller than the size of the copy. Fix it by removing the
if statement which is not needed. It will produce unnecessary gep,
which is not a issue.

Fix memset to work on a subset of a type. It still needs to be
complete type, like for memcpy.