### PR TITLE
Transition SimplifyPointerBitcastPass to opaque pointers

### DIFF
--- a/test/PointerCasts/opaque_trivial_casts.ll
+++ b/test/PointerCasts/opaque_trivial_casts.ll
@@ -1,0 +1,93 @@
+; RUN: clspv-opt %s -o %t --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LABEL: define void @test1() {
+; CHECK: entry:
+; CHECK:   %0 = add i32 0, 4
+; CHECK:   %gep = getelementptr i64, ptr null, i32 %0
+; CHECK:   ret void
+; CHECK: }
+
+define void @test1() {
+entry:
+  %0 = add i32 0, 4
+  %cast = bitcast i32 %0 to i32
+  %gep = getelementptr i64, ptr bitcast (ptr null to ptr), i32 %0
+  ret void
+}
+
+; CHECK-LABEL: define void @test2() {
+; CHECK: entry:
+; CHECK:   %gep = getelementptr i64, ptr null, i32 0
+; CHECK:   ret void
+; CHECK: }
+
+define void @test2() {
+entry:
+  %cast1 = bitcast ptr bitcast ( ptr null to ptr ) to ptr
+  %cast2 = bitcast ptr %cast1 to ptr
+  %gep = getelementptr i64, ptr %cast2, i32 0
+  ret void
+}
+
+; CHECK-LABEL: define void @test3() {
+; CHECK: entry:
+; CHECK:   %gep = getelementptr i64, ptr null, i32 0
+; CHECK:   ret void
+; CHECK: }
+
+define void @test3() {
+entry:
+  %cast1 = bitcast ptr bitcast ( ptr null to ptr ) to ptr
+  %cast2 = bitcast ptr %cast1 to ptr
+  %cast3 = bitcast ptr %cast2 to ptr
+  %gep = getelementptr i64, ptr %cast3, i32 0
+  ret void
+}
+
+; CHECK-LABEL: define void @test4(ptr %in, ptr %out) {
+; CHECK: entry:
+; CHECK:   %gep = getelementptr i32, ptr %in, i32 0
+; CHECK:   %val = load i32, ptr %gep, align 4
+; CHECK:   store i32 %val, ptr %out, align 4
+; CHECK:   ret void
+; CHECK: }
+
+define void @test4(ptr %in, ptr %out) {
+entry:
+  %gep = getelementptr i32, ptr %in, i32 0     
+  %cast = bitcast ptr %gep to ptr
+  %val = load i32, ptr %cast
+  store i32 %val, ptr %out
+  ret void
+}
+
+; CHECK-LABEL: define void @test5(ptr %in) {
+; CHECK: entry:
+; CHECK:   %0 = getelementptr i32, ptr %in, i32 2
+; CHECK:   ret void
+; CHECK: }
+
+define void @test5(ptr %in) {
+entry:
+  %gep1 = getelementptr i32, ptr %in, i32 1
+  %gep2 = getelementptr i32, ptr %gep1, i32 1   
+  ret void
+}
+
+; CHECK-LABEL: define void @test6(ptr %in) {
+; CHECK: entry:
+; CHECK:   %gep1 = getelementptr float, ptr %in, i32 1
+; CHECK:   %gep2 = getelementptr i32, ptr %gep1, i32 1
+; CHECK:   ret void
+; CHECK: }
+
+define void @test6(ptr %in) {
+entry:
+  %gep1 = getelementptr float, ptr %in, i32 1
+  %gep2 = getelementptr i32, ptr %gep1, i32 1  
+  ret void
+}

--- a/test/PointerCasts/trivial_casts.ll
+++ b/test/PointerCasts/trivial_casts.ll
@@ -1,0 +1,81 @@
+; RUN: clspv-opt %s -o %t --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LABEL: define void @test1() {
+; CHECK: entry:
+; CHECK:   %0 = add i32 0, 4
+; CHECK:   %gep = getelementptr i32, i32* null, i32 %0
+; CHECK:   ret void
+; CHECK: }
+
+define void @test1() {
+entry:
+  %0 = add i32 0, 4
+  %cast = bitcast i32 %0 to i32
+  %gep = getelementptr i32, i32* bitcast (float* null to i32*), i32 %0
+  ret void
+}
+
+; CHECK-LABEL: define void @test2() {
+; CHECK: entry:
+; CHECK:   %gep = getelementptr i64, i64* null, i32 250
+; CHECK:   ret void
+; CHECK: }
+
+define void @test2() {
+entry:
+  %cast1 = bitcast i32 bitcast ( i32 250 to i32 ) to float
+  %cast2 = bitcast float %cast1 to i32
+  %gep = getelementptr i64, i64* null, i32 %cast2
+  ret void
+}
+
+; CHECK-LABEL: define void @test3() {
+; CHECK: entry:
+; CHECK:   %0 = bitcast float 0x371F400000000000 to i32
+; CHECK:   %gep = getelementptr i64, i64* null, i32 %0
+; CHECK:   ret void
+; CHECK: }
+
+define void @test3() {
+entry:
+  %cast1 = bitcast float bitcast ( i32 250 to float ) to i32
+  %cast2 = bitcast i32 %cast1 to float
+  %cast3 = bitcast float %cast2 to i32
+  %gep = getelementptr i64, i64* null, i32 %cast3
+  ret void
+}
+
+; CHECK-LABEL: define void @test4(i32* %in, float* %out) {
+; CHECK: entry:
+; CHECK:   %0 = bitcast i32* %in to float*
+; CHECK:   %1 = getelementptr float, float* %0, i32 1
+; CHECK:   %val = load float, float* %1, align 4
+; CHECK:   store float %val, float* %out, align 4
+; CHECK:   ret void
+; CHECK: }
+
+define void @test4(i32* %in, float* %out) {
+entry:
+  %gep = getelementptr i32, i32* %in, i32 1     
+  %cast = bitcast i32* %gep to float*
+  %val = load float, float* %cast
+  store float %val, float* %out
+  ret void
+}
+
+; CHECK-LABEL: define void @test5(i32* %in) {
+; CHECK: entry:
+; CHECK:   %0 = getelementptr i32, i32* %in, i32 2
+; CHECK:   ret void
+; CHECK: }
+
+define void @test5(i32* %in) {
+entry:
+  %gep1 = getelementptr i32, i32* %in, i32 1
+  %gep2 = getelementptr i32, i32* %gep1, i32 1   
+  ret void
+}


### PR DESCRIPTION
# PR changes
* **Modify `SimplifyPointerBitcastPass::runOnBitcastFromGEP`**: This function should simplify cases when we bitcast a pointer that is generated from gep instruction. Before opaque pointers that case was valid as we could transform a pointer type to another pointer type like (i64* to i32*). After opaque pointer changes that case can't happen and will always be a trivial bitcast as we don't have any pointer type other than "ptr". Trivial bitcasts will be handled with `runOnTrivialBitcast`. So, we should delete this function after full transformation to opaque pointers.  
Example: `runOnTrivialBitcast` will delete the bitcast instruction. 
```
%gep = getelementptr i32, ptr %ptr, i32 0     
%cast = bitcast ptr %gep to ptr
```

* **Modify `SimplifyPointerBitcastPass::runOnGEPFromBitcastCstExpr`**: This function should simplify cases when we have gep instruction with its pointer operand as a bitcast constant expression. Which will have a similar trivial case as `SimplifyPointerBitcastPass::runOnBitcastFromGEP`. So, we should delete this function after full transformation to opaque pointers. 
Example:  
`%gep = getelementptr i32, ptr bitcast (ptr %ptr to ptr), i32 0`  
LLVM passes will transform it to `getelementptr i32, ptr %ptr, i32 0`

* **Modify `SimplifyPointerBitcastPass::runOnGEPFromGEP**: This function handles cases when a gep instruction pointer operand is another gep instruction. Implicit casts could occur after opaque pointer transition. So, we make sure that there is no implicit cast before optimizing this cases.

* **Add some trivial and simple bitcast test cases**

### Related issues
https://github.com/google/clspv/issues/816

**This contribution is being made by Codeplay on behalf of Samsung.**