### PR TITLE
Improve support for elided GetElementPtr instructions

### DIFF
--- a/test/PointerCasts/opaque_implicit_gep.cl
+++ b/test/PointerCasts/opaque_implicit_gep.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %s -o %t.spv -enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that with opaque pointers we don't optimize away a GEP into the 1st
+// element of the global ID and omit the OpAccessChain required to access
+// individual elements
+
+void kernel test(global int* out, int n) {
+  out[get_global_id(0)] = n;
+}
+
+// If the OpAccessChain is omited then spirv-val should catch it, but check the
+// spvasm anyway
+// CHECK: OpDecorate %[[global_id:[a-zA-Z0-9_.]+]] BuiltIn GlobalInvocationId
+// CHECK: %[[access_chain:[a-zA-Z0-9_.]+]] = OpAccessChain %{{[a-zA-Z0-9_.]+}} %[[global_id]]
+// CHECK: OpLoad %{{[a-zA-Z0-9_.]+}} %[[access_chain]]

--- a/test/PointerCasts/opaque_implicit_gep.ll
+++ b/test/PointerCasts/opaque_implicit_gep.ll
@@ -1,0 +1,15 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_GlobalInvocationId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+
+define spir_kernel void @test() {
+entry:
+  ; CHECK: %[[gep:[a-zA-Z0-9+]]] = getelementptr <3 x i32>, ptr addrspace(5) @__spirv_GlobalInvocationId, i32 0, i32 0
+  ; CHECK: load i32, ptr addrspace(5) %[[gep]]
+  %0 = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId, align 16
+  ret void
+}

--- a/test/PointerCasts/opaque_implicit_gep_nested_struct.ll
+++ b/test/PointerCasts/opaque_implicit_gep_nested_struct.ll
@@ -1,0 +1,29 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [5 x %struct.T], [4 x i32] }
+%struct.T = type { [4 x <4 x i32>] }
+
+; CHECK: %[[resource0:[a-zA-Z0-9]+]] = call ptr addrspace(1) @_Z14clspv.resource.0
+; CHECK: %[[resource1:[a-zA-Z0-9]+]] = call ptr addrspace(1) @_Z14clspv.resource.1
+; CHECK: %[[gep0:[a-zA-Z0-9]+]] = getelementptr { [0 x %struct.S] }, ptr addrspace(1) %[[resource0]], i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0
+; CHECK: load <4 x i32>, ptr addrspace(1) %[[gep0]]
+; CHECK: %[[gep1:[a-zA-Z0-9]+]] = getelementptr { [0 x i32] }, ptr addrspace(1) %[[resource1]], i32 0, i32 0, i32 0
+; CHECK: store i32 %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %[[gep1]]
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture readonly align 16 %in, ptr addrspace(1) nocapture writeonly align 4 %out) {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x %struct.S] } zeroinitializer) #1
+  %1 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer) #1
+  %2 = load <4 x i32>, ptr addrspace(1) %0, align 16
+  %3 = extractelement <4 x i32> %2, i64 0
+  store i32 %3, ptr addrspace(1) %1, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
+
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })

--- a/test/PointerCasts/opaque_implicit_gep_vector.ll
+++ b/test/PointerCasts/opaque_implicit_gep_vector.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt %s -o %t --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: %[[resource0:[a-zA-Z0-9]+]] = call ptr addrspace(1) @_Z14clspv.resource.0
+; CHECK: %[[resource1:[a-zA-Z0-9]+]] = call ptr addrspace(1) @_Z14clspv.resource.1
+; CHECK: %[[gep0:[a-zA-Z0-9]+]] = getelementptr { [0 x <4 x i32>] }, ptr addrspace(1) %[[resource0]], i32 0, i32 0, i32 0
+; CHECK: load <4 x i32>, ptr addrspace(1) %[[gep0]]
+; CHECK: %[[gep1:[a-zA-Z0-9]+]] = getelementptr { [0 x i32] }, ptr addrspace(1) %[[resource1]], i32 0, i32 0, i32 0
+; CHECK: store i32 %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %[[gep1]]
+
+define spir_kernel void @test(ptr addrspace(1) nocapture readonly align 16 %in, ptr addrspace(1) nocapture writeonly align 4 %out)  {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
+  %1 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
+  %2 = load <4 x i32>, ptr addrspace(1) %0, align 16
+  %3 = extractelement <4 x i32> %2, i64 0
+  store i32 %3, ptr addrspace(1) %1, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <4 x i32>] })
+
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })


### PR DESCRIPTION
LLVM will optimize out the GEP to the first element of a vector or aggregate type when opaque pointers are enabled, as there is no real pointer arithmetic to be done. This needs explicitly handled to prevent the correct access chain being omitted from the SPIR-V.

The ReplacePointerBitcastPass will reinsert elided GEPs where possible.

This fixes some work item builtin calls like `get_global_id(0)`.

This contribution is being made by Codeplay on behalf of Samsung.