### PR TITLE
UBOTypeTransformPass: Handle opaque pointers

### DIFF
--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -86,6 +86,7 @@ clspv::ArgKind GetArgKindForType(Type *type, Type *data_type) {
 namespace clspv {
 
 PodArgImpl GetPodArgsImpl(Function &F) {
+  assert(F.hasMetadata(PodArgsImplMetadataName()));
   auto md = F.getMetadata(PodArgsImplMetadataName());
   auto impl = static_cast<PodArgImpl>(
       cast<ConstantInt>(

--- a/test/UBOTypeTransform/transform_global.ll
+++ b/test/UBOTypeTransform/transform_global.ll
@@ -1,0 +1,59 @@
+; RUN: clspv-opt -int8=0 -constant-args-ubo --passes=ubo-type-transform %s -o %t
+; RUN: FileCheck --check-prefixes TYPE,CHECK %s < %t
+; RUN: FileCheck --check-prefixes TYPE,DECLARE %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; TYPE-DAG: [[DATA_TYPE:%[a-zA-Z0-9_.]+]] = type { i32, i32 }
+; TYPE-DAG: [[DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [0 x [[DATA_TYPE]]] }
+; TYPE-DAG: [[CONST_DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [4096 x [[DATA_TYPE]]] }
+%data_type = type { i32, [12 x i8] }
+%var_array = type { [0 x %data_type] }
+%large_array = type { [4096 x %data_type] }
+
+; CHECK-DAG: [[GLOBAL_CONSTANT:@[a-zA-Z0-9_.]+]] = local_unnamed_addr addrspace(2) constant [2 x [[DATA_TYPE]]] [[[DATA_TYPE]] { i32 0, i32 undef }, [[DATA_TYPE]] { i32 1, i32 undef }], align 16
+@c_var = local_unnamed_addr addrspace(2) constant [2 x %data_type] [%data_type { i32 0, [12 x i8] undef }, %data_type { i32 1, [12 x i8] undef }], align 16
+
+; CHECK: define spir_kernel void @foo([[DATA_TYPE]] addrspace(1)* {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, [[DATA_TYPE]] addrspace(2)* {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, { i32 } {{%[a-zA-Z0-9_.]+}}) !clspv.pod_args_impl [[POD_IMPL_MD:![0-9]+]] {
+define spir_kernel void @foo(%data_type addrspace(1)* nocapture writeonly align 16 %global_arg, %data_type addrspace(2)* nocapture readonly align 16 %constant_arg, { i32 } %int_arg) !clspv.pod_args_impl !0 {
+entry:
+; access arguments
+  ; CHECK: [[GLOBAL:%[a-zA-Z0-9_.]+]] = call [[DATA_TYPE_ARR]] addrspace(1)* @_Z14clspv.resource.0({{.*}} [[DATA_TYPE_ARR]] zeroinitializer)
+  ; CHECK: [[CONSTANT:%[a-zA-Z0-9_.]+]] = call [[CONST_DATA_TYPE_ARR]] addrspace(2)* @_Z14clspv.resource.1({{.*}} [[CONST_DATA_TYPE_ARR]] zeroinitializer)
+  %global = call %var_array addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, %var_array zeroinitializer)
+  %constant = call %large_array addrspace(2)* @_Z14clspv.resource.1(i32 0, i32 1, i32 1, i32 1, i32 1, i32 0, %large_array zeroinitializer)
+  %n_push = call { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { i32 } } zeroinitializer)
+; get offset value, n, not expected to change
+  %n_ptr = getelementptr { { i32 } }, { { i32 } } addrspace(9)* %n_push, i32 0, i32 0
+  %n_struct = load { i32 }, { i32 } addrspace(9)* %n_ptr, align 4
+  %n = extractvalue { i32 } %n_struct, 0
+; read value from constant address space
+  ; CHECK: getelementptr [[CONST_DATA_TYPE_ARR]], [[CONST_DATA_TYPE_ARR]] addrspace(2)* [[CONSTANT]]
+  %constant_ptr = getelementptr %large_array, %large_array addrspace(2)* %constant, i32 0, i32 0, i32 %n, i32 0
+  %constant_x_val = load i32, i32 addrspace(2)* %constant_ptr, align 16
+
+; add the global constant
+  ; CHECK: [[C_VAR_PTR:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [2 x [[DATA_TYPE]]], [2 x [[DATA_TYPE]]] addrspace(2)* [[GLOBAL_CONSTANT]]
+  ; CHECK: load i32, i32 addrspace(2)* [[C_VAR_PTR]], align 16
+  %c_var_ptr = getelementptr inbounds [2 x %data_type], [2 x %data_type] addrspace(2)* @c_var, i32 0, i32 %n, i32 0
+  %c_var_val = load i32, i32 addrspace(2)* %c_var_ptr, align 16
+  %x_plus_c = add nsw i32 %c_var_val, %constant_x_val
+
+; store back to global address space
+  ; CHECK: getelementptr [[DATA_TYPE_ARR]], [[DATA_TYPE_ARR]] addrspace(1)* [[GLOBAL]]
+  %global_ptr = getelementptr %var_array, %var_array addrspace(1)* %global, i32 0, i32 0, i32 %n, i32 0
+  store i32 %x_plus_c, i32 addrspace(1)* %global_ptr, align 16
+  ret void
+}
+
+; DECLARE-DAG: declare [[DATA_TYPE_ARR]] addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, [[DATA_TYPE_ARR]])
+; DECLARE-DAG: declare [[CONST_DATA_TYPE_ARR]] addrspace(2)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, [[CONST_DATA_TYPE_ARR]])
+; DECLARE-DAG: declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
+; functions used to access constant address space
+declare %var_array addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %var_array)
+declare %large_array addrspace(2)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %large_array)
+declare { { i32 } } addrspace(9)* @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
+
+; CHECK: [[POD_IMPL_MD]] = !{i32 2}
+!0 = !{i32 2} ; PodArgImpl::kPushConstant

--- a/test/UBOTypeTransform/transform_global_opaque.ll
+++ b/test/UBOTypeTransform/transform_global_opaque.ll
@@ -1,0 +1,61 @@
+; RUN: clspv-opt -opaque-pointers -int8=0 -constant-args-ubo --passes=ubo-type-transform %s -o %t
+; RUN: FileCheck --check-prefixes TYPE,CHECK %s < %t
+; RUN: FileCheck --check-prefixes TYPE,DECLARE %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; TYPE-DAG: [[DATA_TYPE:%[a-zA-Z0-9_.]+]] = type { i32, i32 }
+; TYPE-DAG: [[DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [0 x [[DATA_TYPE]]] }
+; TYPE-DAG: [[CONST_DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [4096 x [[DATA_TYPE]]] }
+%data_type = type { i32, [12 x i8] }
+%var_array = type { [0 x %data_type] }
+%large_array = type { [4096 x %data_type] }
+
+; CHECK: [[GLOBAL_CONSTANT:@[a-zA-Z0-9_.]+]] = local_unnamed_addr addrspace(2) constant [2 x [[DATA_TYPE]]] [[[DATA_TYPE]] { i32 0, i32 undef }, [[DATA_TYPE]] { i32 1, i32 undef }], align 16
+@c_var = local_unnamed_addr addrspace(2) constant [2 x %data_type] [%data_type { i32 0, [12 x i8] undef }, %data_type { i32 1, [12 x i8] undef }], align 16
+
+; CHECK: define spir_kernel void @foo(ptr addrspace(1) {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, ptr addrspace(2) {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, { i32 } {{%[a-zA-Z0-9_.]+}}) !clspv.pod_args_impl [[POD_IMPL_MD:![0-9]+]] {
+define spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 16 %global_arg, ptr addrspace(2) nocapture readonly align 16 %constant_arg, { i32 } %int_arg) !clspv.pod_args_impl !0 {
+entry:
+; access arguments
+  ; CHECK: [[GLOBAL:%[a-zA-Z0-9_.]+]] = call ptr addrspace(1) @_Z14clspv.resource.0({{.*}} [[DATA_TYPE_ARR]] zeroinitializer)
+  ; CHECK: [[CONSTANT:%[a-zA-Z0-9_.]+]] = call ptr addrspace(2) @_Z14clspv.resource.1({{.*}} [[CONST_DATA_TYPE_ARR]] zeroinitializer)
+  %global = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, %var_array zeroinitializer)
+  %constant = call ptr addrspace(2) @_Z14clspv.resource.1(i32 0, i32 1, i32 1, i32 1, i32 1, i32 0, %large_array zeroinitializer)
+  %n_push = call ptr addrspace(9) @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { i32 } } zeroinitializer)
+
+; get offset value, n, not expected to change
+  %n_ptr = getelementptr { { i32 } }, ptr addrspace(9) %n_push, i32 0, i32 0
+  %n_struct = load { i32 }, ptr addrspace(9) %n_ptr, align 4
+  %n = extractvalue { i32 } %n_struct, 0
+
+; read value from constant address space
+  ; CHECK: getelementptr [[CONST_DATA_TYPE_ARR]], ptr addrspace(2) [[CONSTANT]]
+  %constant_ptr = getelementptr %large_array, ptr addrspace(2) %constant, i32 0, i32 0, i32 %n, i32 0
+  %constant_x_val = load i32, ptr addrspace(2) %constant_ptr, align 16
+
+; add the global constant
+  ; CHECK: [[C_VAR_PTR:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [2 x [[DATA_TYPE]]], ptr addrspace(2) [[GLOBAL_CONSTANT]]
+  ; CHECK: load i32, ptr addrspace(2) [[C_VAR_PTR]], align 16
+  %c_var_ptr = getelementptr inbounds [2 x %data_type], ptr addrspace(2) @c_var, i32 0, i32 %n, i32 0
+  %c_var_val = load i32, ptr addrspace(2) %c_var_ptr, align 16
+  %x_plus_c = add nsw i32 %c_var_val, %constant_x_val
+
+; store back to global address space
+  ; CHECK: getelementptr [[DATA_TYPE_ARR]], ptr addrspace(1) [[GLOBAL]]
+  %global_ptr = getelementptr %var_array, ptr addrspace(1) %global, i32 0, i32 0, i32 %n, i32 0
+  store i32 %x_plus_c, ptr addrspace(1) %global_ptr, align 16
+  ret void
+}
+
+; functions used to access constant address space
+; DECLARE-DAG: declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, [[DATA_TYPE_ARR]])
+; DECLARE-DAG: declare ptr addrspace(2) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, [[CONST_DATA_TYPE_ARR]])
+; DECLARE-DAG: declare ptr addrspace(9) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %var_array)
+declare ptr addrspace(2) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %large_array)
+declare ptr addrspace(9) @_Z14clspv.resource.2(i32, i32, i32, i32, i32, i32, { { i32 } })
+
+; CHECK: [[POD_IMPL_MD]] = !{i32 2}
+!0 = !{i32 2} ; PodArgImpl::kPushConstant

--- a/test/UBOTypeTransform/transform_local.ll
+++ b/test/UBOTypeTransform/transform_local.ll
@@ -1,0 +1,58 @@
+; RUN: clspv-opt -int8=0 -constant-args-ubo --passes=ubo-type-transform %s -o %t
+; RUN: FileCheck --check-prefixes TYPE,CHECK %s < %t
+; RUN: FileCheck --check-prefixes TYPE,DECLARE %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; TYPE-DAG: [[DATA_TYPE:%[a-zA-Z0-9_.]+]] = type { i32, i32 }
+; TYPE-DAG: [[DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [0 x [[DATA_TYPE]]] }
+; TYPE-DAG: [[CONST_DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [4096 x [[DATA_TYPE]]] }
+%data_type = type { i32, [12 x i8] }
+%var_array = type { [0 x %data_type] }
+%large_array = type { [4096 x %data_type] }
+
+
+; CHECK: define dso_local spir_kernel void @foo([[DATA_TYPE]] addrspace(1)* {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, [[DATA_TYPE]] addrspace(2)* {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, [[DATA_TYPE]] addrspace(3)* {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}) !clspv.pod_args_impl [[POD_IMPL_MD:![0-9]+]] {
+define dso_local spir_kernel void @foo(%data_type addrspace(1)* nocapture writeonly align 16 %data, %data_type addrspace(2)* nocapture readonly align 16 %c_arg, %data_type addrspace(3)* nocapture readonly align 16 %l_arg) !clspv.pod_args_impl !0 {
+entry:
+; get args
+; CHECK: [[ARG_LOCAL:%[a-zA-Z0-9_.]+]] = call [0 x [[DATA_TYPE]]] addrspace(3)* @_Z11clspv.local.3(i32 3, [0 x [[DATA_TYPE]]] zeroinitializer)
+; CHECK: [[ARG_GLOBAL:%[a-zA-Z0-9_.]+]] = call [[DATA_TYPE_ARR]] addrspace(1)* @_Z14clspv.resource.0({{.*}} [[DATA_TYPE_ARR]] zeroinitializer)
+; CHECK: [[ARG_CONST:%[a-zA-Z0-9_.]+]] = call [[CONST_DATA_TYPE_ARR]] addrspace(2)* @_Z14clspv.resource.1({{.*}} [[CONST_DATA_TYPE_ARR]] zeroinitializer)
+  %arg_local = call [0 x %data_type] addrspace(3)* @_Z11clspv.local.3(i32 3, [0 x %data_type] zeroinitializer)
+  %arg_global = call %var_array addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, %var_array zeroinitializer)
+  %arg_const = call %large_array addrspace(2)* @_Z14clspv.resource.1(i32 0, i32 1, i32 1, i32 1, i32 1, i32 0, %large_array zeroinitializer)
+
+; load constant addr space arg value
+; CHECK: [[CONST_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [[CONST_DATA_TYPE_ARR]], [[CONST_DATA_TYPE_ARR]] addrspace(2)* [[ARG_CONST]]
+; CHECK: [[CONST_VAL:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(2)* [[CONST_PTR]], align 16
+  %const_ptr = getelementptr %large_array, %large_array addrspace(2)* %arg_const, i32 0, i32 0, i32 0, i32 0
+  %const_val = load i32, i32 addrspace(2)* %const_ptr, align 16
+
+; load local addr space arg value
+; CHECK: [[LOCAL_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [0 x [[DATA_TYPE]]], [0 x [[DATA_TYPE]]] addrspace(3)* [[ARG_LOCAL]]
+; CHECK: [[LOCAL_VAL:%[a-zA-Z0-9_.]+]] = load i32, i32 addrspace(3)* [[LOCAL_PTR]], align 16
+  %local_ptr = getelementptr [0 x %data_type], [0 x %data_type] addrspace(3)* %arg_local, i32 0, i32 0, i32 0
+  %local_val = load i32, i32 addrspace(3)* %local_ptr, align 16
+
+; CHECK: [[SUM:%[a-zA-Z0-9_.]+]] = add nsw i32 [[LOCAL_VAL]], [[CONST_VAL]]
+  %sum = add nsw i32 %local_val, %const_val
+
+; store to global address space
+; CHECK: [[GLOBAL_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [[DATA_TYPE_ARR]], [[DATA_TYPE_ARR]] addrspace(1)* [[ARG_GLOBAL]]
+; CHECK: store i32 [[SUM]], i32 addrspace(1)* [[GLOBAL_PTR]], align 16
+  %global_ptr = getelementptr %var_array, %var_array addrspace(1)* %arg_global, i32 0, i32 0, i32 0, i32 0
+  store i32 %sum, i32 addrspace(1)* %global_ptr, align 16
+  ret void
+}
+
+; DECLARE-DAG: declare [[DATA_TYPE_ARR]] addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, [[DATA_TYPE_ARR]])
+; DECLARE-DAG: declare [[CONST_DATA_TYPE_ARR]] addrspace(2)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, [[CONST_DATA_TYPE_ARR]])
+; DECLARE-DAG: declare [0 x [[DATA_TYPE]]] addrspace(3)* @_Z11clspv.local.3(i32, [0 x [[DATA_TYPE]]])
+declare %var_array addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %var_array)
+declare %large_array addrspace(2)* @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %large_array)
+declare [0 x %data_type] addrspace(3)* @_Z11clspv.local.3(i32, [0 x %data_type])
+
+; CHECK: [[POD_IMPL_MD]] = !{i32 2}
+!0 = !{i32 2}

--- a/test/UBOTypeTransform/transform_local_opaque.ll
+++ b/test/UBOTypeTransform/transform_local_opaque.ll
@@ -1,0 +1,58 @@
+; RUN: clspv-opt -opaque-pointers -int8=0 -constant-args-ubo --passes=ubo-type-transform %s -o %t
+; RUN: FileCheck --check-prefixes TYPE,CHECK %s < %t
+; RUN: FileCheck --check-prefixes TYPE,DECLARE %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; TYPE-DAG: [[DATA_TYPE:%[a-zA-Z0-9_.]+]] = type { i32, i32 }
+; TYPE-DAG: [[DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [0 x [[DATA_TYPE]]] }
+; TYPE-DAG: [[CONST_DATA_TYPE_ARR:%[a-zA-Z0-9_.]+]] = type { [4096 x [[DATA_TYPE]]] }
+%data_type = type { i32, [12 x i8] }
+%var_array = type { [0 x %data_type] }
+%large_array = type { [4096 x %data_type] }
+
+
+; CHECK: define dso_local spir_kernel void @foo(ptr addrspace(1){{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, ptr addrspace(2){{.*}} align 16 {{%[a-zA-Z0-9_.]+}}, ptr addrspace(3) {{.*}} align 16 {{%[a-zA-Z0-9_.]+}}) !clspv.pod_args_impl [[POD_IMPL_MD:![0-9]+]] {
+define dso_local spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 16 %data, ptr addrspace(2) nocapture readonly align 16 %c_arg, ptr addrspace(3) nocapture readonly align 16 %l_arg) !clspv.pod_args_impl !0 {
+entry:
+; get args
+; CHECK: [[ARG_LOCAL:%[a-zA-Z0-9_.]+]] = call ptr addrspace(3) @_Z11clspv.local.3(i32 3, [0 x [[DATA_TYPE]]] zeroinitializer)
+; CHECK: [[ARG_GLOBAL:%[a-zA-Z0-9_.]+]] = call ptr addrspace(1) @_Z14clspv.resource.0({{.*}} [[DATA_TYPE_ARR]] zeroinitializer)
+; CHECK: [[ARG_CONST:%[a-zA-Z0-9_.]+]] = call ptr addrspace(2) @_Z14clspv.resource.1({{.*}} [[CONST_DATA_TYPE_ARR]] zeroinitializer)
+  %arg_local = call ptr addrspace(3) @_Z11clspv.local.3(i32 3, [0 x %data_type] zeroinitializer)
+  %arg_global = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, %var_array zeroinitializer)
+  %arg_const = call ptr addrspace(2) @_Z14clspv.resource.1(i32 0, i32 1, i32 1, i32 1, i32 1, i32 0, %large_array zeroinitializer)
+
+; load constant addr space arg value
+; CHECK: [[CONST_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [[CONST_DATA_TYPE_ARR]], ptr addrspace(2) [[ARG_CONST]]
+; CHECK: [[CONST_VAL:%[a-zA-Z0-9_.]+]] = load i32, ptr addrspace(2) [[CONST_PTR]], align 16
+  %const_ptr = getelementptr %large_array, ptr addrspace(2) %arg_const, i32 0, i32 0, i32 0, i32 0
+  %const_val = load i32, ptr addrspace(2) %const_ptr, align 16
+
+; load local addr space arg value
+; CHECK: [[LOCAL_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [0 x [[DATA_TYPE]]], ptr addrspace(3) [[ARG_LOCAL]]
+; CHECK: [[LOCAL_VAL:%[a-zA-Z0-9_.]+]] = load i32, ptr addrspace(3) [[LOCAL_PTR]], align 16
+  %local_ptr = getelementptr [0 x %data_type], ptr addrspace(3) %arg_local, i32 0, i32 0, i32 0
+  %local_val = load i32, ptr addrspace(3) %local_ptr, align 16
+
+; CHECK: [[SUM:%[a-zA-Z0-9_.]+]] = add nsw i32 [[LOCAL_VAL]], [[CONST_VAL]]
+  %sum = add nsw i32 %local_val, %const_val
+
+; store to global address space
+; CHECK: [[GLOBAL_PTR:%[a-zA-Z0-9_.]+]] = getelementptr [[DATA_TYPE_ARR]], ptr addrspace(1) [[ARG_GLOBAL]]
+; CHECK: store i32 [[SUM]], ptr addrspace(1) [[GLOBAL_PTR]], align 16
+  %global_ptr = getelementptr %var_array, ptr addrspace(1) %arg_global, i32 0, i32 0, i32 0, i32 0
+  store i32 %sum, ptr addrspace(1) %global_ptr, align 16
+  ret void
+}
+
+; DECLARE-DAG: declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, [[DATA_TYPE_ARR]])
+; DECLARE-DAG: declare ptr addrspace(2) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, [[CONST_DATA_TYPE_ARR]])
+; DECLARE-DAG: declare ptr addrspace(3) @_Z11clspv.local.3(i32, [0 x [[DATA_TYPE]]])
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, %var_array)
+declare ptr addrspace(2) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, %large_array)
+declare ptr addrspace(3) @_Z11clspv.local.3(i32, [0 x %data_type])
+
+; CHECK: [[POD_IMPL_MD]] = !{i32 2}
+!0 = !{i32 2}


### PR DESCRIPTION
# Changes
UBOTypeTransform will now read the underlying type of pointer arguments from the clspv resource builtins.
I also removed an unneeded copy of the offsets when building the new struct type and ensured attributes were copied when created new global variables and functions.

# Related Issue
#816

This contribution is being made by Codeplay on behalf of Samsung.