### PR TITLE
Handle opaque pointer in UndoInstCombinePass

### DIFF
--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -252,7 +252,6 @@ bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
   }
   shuffle->replaceAllUsesWith(insert);
   dead_.push_back(shuffle);
-  // TODO: #816 remove after final switch.
   if (in1_cast)
     potentially_dead_.insert(in1_cast);
 

--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -76,7 +76,7 @@ VectorType *InferTypeForOpaqueLoad(LoadInst *load, uint64_t vec_size) {
   // Calculate the largest vector that the target can be split into.
   // If the indexes don't work at the resulting size then they won't work for a
   // smaller size.
-  uint64_t new_size = 4;
+  uint64_t new_size = max_vector_size;
   while (vec_size % new_size) {
     --new_size;
   }

--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -22,6 +22,7 @@
 #include "llvm/IR/Operator.h"
 #include "llvm/Pass.h"
 
+#include "Constants.h"
 #include "UndoInstCombinePass.h"
 
 #define DEBUG_TYPE "undoinstcombine"
@@ -66,6 +67,27 @@ bool clspv::UndoInstCombinePass::runOnFunction(Function &F) {
   return changed;
 }
 
+VectorType *InferTypeForOpaqueLoad(LoadInst *load, uint64_t vec_size) {
+  assert(load);
+  assert(load->getPointerOperandTy()->isOpaquePointerTy());
+  // Calculate the largest vector that the target can be split into.
+  // If the indexes don't work at the resulting size then they won't work for a
+  // smaller size.
+  uint64_t new_size = clspv::SPIRVMaxVectorSize();
+  while (vec_size % new_size) { // will always break at new_size == 1
+    new_size -= 1;
+  }
+  uint64_t divisor = vec_size / new_size;
+
+  const auto old_type = llvm::cast<VectorType>(load->getType());
+  auto new_bit_width =
+      cast<IntegerType>(old_type->getElementType())->getBitWidth() * divisor;
+
+  return VectorType::get(
+      IntegerType::get(old_type->getContext(), new_bit_width), new_size,
+      old_type->getElementCount().isScalable());
+}
+
 bool clspv::UndoInstCombinePass::UndoWideVectorExtractCast(Instruction *inst) {
   auto extract = dyn_cast<ExtractElementInst>(inst);
   if (!extract)
@@ -73,7 +95,7 @@ bool clspv::UndoInstCombinePass::UndoWideVectorExtractCast(Instruction *inst) {
 
   auto vec_ty = extract->getVectorOperandType();
   auto vec_size = vec_ty->getElementCount().getKnownMinValue();
-  if (vec_size <= 4)
+  if (vec_size <= clspv::SPIRVMaxVectorSize())
     return false;
 
   // Instcombine only transforms TruncInst (which operates on integers).
@@ -84,99 +106,70 @@ bool clspv::UndoInstCombinePass::UndoWideVectorExtractCast(Instruction *inst) {
   if (!const_idx)
     return false;
 
-  auto load = dyn_cast<LoadInst>(extract->getVectorOperand());
-  if (load && load->getPointerOperand()->getType()->isOpaquePointerTy()) {
-    // calculate the smallest vector we can create and still access the target
-    // bytes
-    uint64_t idx = const_idx->getZExtValue();
-    uint64_t new_size = 4;
-    while (vec_size % new_size) { // will always break at new_size == 1
-      new_size -= 1;
-    }
-    uint64_t divisor = vec_size / new_size;
+  auto extract_src = extract->getVectorOperand();
+  auto load = dyn_cast<LoadInst>(extract_src);
+  // If this is a load, check for a cast on the pointer operand
+  auto cast =
+      dyn_cast<BitCastOperator>(load ? load->getPointerOperand() : extract_src);
 
-    uint64_t new_idx = idx / divisor;
-    IRBuilder<> builder(inst);
-    const auto old_type = llvm::cast<VectorType>(load->getType());
+  Value *src =
+      cast ? cast->getOperand(0) : (load ? load->getPointerOperand() : nullptr);
+  if (!src)
+    return false;
 
-    auto new_bit_width =
-        cast<IntegerType>(old_type->getElementType())->getBitWidth() * divisor;
-
-    Value *new_load = builder.CreateLoad(
-        VectorType::get(IntegerType::get(old_type->getContext(), new_bit_width),
-                        new_size, old_type->getElementCount().isScalable()),
-        load->getPointerOperand());
-
-    Value *new_src =
-        builder.CreateExtractElement(new_load, builder.getInt32(new_idx));
-    auto trunc = builder.CreateTrunc(new_src, extract->getType());
-
-    extract->replaceAllUsesWith(trunc);
-    dead_.push_back(extract);
-
-    potentially_dead_.insert(load);
-    return true;
-  } else {
-
-    auto cast = load ? dyn_cast<BitCastOperator>(load->getPointerOperand())
-                     : dyn_cast<BitCastOperator>(extract->getVectorOperand());
-
-    if (!cast)
-      return false;
-
-    auto src = cast->getOperand(0);
-    auto src_ty = src->getType();
-    VectorType *src_vec_ty = nullptr;
-    // TODO: #816 remove after final switch. would not do a bitcast on a pointer
-    if (isa<PointerType>(src_ty)) {
-      // In the load cast, go through the pointer first.
-      src_vec_ty =
-          dyn_cast<VectorType>(src_ty->getNonOpaquePointerElementType());
+  auto src_ty = src->getType();
+  VectorType *src_vec_ty = [src_ty, load, vec_size] {
+    if (src_ty->isOpaquePointerTy()) {
+      return InferTypeForOpaqueLoad(load, vec_size);
+      // TODO: #816 remove after final switch.
+    } else if (src_ty->isPointerTy()) {
+      return dyn_cast<VectorType>(src_ty->getNonOpaquePointerElementType());
     } else {
-      src_vec_ty = dyn_cast<VectorType>(src_ty);
+      return dyn_cast<VectorType>(src_ty);
     }
+  }();
 
-    if (!src_vec_ty)
-      return false;
+  if (!src_vec_ty)
+    return false;
 
-    uint64_t src_elements = src_vec_ty->getElementCount().getKnownMinValue();
-    uint64_t dst_elements = vec_ty->getElementCount().getKnownMinValue();
+  uint64_t src_elements = src_vec_ty->getElementCount().getKnownMinValue();
 
-    if (dst_elements < src_elements)
-      return false;
+  if (vec_size <= src_elements)
+    return false;
 
-    uint64_t idx = const_idx->getZExtValue();
-    uint64_t ratio = dst_elements / src_elements;
-    uint64_t new_idx = idx / ratio;
+  uint64_t idx = const_idx->getZExtValue();
+  uint64_t ratio = vec_size / src_elements;
+  uint64_t new_idx = idx / ratio;
 
-    // Instcombine should never have generated an odd index, so don't handle
-    // right now.
-    if (idx & 0x1)
-      return false;
+  // Instcombine should never have generated an odd index, so don't handle
+  // right now.
+  if (idx & 0x1)
+    return false;
 
-    // Create a truncate of an extract element.
-    IRBuilder<> builder(inst);
-    Value *new_src = nullptr;
-    // TODO: #816 remove after final switch. (load handled by opaque pointer
-    // case)
-    if (load) {
-      potentially_dead_.insert(load);
-      new_src = builder.CreateLoad(src_vec_ty, src);
-      src = new_src;
-    }
-    new_src = builder.CreateExtractElement(src, builder.getInt32(new_idx));
-    auto trunc = builder.CreateTrunc(new_src, extract->getType());
-    extract->replaceAllUsesWith(trunc);
-    dead_.push_back(extract);
+  IRBuilder<> builder(inst);
+  src = load ? builder.CreateLoad(src_vec_ty, src) : src;
+  if (load) {
+    potentially_dead_.insert(load);
+  }
+  auto new_src = builder.CreateExtractElement(src, builder.getInt32(new_idx));
+  auto trunc = builder.CreateTrunc(new_src, extract->getType());
+  extract->replaceAllUsesWith(trunc);
+
+  dead_.push_back(extract);
+  if (cast)
     potentially_dead_.insert(cast);
 
-    return true;
-  }
+  return true;
 }
 
 bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
   auto shuffle = dyn_cast<ShuffleVectorInst>(inst);
   if (!shuffle)
+    return false;
+
+  // Instcombine only produces shuffles with an undef second input, so don't
+  // handle other cases for now.
+  if (!isa<UndefValue>(shuffle->getOperand(1)))
     return false;
 
   // Instcombine only transforms TruncInst (which operates on integers).
@@ -186,44 +179,39 @@ bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
 
   auto in1 = shuffle->getOperand(0);
   auto in1_vec_ty = cast<VectorType>(in1->getType());
-  if (in1_vec_ty->getElementCount().getKnownMinValue() <= 4)
+  auto in1_vec_size = in1_vec_ty->getElementCount().getKnownMinValue();
+  if (in1_vec_size <= clspv::SPIRVMaxVectorSize())
     return false;
 
   auto in1_load = dyn_cast<LoadInst>(in1);
-  auto in1_cast = dyn_cast<BitCastOperator>(in1);
-  if (in1_load) {
-    // If this is a load, check for a cast on the pointer operand
-    in1_cast = dyn_cast<BitCastOperator>(in1_load->getPointerOperand());
-  }
+  // If this is a load, check for a cast on the pointer operand
+  auto in1_cast =
+      dyn_cast<BitCastOperator>(in1_load ? in1_load->getPointerOperand() : in1);
 
-  if (!in1_cast)
+  Value *src = in1_cast ? in1_cast->getOperand(0)
+                        : (in1_load ? in1_load->getPointerOperand() : nullptr);
+  if (!src)
     return false;
 
-  // Instcombine only produces shuffles with an undef second input, so don't
-  // handle other cases for now.
-  if (!isa<UndefValue>(shuffle->getOperand(1)))
-    return false;
-
-  auto src = in1_cast->getOperand(0);
   auto src_ty = src->getType();
-  VectorType *src_vec_ty = nullptr;
-  // TODO: #816 remove after final switch.
-  if (isa<PointerType>(src_ty)) {
-    // In the load cast, go through the pointer first.
-    if (src_ty->isOpaquePointerTy())
-      return false;
-    src_vec_ty = dyn_cast<VectorType>(src_ty->getNonOpaquePointerElementType());
-  } else {
-    src_vec_ty = dyn_cast<VectorType>(src_ty);
-  }
+  VectorType *src_vec_ty = [src_ty, in1_load, in1_vec_size] {
+    if (src_ty->isOpaquePointerTy()) {
+      return InferTypeForOpaqueLoad(in1_load, in1_vec_size);
+      // TODO: #816 remove after final switch.
+    } else if (src_ty->isPointerTy()) {
+      return dyn_cast<VectorType>(src_ty->getNonOpaquePointerElementType());
+    } else {
+      return dyn_cast<VectorType>(src_ty);
+    }
+  }();
 
   if (!src_vec_ty)
     return false;
 
   uint64_t src_elements = src_vec_ty->getElementCount().getKnownMinValue();
-  uint64_t dst_elements = in1_vec_ty->getElementCount().getKnownMinValue();
+  uint64_t dst_elements = in1_vec_size;
 
-  if (dst_elements < src_elements)
+  if (dst_elements <= src_elements)
     return false;
 
   uint64_t ratio = dst_elements / src_elements;
@@ -247,6 +235,7 @@ bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
     src = builder.CreateLoad(src_vec_ty, src);
   }
 
+  // TODO could replace with a shuffle and vectorized trunc
   int i = 0;
   for (auto idx : mask) {
     if (idx == UndefMaskElem)
@@ -263,7 +252,8 @@ bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
   }
   shuffle->replaceAllUsesWith(insert);
   dead_.push_back(shuffle);
-  potentially_dead_.insert(in1_cast);
+  if (in1_cast)
+    potentially_dead_.insert(in1_cast);
 
   return true;
 }

--- a/test/UndoInstCombine/extract_load_cast_3xi32_to_12xi8.ll
+++ b/test/UndoInstCombine/extract_load_cast_3xi32_to_12xi8.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t.ll --passes=undo-instcombine -opaque-pointers
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load <3 x i32>, ptr addrspace(8) @__spirv_WorkgroupSize
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 1
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex]] to i8
+; CHECK: sext i8 [[trunc]] to i32
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(ptr addrspace(1) nocapture %out) {
+entry:
+  %0 = load <12 x i8>, ptr addrspace(8) @__spirv_WorkgroupSize 
+  %conv = extractelement <12 x i8> %0, i32 4
+  %conv1 = sext i8 %conv to i32
+  store i32 %conv1, ptr addrspace(1) %out, align 4
+  ret void
+}
+

--- a/test/UndoInstCombine/extract_load_cast_opaque.ll
+++ b/test/UndoInstCombine/extract_load_cast_opaque.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t.ll -opaque-pointers --passes=undo-instcombine
+; RUN: FileCheck %s < %t.ll
+
+; COM: No information to allow transformation
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load <3 x i32>, ptr addrspace(8) @__spirv_WorkgroupSize
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 0
+; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex]] to i16
+; CHECK: sext i16 [[trunc]] to i32
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(ptr addrspace(1) %out) {
+entry:
+  %0 = load <6 x i16>, ptr addrspace(8) bitcast (ptr addrspace(8) @__spirv_WorkgroupSize to ptr addrspace(8)), align 16
+  %conv = extractelement <6 x i16> %0, i32 0
+  %conv1 = sext i16 %conv to i32
+  store i32 %conv1, ptr addrspace(1) %out, align 4
+  ret void
+}
+

--- a/test/UndoInstCombine/extract_load_cast_opaque.ll
+++ b/test/UndoInstCombine/extract_load_cast_opaque.ll
@@ -1,9 +1,8 @@
 ; RUN: clspv-opt %s -o %t.ll -opaque-pointers --passes=undo-instcombine
 ; RUN: FileCheck %s < %t.ll
 
-; COM: No information to allow transformation
 ; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load <3 x i32>, ptr addrspace(8) @__spirv_WorkgroupSize
-; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 0
+; CHECK: [[ex:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 2
 ; CHECK: [[trunc:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex]] to i16
 ; CHECK: sext i16 [[trunc]] to i32
 
@@ -15,7 +14,7 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @foo(ptr addrspace(1) %out) {
 entry:
   %0 = load <6 x i16>, ptr addrspace(8) bitcast (ptr addrspace(8) @__spirv_WorkgroupSize to ptr addrspace(8)), align 16
-  %conv = extractelement <6 x i16> %0, i32 0
+  %conv = extractelement <6 x i16> %0, i32 4
   %conv1 = sext i16 %conv to i32
   store i32 %conv1, ptr addrspace(1) %out, align 4
   ret void

--- a/test/UndoInstCombine/undo_extract_cast.cl
+++ b/test/UndoInstCombine/undo_extract_cast.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv --enable-opaque-pointers
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-NOT: OpTypeVector {{.*}} 16
 
 __kernel void test_r_uint8(read_only image2d_t srcimg, __global unsigned char *dst, sampler_t sampler)

--- a/test/UndoInstCombine/undo_shuffle_cast.cl
+++ b/test/UndoInstCombine/undo_shuffle_cast.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv --enable-opaque-pointers
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-NOT: OpTypeVector {{.*}} 16
 
 __kernel void testReadi(read_only image2d_t srcimg, __global uchar4 *dst)

--- a/test/UndoInstCombine/undo_shuffle_load_cast_opaque.ll
+++ b/test/UndoInstCombine/undo_shuffle_load_cast_opaque.ll
@@ -16,8 +16,7 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @test(ptr addrspace(1) %out) {
 entry:
   %alloca = alloca <3 x i32>
-  %cast = bitcast ptr %alloca to ptr
-  %load = load <6 x i16>, ptr %cast, align 16
+  %load = load <6 x i16>, ptr %alloca, align 16
   %conv = shufflevector <6 x i16> %load, <6 x i16> undef, <2 x i32> <i32 2, i32 4>
   store <2 x i16> %conv, ptr addrspace(1) %out, align 1
   ret void

--- a/test/UndoInstCombine/undo_shuffle_load_cast_opaque.ll
+++ b/test/UndoInstCombine/undo_shuffle_load_cast_opaque.ll
@@ -1,0 +1,25 @@
+; RUN: clspv-opt %s -o %t.ll -opaque-pointers --passes=undo-instcombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[ld:%[a-zA-Z0-9_.]+]] = load <3 x i32>, ptr %alloca
+; CHECK: [[ex0:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 1
+; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex0]] to i16
+; CHECK: [[in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x i16> zeroinitializer, i16 [[trunc0]], i32 0
+; CHECK: [[ex1:%[a-zA-Z0-9_.]+]] = extractelement <3 x i32> [[ld]], i32 2
+; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = trunc i32 [[ex1]] to i16
+; CHECK: [[in1:%[a-zA-Z0-9_.]+]] = insertelement <2 x i16> [[in0]], i16 [[trunc1]], i32 1
+; CHECK: store <2 x i16> [[in1]]
+
+define spir_kernel void @test(ptr addrspace(1) %out) {
+entry:
+  %alloca = alloca <3 x i32>
+  %cast = bitcast ptr %alloca to ptr
+  %load = load <6 x i16>, ptr %cast, align 16
+  %conv = shufflevector <6 x i16> %load, <6 x i16> undef, <2 x i32> <i32 2, i32 4>
+  store <2 x i16> %conv, ptr addrspace(1) %out, align 1
+  ret void
+}
+


### PR DESCRIPTION
Handles opaque pointers in the UndoInstCombinePass by giving up on finding the original type when the pointer is opaque.
Obviously this does have a slight problem in that the purpose of the pass isn't really being fulfilled any more.

Is this currently a plan on how to deal with this or should I look further into inferring the type?

This is to contribute towards issue #816

This contribution is being made by Codeplay on behalf of Samsung.