### PR TITLE
Add FixupBuiltinsPass to ensure NaN check is performed on sqrt and rsqrt

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DirectResourceAccessPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/FixupBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FixupStructuredCFGPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/HideConstantLoadsPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -477,6 +477,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     // ReplaceOpenCLBuiltinPass can generate vec8 and vec16 elements. It needs
     // to be before the potential LongVectorLoweringPass pass.
     pm.addPass(clspv::ReplaceOpenCLBuiltinPass());
+    pm.addPass(clspv::FixupBuiltinsPass());
     pm.addPass(clspv::ThreeElementVectorLoweringPass());
 
     // Lower longer vectors when requested. Note that this pass depends on

--- a/lib/FixupBuiltinsPass.cpp
+++ b/lib/FixupBuiltinsPass.cpp
@@ -1,0 +1,65 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+
+#include "Builtins.h"
+#include "FixupBuiltinsPass.h"
+
+using namespace clspv;
+using namespace llvm;
+
+PreservedAnalyses FixupBuiltinsPass::run(Module &M, ModuleAnalysisManager &) {
+  PreservedAnalyses PA;
+  for (auto &F : M) {
+    runOnFunction(F);
+  }
+  return PA;
+}
+
+bool FixupBuiltinsPass::runOnFunction(Function &F) {
+  auto &FI = Builtins::Lookup(&F);
+  switch (FI.getType()) {
+  case Builtins::kSqrt:
+  case Builtins::kRsqrt:
+    return fixupSqrt(F);
+  default:
+    return false;
+  }
+}
+
+bool FixupBuiltinsPass::fixupSqrt(Function &F) {
+  // We only want to perform this transformation if no sqrt/rsqrt
+  // implementation has been linked.
+  if (!F.isDeclaration()) {
+    return false;
+  }
+  bool modified = false;
+  for (auto &U : F.uses()) {
+    if (auto CI = dyn_cast<CallInst>(U.getUser())) {
+      IRBuilder<> builder(CI);
+      auto nan = ConstantFP::getNaN(CI->getType());
+      auto zero = ConstantFP::getZero(CI->getType());
+      auto op_is_positive = builder.CreateFCmpOGE(CI->getOperand(0), zero);
+      builder.SetInsertPoint(CI->getNextNode());
+      SelectInst *select =
+          cast<SelectInst>(builder.CreateSelect(op_is_positive, zero, nan));
+      CI->replaceAllUsesWith(select);
+      select->setTrueValue(CI);
+      modified = true;
+    }
+  }
+  return modified;
+}

--- a/lib/FixupBuiltinsPass.h
+++ b/lib/FixupBuiltinsPass.h
@@ -1,0 +1,37 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+#ifndef _CLSPV_LIB_BUILTIN_FIXUP_PASS_H
+#define _CLSPV_LIB_BUILTIN_FIXUP_PASS_H
+
+namespace clspv {
+// This pass performs transformations on calls to builtin functions without
+// erasing them from the module.
+struct FixupBuiltinsPass : llvm::PassInfoMixin<FixupBuiltinsPass> {
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+
+private:
+  bool runOnFunction(llvm::Function &F);
+
+  // If this detects builtin calls that will generate calls to the Sqrt or
+  // InverseSqrt glsl instructions it adds checks to guarantee the result is a
+  // NaN if the input is negative.
+  bool fixupSqrt(llvm::Function &F);
+};
+} // namespace clspv
+
+#endif // _CLSPV_LIB_BUILTIN_FIXUP_PASS_H

--- a/lib/PassRegistry.def
+++ b/lib/PassRegistry.def
@@ -25,6 +25,7 @@ MODULE_PASS("cluster-pod-kernel-args-pass", clspv::ClusterPodKernelArgumentsPass
 MODULE_PASS("declare-push-constants", clspv::DeclarePushConstantsPass)
 MODULE_PASS("define-opencl-workitem-builtins", clspv::DefineOpenCLWorkItemBuiltinsPass)
 MODULE_PASS("direct-resource-access", clspv::DirectResourceAccessPass)
+MODULE_PASS("fixup-builtins", clspv::FixupBuiltinsPass)
 MODULE_PASS("function-internalizer", clspv::FunctionInternalizerPass)
 MODULE_PASS("hide-constant-loads", clspv::HideConstantLoadsPass)
 MODULE_PASS("inline-entry-points-pass", clspv::InlineEntryPointsPass)

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -23,6 +23,7 @@
 #include "DeclarePushConstantsPass.h"
 #include "DefineOpenCLWorkItemBuiltinsPass.h"
 #include "DirectResourceAccessPass.h"
+#include "FixupBuiltinsPass.h"
 #include "FixupStructuredCFGPass.h"
 #include "FunctionInternalizerPass.h"
 #include "HideConstantLoadsPass.h"

--- a/test/MathBuiltins/sqrt/float2_rsqrt.cl
+++ b/test/MathBuiltins/sqrt/float2_rsqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)
 {

--- a/test/MathBuiltins/sqrt/float2_sqrt.cl
+++ b/test/MathBuiltins/sqrt/float2_sqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)
 {

--- a/test/MathBuiltins/sqrt/float3_rsqrt.cl
+++ b/test/MathBuiltins/sqrt/float3_rsqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/sqrt/float3_sqrt.cl
+++ b/test/MathBuiltins/sqrt/float3_sqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/sqrt/float4_rsqrt.cl
+++ b/test/MathBuiltins/sqrt/float4_rsqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
 {

--- a/test/MathBuiltins/sqrt/float4_sqrt.cl
+++ b/test/MathBuiltins/sqrt/float4_sqrt.cl
@@ -6,9 +6,13 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
+// CHECK: %[[NAN_VEC:[a-zA-Z0-9_]*]] = OpConstantComposite %[[FLOAT_VECTOR_TYPE_ID]] %[[NAN]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_VECTOR_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN_VEC]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
 {

--- a/test/MathBuiltins/sqrt/float_rsqrt.cl
+++ b/test/MathBuiltins/sqrt/float_rsqrt.cl
@@ -5,9 +5,12 @@
 
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] InverseSqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
 {

--- a/test/MathBuiltins/sqrt/float_sqrt.cl
+++ b/test/MathBuiltins/sqrt/float_sqrt.cl
@@ -5,9 +5,12 @@
 
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[NAN:[a-zA-Z0-9_]*]] = OpConstant %float 0x1.8p+128
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK: %[[ZERO_COMP:[a-zA-Z0-9_]*]] = OpFOrdGreaterThanEqual %{{[a-zA-Z0-9_]*}} %[[LOADB_ID]]
 // CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Sqrt %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[SELECT_ID:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_TYPE_ID]] %[[ZERO_COMP]] %[[OP_ID]] %[[NAN]]
+// CHECK: OpStore {{.*}} %[[SELECT_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
 {


### PR DESCRIPTION
This is the first step towards removing these builtins from our libclc
SOURCES and relying entirely on the GLSL instructions.

FixupBuiltinsPass is intended to be generic, and an alternative to
ReplaceOpenCLBuiltinsPass that doesn't necessitate erasing the original
function from the module.

This contribution is being made by Codeplay on behalf of Samsung.