### PR TITLE
Transition three element vector lowering pass to opaque pointers

### DIFF
--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -34,6 +34,7 @@
 #include "BitcastUtils.h"
 #include "Builtins.h"
 #include "ThreeElementVectorLoweringPass.h"
+#include "Types.h"
 
 #include <array>
 #include <functional>
@@ -217,36 +218,6 @@ std::string getVec4Name(const clspv::Builtins::FunctionInfo &IInfo) {
   return clspv::Builtins::GetMangledFunctionName(Info);
 }
 
-/// In order not to overflow, we need to copy elements one by one when
-/// CopyMemory arguments are transformed from vec3 to vec4.
-Value *convertOpCopyMemoryOperation(CallInst &VectorCall,
-                                    ArrayRef<Value *> EquivalentArgs) {
-  auto *DstOperand = EquivalentArgs[1];
-  auto *SrcOperand = EquivalentArgs[2];
-  assert(DstOperand->getType()->getPointerElementType()->isVectorTy());
-  assert(dyn_cast<VectorType>(DstOperand->getType()->getPointerElementType())
-             ->getElementCount()
-             .getKnownMinValue() == 4);
-
-  IRBuilder<> B(&VectorCall);
-  Value *ReturnValue = nullptr;
-
-  // for each element
-  for (unsigned eachElem = 0; eachElem < 3; eachElem++) {
-    auto *SrcGEP = B.CreateGEP(
-        SrcOperand->getType()->getScalarType()->getPointerElementType(),
-        SrcOperand, {B.getInt32(0), B.getInt32(eachElem)});
-    auto *Val =
-        B.CreateLoad(SrcGEP->getType()->getPointerElementType(), SrcGEP);
-    auto *DstGEP = B.CreateGEP(
-        DstOperand->getType()->getScalarType()->getPointerElementType(),
-        DstOperand, {B.getInt32(0), B.getInt32(eachElem)});
-    ReturnValue = B.CreateStore(Val, DstGEP);
-  }
-
-  return ReturnValue;
-}
-
 /// SIMD Builtin are builtin where the instruction uses only 1 data element
 bool isBuiltinSIMD(clspv::Builtins::BuiltinType Builtin) {
   if (Builtin > clspv::Builtins::kType_Math_Start &&
@@ -257,39 +228,6 @@ bool isBuiltinSIMD(clspv::Builtins::BuiltinType Builtin) {
     return true;
   switch (Builtin) {
   default:
-    return false;
-  }
-}
-
-/// Look for bitcast of vec3 inside the function
-bool vec3BitcastInFunction(Function &F) {
-  for (Instruction &I : instructions(F)) {
-    if (auto *Inst = dyn_cast<CastInst>(&I)) {
-      auto *Type = Inst->getSrcTy();
-      if (Type->isPointerTy()) {
-        auto *PointeeType = Type->getPointerElementType();
-        if (auto *VectorType = dyn_cast<FixedVectorType>(PointeeType)) {
-          if (VectorType->getElementCount().getKnownMinValue())
-            return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
-/// Returns whether the vec3 should be transform into vec4
-bool vec3ShouldBeLowered(Module &M) {
-  switch (clspv::Option::Vec3ToVec4()) {
-  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportForce:
-    return true;
-  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportDisable:
-    return false;
-  default:
-    for (auto &F : M.functions()) {
-      if (vec3BitcastInFunction(F))
-        return true;
-    }
     return false;
   }
 }
@@ -308,10 +246,82 @@ clspv::ThreeElementVectorLoweringPass::run(Module &M, ModuleAnalysisManager &) {
     runOnFunction(F);
   }
 
+  replaceAllVec3Instances();
+
+  cleanDeadInstructions();
+
+  for (auto &F : M.functions()) {
+    LLVM_DEBUG(dbgs() << "Final version for " << F.getName() << '\n');
+    LLVM_DEBUG(dbgs() << F << '\n');
+  }
+
   cleanDeadFunctions();
   cleanDeadGlobals();
 
   return PA;
+}
+
+bool clspv::ThreeElementVectorLoweringPass::vec3ShouldBeLowered(Module &M) {
+  switch (clspv::Option::Vec3ToVec4()) {
+  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportForce:
+    return true;
+  case clspv::Option::Vec3ToVec4SupportClass::vec3ToVec4SupportDisable:
+    return false;
+  default:
+    for (auto &F : M.functions()) {
+      if (vec3BitcastInFunction(F))
+        return true;
+    }
+    return false;
+  }
+}
+
+bool clspv::ThreeElementVectorLoweringPass::vec3BitcastInFunction(Function &F) {
+  for (Instruction &I : instructions(F)) {
+    if (auto *Inst = dyn_cast<CastInst>(&I)) {
+      auto *Type = Inst->getSrcTy();
+      if (Type->isPointerTy() && !Type->isOpaquePointerTy()) {
+        auto *PointeeType = Type->getNonOpaquePointerElementType();
+        if (auto *VectorType = dyn_cast<FixedVectorType>(PointeeType)) {
+          if (VectorType->getElementCount().getKnownMinValue() == 3)
+            return true;
+        }
+      }
+    }
+  }
+
+  int ArgIndex = 0;
+  for (auto &Arg : F.args()) {
+    // If the argument is of opaque pointer type...
+    if (Arg.getType()->isOpaquePointerTy() &&
+        F.getMetadata("kernel_arg_type")) {
+      auto const &type_op =
+          F.getMetadata("kernel_arg_type")->getOperand(ArgIndex);
+      auto const &type_name_str = dyn_cast<MDString>(type_op)->getString();
+
+      auto ArgInferredType =
+          clspv::InferType(&Arg, F.getContext(), &type_cache_);
+
+      // ... and its main type is a vec3 type...
+      if (type_name_str.endswith("3*")) {
+        auto arg_base_type = type_name_str.drop_back(2);
+
+        // ... and its inferred type is of scalar type...
+        if (!ArgInferredType->isVectorTy()) {
+          return true;
+        }
+
+        // .. or have a mismatched vector size...
+        auto *VectorType = dyn_cast<FixedVectorType>(ArgInferredType);
+        if (VectorType->getElementCount().getKnownMinValue() != 3) {
+          return true;
+        }
+      }
+    }
+    ArgIndex++;
+  }
+
+  return false;
 }
 
 Value *clspv::ThreeElementVectorLoweringPass::visit(Value *V) {
@@ -409,7 +419,8 @@ Value *clspv::ThreeElementVectorLoweringPass::visitConstant(Constant &Cst) {
         return CE;
       }
       auto *EquivalentSourceTy = getEquivalentType(GEP->getSourceElementType());
-      auto *EquivalentPointer = cast<Constant>(visit(GEP->getPointerOperand()));
+      auto *EquivalentPointer =
+          cast<Constant>(visitOrSelf(GEP->getPointerOperand()));
       SmallVector<Value *, 4> Indices(GEP->idx_begin(), GEP->idx_end());
 
       auto *EquivalentGEP = ConstantExpr::getGetElementPtr(
@@ -494,14 +505,17 @@ Value *clspv::ThreeElementVectorLoweringPass::visitCallInst(CallInst &I) {
 
   auto *ReturnTy = I.getType();
   auto *EquivalentReturnTy = getEquivalentTypeOrSelf(ReturnTy);
-
+// disable for opaque pointers as they will have Equivalent Arg of nullptr until
+// they are inferred from other instructions.
 #ifndef NDEBUG
   bool NeedHandling = false;
-  NeedHandling |= (EquivalentReturnTy != ReturnTy);
+  NeedHandling |=
+      ReturnTy->isOpaquePointerTy() || (EquivalentReturnTy != ReturnTy);
   NeedHandling |=
       !std::equal(I.arg_begin(), I.arg_end(), std::begin(EquivalentArgs),
                   [](auto const &ArgUse, Value *EquivalentArg) {
-                    return ArgUse.get() == EquivalentArg;
+                    return !EquivalentArg->getType()->isOpaquePointerTy() &&
+                           ArgUse.get() == EquivalentArg;
                   });
   assert(NeedHandling && "Expected something to lower for this call.");
 #endif
@@ -526,6 +540,9 @@ Value *clspv::ThreeElementVectorLoweringPass::visitCallInst(CallInst &I) {
   } else {
     V = convertUserDefinedFunctionCall(I, EquivalentArgs);
   }
+
+  if (V == nullptr)
+    return nullptr;
 
   registerReplacement(I, *V);
   return V;
@@ -613,15 +630,26 @@ Value *clspv::ThreeElementVectorLoweringPass::visitGetElementPtrInst(
     return &I;
   }
 
-  auto *EquivalentPointer = visit(I.getPointerOperand());
-  if (EquivalentPointer == nullptr)
+  Type *EquivalentType = nullptr;
+  Value *EquivalentPointer = visitOrSelf(I.getPointerOperand());
+
+  bool isOpaque = I.getPointerOperand()->getType()->isOpaquePointerTy();
+
+  if (isOpaque) {
+    EquivalentType = getEquivalentType(I.getSourceElementType());
+  } else {
+    EquivalentType = EquivalentPointer->getType()
+                         ->getScalarType()
+                         ->getNonOpaquePointerElementType();
+  }
+
+  if (EquivalentType == nullptr ||
+      (!isOpaque && EquivalentPointer == I.getPointerOperand()))
     return nullptr;
 
   IRBuilder<> B(&I);
   SmallVector<Value *, 4> Indices(I.indices());
-  auto *V = B.CreateInBoundsGEP(
-      EquivalentPointer->getType()->getScalarType()->getPointerElementType(),
-      EquivalentPointer, Indices);
+  auto *V = B.CreateInBoundsGEP(EquivalentType, EquivalentPointer, Indices);
   registerReplacement(I, *V);
   return V;
 }
@@ -673,13 +701,25 @@ Value *clspv::ThreeElementVectorLoweringPass::visitLoadInst(LoadInst &I) {
     return &I;
   }
 
-  Value *EquivalentPointer = visit(I.getPointerOperand());
-  Type *EquivalentTy = getEquivalentType(I.getType());
-  if (EquivalentPointer == nullptr || EquivalentTy == nullptr)
+  Type *EquivalentType = nullptr;
+  Value *EquivalentPointer = visitOrSelf(I.getPointerOperand());
+
+  bool isOpaque = I.getPointerOperand()->getType()->isOpaquePointerTy();
+
+  if (isOpaque) {
+    EquivalentType = getEquivalentType(I.getType());
+  } else {
+    EquivalentType = EquivalentPointer->getType()
+                         ->getScalarType()
+                         ->getNonOpaquePointerElementType();
+  }
+
+  if (EquivalentType == nullptr ||
+      (!isOpaque && EquivalentPointer == I.getPointerOperand()))
     return nullptr;
 
   IRBuilder<> B(&I);
-  auto *V = B.CreateAlignedLoad(EquivalentTy, EquivalentPointer, I.getAlign(),
+  auto *V = B.CreateAlignedLoad(EquivalentType, EquivalentPointer, I.getAlign(),
                                 I.isVolatile());
   registerReplacement(I, *V);
   return V;
@@ -786,7 +826,13 @@ Value *clspv::ThreeElementVectorLoweringPass::visitShuffleVectorInst(
 
 Value *clspv::ThreeElementVectorLoweringPass::visitStoreInst(StoreInst &I) {
   Value *EquivalentValue = visit(I.getValueOperand());
-  Value *EquivalentPointer = visit(I.getPointerOperand());
+  Value *EquivalentPointer = nullptr;
+
+  if (I.getPointerOperand()->getType()->isOpaquePointerTy()) {
+    EquivalentPointer = I.getPointerOperand();
+  } else {
+    EquivalentPointer = visit(I.getPointerOperand());
+  }
 
   if (EquivalentValue == nullptr || EquivalentPointer == nullptr)
     return nullptr;
@@ -804,13 +850,17 @@ clspv::ThreeElementVectorLoweringPass::visitUnaryOperator(UnaryOperator &I) {
 }
 
 bool clspv::ThreeElementVectorLoweringPass::handlingRequired(User &U) {
-  if (getEquivalentType(U.getType()) != nullptr) {
+  if (getEquivalentType(clspv::InferType(&U, U.getContext(), &type_cache_)) !=
+      nullptr) {
     return true;
   }
 
   for (auto &Operand : U.operands()) {
     auto *OperandTy = Operand.get()->getType();
-    if (getEquivalentType(OperandTy) != nullptr) {
+    if (OperandTy->isOpaquePointerTy()) {
+      OperandTy = clspv::InferType(Operand, U.getContext(), &type_cache_);
+    }
+    if (OperandTy != nullptr && getEquivalentType(OperandTy) != nullptr) {
       return true;
     }
   }
@@ -820,23 +870,29 @@ bool clspv::ThreeElementVectorLoweringPass::handlingRequired(User &U) {
 
 void clspv::ThreeElementVectorLoweringPass::registerReplacement(Value &U,
                                                                 Value &V) {
-  LLVM_DEBUG(dbgs() << "Replacement for " << U << ": " << V << '\n');
   assert(ValueMap.count(&U) == 0 && "Value already registered");
   ValueMap.insert({&U, &V});
+}
 
-  if (U.getType() == V.getType()) {
-    LLVM_DEBUG(dbgs() << "\tAnd replace its usages.\n");
-    U.replaceAllUsesWith(&V);
-  }
+void clspv::ThreeElementVectorLoweringPass::replaceAllVec3Instances() {
+  for (auto mapping : ValueMap) {
+    auto U = mapping.first;
+    auto V = mapping.second;
+    LLVM_DEBUG(dbgs() << "Replacement for " << *U << ": " << *V << '\n');
+    if (U->getType() == V->getType()) {
+      LLVM_DEBUG(dbgs() << "\tAnd replace its usages.\n");
+      U->replaceAllUsesWith(V);
+    }
 
-  if (U.hasName()) {
-    V.takeName(&U);
-  }
+    if (U->hasName()) {
+      V->takeName(U);
+    }
 
-  auto *I = dyn_cast<Instruction>(&U);
-  auto *J = dyn_cast<Instruction>(&V);
-  if (I && J) {
-    J->copyMetadata(*I);
+    auto *I = dyn_cast<Instruction>(U);
+    auto *J = dyn_cast<Instruction>(V);
+    if (I && J) {
+      J->copyMetadata(*I);
+    }
   }
 }
 
@@ -860,7 +916,7 @@ Type *clspv::ThreeElementVectorLoweringPass::getEquivalentType(Type *Ty) {
 
 Type *clspv::ThreeElementVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   if (Ty->isIntegerTy() || Ty->isFloatingPointTy() || Ty->isVoidTy() ||
-      Ty->isLabelTy() || Ty->isMetadataTy()) {
+      Ty->isLabelTy() || Ty->isMetadataTy() || Ty->isOpaquePointerTy()) {
     // No lowering required.
     return nullptr;
   }
@@ -885,6 +941,7 @@ Type *clspv::ThreeElementVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
     return nullptr;
   }
 
+  // TODO(#816): remove condition after final transition.
   if (auto *PointerTy = dyn_cast<PointerType>(Ty)) {
     if (auto *ElementTy =
             getEquivalentType(PointerTy->getNonOpaquePointerElementType())) {
@@ -984,6 +1041,11 @@ bool clspv::ThreeElementVectorLoweringPass::runOnGlobals(Module &M) {
           EquivalentInitializer, "",
           /* insert before: */ &GV, GV.getThreadLocalMode(),
           GV.getAddressSpace(), GV.isExternallyInitialized());
+
+      if (GV.getType() == EquivalentGV->getType()) {
+        GV.replaceAllUsesWith(EquivalentGV);
+      }
+
       EquivalentGV->takeName(&GV);
       EquivalentGV->setAlignment(GV.getAlign());
       EquivalentGV->copyMetadata(&GV, /* offset: */ 0);
@@ -1027,12 +1089,62 @@ bool clspv::ThreeElementVectorLoweringPass::runOnFunction(Function &F) {
     Modified |= (visit(static_cast<Value *>(&I)) != nullptr);
   }
 
-  cleanDeadInstructions();
-
-  LLVM_DEBUG(dbgs() << "Final version for " << F.getName() << '\n');
-  LLVM_DEBUG(dbgs() << *FunctionToVisit << '\n');
-
   return Modified;
+}
+
+Value *clspv::ThreeElementVectorLoweringPass::convertOpCopyMemoryOperation(
+    CallInst &VectorCall, ArrayRef<Value *> EquivalentArgs) {
+  auto *DstOperand = EquivalentArgs[1];
+  auto *SrcOperand = EquivalentArgs[2];
+
+  if (DstOperand->getType()->isOpaquePointerTy()) {
+    auto ptrTy =
+        clspv::InferType(DstOperand, VectorCall.getContext(), &type_cache_);
+    assert(ptrTy->isVectorTy());
+    auto *VectorType = dyn_cast<FixedVectorType>(ptrTy);
+    assert(VectorType->getElementCount().getKnownMinValue() == 4);
+  } else {
+    assert(
+        DstOperand->getType()->getNonOpaquePointerElementType()->isVectorTy());
+    assert(dyn_cast<VectorType>(
+               DstOperand->getType()->getNonOpaquePointerElementType())
+               ->getElementCount()
+               .getKnownMinValue() == 4);
+  }
+
+  IRBuilder<> B(&VectorCall);
+  Value *ReturnValue = nullptr;
+
+  // for each element
+  for (unsigned eachElem = 0; eachElem < 3; eachElem++) {
+    auto SrcOperandTy = SrcOperand->getType();
+    auto DstOperandTy = DstOperand->getType();
+    if (SrcOperandTy->isOpaquePointerTy() ||
+        DstOperandTy->isOpaquePointerTy()) {
+      SrcOperandTy =
+          clspv::InferType(SrcOperand, VectorCall.getContext(), &type_cache_);
+      DstOperandTy =
+          clspv::InferType(DstOperand, VectorCall.getContext(), &type_cache_);
+      auto *SrcGEP = B.CreateGEP(SrcOperandTy, SrcOperand,
+                                 {B.getInt32(0), B.getInt32(eachElem)});
+      auto *Val = B.CreateLoad(SrcOperandTy->getScalarType(), SrcGEP);
+      auto *DstGEP = B.CreateGEP(DstOperandTy, DstOperand,
+                                 {B.getInt32(0), B.getInt32(eachElem)});
+      ReturnValue = B.CreateStore(Val, DstGEP);
+    } else {
+      auto *SrcGEP = B.CreateGEP(
+          SrcOperandTy->getScalarType()->getNonOpaquePointerElementType(),
+          SrcOperand, {B.getInt32(0), B.getInt32(eachElem)});
+      auto *Val = B.CreateLoad(
+          SrcGEP->getType()->getNonOpaquePointerElementType(), SrcGEP);
+      auto *DstGEP = B.CreateGEP(
+          DstOperandTy->getScalarType()->getNonOpaquePointerElementType(),
+          DstOperand, {B.getInt32(0), B.getInt32(eachElem)});
+      ReturnValue = B.CreateStore(Val, DstGEP);
+    }
+  }
+
+  return ReturnValue;
 }
 
 Value *clspv::ThreeElementVectorLoweringPass::convertBuiltinCall(
@@ -1160,7 +1272,9 @@ CallInst *clspv::ThreeElementVectorLoweringPass::convertUserDefinedFunctionCall(
   assert(Callee);
 
   Function *EquivalentFunction = convertUserDefinedFunction(*Callee);
-  assert(EquivalentFunction);
+  if (EquivalentFunction == nullptr) {
+    return nullptr;
+  }
 
   IRBuilder<> B(&Call);
   CallInst *NewCall = B.CreateCall(EquivalentFunction, EquivalentArgs);

--- a/lib/ThreeElementVectorLoweringPass.h
+++ b/lib/ThreeElementVectorLoweringPass.h
@@ -107,8 +107,12 @@ private:
   /// Look for bitcast of vec3 inside the function
   bool vec3BitcastInFunction(llvm::Function &F);
 
-  /// Returns whether the vec3 should be transform into vec4
+  /// Returns whether the vec3 should be transformed into vec4
   bool vec3ShouldBeLowered(llvm::Module &M);
+
+  /// Returns whether a value have an implicit cast or not, works only with
+  /// opaque pointers
+  bool haveImplicitCast(llvm::Value *Value);
 
   /// Lower all global variables in the module.
   bool runOnGlobals(llvm::Module &M);

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -195,7 +195,7 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
     if (user->getType()->isPointerTy() || isPointerTy) {
       // Handle stores with only pointer operands.
       auto *store = dyn_cast<StoreInst>(user);
-      if (store &&  store->getPointerOperand() != v) {
+      if (store && store->getPointerOperand() != v) {
         user = dyn_cast<User>(store->getPointerOperand());
       }
       for (auto &use : user->uses())

--- a/test/CommonBuiltins/clamp/float3_clamp_novec3.cl
+++ b/test/CommonBuiltins/clamp/float3_clamp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/CommonBuiltins/clamp/half3_clamp_novec3.cl
+++ b/test/CommonBuiltins/clamp/half3_clamp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/float3_degrees_novec3.cl
+++ b/test/CommonBuiltins/float3_degrees_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/float3_radians_novec3.cl
+++ b/test/CommonBuiltins/float3_radians_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/float3_sign_novec3.cl
+++ b/test/CommonBuiltins/float3_sign_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/max/float3_max_novec3.cl
+++ b/test/CommonBuiltins/max/float3_max_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/CommonBuiltins/max/half3_fmax_novec3.cl
+++ b/test/CommonBuiltins/max/half3_fmax_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/max/half3_max_novec3.cl
+++ b/test/CommonBuiltins/max/half3_max_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/min/float3_min_novec3.cl
+++ b/test/CommonBuiltins/min/float3_min_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/CommonBuiltins/min/half3_fmin_novec3.cl
+++ b/test/CommonBuiltins/min/half3_fmin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/min/half3_min_novec3.cl
+++ b/test/CommonBuiltins/min/half3_min_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/mix/float3_mix_novec3.cl
+++ b/test/CommonBuiltins/mix/float3_mix_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/mix/half3_mix_novec3.cl
+++ b/test/CommonBuiltins/mix/half3_mix_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[EXT:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
 // CHECK-DAG: [[half4:%[a-zA-Z0-9_]+]] = OpTypeVector [[half]] 4

--- a/test/CommonBuiltins/smoothstep/smoothstep_float3_novec3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
+++ b/test/CommonBuiltins/smoothstep/smoothstep_float_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/step/step_float3_novec3.cl
+++ b/test/CommonBuiltins/step/step_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/CommonBuiltins/step/step_float_float3_novec3.cl
+++ b/test/CommonBuiltins/step/step_float_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4

--- a/test/GeometricBuiltins/float3_cross_novec3.cl
+++ b/test/GeometricBuiltins/float3_cross_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_distance_novec3.cl
+++ b/test/GeometricBuiltins/float3_distance_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_dot_novec3.cl
+++ b/test/GeometricBuiltins/float3_dot_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
 // CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/GeometricBuiltins/float3_fast_distance_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_distance_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_fast_length_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_length_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_fast_normalize_novec3.cl
+++ b/test/GeometricBuiltins/float3_fast_normalize_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_length_novec3.cl
+++ b/test/GeometricBuiltins/float3_length_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float3_normalize_novec3.cl
+++ b/test/GeometricBuiltins/float3_normalize_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/GeometricBuiltins/float4_cross_novec3.cl
+++ b/test/GeometricBuiltins/float4_cross_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/GeometricBuiltins/half3_dot_novec3.cl
+++ b/test/GeometricBuiltins/half3_dot_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
 // CHECK-DAG: %[[HALF4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
 // CHECK-DAG: %[[HALF3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 3

--- a/test/IntegerBuiltins/abs/abs_char3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global uchar3* a, global char3* b) {
   *a = abs(*b);
 }

--- a/test/IntegerBuiltins/abs/abs_int3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/abs/abs_long3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/abs/abs_short3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/abs/abs_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global uchar3* a, global uchar3* b) {
   *a = abs(*b);
 }

--- a/test/IntegerBuiltins/abs/abs_uint3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]

--- a/test/IntegerBuiltins/abs/abs_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK:     %[[__original_id_17:[0-9]+]] = OpLoad %[[v4ulong]]

--- a/test/IntegerBuiltins/abs/abs_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/abs/abs_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK:     %[[__original_id_17:[0-9]+]] = OpLoad %[[v4ushort]]

--- a/test/IntegerBuiltins/abs_diff/abs_diff_char3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_int3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_long3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_short3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK-DAG: %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_uint3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/abs_diff/abs_diff_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/abs_diff/abs_diff_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[void:[0-9a-zA-Z_]+]] = OpTypeVoid

--- a/test/IntegerBuiltins/clamp/clamp_char3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK:     %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4

--- a/test/IntegerBuiltins/clamp/clamp_int3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK:     %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4

--- a/test/IntegerBuiltins/clamp/clamp_long3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK:     %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/clamp/clamp_short3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK:     %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/clamp/clamp_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK:     %[[v4uchar:[0-9a-zA-Z_]+]] = OpTypeVector %[[uchar]] 4

--- a/test/IntegerBuiltins/clamp/clamp_uint3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK:     %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4

--- a/test/IntegerBuiltins/clamp/clamp_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK:     %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/clamp/clamp_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/clamp/clamp_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[glsl_ext:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK:     %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK:     %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/clz/int3_clz_novec3.cl
+++ b/test/IntegerBuiltins/clz/int3_clz_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3

--- a/test/IntegerBuiltins/clz/uint3_clz_novec3.cl
+++ b/test/IntegerBuiltins/clz/uint3_clz_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR3_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3

--- a/test/IntegerBuiltins/int3_mad24_novec3.cl
+++ b/test/IntegerBuiltins/int3_mad24_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42

--- a/test/IntegerBuiltins/int3_max_var_novec3.cl
+++ b/test/IntegerBuiltins/int3_max_var_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/int3_min_var_novec3.cl
+++ b/test/IntegerBuiltins/int3_min_var_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/int3_mul24_novec3.cl
+++ b/test/IntegerBuiltins/int3_mul24_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42

--- a/test/IntegerBuiltins/max/max_char3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global char3* a, global char3* b, global char3* c) {
   *a = max(*b, *c);
 }

--- a/test/IntegerBuiltins/max/max_int3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/max/max_long3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/max/max_short3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/max/max_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global uchar3* a, global uchar3* b, global uchar3* c) {
   *a = max(*b, *c);
 }

--- a/test/IntegerBuiltins/max/max_uint3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/max/max_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/max/max_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/max/max_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/min/min_char3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global char3* a, global char3* b, global char3* c)
 {
     *a = min(*b, *c);

--- a/test/IntegerBuiltins/min/min_int3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/min/min_long3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/min/min_short3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/min/min_uchar3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uchar3* a, global uchar3* b, global uchar3* c)
 {
     *a = min(*b, *c);

--- a/test/IntegerBuiltins/min/min_uint3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4

--- a/test/IntegerBuiltins/min/min_ulong3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/IntegerBuiltins/min/min_ushort3_novec3.cl
+++ b/test/IntegerBuiltins/min/min_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK:     %[[__original_id_1:[0-9]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/char3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global char3* a, global char3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/popcount/int3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/int3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]

--- a/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/long3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global long3* a, global long3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/short3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global short3* a, global short3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/uchar3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global uchar3* a, global uchar3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/popcount/uint3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/uint3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT_VECTOR_TYPE_ID]]

--- a/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ulong3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global ulong3* a, global ulong3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
+++ b/test/IntegerBuiltins/popcount/ushort3_popcount_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global ushort3* a, global ushort3* b) {
   *a = popcount(*b);
 }

--- a/test/IntegerBuiltins/uint3_mad24_novec3.cl
+++ b/test/IntegerBuiltins/uint3_mad24_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42

--- a/test/IntegerBuiltins/uint3_mul24_novec3.cl
+++ b/test/IntegerBuiltins/uint3_mul24_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42

--- a/test/MathBuiltins/acos/float3_acos_novec3.cl
+++ b/test/MathBuiltins/acos/float3_acos_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/acos/float3_acosh_novec3.cl
+++ b/test/MathBuiltins/acos/float3_acosh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/asin/float3_asin_novec3.cl
+++ b/test/MathBuiltins/asin/float3_asin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/asin/float3_asinh_novec3.cl
+++ b/test/MathBuiltins/asin/float3_asinh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/atan/float3_atan2_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atan2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/atan/float3_atan_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atan_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/atan/float3_atanh_novec3.cl
+++ b/test/MathBuiltins/atan/float3_atanh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/ceil/float3_ceil_novec3.cl
+++ b/test/MathBuiltins/ceil/float3_ceil_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/cos/float3_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_cos_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/cos/float3_cosh_novec3.cl
+++ b/test/MathBuiltins/cos/float3_cosh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/cos/float3_half_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_half_cos_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/cos/float3_native_cos_novec3.cl
+++ b/test/MathBuiltins/cos/float3_native_cos_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/divide/float3_half_divide_novec3.cl
+++ b/test/MathBuiltins/divide/float3_half_divide_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42

--- a/test/MathBuiltins/divide/float3_native_divide_novec3.cl
+++ b/test/MathBuiltins/divide/float3_native_divide_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_FLOAT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42

--- a/test/MathBuiltins/exp/float3_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_exp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_half_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_half_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_half_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_half_exp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_native_exp10_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_native_exp2_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/exp/float3_native_exp_novec3.cl
+++ b/test/MathBuiltins/exp/float3_native_exp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/fabs/float3_fabs_novec3.cl
+++ b/test/MathBuiltins/fabs/float3_fabs_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/floor/float3_floor_novec3.cl
+++ b/test/MathBuiltins/floor/float3_floor_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/fma/float3_fma_novec3.cl
+++ b/test/MathBuiltins/fma/float3_fma_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/fmax/float3_fmax_novec3.cl
+++ b/test/MathBuiltins/fmax/float3_fmax_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/fmin/float3_fmin_novec3.cl
+++ b/test/MathBuiltins/fmin/float3_fmin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/ldexp/float3_ldexp_novec3.cl
+++ b/test/MathBuiltins/ldexp/float3_ldexp_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_half_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_half_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_half_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_half_log_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_log10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_log2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_log_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_native_log10_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log10_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_native_log2_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log2_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/log/float3_native_log_novec3.cl
+++ b/test/MathBuiltins/log/float3_native_log_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/mad/float3_mad_novec3.cl
+++ b/test/MathBuiltins/mad/float3_mad_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 42

--- a/test/MathBuiltins/mad/half3_mad_novec3.cl
+++ b/test/MathBuiltins/mad/half3_mad_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
 // CHECK-DAG: %[[HALF_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[HALF_TYPE_ID]] 0x1.5p+5

--- a/test/MathBuiltins/pow/float3_half_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_half_powr_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/pow/float3_native_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_native_powr_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/pow/float3_pow_novec3.cl
+++ b/test/MathBuiltins/pow/float3_pow_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/pow/float3_powr_novec3.cl
+++ b/test/MathBuiltins/pow/float3_powr_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/recip/float3_half_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_half_recip_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_UNDEF:[a-zA-Z0-9_]*]] = OpUndef %[[FLOAT_TYPE_ID]]
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/recip/float3_native_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_native_recip_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_FLOAT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1

--- a/test/MathBuiltins/rint/float3_rint_novec3.cl
+++ b/test/MathBuiltins/rint/float3_rint_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/round/float3_round_novec3.cl
+++ b/test/MathBuiltins/round/float3_round_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: [[ext_inst:%[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[int3:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 3

--- a/test/MathBuiltins/sin/float3_half_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_half_sin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sin/float3_native_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_native_sin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sin/float3_sin_novec3.cl
+++ b/test/MathBuiltins/sin/float3_sin_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sin/float3_sinh_novec3.cl
+++ b/test/MathBuiltins/sin/float3_sinh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_half_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_half_rsqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_half_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_half_sqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_native_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_native_rsqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_native_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_native_sqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_rsqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
+++ b/test/MathBuiltins/sqrt/float3_sqrt_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 -cl-native-math --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/tan/float3_half_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_half_tan_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/tan/float3_native_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_native_tan_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/tan/float3_tan_novec3.cl
+++ b/test/MathBuiltins/tan/float3_tan_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/tan/float3_tanh_novec3.cl
+++ b/test/MathBuiltins/tan/float3_tanh_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -cl-native-math -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/MathBuiltins/trunc/float3_trunc_novec3.cl
+++ b/test/MathBuiltins/trunc/float3_trunc_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -module-constants-in-storage-buffer -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv-reflection %t.spv -o %t.map
+// RUN: FileCheck -check-prefix=MAP %s < %t.map
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // Proves ConstantDataVector and ConstantArray work.
 
 __constant uint3 ppp[2] = {(uint3)(1,2,3), (uint3)(5)};

--- a/test/RelationalBuiltins/all/all_char3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global int* a, global char3* b) {
   *a = all(*b);
 }

--- a/test/RelationalBuiltins/all/all_int3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool

--- a/test/RelationalBuiltins/all/all_long3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/RelationalBuiltins/all/all_short3_novec3.cl
+++ b/test/RelationalBuiltins/all/all_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/RelationalBuiltins/any/any_char3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global int* a, global char3* b) {
   *a = any(*b);
 }

--- a/test/RelationalBuiltins/any/any_int3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool

--- a/test/RelationalBuiltins/any/any_long3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4

--- a/test/RelationalBuiltins/any/any_short3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4

--- a/test/RelationalBuiltins/bitselect/bitselect_char3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global char3* a, global char3* b, global char3* c) {
   *a = bitselect(*a, *b, *c);
 }

--- a/test/RelationalBuiltins/bitselect/bitselect_int3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[uint_4294967295:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295

--- a/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[ulong_18446744073709551615:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 18446744073709551615

--- a/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[ushort_65535:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 65535

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global uchar3* a, global uchar3* b, global uchar3* c) {
   *a = bitselect(*a, *b, *c);
 }

--- a/test/RelationalBuiltins/bitselect/bitselect_uint3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[uint_4294967295:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 4294967295

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[ulong_18446744073709551615:[0-9a-zA-Z_]+]] = OpConstant %[[ulong]] 18446744073709551615

--- a/test/RelationalBuiltins/bitselect/bitselect_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[ushort_65535:[0-9a-zA-Z_]+]] = OpConstant %[[ushort]] 65535

--- a/test/RelationalBuiltins/isequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isequal_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isgreater_float3_novec3.cl
+++ b/test/RelationalBuiltins/isgreater_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isgreaterequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isgreaterequal_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isinf_float3_novec3.cl
+++ b/test/RelationalBuiltins/isinf_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isless_float3_novec3.cl
+++ b/test/RelationalBuiltins/isless_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/islessequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/islessequal_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isnan_float3_novec3.cl
+++ b/test/RelationalBuiltins/isnan_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/isnotequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isnotequal_float3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/RelationalBuiltins/select/select_char3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_char3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 kernel void foo(global char3* a, global char3* b, global uchar3* c) {
   *a = select(*a, *b, *c);
 }

--- a/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0

--- a/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[float:[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: %[[v4float:[0-9a-zA-Z_]+]] = OpTypeVector %[[float]] 4
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0

--- a/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: %[[v4uint:[0-9a-zA-Z_]+]] = OpTypeVector %[[uint]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ulong:[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: %[[v4ulong:[0-9a-zA-Z_]+]] = OpTypeVector %[[ulong]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[ushort:[0-9a-zA-Z_]+]] = OpTypeInt 16 0
 // CHECK-DAG: %[[v4ushort:[0-9a-zA-Z_]+]] = OpTypeVector %[[ushort]] 4
 // CHECK-DAG: %[[bool:[0-9a-zA-Z_]+]] = OpTypeBool

--- a/test/div/float3_div_cst_novec3.cl
+++ b/test/div/float3_div_cst_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
 // CHECK-DAG: %[[CONSTANT_ID:[a-zA-Z0-9_]*]] = OpConstant %[[TYPE_ID]] 42

--- a/test/div/float3_div_novec3.cl
+++ b/test/div/float3_div_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
 // CHECK-DAG: %[[BOOL_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeBool

--- a/test/float3_add_novec3.cl
+++ b/test/float3_add_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/float3_mul_novec3.cl
+++ b/test/float3_mul_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/float3_sub_novec3.cl
+++ b/test/float3_sub_novec3.cl
@@ -3,6 +3,11 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
 // CHECK-DAG: %[[TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[VEC_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[TYPE_ID]] 4
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)

--- a/test/issue-679_opaque.cl
+++ b/test/issue-679_opaque.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t2.spv --enable-opaque-pointers
+// RUN: spirv-dis -o %t2.spvasm %t2.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t2.spv
+
+kernel void bar(global float3* data) {
+  global float3* tmp1 = &(data[3]);
+  global float4* tmp2 = (global float4*)tmp1;
+  *tmp2 = (float4)(0.0f,0.0f,0.0f,0.0f);
+}
+
+// CHECK-DAG: [[uint:%[0-9a-zA-Z_]*]] = OpTypeInt 32 0
+// CHECK-DAG: [[float:%[0-9a-zA-Z_]*]] = OpTypeFloat 32
+// CHECK-DAG: [[vec4:%[0-9a-zA-Z_]*]] = OpTypeVector [[float]] 4
+// CHECK-DAG: [[ptr_storage_buffer_vec4:%[0-9a-zA-Z_]*]] = OpTypePointer StorageBuffer [[vec4]]
+// CHECK-DAG: [[uint_0:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_2:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 2
+// CHECK-DAG: [[uint_3:%[0-9a-zA-Z_]*]] = OpConstant [[uint]] 3
+// CHECK-DAG: [[empty_vec4:%[0-9a-zA-Z_]*]] = OpConstantNull [[vec4]] 
+// CHECK: [[vec4_ptr:%[0-9a-zA-Z_]*]] = OpAccessChain [[ptr_storage_buffer_vec4]] {{.*}} [[uint_0]] [[uint_3]]
+// CHECK: OpStore [[vec4_ptr]] [[empty_vec4]]

--- a/test/issue-679_opaque.ll
+++ b/test/issue-679_opaque.ll
@@ -1,0 +1,102 @@
+; RUN: clspv-opt --passes=three-element-vector-lowering %s -o %t --opaque-pointers=true
+; RUN: FileCheck %s < %t
+
+@__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @test(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !7 !kernel_arg_type_qual !8 !clspv.pod_args_impl !9 {
+entry:
+  %out.addr = alloca ptr addrspace(1)
+  store ptr addrspace(1) null, ptr %out.addr
+  %in.addr = alloca ptr addrspace(1)
+  store ptr addrspace(1) null, ptr %in.addr
+  %gid = alloca i32
+  store i32 0, ptr %gid
+  %x = alloca <3 x float>
+  store <3 x float> zeroinitializer, ptr %x
+  store ptr addrspace(1) %out, ptr %out.addr
+  store ptr addrspace(1) %in, ptr %in.addr
+  %0 = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId
+  store i32 %0, ptr %gid
+  %1 = load i32, ptr %gid
+  %2 = load ptr addrspace(1), ptr %in.addr
+  %3 = mul i32 %1, 3
+  %4 = add i32 %3, 0
+  %5 = getelementptr float, ptr addrspace(1) %2, i32 %4
+  %6 = load float, ptr addrspace(1) %5
+  %7 = insertelement <3 x float> undef, float %6, i64 0
+  %8 = add i32 %3, 1
+  %9 = getelementptr float, ptr addrspace(1) %2, i32 %8
+  %10 = load float, ptr addrspace(1) %9
+  %11 = insertelement <3 x float> %7, float %10, i64 1
+  %12 = add i32 %3, 2
+  %13 = getelementptr float, ptr addrspace(1) %2, i32 %12
+  %14 = load float, ptr addrspace(1) %13
+  %15 = insertelement <3 x float> %11, float %14, i64 2
+  store <3 x float> %15, ptr %x
+  %16 = load <3 x float>, ptr %x
+  %vecext = extractelement <3 x float> %16, i32 0
+  %17 = load <3 x float>, ptr %x
+  %vecext2 = extractelement <3 x float> %17, i32 1
+  %add = fadd float %vecext, %vecext2
+  %18 = load <3 x float>, ptr %x
+  %vecext3 = extractelement <3 x float> %18, i32 2
+  %add4 = fadd float %add, %vecext3
+  %19 = load ptr addrspace(1), ptr %out.addr
+  %20 = load i32, ptr %gid
+  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %19, i32 %20
+  store float %add4, ptr addrspace(1) %arrayidx
+  ret void
+}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{!"clang version 15.0.0 (https://github.com/llvm/llvm-project 4c79e1a3f4eb790f40239833ae237e828ce07386)"}
+!3 = !{!"clang version 12.0.0 (git@github.com:llvm/llvm-project.git 0c82fa677f24d8a9656af41ac9cc64ea4f818bc0)"}
+!4 = !{i32 1, i32 1}
+!5 = !{!"none", !"none"}
+!6 = !{!"float*", !"float3*"}
+!7 = !{!"float*", !"float __attribute__((ext_vector_type(3)))*"}
+!8 = !{!"", !""}
+!9 = !{i32 2}
+
+; CHECK: %out.addr = alloca ptr addrspace(1)
+; CHECK: store ptr addrspace(1) null, ptr %out.addr
+; CHECK: %in.addr = alloca ptr addrspace(1)
+; CHECK: store ptr addrspace(1) null, ptr %in.addr
+; CHECK: %gid = alloca i32
+; CHECK: store i32 0, ptr %gid
+; CHECK: %x = alloca <4 x float>
+; CHECK: store <4 x float> zeroinitializer, ptr %x
+; CHECK: store ptr addrspace(1) %out, ptr %out.addr
+; CHECK: store ptr addrspace(1) %in, ptr %in.addr
+; CHECK: [[localid0:%[a-zA-Z0-9_.]+]] = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId
+; CHECK: store i32 [[localid0]], ptr %gid
+; CHECK: [[localid1:%[a-zA-Z0-9_.]+]] = load i32, ptr %gid
+; CHECK: [[localid2:%[a-zA-Z0-9_.]+]] = load ptr addrspace(1), ptr %in.addr
+; CHECK: [[localid3:%[a-zA-Z0-9_.]+]] = mul i32 [[localid1]], 3
+; CHECK: [[localid4:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 0
+; CHECK: [[localid5:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid4]]
+; CHECK: [[localid6:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid5]]
+; CHECK: [[localid7:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[localid6]], i64 0
+; CHECK: [[localid8:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 1
+; CHECK: [[localid9:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid8]]
+; CHECK: [[localid10:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid9]]
+; CHECK: [[localid11:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[localid7]], float [[localid10]], i64 1
+; CHECK: [[localid12:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 2
+; CHECK: [[localid13:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid12]]
+; CHECK: [[localid14:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid13]]
+; CHECK: [[localid15:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[localid11]], float [[localid14]], i64 2
+; CHECK: store <4 x float> [[localid15]], ptr %x
+; CHECK: [[localid16:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
+; CHECK: %vecext = extractelement <4 x float> [[localid16]], i32 0
+; CHECK: [[localid17:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
+; CHECK: %vecext2 = extractelement <4 x float> [[localid17]], i32 1
+; CHECK: %add = fadd float %vecext, %vecext2
+; CHECK: [[localid18:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
+; CHECK: %vecext3 = extractelement <4 x float> [[localid18]], i32 2
+; CHECK: %add4 = fadd float %add, %vecext3
+; CHECK: [[localid19:%[a-zA-Z0-9_.]+]] = load ptr addrspace(1), ptr %out.addr
+; CHECK: [[localid20:%[a-zA-Z0-9_.]+]] = load i32, ptr %gid
+; CHECK: %arrayidx = getelementptr inbounds float, ptr addrspace(1) [[localid19]], i32 [[localid20]]
+; CHECK: store float %add4, ptr addrspace(1) %arrayidx

--- a/test/issue-679_opaque.ll
+++ b/test/issue-679_opaque.ll
@@ -1,102 +1,74 @@
-; RUN: clspv-opt --passes=three-element-vector-lowering %s -o %t --opaque-pointers=true
+; RUN: clspv-opt --passes=three-element-vector-lowering %s -o %t --opaque-pointers
 ; RUN: FileCheck %s < %t
 
-@__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
-@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
 
-define dso_local spir_kernel void @test(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !7 !kernel_arg_type_qual !8 !clspv.pod_args_impl !9 {
+define spir_kernel void @test1(ptr %in, i32 %n) {
 entry:
-  %out.addr = alloca ptr addrspace(1)
-  store ptr addrspace(1) null, ptr %out.addr
-  %in.addr = alloca ptr addrspace(1)
-  store ptr addrspace(1) null, ptr %in.addr
-  %gid = alloca i32
-  store i32 0, ptr %gid
-  %x = alloca <3 x float>
-  store <3 x float> zeroinitializer, ptr %x
-  store ptr addrspace(1) %out, ptr %out.addr
-  store ptr addrspace(1) %in, ptr %in.addr
-  %0 = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId
-  store i32 %0, ptr %gid
-  %1 = load i32, ptr %gid
-  %2 = load ptr addrspace(1), ptr %in.addr
-  %3 = mul i32 %1, 3
-  %4 = add i32 %3, 0
-  %5 = getelementptr float, ptr addrspace(1) %2, i32 %4
-  %6 = load float, ptr addrspace(1) %5
-  %7 = insertelement <3 x float> undef, float %6, i64 0
-  %8 = add i32 %3, 1
-  %9 = getelementptr float, ptr addrspace(1) %2, i32 %8
-  %10 = load float, ptr addrspace(1) %9
-  %11 = insertelement <3 x float> %7, float %10, i64 1
-  %12 = add i32 %3, 2
-  %13 = getelementptr float, ptr addrspace(1) %2, i32 %12
-  %14 = load float, ptr addrspace(1) %13
-  %15 = insertelement <3 x float> %11, float %14, i64 2
-  store <3 x float> %15, ptr %x
-  %16 = load <3 x float>, ptr %x
-  %vecext = extractelement <3 x float> %16, i32 0
-  %17 = load <3 x float>, ptr %x
-  %vecext2 = extractelement <3 x float> %17, i32 1
-  %add = fadd float %vecext, %vecext2
-  %18 = load <3 x float>, ptr %x
-  %vecext3 = extractelement <3 x float> %18, i32 2
-  %add4 = fadd float %add, %vecext3
-  %19 = load ptr addrspace(1), ptr %out.addr
-  %20 = load i32, ptr %gid
-  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %19, i32 %20
-  store float %add4, ptr addrspace(1) %arrayidx
+    %gep = getelementptr <3 x float>, ptr %in, i32 %n
+    %alloca = alloca float
+    store ptr %alloca, ptr %gep, align 4
+    ret void
+}
+
+; CHECK: define spir_kernel void @test1(ptr %in, i32 %n) {
+; CHECK: %gep = getelementptr inbounds <4 x float>, ptr %in, i32 %n
+; CHECK: %alloca = alloca float, align 4
+; CHECK: store ptr %alloca, ptr %gep, align 4
+
+define void @test2(ptr addrspace(1) %data) {
+entry:
+  %gep1 = getelementptr <3 x i32>, ptr addrspace(1) %data, i32 0, i32 2
+  %gep2 = getelementptr i32, ptr addrspace(1) %gep1, i32 3
+  store i32 0, ptr addrspace(1) %gep2
   ret void
 }
 
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 1, i32 2}
-!2 = !{!"clang version 15.0.0 (https://github.com/llvm/llvm-project 4c79e1a3f4eb790f40239833ae237e828ce07386)"}
-!3 = !{!"clang version 12.0.0 (git@github.com:llvm/llvm-project.git 0c82fa677f24d8a9656af41ac9cc64ea4f818bc0)"}
-!4 = !{i32 1, i32 1}
-!5 = !{!"none", !"none"}
-!6 = !{!"float*", !"float3*"}
-!7 = !{!"float*", !"float __attribute__((ext_vector_type(3)))*"}
-!8 = !{!"", !""}
-!9 = !{i32 2}
+; CHECK: define void @test2(ptr addrspace(1) %data) {
+; CHECK: %gep1 = getelementptr inbounds <4 x i32>, ptr addrspace(1) %data, i32 0, i32 2
+; CHECK: %gep2 = getelementptr i32, ptr addrspace(1) %gep1, i32 3
+; CHECK: store i32 0, ptr addrspace(1) %gep2
 
-; CHECK: %out.addr = alloca ptr addrspace(1)
-; CHECK: store ptr addrspace(1) null, ptr %out.addr
-; CHECK: %in.addr = alloca ptr addrspace(1)
-; CHECK: store ptr addrspace(1) null, ptr %in.addr
-; CHECK: %gid = alloca i32
-; CHECK: store i32 0, ptr %gid
-; CHECK: %x = alloca <4 x float>
-; CHECK: store <4 x float> zeroinitializer, ptr %x
-; CHECK: store ptr addrspace(1) %out, ptr %out.addr
-; CHECK: store ptr addrspace(1) %in, ptr %in.addr
-; CHECK: [[localid0:%[a-zA-Z0-9_.]+]] = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId
-; CHECK: store i32 [[localid0]], ptr %gid
-; CHECK: [[localid1:%[a-zA-Z0-9_.]+]] = load i32, ptr %gid
-; CHECK: [[localid2:%[a-zA-Z0-9_.]+]] = load ptr addrspace(1), ptr %in.addr
-; CHECK: [[localid3:%[a-zA-Z0-9_.]+]] = mul i32 [[localid1]], 3
-; CHECK: [[localid4:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 0
-; CHECK: [[localid5:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid4]]
-; CHECK: [[localid6:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid5]]
-; CHECK: [[localid7:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> undef, float [[localid6]], i64 0
-; CHECK: [[localid8:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 1
-; CHECK: [[localid9:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid8]]
-; CHECK: [[localid10:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid9]]
-; CHECK: [[localid11:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[localid7]], float [[localid10]], i64 1
-; CHECK: [[localid12:%[a-zA-Z0-9_.]+]] = add i32 [[localid3]], 2
-; CHECK: [[localid13:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[localid2]], i32 [[localid12]]
-; CHECK: [[localid14:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[localid13]]
-; CHECK: [[localid15:%[a-zA-Z0-9_.]+]] = insertelement <4 x float> [[localid11]], float [[localid14]], i64 2
-; CHECK: store <4 x float> [[localid15]], ptr %x
-; CHECK: [[localid16:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
-; CHECK: %vecext = extractelement <4 x float> [[localid16]], i32 0
-; CHECK: [[localid17:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
-; CHECK: %vecext2 = extractelement <4 x float> [[localid17]], i32 1
-; CHECK: %add = fadd float %vecext, %vecext2
-; CHECK: [[localid18:%[a-zA-Z0-9_.]+]] = load <4 x float>, ptr %x
-; CHECK: %vecext3 = extractelement <4 x float> [[localid18]], i32 2
-; CHECK: %add4 = fadd float %add, %vecext3
-; CHECK: [[localid19:%[a-zA-Z0-9_.]+]] = load ptr addrspace(1), ptr %out.addr
-; CHECK: [[localid20:%[a-zA-Z0-9_.]+]] = load i32, ptr %gid
-; CHECK: %arrayidx = getelementptr inbounds float, ptr addrspace(1) [[localid19]], i32 [[localid20]]
-; CHECK: store float %add4, ptr addrspace(1) %arrayidx
+define i32 @test3(ptr addrspace(1) %data) {
+entry:
+  %gep1 = getelementptr <3 x i32>, ptr addrspace(1) %data, i32 0, i32 2
+  %gep2 = getelementptr i32, ptr addrspace(1) %gep1, i32 3
+  %ld = load i32, ptr addrspace(1) %gep2
+  ret i32 %ld
+}
+
+; CHECK: define i32 @test3(ptr addrspace(1) %data) {
+; CHECK: %gep1 = getelementptr inbounds <4 x i32>, ptr addrspace(1) %data, i32 0, i32 2
+; CHECK: %gep2 = getelementptr i32, ptr addrspace(1) %gep1, i32 3
+; CHECK: %ld = load i32, ptr addrspace(1) %gep2
+
+define void @test4() {
+entry:
+  %data = alloca <3 x i32>
+  %gep1 = getelementptr <3 x i32>, ptr %data, i32 0, i32 2
+  %gep2 = getelementptr i32, ptr %gep1, i32 3
+  store i32 0, ptr %gep2
+  ret void
+}
+
+; CHECK: define void @test4() {
+; CHECK: %data = alloca <4 x i32>
+; CHECK: %gep1 = getelementptr inbounds <4 x i32>, ptr %data, i32 0, i32 2
+; CHECK: %gep2 = getelementptr i32, ptr %gep1, i32 3
+; CHECK: store i32 0, ptr %gep2
+
+define i32 @test5() {
+entry:
+  %data = alloca <3 x i32>
+  %gep1 = getelementptr <3 x i32>, ptr %data, i32 0, i32 2
+  %gep2 = getelementptr i32, ptr %gep1, i32 3
+  %ld = load i32, ptr %gep2
+  ret i32 %ld
+}
+
+; CHECK: define i32 @test5() {
+; CHECK: %data = alloca <4 x i32>
+; CHECK: %gep1 = getelementptr inbounds <4 x i32>, ptr %data, i32 0, i32 2
+; CHECK: %gep2 = getelementptr i32, ptr %gep1, i32 3
+; CHECK: %ld = load i32, ptr %gep2

--- a/test/packed_struct_novec3.ll
+++ b/test/packed_struct_novec3.ll
@@ -1,6 +1,9 @@
 ; RUN: clspv-opt --passes=three-element-vector-lowering -vec3-to-vec4 %s -o %t
 ; RUN: FileCheck %s < %t
 
+; RUN: clspv-opt --passes=three-element-vector-lowering -vec3-to-vec4 --opaque-pointers=true %s -o %t
+; RUN: FileCheck %s < %t
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/packed_struct_novec3.ll
+++ b/test/packed_struct_novec3.ll
@@ -1,9 +1,6 @@
 ; RUN: clspv-opt --passes=three-element-vector-lowering -vec3-to-vec4 %s -o %t
 ; RUN: FileCheck %s < %t
 
-; RUN: clspv-opt --passes=three-element-vector-lowering -vec3-to-vec4 --opaque-pointers=true %s -o %t
-; RUN: FileCheck %s < %t
-
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/simple_vec3_to_vec4_opaque.ll
+++ b/test/simple_vec3_to_vec4_opaque.ll
@@ -1,0 +1,34 @@
+; RUN: clspv-opt --vec3-to-vec4 --passes=three-element-vector-lowering --opaque-pointers=true %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+declare void @_Z8spirv.op.63.PU3AS3Dv3_hPU3AS1Dv3_h(i32, ptr, ptr)
+
+define spir_kernel void @simple_call(ptr %a, ptr %b) {
+entry:
+  %src = getelementptr <3 x i8>, ptr %a, i32 0
+  %dst = getelementptr <3 x i8>, ptr %b, i32 0
+
+  store <3 x i8> <i8 1, i8 2, i8 3>, ptr %src
+  
+  %load = load <3 x i8>, ptr %a
+
+  call void @_Z8spirv.op.63.PU3AS3Dv3_hPU3AS1Dv3_h(i32 63, ptr %dst, ptr %src)
+  ret void
+}
+
+; CHECK: %src = getelementptr inbounds <4 x i8>, ptr %a, i32 0
+; CHECK: %dst = getelementptr inbounds <4 x i8>, ptr %b, i32 0
+; CHECK: store <4 x i8> <i8 1, i8 2, i8 3, i8 1>, ptr %src, align 4
+; CHECK: %load = load <4 x i8>, ptr %a, align 4
+; CHECK: [[localid0:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %src, i32 0, i32 0
+; CHECK: [[localid1:%[a-zA-Z0-9_.]+]] = load i8, ptr [[localid0]], align 1
+; CHECK: [[localid2:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %dst, i32 0, i32 0
+; CHECK: store i8 [[localid1]], ptr [[localid2]], align 1
+; CHECK: [[localid3:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %src, i32 0, i32 1
+; CHECK: [[localid4:%[a-zA-Z0-9_.]+]] = load i8, ptr [[localid3]], align 1
+; CHECK: [[localid5:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %dst, i32 0, i32 1
+; CHECK: store i8 [[localid4]], ptr [[localid5]], align 1
+; CHECK: [[localid6:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %src, i32 0, i32 2
+; CHECK: [[localid7:%[a-zA-Z0-9_.]+]] = load i8, ptr [[localid6]], align 1
+; CHECK: [[localid8:%[a-zA-Z0-9_.]+]] = getelementptr <4 x i8>, ptr %dst, i32 0, i32 2
+; CHECK: store i8 [[localid7]], ptr [[localid8]], align 1

--- a/test/simple_vec3_to_vec4_opaque.ll
+++ b/test/simple_vec3_to_vec4_opaque.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt --vec3-to-vec4 --passes=three-element-vector-lowering --opaque-pointers=true %s -o %t.ll
+; RUN: clspv-opt --vec3-to-vec4 --passes=three-element-vector-lowering --opaque-pointers %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 declare void @_Z8spirv.op.63.PU3AS3Dv3_hPU3AS1Dv3_h(i32, ptr, ptr)


### PR DESCRIPTION
# PR Describtion
Transform ThreeElementVectorLoweringPass to support both opaque and non-opaque pointers:
* Change the main logic of the pass to save all instructions that need to be changed, and change them together at the end. The motivation for that is that opaque pointers types need to be inferred from other instructions so if we change them directly that will add an overhead of analysing the original types before instructions change.
* Add support for opaque pointers in `visitGetElementPtrInst`, `visitLoadInst`, `visitCallInst`, `convertOpCopyMemoryOperation`, `visitStoreInst`, `HandlingRequired` and `runOnGlobals`.
* Add support for recursive type inferring for loads/stores with pointer operands only.
* Migrate `vec3-to-vec4` tests to have an opaque version.
* Add `simple-vec3-to-vec4-opaque.ll` test which should be a simple test for different parts that had support for opaque pointers.

### [Related issue](https://github.com/google/clspv/issues/816)

**This contribution is being made by Codeplay on behalf of Samsung.**