### PR TITLE
enable native half support if fp16 is enable

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -268,6 +268,10 @@ int SetCompilerInstanceOptions(
   instance.getLangOpts().ModulesSearchAll = false;
   instance.getLangOpts().SinglePrecisionConstants = true;
   instance.getLangOpts().DeclareOpenCLBuiltins = true;
+  if (clspv::Option::FP16()) {
+    instance.getLangOpts().NativeHalfType = true;
+    instance.getLangOpts().NativeHalfArgsAndReturns = true;
+  }
   instance.getCodeGenOpts().StackRealignment = true;
   instance.getCodeGenOpts().SimplifyLibCalls = false;
   instance.getCodeGenOpts().EmitOpenCLArgMetadata = false;

--- a/test/half-fma.cl
+++ b/test/half-fma.cl
@@ -1,0 +1,19 @@
+// RUN: clspv  %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpCapability Float16
+// CHECK: [[half:%[^ ]+]] = OpTypeFloat 16
+// CHECK: [[a:%[^ ]+]] = OpLoad [[half]]
+// CHECK: [[b:%[^ ]+]] = OpLoad [[half]]
+// CHECK: [[c:%[^ ]+]] = OpLoad [[half]]
+// CHECK: [[fma:%[^ ]+]] = OpExtInst [[half]] {{.*}} Fma [[a]] [[b]] [[c]]
+// CHECK: OpStore {{.*}} [[fma]]
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+kernel void foo(global half *dst, global half *srcA, global half *srcB, global half *srcC) {
+    int gid = get_global_id(0);
+    dst[gid] = srcA[gid] * srcB[gid] + srcC[gid];
+}
+


### PR DESCRIPTION
This is improving a lot workload using fp16.
It has been tested on tensorflow lite.