### PR TITLE
compiler: allow compilation of several inputs file together

### DIFF
--- a/include/clspv/Compiler.h
+++ b/include/clspv/Compiler.h
@@ -32,6 +32,15 @@ int CompileFromSourceString(const std::string &program,
                             const std::string &options,
                             std::vector<uint32_t> *output_binary,
                             std::string *output_log = nullptr);
+
+// Compile from multiple source strings.
+//
+// For use in clLinkProgram.
+// Command line options to clspv are passed as |options|.
+int CompileFromSourcesString(const std::vector<std::string> &programs,
+                             const std::string &options,
+                             std::vector<uint32_t> *output_buffer,
+                             std::string *output_log);
 } // namespace clspv
 
 #endif // CLSPV_INCLUDE_CLSPV_COMPILER_H_

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -887,6 +887,7 @@ int CompilePrograms(const std::vector<std::string> &programs,
                     std::vector<uint32_t> *output_buffer,
                     std::string *output_log) {
   std::vector<std::unique_ptr<llvm::Module>> modules;
+  modules.reserve(programs.size());
 
   llvm::LLVMContext context;
   for (auto program : programs) {

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -155,11 +155,16 @@ enum OutputFormat {
 static llvm::cl::opt<enum OutputFormat> OutputFormat(
     "output-format", llvm::cl::desc("Select output format (ll|bc|spv|c)"),
     llvm::cl::init(OutputFormatSPIRV),
-    llvm::cl::values(clEnumValN(OutputFormatSPIRV, "spv", "SPIRV"),
-                     clEnumValN(OutputFormatLLVMIR, "ll", "Readable LLVM IR"),
-                     clEnumValN(OutputFormatLLVMIRBinary, "bc",
-                                "Binary LLVM IR"),
-                     clEnumValN(OutputFormatC, "c", "C initializer list")));
+    llvm::cl::values(
+        clEnumValN(OutputFormatSPIRV, "spv", "Vulkan SPIR-V"),
+        clEnumValN(
+            OutputFormatLLVMIR, "ll",
+            "Readable LLVM IR (Stop compilation before clspv specific passes)"),
+        clEnumValN(
+            OutputFormatLLVMIRBinary, "bc",
+            "Binary LLVM IR (Stop compilation before clspv specific passes)"),
+        clEnumValN(OutputFormatC, "c",
+                   "C initializer list (of Vulkan SPIR-V)")));
 
 namespace {
 struct OpenCLBuiltinMemoryBuffer final : public llvm::MemoryBuffer {

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -897,8 +897,7 @@ int CompilePrograms(const std::vector<std::string> &programs,
     if (error != 0)
       return error;
   }
-  if (modules.size() == 0 || modules.back() == nullptr)
-    return -1;
+  assert(modules.size() > 0 && modules.back() != nullptr);
 
   std::unique_ptr<llvm::Module> module(modules.back().release());
   modules.pop_back();

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -972,9 +972,9 @@ int Compile(const int argc, const char *const argv[]) {
     programs.reserve(InputsFilename.size());
     for (auto InputFilename : InputsFilename) {
       std::ifstream stream(InputFilename);
-      std::string program((std::istreambuf_iterator<char>(stream)),
-                          std::istreambuf_iterator<char>());
-      programs.push_back(std::move(program));
+       programs.emplace_back(std::istreambuf_iterator<char>(stream),
+                             std::istreambuf_iterator<char>());
+
     }
 
     return CompilePrograms(programs, nullptr, nullptr);

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -866,8 +866,7 @@ int CompileModule(const llvm::StringRef &input_filename,
   SmallVector<char, 10000> binary;
   llvm::raw_svector_ostream binaryStream(binary);
 
-  // If --emit-ir or --emit-binary-ir was requested, emit the initial LLVM IR
-  // and stop compilation.
+  // If LLVM IR output format was requested, emit the file and stop compilation.
   if (OutputFormat == OutputFormatLLVMIR ||
       OutputFormat == OutputFormatLLVMIRBinary) {
     return GenerateIRFile(module, output_buffer);

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -969,6 +969,7 @@ int Compile(const int argc, const char *const argv[]) {
     return CompileProgram(inputFilename, program, nullptr, nullptr);
   } else {
     std::vector<std::string> programs;
+    programs.reserve(InputsFilename.size());
     for (auto InputFilename : InputsFilename) {
       std::ifstream stream(InputFilename);
       std::string program((std::istreambuf_iterator<char>(stream)),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
   set (LLVM_BINARY_SUBDIR ${CMAKE_BUILD_TYPE}/bin)
 endif()
 
-set(CLSPV_TEST_DEPENDS clspv clspv-reflection spirv-as spirv-dis spirv-val spirv-opt)
+set(CLSPV_TEST_DEPENDS clspv clspv-reflection spirv-as spirv-dis spirv-val spirv-opt llvm-dis)
 if (NOT ${EXTERNAL_LLVM} EQUAL 1)
   set(CLSPV_TEST_DEPENDS ${CLSPV_TEST_DEPENDS} FileCheck not)
 endif()

--- a/test/LongVectorLowering/phi.cl
+++ b/test/LongVectorLowering/phi.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s --long-vector --emit-ir %t.ll
+// RUN: clspv %s --long-vector --output-format=ll -o %t.ll
 // RUN: clspv-opt %t.ll --passes=long-vector-lowering -o %t.out.ll
 // RUN: FileCheck %s < %t.out.ll
 

--- a/test/MultipleInputs/kernel.cl
+++ b/test/MultipleInputs/kernel.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -o %t.spv %s %s2
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpEntryPoint GLCompute [[entry_point:%[^ ]+]] "foo"
+// CHECK: [[entry_point]] = OpFunction
+// CHECK-NEXT: OpLabel
+// CHECK-NEXT: OpAccessChain
+// CHECK-NEXT: OpAccessChain
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpStore
+// CHECK-NEXT: OpReturn
+// CHECK-NEXT: OpFunctionEnd
+
+extern void bar(global uint *dst, global uint *src);
+
+kernel void foo(global uint *dst, global uint *src) {
+    bar(dst, src);
+}

--- a/test/MultipleInputs/kernel.cl2
+++ b/test/MultipleInputs/kernel.cl2
@@ -1,0 +1,6 @@
+void bar(global uint *dst, global uint *src);
+
+void bar(global uint *dst, global uint *src) {
+    dst[0] = src[0];
+}
+

--- a/test/MultipleInputs/kernel.ll
+++ b/test/MultipleInputs/kernel.ll
@@ -1,0 +1,25 @@
+; RUN: clspv -x ir %s %s2 -o %t
+; RUN: spirv-val %t
+; RUN: spirv-dis -o %t2 %t
+; RUN: FileCheck %s < %t2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(i32 addrspace(1)* align 4 %dst, i32 addrspace(1)* align 4 %src) {
+entry:
+  call spir_func void @bar(i32 addrspace(1)* %dst, i32 addrspace(1)* %src)
+  ret void
+}
+
+declare spir_func void @bar(i32 addrspace(1)*, i32 addrspace(1)*)
+
+; CHECK: OpEntryPoint GLCompute [[entry_point:%[^ ]+]] "foo"
+; CHECK: [[entry_point]] = OpFunction
+; CHECK-NEXT: OpLabel
+; CHECK-NEXT: OpAccessChain
+; CHECK-NEXT: OpAccessChain
+; CHECK-NEXT: OpLoad
+; CHECK-NEXT: OpStore
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd

--- a/test/MultipleInputs/kernel.ll2
+++ b/test/MultipleInputs/kernel.ll2
@@ -1,0 +1,9 @@
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_func void @bar(i32 addrspace(1)* %dst, i32 addrspace(1)* %src) {
+entry:
+  %0 = load i32, i32 addrspace(1)* %src, align 4
+  store i32 %0, i32 addrspace(1)* %dst, align 4
+  ret void
+}

--- a/test/emit_ir.cl
+++ b/test/emit_ir.cl
@@ -1,6 +1,14 @@
 // RUN: clspv %s --emit-ir=%t.ll
 // RUN: FileCheck %s < %t.ll
 
+// RUN: clspv %s --emit-ir=%t.bc --emit-binary-ir
+// RUN: llvm-dis %t.bc -o %t.bc.ll
+// RUN: FileCheck %s < %t.bc.ll
+
+// RUN: clspv %s --emit-binary-ir -o %t.2.bc
+// RUN: llvm-dis %t.2.bc -o %t.2.bc.ll
+// RUN: FileCheck %s < %t.2.bc.ll
+
 void kernel foo(global double *out, int in)
 {
   *out = in / 2.304;

--- a/test/emit_ir.cl
+++ b/test/emit_ir.cl
@@ -1,13 +1,9 @@
-// RUN: clspv %s --emit-ir=%t.ll
+// RUN: clspv %s --output-format=ll -o %t.ll
 // RUN: FileCheck %s < %t.ll
 
-// RUN: clspv %s --emit-ir=%t.bc --emit-binary-ir
+// RUN: clspv %s --output-format=bc -o %t.bc
 // RUN: llvm-dis %t.bc -o %t.bc.ll
 // RUN: FileCheck %s < %t.bc.ll
-
-// RUN: clspv %s --emit-binary-ir -o %t.2.bc
-// RUN: llvm-dis %t.2.bc -o %t.2.bc.ll
-// RUN: FileCheck %s < %t.2.bc.ll
 
 void kernel foo(global double *out, int in)
 {

--- a/test/mfmt_c.cl
+++ b/test/mfmt_c.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -mfmt=c -o %t.inc
+// RUN: clspv %s --output-format=c -o %t.inc
 // RUN: FileCheck %s < %t.inc
 
 // The first three words in the header.


### PR DESCRIPTION
This is a first step to fix OpenCL-CTS 'compiler' tests in clvk.

The idea is to use llvm IR as the intermediate language to link
program together.
To do that, this PR is now exposing one new function:
- CompileFromSourcesString: which will allow to take several input
files, compile and link them together into 1 output buffer.

Major changes:
- 'InputFilename' (now 'InputsFilename') allows for multiple inputs.
- New option 'OutputFormat' allows to choose the output format among those 4 possibilities:
  - `ll` Readable LLVM IR
  - `bc` Binary LLVM IR
  - `spv` Vulkan SPIR-V
  - `c` C initializer list of Vulkan SPIR-V
  Also clean now unused options `-emit-ir` and `-mfmt`.
- 'SetCompilerInstanceOptions' (and new function 'ProgramToModule')
expects 'program' to never be empty. The frontend 'Compile' function
is now making sure of it.
- Logs are now accumulated as many files can be parsed in one call to
clspv.