### PR TITLE
Use LLVM's StandardInstrumentations with the pass builder

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -26,6 +26,7 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/LinkAllPasses.h"
 #include "llvm/Linker/Linker.h"
@@ -407,7 +408,9 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
   llvm::CGSCCAnalysisManager cgam;
   llvm::ModuleAnalysisManager mam;
   llvm::PassInstrumentationCallbacks PIC;
+  llvm::StandardInstrumentations si(false /*DebugLogging*/);
   clspv::RegisterClspvPasses(&PIC);
+  si.registerCallbacks(PIC, &fam);
   llvm::PassBuilder pb(nullptr, llvm::PipelineTuningOptions(), llvm::None,
                        &PIC);
   pb.registerModuleAnalyses(mam);

--- a/test/print-all.cl
+++ b/test/print-all.cl
@@ -1,5 +1,3 @@
-// TODO: figure out how to setup the pass printing properly again
-// XFAIL: *
 // RUN: clspv %s -cluster-pod-kernel-args -o %t-before.spv -print-before-all 2> %t-before.txt
 // RUN: FileCheck -check-prefix=BEFORE %s < %t-before.txt
 // RUN: clspv %s -cluster-pod-kernel-args -o %t-after.spv -print-after-all 2> %t-after.txt
@@ -13,6 +11,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, u
   }
 }
 
-// BEFORE: *** IR Dump Before Cluster POD Kernel Arguments Pass
+// Ideally the pass name would be the registered 'cluster-pod-kernel-args-pass'
+// name rather than the class name, but it's informative enough
 
-// AFTER: *** IR Dump After Cluster POD Kernel Arguments Pass
+// BEFORE: *** IR Dump Before clspv::ClusterPodKernelArgumentsPass
+
+// AFTER: *** IR Dump After clspv::ClusterPodKernelArgumentsPass


### PR DESCRIPTION
This allows flags like '-print-after-all' to work again with clspv


It doesn't print the names registered in `PassRegistry.def` for some reason, but printing the class names is good enough for general debugging use. I did check to see if this was related to the passes being in the clspv namespace but it doesn't seem to be the case.

This contribution is being made by Codeplay on behalf of Samsung.