### PR TITLE
Stop trying to lower extremely long vectors.

### DIFF
--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1426,8 +1426,10 @@ Type *clspv::LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   }
 
   if (auto *VectorTy = dyn_cast<VectorType>(Ty)) {
-    unsigned Arity = VectorTy->getElementCount().getKnownMinValue();
-    bool RequireLowering = (Arity >= 8);
+    unsigned VecWidth = VectorTy->getElementCount().getKnownMinValue();
+    // Larger vector types can be produced by optimizations like InstCombine,
+    // these will be handled in our UndoInstCombine pass.
+    bool RequireLowering = (VecWidth >= 8 && VecWidth <= 16);
 
     if (RequireLowering) {
       assert(!VectorTy->getElementCount().isScalable() &&
@@ -1439,7 +1441,7 @@ Type *clspv::LongVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
       assert((ScalarTy->isFloatingPointTy() || ScalarTy->isIntegerTy()) &&
              "Unsupported scalar type");
 
-      return ArrayType::get(ScalarTy, Arity);
+      return ArrayType::get(ScalarTy, VecWidth);
     }
 
     return nullptr;


### PR DESCRIPTION
Vector types wider than sixteen can be generated by optimizations, and if we
try to lower them we're prone to hitting asserts. The UndoInstCombine pass is
capable of handling long vectors in these cases so we're better off
leaving them for it to take care of.

The specific motivating case for this is if we include the libclc
conversion implementations in our builtins module and continue building
it with -O3 the resultant module has very long vectors in it that
UndoInstCombine handles better than LongVectorLowering does.

This contribution is being made by Codeplay on behalf of Samsung.
