### PR TITLE
Added command line option to specify CL3.0 feature macros

### DIFF
--- a/include/clspv/FeatureMacro.h
+++ b/include/clspv/FeatureMacro.h
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <utility>
+#include <string>
 
 namespace clspv {
 

--- a/include/clspv/FeatureMacro.h
+++ b/include/clspv/FeatureMacro.h
@@ -1,0 +1,73 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLSPV_LIB_FEATUREMACRO_H
+#define CLSPV_LIB_FEATUREMACRO_H
+
+#include <array>
+#include <utility>
+
+namespace clspv {
+
+enum class FeatureMacro {
+  error,
+  __opencl_c_3d_image_writes,
+  __opencl_c_atomic_order_acq_rel,
+  __opencl_c_fp64,
+  __opencl_c_images,
+  __opencl_c_subgroups,
+  // following items are not supported
+  __opencl_c_device_enqueue,
+  __opencl_c_generic_address_space,
+  __opencl_c_pipes,
+  __opencl_c_program_scope_global_variables,
+  // following items are always enabled, but no point in complaining if they are
+  // also enabled by the user.
+  // int64 is assumed defined for FULL profile
+  // https://github.com/llvm/llvm-project/blob/main/clang/lib/Frontend/InitPreprocessor.cpp
+  __opencl_c_int64,
+  // Some macros are already defined for OpenCL C 3.0 with SPIR-V -
+  // https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/opencl-c-base.h
+  __opencl_c_atomic_order_seq_cst,
+  __opencl_c_read_write_images,
+  __opencl_c_atomic_scope_device,
+  __opencl_c_atomic_scope_all_devices,
+  __opencl_c_work_group_collective_functions
+};
+
+#define FeatureStr(f) std::make_pair(FeatureMacro::f, #f)
+constexpr std::array<std::pair<FeatureMacro, const char *>, 15>
+    FeatureMacroList{
+        FeatureStr(__opencl_c_3d_image_writes),
+        FeatureStr(__opencl_c_atomic_order_acq_rel),
+        FeatureStr(__opencl_c_fp64), FeatureStr(__opencl_c_images),
+        FeatureStr(__opencl_c_subgroups),
+        // following items are always enabled by clang
+        FeatureStr(__opencl_c_int64),
+        FeatureStr(__opencl_c_atomic_order_seq_cst),
+        FeatureStr(__opencl_c_read_write_images),
+        FeatureStr(__opencl_c_atomic_scope_device),
+        FeatureStr(__opencl_c_atomic_scope_all_devices),
+        FeatureStr(__opencl_c_work_group_collective_functions),
+        // following items cannot be enabled so are automatically disabled
+        FeatureStr(__opencl_c_device_enqueue),
+        FeatureStr(__opencl_c_generic_address_space),
+        FeatureStr(__opencl_c_pipes),
+        FeatureStr(__opencl_c_program_scope_global_variables)};
+#undef FeatureStr
+
+FeatureMacro FeatureMacroLookup(const std::string &name);
+} // namespace clspv
+
+#endif // CLSPV_LIB_FEATUREMACRO_H

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -15,6 +15,8 @@
 #ifndef CLSPV_INCLUDE_CLSPV_OPTION_H_
 #define CLSPV_INCLUDE_CLSPV_OPTION_H_
 
+#include "FeatureMacro.h"
+
 #include <cstdint>
 #include <set>
 
@@ -255,6 +257,8 @@ bool OpaquePointers();
 
 // Returns true if the debug information should be generated
 bool DebugInfo();
+
+std::set<FeatureMacro> EnabledFeatureMacros();
 
 } // namespace Option
 } // namespace clspv

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/DefineOpenCLWorkItemBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DescriptorCounter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/DirectResourceAccessPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/FeatureMacro.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FixupBuiltinsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FixupStructuredCFGPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionInternalizerPass.cpp
@@ -162,6 +163,7 @@ if (ENABLE_CLSPV_INSTALL)
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/AddressSpace.h
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/ArgKind.h
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Compiler.h
+      ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/FeatureMacro.h
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Option.h
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/Passes.h
       ${CMAKE_CURRENT_SOURCE_DIR}/../include/clspv/PushConstant.h

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -741,16 +741,14 @@ int ParseOptions(const int argc, const char *const argv[]) {
 
   const auto enabled_feature_macros = clspv::Option::EnabledFeatureMacros();
   if (!clspv::Option::FP64() &&
-      enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_fp64) !=
-          enabled_feature_macros.end()) {
+      enabled_feature_macros.count(clspv::FeatureMacro::__opencl_c_fp64)) {
     llvm::errs() << "error: Cannot enabled feature macro __opencl_c_fp64 while "
                     "-fp64 is disabled!\n";
     return -1;
   }
 
   if (!clspv::Option::ImageSupport() &&
-      enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_images) !=
-          enabled_feature_macros.end()) {
+      enabled_feature_macros.count(clspv::FeatureMacro::__opencl_c_images)) {
     llvm::errs()
         << "error: Cannot enabled feature macro __opencl_c_images while "
            "-images is disabled!\n";

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -740,7 +740,7 @@ int ParseOptions(const int argc, const char *const argv[]) {
   }
 
   const auto enabled_feature_macros = clspv::Option::EnabledFeatureMacros();
-  if (not clspv::Option::FP64() &&
+  if (!clspv::Option::FP64() &&
       enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_fp64) !=
           enabled_feature_macros.end()) {
     llvm::errs() << "error: Cannot enabled feature macro __opencl_c_fp64 while "
@@ -748,7 +748,7 @@ int ParseOptions(const int argc, const char *const argv[]) {
     return -1;
   }
 
-  if (not clspv::Option::ImageSupport() &&
+  if (!clspv::Option::ImageSupport() &&
       enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_images) !=
           enabled_feature_macros.end()) {
     llvm::errs()

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -739,6 +739,24 @@ int ParseOptions(const int argc, const char *const argv[]) {
     return -1;
   }
 
+  const auto enabled_feature_macros = clspv::Option::EnabledFeatureMacros();
+  if (not clspv::Option::FP64() &&
+      enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_fp64) !=
+          enabled_feature_macros.end()) {
+    llvm::errs() << "error: Cannot enabled feature macro __opencl_c_fp64 while "
+                    "-fp64 is disabled!\n";
+    return -1;
+  }
+
+  if (not clspv::Option::ImageSupport() &&
+      enabled_feature_macros.find(clspv::FeatureMacro::__opencl_c_images) !=
+          enabled_feature_macros.end()) {
+    llvm::errs()
+        << "error: Cannot enabled feature macro __opencl_c_images while "
+           "-images is disabled!\n";
+    return -1;
+  }
+
   return 0;
 }
 

--- a/lib/FeatureMacro.cpp
+++ b/lib/FeatureMacro.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "llvm/Support/raw_ostream.h"
+
 #include "clspv/FeatureMacro.h"
 #include <algorithm>
 
@@ -28,12 +30,18 @@ FeatureMacro FeatureMacroLookup(const std::string &name) {
       FeatureMacroList.begin(), FeatureMacroList.end(),
       [name](const auto &macro) { return std::get<1>(macro) == name; });
 
-  if (macro_ptr == FeatureMacroList.end() ||
-      std::find(NotSuppported.begin(), NotSuppported.end(),
-                std::get<0>(*macro_ptr)) != NotSuppported.end()) {
-    return FeatureMacro::error;
-  } else {
-    return std::get<0>(*macro_ptr);
+  if (macro_ptr != FeatureMacroList.end()) {
+    const auto feature = std::get<0>(*macro_ptr);
+    const auto supported = std::find(NotSuppported.begin(), NotSuppported.end(),
+                                     feature) == NotSuppported.end();
+
+    if (supported)
+      return feature;
+
+    llvm::errs() << name << " is not a supported feature macro.\n";
   }
+
+  return FeatureMacro::error;
 }
+
 } // namespace clspv

--- a/lib/FeatureMacro.cpp
+++ b/lib/FeatureMacro.cpp
@@ -1,0 +1,39 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "clspv/FeatureMacro.h"
+#include <algorithm>
+
+namespace clspv {
+
+FeatureMacro FeatureMacroLookup(const std::string &name) {
+  constexpr std::array<FeatureMacro, 4> NotSuppported{
+      FeatureMacro::__opencl_c_pipes,
+      FeatureMacro::__opencl_c_generic_address_space,
+      FeatureMacro::__opencl_c_device_enqueue,
+      FeatureMacro::__opencl_c_program_scope_global_variables};
+
+  const auto *macro_ptr = std::find_if(
+      FeatureMacroList.begin(), FeatureMacroList.end(),
+      [name](const auto &macro) { return std::get<1>(macro) == name; });
+
+  if (macro_ptr == FeatureMacroList.end() ||
+      std::find(NotSuppported.begin(), NotSuppported.end(),
+                std::get<0>(*macro_ptr)) != NotSuppported.end()) {
+    return FeatureMacro::error;
+  } else {
+    return std::get<0>(*macro_ptr);
+  }
+}
+} // namespace clspv

--- a/lib/FeatureMacro.cpp
+++ b/lib/FeatureMacro.cpp
@@ -26,12 +26,12 @@ FeatureMacro FeatureMacroLookup(const std::string &name) {
       FeatureMacro::__opencl_c_device_enqueue,
       FeatureMacro::__opencl_c_program_scope_global_variables};
 
-  const auto *macro_ptr = std::find_if(
+  const auto macro_itr = std::find_if(
       FeatureMacroList.begin(), FeatureMacroList.end(),
       [name](const auto &macro) { return std::get<1>(macro) == name; });
 
-  if (macro_ptr != FeatureMacroList.end()) {
-    const auto feature = std::get<0>(*macro_ptr);
+  if (macro_itr != FeatureMacroList.end()) {
+    const auto feature = std::get<0>(*macro_itr);
     const auto supported = std::find(NotSuppported.begin(), NotSuppported.end(),
                                      feature) == NotSuppported.end();
 

--- a/lib/FeatureMacro.cpp
+++ b/lib/FeatureMacro.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/FeatureMacro.h"
+
 #include <algorithm>
 
 namespace clspv {

--- a/test/Features/cl3-all-features.cl
+++ b/test/Features/cl3-all-features.cl
@@ -1,0 +1,71 @@
+// RUN: clspv -cl-std=CL3.0 --enable-feature-macros=__opencl_c_3d_image_writes,__opencl_c_atomic_order_acq_rel,__opencl_c_fp64,__opencl_c_images,__opencl_c_subgroups,__opencl_c_int64,__opencl_c_atomic_order_seq_cst,__opencl_c_read_write_images,__opencl_c_atomic_scope_device,__opencl_c_atomic_scope_all_devices,__opencl_c_work_group_collective_functions %s -verify
+
+#ifndef __opencl_c_3d_image_writes
+#error __opencl_c_3d_image_writes should be defined
+#endif
+
+#ifndef __opencl_c_atomic_order_acq_rel
+#error __opencl_c_atomic_order_acq_rel should be defined
+#endif
+
+
+#ifndef __opencl_c_fp64
+#error __opencl_c_fp64 should be defined
+#endif
+
+#ifndef __opencl_c_images
+#error __opencl_c_images should be defined
+#endif
+
+#ifndef __opencl_c_subgroups
+#error __opencl_c_subgroups should be defined
+#endif
+
+// not supported
+
+#ifdef __opencl_c_device_enqueue
+#error __opencl_c_device_enqueue should not be defined
+#endif
+
+#ifdef __opencl_c_generic_address_space
+#error __opencl_c_generic_address_space should not be defined
+#endif
+
+#ifdef __opencl_c_pipes
+#error __opencl_c_pipes should not be defined
+#endif
+
+#ifdef __opencl_c_program_scope_global_variables
+#error __opencl_c_program_scope_global_variables should not be defined
+#endif
+
+
+// assumed for full profile
+
+#ifndef __opencl_c_int64
+#error __opencl_c_int64 should be defined
+#endif
+
+// assumed for SPIR-V
+
+#ifndef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should be defined
+#endif
+
+#ifndef __opencl_c_atomic_scope_all_devices
+#error __opencl_c_atomic_scope_all_devices should be defined
+#endif
+
+#ifndef __opencl_c_work_group_collective_functions
+#error __opencl_c_work_group_collective_functions should be defined
+#endif
+
+#ifndef __opencl_c_read_write_images
+#error __opencl_c_read_write_images should be defined
+#endif
+
+#ifndef __opencl_c_atomic_order_seq_cst
+#error __opencl_c_atomic_order_seq_cst should be defined
+#endif
+
+//expected-no-diagnostics

--- a/test/Features/cl3-no-features.cl
+++ b/test/Features/cl3-no-features.cl
@@ -1,0 +1,69 @@
+// RUN: clspv -fp64=0 -images=0 -cl-std=CL3.0 %s -verify
+
+#ifdef __opencl_c_3d_image_writes
+#error __opencl_c_3d_image_writes should not be defined
+#endif
+
+#ifdef __opencl_c_atomic_order_acq_rel
+#error __opencl_c_atomic_order_acq_rel should not be defined
+#endif
+
+#ifdef __opencl_c_fp64
+#error __opencl_c_fp64 should not be defined
+#endif
+
+#ifdef __opencl_c_images
+#error __opencl_c_images should not be defined
+#endif
+
+#ifdef __opencl_c_subgroups
+#error __opencl_c_subgroups should not be defined
+#endif
+
+// not supported
+
+#ifdef __opencl_c_device_enqueue
+#error __opencl_c_device_enqueue should not be defined
+#endif
+
+#ifdef __opencl_c_generic_address_space
+#error __opencl_c_generic_address_space should not be defined
+#endif
+
+#ifdef __opencl_c_pipes
+#error __opencl_c_pipes should not be defined
+#endif
+
+#ifdef __opencl_c_program_scope_global_variables
+#error __opencl_c_program_scope_global_variables should not be defined
+#endif
+
+// assumed for full profile
+
+#ifndef __opencl_c_int64
+#error __opencl_c_int64 should be defined
+#endif
+
+// assumed for SPIR-V
+
+#ifndef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should be defined
+#endif
+
+#ifndef __opencl_c_atomic_scope_all_devices
+#error __opencl_c_atomic_scope_all_devices should be defined
+#endif
+
+#ifndef __opencl_c_work_group_collective_functions
+#error __opencl_c_work_group_collective_functions should be defined
+#endif
+
+#ifndef __opencl_c_read_write_images
+#error __opencl_c_read_write_images should be defined
+#endif
+
+#ifndef __opencl_c_atomic_order_seq_cst
+#error __opencl_c_atomic_order_seq_cst should be defined
+#endif
+
+//expected-no-diagnostics

--- a/test/Features/cl3-some-features.cl
+++ b/test/Features/cl3-some-features.cl
@@ -1,0 +1,70 @@
+// RUN: clspv  -fp64=0 -images=0 -cl-std=CL3.0 --enable-feature-macros=__opencl_c_atomic_order_acq_rel,__opencl_c_images %s -verify
+
+#ifdef __opencl_c_3d_image_writes
+#error __opencl_c_3d_image_writes should not be defined
+#endif
+
+#ifndef __opencl_c_atomic_order_acq_rel
+#error __opencl_c_atomic_order_acq_rel should be defined
+#endif
+
+#ifdef __opencl_c_fp64
+#error __opencl_c_fp64 should not be defined
+#endif
+
+#ifndef __opencl_c_images
+#error __opencl_c_images should be defined
+#endif
+
+#ifdef __opencl_c_subgroups
+#error __opencl_c_subgroups should not be defined
+#endif
+
+// not supported
+
+#ifdef __opencl_c_device_enqueue
+#error __opencl_c_device_enqueue should not be defined
+#endif
+
+#ifdef __opencl_c_generic_address_space
+#error __opencl_c_generic_address_space should not be defined
+#endif
+
+#ifdef __opencl_c_pipes
+#error __opencl_c_pipes should not be defined
+#endif
+
+#ifdef __opencl_c_program_scope_global_variables
+#error __opencl_c_program_scope_global_variables should not be defined
+#endif
+
+
+// assumed for full profile
+
+#ifndef __opencl_c_int64
+#error __opencl_c_int64 should be defined
+#endif
+
+// assumed for SPIR-V
+
+#ifndef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should be defined
+#endif
+
+#ifndef __opencl_c_atomic_scope_all_devices
+#error __opencl_c_atomic_scope_all_devices should be defined
+#endif
+
+#ifndef __opencl_c_work_group_collective_functions
+#error __opencl_c_work_group_collective_functions should be defined
+#endif
+
+#ifndef __opencl_c_read_write_images
+#error __opencl_c_read_write_images should be defined
+#endif
+
+#ifndef __opencl_c_atomic_order_seq_cst
+#error __opencl_c_atomic_order_seq_cst should be defined
+#endif
+
+//expected-no-diagnostics

--- a/test/Features/cl3-some-features.cl
+++ b/test/Features/cl3-some-features.cl
@@ -1,4 +1,4 @@
-// RUN: clspv  -fp64=0 -images=0 -cl-std=CL3.0 --enable-feature-macros=__opencl_c_atomic_order_acq_rel,__opencl_c_images %s -verify
+// RUN: clspv -cl-std=CL3.0 -fp64=0 --enable-feature-macros=__opencl_c_atomic_order_acq_rel,__opencl_c_images %s -verify
 
 #ifdef __opencl_c_3d_image_writes
 #error __opencl_c_3d_image_writes should not be defined


### PR DESCRIPTION
This adds the ability to specify OpenCL3.0 feature macros that should be enabled by the clang frontend.

One thing I'm not sure about in this PR is the overlap of some options, specifically FP64 and ImageSupport. I think it would be best for the program to error out when one of these is disabled but the feature macro is enabled, but I'm not sure how CLSPV usually manages that.

This contribution is being made by Codeplay on behalf of Samsung.