### PR TITLE
Kokoro: Bump GCC from 7 -> 9

### DIFF
--- a/kokoro/scripts/linux/build-amber.sh
+++ b/kokoro/scripts/linux/build-amber.sh
@@ -23,7 +23,7 @@ set -x
 
 # Common tools.
 using cmake-3.17.2
-using gcc-7
+using gcc-9
 using ninja-1.10.0
 
 BUILD_ROOT=$PWD

--- a/kokoro/scripts/linux/build-clvk.sh
+++ b/kokoro/scripts/linux/build-clvk.sh
@@ -23,7 +23,7 @@ set -x
 
 # Common tools.
 using cmake-3.17.2
-using gcc-7
+using gcc-9
 using ninja-1.10.0
 
 BUILD_ROOT=$PWD

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -23,7 +23,7 @@ set -x
 
 # Common tools.
 using cmake-3.17.2
-using gcc-7
+using gcc-9
 using ninja-1.10.0
 
 BUILD_ROOT=$PWD


### PR DESCRIPTION
I'm planning on adding `gcc-10` and removing `gcc-7` from the docker image.