### PR TITLE
Hack preprocessor to allow disabling all feature macros

### DIFF
--- a/include/clspv/FeatureMacro.h
+++ b/include/clspv/FeatureMacro.h
@@ -16,8 +16,8 @@
 #define CLSPV_LIB_FEATUREMACRO_H
 
 #include <array>
-#include <utility>
 #include <string>
+#include <utility>
 
 namespace clspv {
 

--- a/test/AtomicBuiltins/enum_values.cl
+++ b/test/AtomicBuiltins/enum_values.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target --cl-std=CL3.0 %s -o %t.spv
+// RUN: clspv %target --enable-feature-macros=__opencl_c_atomic_scope_all_devices,__opencl_c_atomic_order_seq_cst --cl-std=CL3.0 %s -o %t.spv
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 //

--- a/test/Features/cl3-all-features.cl
+++ b/test/Features/cl3-all-features.cl
@@ -21,33 +21,6 @@
 #error __opencl_c_subgroups should be defined
 #endif
 
-// not supported
-
-#ifdef __opencl_c_device_enqueue
-#error __opencl_c_device_enqueue should not be defined
-#endif
-
-#ifdef __opencl_c_generic_address_space
-#error __opencl_c_generic_address_space should not be defined
-#endif
-
-#ifdef __opencl_c_pipes
-#error __opencl_c_pipes should not be defined
-#endif
-
-#ifdef __opencl_c_program_scope_global_variables
-#error __opencl_c_program_scope_global_variables should not be defined
-#endif
-
-
-// assumed for full profile
-
-#ifndef __opencl_c_int64
-#error __opencl_c_int64 should be defined
-#endif
-
-// assumed for SPIR-V
-
 #ifndef __opencl_c_atomic_scope_device
 #error __opencl_c_atomic_scope_device should be defined
 #endif
@@ -66,6 +39,28 @@
 
 #ifndef __opencl_c_atomic_order_seq_cst
 #error __opencl_c_atomic_order_seq_cst should be defined
+#endif
+
+#ifndef __opencl_c_int64
+#error __opencl_c_int64 should be defined
+#endif
+
+// not supported
+
+#ifdef __opencl_c_device_enqueue
+#error __opencl_c_device_enqueue should not be defined
+#endif
+
+#ifdef __opencl_c_generic_address_space
+#error __opencl_c_generic_address_space should not be defined
+#endif
+
+#ifdef __opencl_c_pipes
+#error __opencl_c_pipes should not be defined
+#endif
+
+#ifdef __opencl_c_program_scope_global_variables
+#error __opencl_c_program_scope_global_variables should not be defined
 #endif
 
 //expected-no-diagnostics

--- a/test/Features/cl3-no-features.cl
+++ b/test/Features/cl3-no-features.cl
@@ -20,6 +20,30 @@
 #error __opencl_c_subgroups should not be defined
 #endif
 
+#ifdef __opencl_c_atomic_order_seq_cst
+#error __opencl_c_atomic_order_seq_cst should not be defined
+#endif
+
+#ifdef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should not be defined
+#endif
+
+#ifdef __opencl_c_atomic_scope_all_devices
+#error __opencl_c_atomic_scope_all_devices should not be defined
+#endif
+
+#ifdef __opencl_c_work_group_collective_functions
+#error __opencl_c_work_group_collective_functions should not be defined
+#endif
+
+#ifdef __opencl_c_read_write_images
+#error __opencl_c_read_write_images should not be defined
+#endif
+
+#ifdef __opencl_c_int64
+#error __opencl_c_int64 should not be defined
+#endif
+
 // not supported
 
 #ifdef __opencl_c_device_enqueue
@@ -36,34 +60,6 @@
 
 #ifdef __opencl_c_program_scope_global_variables
 #error __opencl_c_program_scope_global_variables should not be defined
-#endif
-
-// assumed for full profile
-
-#ifndef __opencl_c_int64
-#error __opencl_c_int64 should be defined
-#endif
-
-// assumed for SPIR-V
-
-#ifndef __opencl_c_atomic_scope_device
-#error __opencl_c_atomic_scope_device should be defined
-#endif
-
-#ifndef __opencl_c_atomic_scope_all_devices
-#error __opencl_c_atomic_scope_all_devices should be defined
-#endif
-
-#ifndef __opencl_c_work_group_collective_functions
-#error __opencl_c_work_group_collective_functions should be defined
-#endif
-
-#ifndef __opencl_c_read_write_images
-#error __opencl_c_read_write_images should be defined
-#endif
-
-#ifndef __opencl_c_atomic_order_seq_cst
-#error __opencl_c_atomic_order_seq_cst should be defined
 #endif
 
 //expected-no-diagnostics

--- a/test/Features/cl3-some-features.cl
+++ b/test/Features/cl3-some-features.cl
@@ -1,4 +1,4 @@
-// RUN: clspv -cl-std=CL3.0 -fp64=0 --enable-feature-macros=__opencl_c_atomic_order_acq_rel,__opencl_c_images %s -verify
+// RUN: clspv -cl-std=CL3.0 -fp64=0 --enable-feature-macros=__opencl_c_atomic_order_acq_rel,__opencl_c_images,__opencl_c_atomic_order_seq_cst,__opencl_c_int64 %s -verify
 
 #ifdef __opencl_c_3d_image_writes
 #error __opencl_c_3d_image_writes should not be defined
@@ -20,6 +20,30 @@
 #error __opencl_c_subgroups should not be defined
 #endif
 
+#ifndef __opencl_c_atomic_order_seq_cst
+#error __opencl_c_atomic_order_seq_cst should be defined
+#endif
+
+#ifdef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should not be defined
+#endif
+
+#ifdef __opencl_c_atomic_scope_all_devices
+#error __opencl_c_atomic_scope_all_devices should not be defined
+#endif
+
+#ifdef __opencl_c_work_group_collective_functions
+#error __opencl_c_work_group_collective_functions should not be defined
+#endif
+
+#ifdef __opencl_c_read_write_images
+#error __opencl_c_read_write_images should not be defined
+#endif
+
+#ifndef __opencl_c_int64
+#error __opencl_c_int64 should be defined
+#endif
+
 // not supported
 
 #ifdef __opencl_c_device_enqueue
@@ -36,35 +60,6 @@
 
 #ifdef __opencl_c_program_scope_global_variables
 #error __opencl_c_program_scope_global_variables should not be defined
-#endif
-
-
-// assumed for full profile
-
-#ifndef __opencl_c_int64
-#error __opencl_c_int64 should be defined
-#endif
-
-// assumed for SPIR-V
-
-#ifndef __opencl_c_atomic_scope_device
-#error __opencl_c_atomic_scope_device should be defined
-#endif
-
-#ifndef __opencl_c_atomic_scope_all_devices
-#error __opencl_c_atomic_scope_all_devices should be defined
-#endif
-
-#ifndef __opencl_c_work_group_collective_functions
-#error __opencl_c_work_group_collective_functions should be defined
-#endif
-
-#ifndef __opencl_c_read_write_images
-#error __opencl_c_read_write_images should be defined
-#endif
-
-#ifndef __opencl_c_atomic_order_seq_cst
-#error __opencl_c_atomic_order_seq_cst should be defined
 #endif
 
 //expected-no-diagnostics


### PR DESCRIPTION
This contribution is being made by Codeplay on behalf of Samsung.

This will allow CLSPV to turn off all the feature macros.

Due to opencl-c-base.h in the clang project [always defining](https://github.com/llvm/llvm-project/blob/1215e86a0e4703d4c6657564e1a758d95ea59c56/clang/lib/Headers/opencl-c-base.h#L68) certain preprocessor macros, I've added an `#undefine` for `__SPIR__`  and `__SPIRV__`. These defines should not be necessary since the [`BaseSPIRTargetInfo`](https://github.com/llvm/llvm-project/blob/1215e86a0e4703d4c6657564e1a758d95ea59c56/clang/lib/Basic/Targets/SPIR.h#L161) already defines all these feature macros, but I think it's not been fixed properly since a few are missing from [OpenCLExtensions.def](https://github.com/llvm/llvm-project/blob/1215e86a0e4703d4c6657564e1a758d95ea59c56/clang/include/clang/Basic/OpenCLExtensions.def#L119). Due to the missing feature macros in OpenCLExtension.def, I've also had to add those symbols in as a special case.

I've also created a PR to fix this upstream but it's not got any interest yet https://reviews.llvm.org/D137652.