### PR TITLE
Add vulkanMemoryModel

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -199,9 +199,14 @@ shader is as follows:
   ID is reported in the descriptor map file, generated via the `-descriptormap`
   option.
 
-The shaders produced use the GLSL450 memory model. As such, there is an assumption of
+#### Memory Model
+
+The default shaders produced use the GLSL450 memory model. As such, there is an assumption of
 no aliasing by default. The compiler does not generate *Aliased* decorations
 currently. Users should be aware of this and ensure they are not relying on aliasing.
+
+`vulkan-memory-model` option could be used to produce Vulkan memory model shaders. Memory scopes for loads and stores in this mode will be decided
+according to the pointer type.
 
 #### Embedded Reflection Instructions
 

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -260,6 +260,9 @@ Vec3ToVec4SupportClass Vec3ToVec4();
 // Returns true if opaque pointers are enabled
 bool OpaquePointers();
 
+// Returns true if vulkan memory model is enabled
+bool VulkanMemoryModel();
+
 // Returns true if the debug information should be generated
 bool DebugInfo();
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -382,6 +382,11 @@ static llvm::cl::opt<bool>
                     llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+    vulkan_memory_model("vulkan-memory-model",
+                        llvm::cl::desc("Use vulkan memory model"),
+                        llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
     debug_info("g", llvm::cl::init(false),
                llvm::cl::desc("Produce debug information."));
 
@@ -499,6 +504,8 @@ Vec3ToVec4SupportClass Vec3ToVec4() {
 }
 
 bool OpaquePointers() { return opaque_pointers; }
+
+bool VulkanMemoryModel() { return vulkan_memory_model; }
 
 bool DebugInfo() { return debug_info; }
 

--- a/test/VulkanMemoryModel/atom_add.cl
+++ b/test/VulkanMemoryModel/atom_add.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicIAdd %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+// CHECK:     OpStore {{.*}} %[[__original_id_18]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_add(b, 42);
+}
+

--- a/test/VulkanMemoryModel/atom_and.cl
+++ b/test/VulkanMemoryModel/atom_and.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicAnd %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+// CHECK:     OpStore {{.*}} %[[__original_id_18]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_and(b, 42);
+}

--- a/test/VulkanMemoryModel/atom_cmpxchg.cl
+++ b/test/VulkanMemoryModel/atom_cmpxchg.cl
@@ -1,0 +1,20 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 66
+// CHECK-DAG: %[[uint_31:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 31
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_19:[0-9]+]] = OpAtomicCompareExchange %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_FLAG_ACQUIRE]] %[[uint_31]] %[[uint_42]]
+// CHECK:     OpStore {{.*}} %[[__original_id_19]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_cmpxchg(b, 42, 31);
+}

--- a/test/VulkanMemoryModel/atom_dec.cl
+++ b/test/VulkanMemoryModel/atom_dec.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpAtomicIDecrement %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_dec(b);
+}
+

--- a/test/VulkanMemoryModel/atom_inc.cl
+++ b/test/VulkanMemoryModel/atom_inc.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK:     %[[__original_id_17:[0-9]+]] = OpAtomicIIncrement %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_inc(b);
+}

--- a/test/VulkanMemoryModel/atom_max.cl
+++ b/test/VulkanMemoryModel/atom_max.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicSMax %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_max(b, 42);
+}

--- a/test/VulkanMemoryModel/atom_min.cl
+++ b/test/VulkanMemoryModel/atom_min.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicSMin %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_min(b, 42);
+}
+

--- a/test/VulkanMemoryModel/atom_or.cl
+++ b/test/VulkanMemoryModel/atom_or.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicOr %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_or(b, 42);
+}
+

--- a/test/VulkanMemoryModel/atom_sub.cl
+++ b/test/VulkanMemoryModel/atom_sub.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicISub %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_sub(b, 42);
+}

--- a/test/VulkanMemoryModel/atom_xchg.cl
+++ b/test/VulkanMemoryModel/atom_xchg.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicExchange %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_xchg(b, 42);
+}
+

--- a/test/VulkanMemoryModel/atom_xor.cl
+++ b/test/VulkanMemoryModel/atom_xor.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[uint:[0-9a-zA-Z_]+]] = OpTypeInt 32 0
+// CHECK-DAG: %[[uint_0:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 0
+// CHECK-DAG: %[[uint_1:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 72
+// CHECK-DAG: %[[uint_42:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 42
+// CHECK:     %[[__original_id_18:[0-9]+]] = OpAtomicXor %[[uint]] {{.*}} %[[uint_1]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[uint_42]]
+
+
+kernel void __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+    *a = atom_xor(b, 42);
+}
+

--- a/test/VulkanMemoryModel/atomic_add.cl
+++ b/test/VulkanMemoryModel/atomic_add.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicIAdd %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_add(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_and.cl
+++ b/test/VulkanMemoryModel/atomic_and.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicAnd %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_and(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_cmpxchg.cl
+++ b/test/VulkanMemoryModel/atomic_cmpxchg.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 66
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK-DAG: %[[CONSTANT_13_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 13
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicCompareExchange %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_FLAG_ACQUIRE]] %[[CONSTANT_42_ID]] %[[CONSTANT_13_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_cmpxchg(b, 13, 42);
+}

--- a/test/VulkanMemoryModel/atomic_dec.cl
+++ b/test/VulkanMemoryModel/atomic_dec.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicIDecrement %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_dec(b);
+}

--- a/test/VulkanMemoryModel/atomic_inc.cl
+++ b/test/VulkanMemoryModel/atomic_inc.cl
@@ -1,0 +1,15 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicIIncrement %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_inc(b);
+}

--- a/test/VulkanMemoryModel/atomic_max.cl
+++ b/test/VulkanMemoryModel/atomic_max.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicSMax %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_max(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_min.cl
+++ b/test/VulkanMemoryModel/atomic_min.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicSMin %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_min(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_or.cl
+++ b/test/VulkanMemoryModel/atomic_or.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicOr %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_or(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_sub.cl
+++ b/test/VulkanMemoryModel/atomic_sub.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicISub %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_sub(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_xchg.cl
+++ b/test/VulkanMemoryModel/atomic_xchg.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicExchange %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_xchg(b, 42);
+}

--- a/test/VulkanMemoryModel/atomic_xor.cl
+++ b/test/VulkanMemoryModel/atomic_xor.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
+// CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
+// CHECK-DAG: %[[CONSTANT_FLAG_ACQUIRE_RELEASE:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 72
+// CHECK-DAG: %[[CONSTANT_42_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 42
+// CHECK: %[[ATOMIC_OP_ID:[a-zA-Z0-9_]*]] = OpAtomicXor %[[UINT_TYPE_ID]] {{.*}} %[[CONSTANT_1_ID]] %[[CONSTANT_FLAG_ACQUIRE_RELEASE]] %[[CONSTANT_42_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global int* a, global int* b)
+{
+  *a = atomic_xor(b, 42);
+}

--- a/test/VulkanMemoryModel/coherent_image.cl
+++ b/test/VulkanMemoryModel/coherent_image.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5 -cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+kernel void foo(read_write image1d_t im) {
+  uint4 x = read_imageui(im, 0);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  write_imageui(im, 0, x);
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: {{.*}} = OpImageRead {{.*}} {{.*}} {{.*}} MakeTexelVisible|NonPrivateTexel|ZeroExtend [[DEVICE_SCOPE]]
+// CHECK: OpImageWrite {{.*}} {{.*}} {{.*}} MakeTexelAvailable|NonPrivateTexel|ZeroExtend [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/coherent_multiple_subfunctions.cl
+++ b/test/VulkanMemoryModel/coherent_multiple_subfunctions.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %target %s -o %t.spv -no-inline-single -no-dra -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+__attribute__((noinline))
+int baz(global int* x) { return x[0]; }
+
+__attribute__((noinline))
+int bar(global int* x) { return baz(x); }
+
+kernel void foo(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/coherent_simple.cl
+++ b/test/VulkanMemoryModel/coherent_simple.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+kernel void foo(global int* data) {
+  int x = data[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: {{.*}} = OpLoad [[uint]] {{.*}} MakePointerVisible|NonPrivatePointer [[DEVICE_SCOPE]]
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/coherent_subfunction_parameter.cl
+++ b/test/VulkanMemoryModel/coherent_subfunction_parameter.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+__attribute__((noinline))
+int bar(global int* x) { return x[0]; }
+
+kernel void foo(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]
+// CHECK: {{.*}} = OpLoad [[uint]] {{.*}} MakePointerVisible|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/copy.ll
+++ b/test/VulkanMemoryModel/copy.ll
@@ -1,0 +1,33 @@
+; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.5 -vulkan-memory-model
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+; CHECK-NOT: OpDecorate {{.*}} Coherent
+; CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+; CHECK: [[uint_16:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 16
+; CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+; CHECK: OpStore {{.*}} {{.*}} Aligned|MakePointerAvailable|NonPrivatePointer 16 [[DEVICE_SCOPE]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
+  %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
+  call void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)* %gep_out, %struct.S addrspace(3)* %gep_mem, i32 16, i32 16, i32 0)
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
+
+declare void @_Z17spirv.copy_memory.1(%struct.S addrspace(1)*, %struct.S addrspace(3)*, i32, i32, i32)
+
+!1 = !{i32 2}

--- a/test/VulkanMemoryModel/frexp.cl
+++ b/test/VulkanMemoryModel/frexp.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+kernel void foo(global int *data, global float* x) {
+  float y = data[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  *x = frexp(y, data + 1);
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: {{.*}} = OpLoad [[uint]] {{.*}} MakePointerVisible|NonPrivatePointer [[DEVICE_SCOPE]]
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/load.ll
+++ b/test/VulkanMemoryModel/load.ll
@@ -1,0 +1,29 @@
+; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.5 -vulkan-memory-model
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+; CHECK-NOT: OpDecorate {{.*}} Coherent
+; CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+; CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+; CHECK: {{.*}} = OpLoad {{.*}} {{.*}} MakePointerVisible|NonPrivatePointer [[DEVICE_SCOPE]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %in) !clspv.pod_args_impl !1 {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
+  %gep = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %ld = load %struct.S, %struct.S addrspace(1)* %gep
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
+
+!1 = !{i32 2}
+

--- a/test/VulkanMemoryModel/parameter_one_use_is_coherent.cl
+++ b/test/VulkanMemoryModel/parameter_one_use_is_coherent.cl
@@ -1,0 +1,24 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+__attribute__((noinline))
+int bar(global int* x) { return x[0]; }
+
+kernel void foo1(global int* data) {
+  int x = bar(data);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  data[1] = x;
+}
+
+kernel void foo2(global int* x, global int* y) {
+  int z = bar(x);
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  y[0] = z;
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/selection.cl
+++ b/test/VulkanMemoryModel/selection.cl
@@ -1,0 +1,21 @@
+// RUN: clspv %target %s -o %t.spv -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t.spvasm %t.spv
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// Both x's should be coherent. y should not be coherent because it is not read.
+__attribute__((noinline))
+void bar(global int* x, int y) { *x = y; }
+
+kernel void foo(global int* x, global int* y, int c) {
+  int z = x[0];
+  barrier(CLK_GLOBAL_MEM_FENCE);
+  global int* ptr = c ? x : y;
+  bar(ptr + 1, z);
+}
+
+// CHECK-NOT: OpDecorate {{.*}} Coherent
+// CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+// CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+// CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]
+// CHECK: {{.*}} = OpLoad [[uint]] {{.*}} MakePointerVisible|NonPrivatePointer [[DEVICE_SCOPE]]

--- a/test/VulkanMemoryModel/simple_kernel.cl
+++ b/test/VulkanMemoryModel/simple_kernel.cl
@@ -1,0 +1,11 @@
+// RUN: clspv %target -o %t.spv < %s -vulkan-memory-model -spv-version=1.5
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VulkanMemoryModel
+// CHECK: OpMemoryModel Logical Vulkan
+void kernel foo()
+{
+}

--- a/test/VulkanMemoryModel/simple_kernel_old_spv.cl
+++ b/test/VulkanMemoryModel/simple_kernel_old_spv.cl
@@ -1,0 +1,12 @@
+// RUN: clspv %target -o %t.spv < %s -vulkan-memory-model
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpCapability Shader
+// CHECK: OpCapability VulkanMemoryModel
+// CHECK: OpExtension "SPV_KHR_vulkan_memory_model"
+// CHECK: OpMemoryModel Logical Vulkan
+void kernel foo()
+{
+}

--- a/test/VulkanMemoryModel/store.ll
+++ b/test/VulkanMemoryModel/store.ll
@@ -1,0 +1,32 @@
+; RUN: clspv-opt --passes=spirv-producer %s -o %t.ll -producer-out-file %t.spv -spv-version=1.5 -vulkan-memory-model
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val --target-env vulkan1.2spv1.5 %t.spv
+
+; CHECK-NOT: OpDecorate {{.*}} Coherent
+; CHECK: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
+; CHECK: [[uint_16:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 16
+; CHECK: [[DEVICE_SCOPE:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 1
+; CHECK: OpStore {{.*}} {{.*}} MakePointerAvailable|NonPrivatePointer [[DEVICE_SCOPE]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { [4 x i32], <4 x float> }
+
+@foo.mem = internal unnamed_addr addrspace(3) global [16 x %struct.S] undef, align 16
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define spir_kernel void @foo(%struct.S addrspace(1)* %out) !clspv.pod_args_impl !1 {
+entry:
+  %res = call { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, { [0 x %struct.S] } zeroinitializer)
+  %gep_out = getelementptr { [0 x %struct.S] }, { [0 x %struct.S] } addrspace(1)* %res, i32 0, i32 0, i32 0
+  %gep_mem = getelementptr [16 x %struct.S], [16 x %struct.S] addrspace(3)* @foo.mem, i32 0, i32 0
+  %ld = load %struct.S, %struct.S addrspace(3)* %gep_mem
+  store %struct.S %ld, %struct.S addrspace(1)* %gep_out
+  ret void
+}
+
+declare { [0 x %struct.S] } addrspace(1)* @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x %struct.S] })
+
+!1 = !{i32 2}


### PR DESCRIPTION
# PR Changes
* Add `vulkan-memory-model` option to clspv
* Generate VulkanMemoryModel shaders from clspv
* Change memorySemantics for atomics on VulkanMemoryModel
* Remove Coherent decoration on VulkanMemoryModel as it is not supported and replace it with relevant `Available` and `Visible` on read and write instructions

### [Related issue](https://github.com/google/clspv/issues/268)

**This contribution is being made by Codeplay on behalf of Samsung.**