### PR TITLE
fix decorate non uniform

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4439,7 +4439,8 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
     addSPIRVInst(spv::OpNoLine);
   }
 
-  if (clspv::Option::DecorateNonUniform()) {
+  if (clspv::Option::DecorateNonUniform() &&
+      I.getOpcode() != Instruction::PHI) {
     for (auto &op : I.operands()) {
       if (!isPointerUniform(op)) {
         setNonUniformPointers();


### PR DESCRIPTION
PHI node's operands may have not been process yet by `GenerateInstruction`, which can lead to `GetSPIRVValue` to fail when trying to decorate an operand that has not been processed.