### PR TITLE
Transition builtins and spirv producers to opaque pointers

### DIFF
--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -514,7 +514,9 @@ std::string Builtins::GetMangledTypeName(Type *Ty) {
       std::string AS_name = "AS" + std::to_string(AS);
       mangled_type_str += "U" + std::to_string(AS_name.size()) + AS_name;
     }
-    mangled_type_str += GetMangledTypeName(Ty->getPointerElementType());
+    if (!Ty->isOpaquePointerTy()) {
+      mangled_type_str += GetMangledTypeName(Ty->getNonOpaquePointerElementType());
+    }
     break;
   }
   case Type::FixedVectorTyID: {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6058,6 +6058,7 @@ bool SPIRVProducerPassImpl::IsTypeNullable(const Type *type) const {
         return false;
       }
     }
+  }
   case Type::ArrayTyID:
     return IsTypeNullable(type->getArrayElementType());
   case Type::StructTyID: {


### PR DESCRIPTION
Contributes to #816

* Final few cases in SPIRVProducerPass
* Small change in builtins