### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "ed2fdace89425148dbf37cd7f0473671ca698e09"
+      "commit" : "50882b4daf77b9d93e025f804b0855c94a83f237"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5108,7 +5108,7 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         auto op1 = I.getOperand(1);
         auto vec_ty = dyn_cast<VectorType>(op0->getType());
         auto num_eles = vec_ty->getElementCount().getFixedValue();
-        bool use_op0 = mask < num_eles;
+        bool use_op0 = mask < (int)num_eles;
         auto op = use_op0 ? op0 : op1;
         auto mask_byte = mask % num_eles;
         if (!isa<UndefValue>(op) && !isa<PoisonValue>(op)) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4511,6 +4511,16 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         Ops << OpTy << I.getOperand(0) << getSPIRVInt32Constant(255);
 
         RID = addSPIRVInst(spv::OpBitwiseAnd, Ops);
+      } else if (!clspv::Option::Int8Support() &&
+                 I.getOpcode() == Instruction::BitCast &&
+                 ((Ty->isIntOrIntVectorTy(8) && OpTy->isIntOrIntVectorTy(32)) ||
+                  (Ty->isIntOrIntVectorTy(32) &&
+                   OpTy->isIntOrIntVectorTy(8)))) {
+        // Without int8 support, <4 x i8> is represented as i32.
+        // The only valid bitcast involving i8 and i32 is <4 x i8> <--> i32
+        // because Vulkan's max vector size is 4 and the total bitwidth must
+        // match.
+        RID = getSPIRVValue(I.getOperand(0));
       } else if (Ty->isIntOrIntVectorTy(1) &&
                  I.getOpcode() == Instruction::Trunc) {
         // We usually map trunc to OpUConvert.
@@ -5085,25 +5095,71 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
     // Ops[3] ... Ops[n] = Components (Literal Number)
     SPIRVOperandVec Ops;
 
-    Ops << I.getType() << I.getOperand(0) << I.getOperand(1);
+    if (!clspv::Option::Int8Support() && I.getType()->isIntOrIntVectorTy(8)) {
+      // <4 x i8> is translated as i32. So shufflevector on <4 x i8> must be
+      // implemented as bit operations.
+      // This could be optimized, but it is a legacy support case.
+      auto int32_ty = Type::getInt32Ty(module->getContext());
+      auto tmp = getSPIRVConstant(Constant::getNullValue(int32_ty));
+      const auto shuffle = dyn_cast<ShuffleVectorInst>(&I);
+      uint32_t i = 0;
+      for (auto mask : shuffle->getShuffleMask()) {
+        auto op0 = I.getOperand(0);
+        auto op1 = I.getOperand(1);
+        auto vec_ty = dyn_cast<VectorType>(op0->getType());
+        auto num_eles = vec_ty->getElementCount().getFixedValue();
+        bool use_op0 = mask < num_eles;
+        auto op = use_op0 ? op0 : op1;
+        auto mask_byte = mask % num_eles;
+        if (!isa<UndefValue>(op) && !isa<PoisonValue>(op)) {
+          Ops.clear();
 
-    auto shuffle = cast<ShuffleVectorInst>(&I);
-    SmallVector<int, 4> mask;
-    shuffle->getShuffleMask(mask);
-    for (auto i : mask) {
-      if (i == UndefMaskElem) {
-        if (clspv::Option::HackUndef())
-          // Use 0 instead of undef.
-          Ops << 0;
-        else
-          // Undef for shuffle in SPIR-V.
-          Ops << 0xffffffff;
-      } else {
-        Ops << i;
+          // This element goes in the |i|'th byte using the |mask_byte| byte of
+          // |op|.
+          const uint32_t bitmask = 0xff << (mask_byte * 8);
+          auto bitmask_const =
+              getSPIRVConstant(ConstantInt::get(int32_ty, bitmask));
+          Ops << op->getType() << op << bitmask_const;
+          auto and_mask = addSPIRVInst(spv::OpBitwiseAnd, Ops);
+          Ops.clear();
+
+          const int32_t shift_amount = i * 8 - mask_byte * 8;
+          const bool shl = shift_amount > 0;
+          if (shift_amount != 0) {
+            Ops << op->getType() << and_mask
+                << getSPIRVConstant(ConstantInt::get(int32_ty, shift_amount));
+            and_mask = addSPIRVInst(
+                shl ? spv::OpShiftLeftLogical : spv::OpShiftRightLogical, Ops);
+            Ops.clear();
+          }
+
+          Ops << I.getType() << tmp << and_mask;
+          tmp = addSPIRVInst(spv::OpBitwiseOr, Ops);
+        }
+        ++i;
       }
-    }
+      RID = tmp;
+    } else {
+      Ops << I.getType() << I.getOperand(0) << I.getOperand(1);
 
-    RID = addSPIRVInst(spv::OpVectorShuffle, Ops);
+      auto shuffle = cast<ShuffleVectorInst>(&I);
+      SmallVector<int, 4> mask;
+      shuffle->getShuffleMask(mask);
+      for (auto i : mask) {
+        if (i == UndefMaskElem) {
+          if (clspv::Option::HackUndef())
+            // Use 0 instead of undef.
+            Ops << 0;
+          else
+            // Undef for shuffle in SPIR-V.
+            Ops << 0xffffffff;
+        } else {
+          Ops << i;
+        }
+      }
+
+      RID = addSPIRVInst(spv::OpVectorShuffle, Ops);
+    }
     break;
   }
   case Instruction::ICmp:

--- a/test/Structs/insert_value_issue_14.cl
+++ b/test/Structs/insert_value_issue_14.cl
@@ -32,7 +32,18 @@ kernel void foo(global S* A, global uchar4* B, int n) {
 
 // With undef mapping to 0 byte, (undef,1,2,3) maps to 66051.
 // CHECK-DAG: [[theconst:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 66051
+// CHECK-DAG: [[int_65280:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 65280
+// CHECK-DAG: [[int_16711680:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 16711680
+// CHECK-DAG: [[int_4278190080:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4278190080
+// CHECK-DAG: [[int_255:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 255
 
 // no longer checked: [[undef_struct:%[_a-zA-Z0-9]+]] = OpUndef [[struct]]
 
-// CHECK: OpBitwiseAnd [[uint]] [[theconst]] {{%[_a-zA-Z0-9]+}}
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] %{{.*}} [[int_255]]
+// CHECK: [[or1:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] %{{.*}} [[and]]
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_65280]]
+// CHECK: [[or2:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] [[or1]] [[and]]
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_16711680]]
+// CHECK: [[or3:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] [[or2]] [[and]]
+// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_4278190080]]
+// CHECK: OpBitwiseOr [[uint]] [[or3]] [[and]]


### PR DESCRIPTION
* Codegen changed to generate shufflevector of <4 x i8>
* SPIRVProducer was producing invalid code in this case
  * bitcasting i32 to i32
  * vector shuffle on i32
* Fix code and test expectations