### PR TITLE
Support PhysicalStorageBuffers for constant address space, including module-scope constants

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,7 +14,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "branch" : "master",
       "subdir" : "third_party/SPIRV-Headers",
-      "commit" : "c214f6f2d1a7253bb0e9f195c2dc5b0659dc99ef"
+      "commit" : "d13b52222c39a7e9a401b44646f0ca3a640fbd47"
     },
     {
       "name" : "SPIRV-Tools",

--- a/include/clspv/PushConstant.h
+++ b/include/clspv/PushConstant.h
@@ -27,6 +27,7 @@ enum class PushConstant : int {
   RegionGroupOffset,
   KernelArgument,
   ImageMetadata,
+  ModuleConstantsPointer,
 };
 
 enum class ImageMetadata : int {

--- a/lib/DeclarePushConstantsPass.cpp
+++ b/lib/DeclarePushConstantsPass.cpp
@@ -60,6 +60,10 @@ clspv::DeclarePushConstantsPass::run(Module &M, ModuleAnalysisManager &) {
     PushConstants.push_back(clspv::PushConstant::RegionGroupOffset);
   }
 
+  if (clspv::ShouldDeclareModuleConstantsPointerPushConstant(M)) {
+    PushConstants.push_back(clspv::PushConstant::ModuleConstantsPointer);
+  }
+
   if (PushConstants.size() > 0) {
 
     std::vector<Type *> Members;

--- a/lib/NormalizeGlobalVariable.cpp
+++ b/lib/NormalizeGlobalVariable.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "clspv/AddressSpace.h"
+#include "Constants.h"
 
 #include "NormalizeGlobalVariable.h"
 
@@ -218,7 +219,8 @@ void NormalizeVariableUsers(GlobalVariable *GV) {
   }
 
   GV->removeDeadConstantUsers();
-  if (GV->use_empty()) {
+  if (GV->use_empty() &&
+      GV->getName() != clspv::ClusteredConstantsVariableName()) {
     GV->eraseFromParent();
   }
 }

--- a/lib/PhysicalPointerArgsPass.cpp
+++ b/lib/PhysicalPointerArgsPass.cpp
@@ -52,7 +52,8 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
                               clspv::IsSamplerType(ArgStructTy);
         }
 
-        if (PtrTy->getAddressSpace() == clspv::AddressSpace::Global &&
+        if ((PtrTy->getAddressSpace() == clspv::AddressSpace::Global ||
+             PtrTy->getAddressSpace() == clspv::AddressSpace::Constant) &&
             !IsBuiltinStructTy) {
           NewParamTypes.push_back(PtrIntTy);
           UpdateNeeded = true;

--- a/lib/PushConstant.h
+++ b/lib/PushConstant.h
@@ -54,8 +54,11 @@ bool ShouldDeclareNumWorkgroupsPushConstant(llvm::Module &);
 // Returns true if non-uniform NDRange region group offset is needed.
 bool ShouldDeclareRegionGroupOffsetPushConstant(llvm::Module &);
 
-// Returns the size of global push constants.
-uint64_t GlobalPushConstantsSize(llvm::Module &);
+// Returns true if module-scope constants pointer is needed.
+bool ShouldDeclareModuleConstantsPointerPushConstant(llvm::Module &);
+
+// Returns the type of the global push constants struct.
+llvm::StructType *GlobalPushConstantsType(llvm::Module &);
 
 // (Re-)Declares the global push constant variable with |mangled_struct_ty|
 // as the last member.

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -570,7 +570,9 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
             clspv::Option::PhysicalStorageBuffers()) {
           if (auto *source_ptr_ty = dyn_cast<PointerType>(source->getType())) {
             if (source_ptr_ty->getAddressSpace() ==
-                clspv::AddressSpace::Global) {
+                    clspv::AddressSpace::Global ||
+                source_ptr_ty->getAddressSpace() ==
+                    clspv::AddressSpace::Constant) {
               continue;
             }
           }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -992,7 +992,8 @@ void SPIRVProducerPassImpl::FindGlobalConstVars() {
   SmallVector<GlobalVariable *, 8> DeadGVList;
   for (GlobalVariable &GV : module->globals()) {
     if (GV.getType()->getAddressSpace() == AddressSpace::Constant) {
-      if (GV.use_empty()) {
+      if (GV.use_empty() &&
+          GV.getName() != clspv::ClusteredConstantsVariableName()) {
         DeadGVList.push_back(&GV);
       } else {
         GVList.push_back(&GV);
@@ -1417,7 +1418,7 @@ SPIRVProducerPassImpl::GetStorageClass(unsigned AddrSpace) const {
   case AddressSpace::Constant:
     return clspv::Option::ConstantArgsInUniformBuffer()
                ? spv::StorageClassUniform
-               : spv::StorageClassStorageBuffer;
+               : GetStorageBufferClass();
   case AddressSpace::Input:
     return spv::StorageClassInput;
   case AddressSpace::Local:
@@ -2819,10 +2820,13 @@ void SPIRVProducerPassImpl::GenerateGlobalVar(GlobalVariable &GV) {
       (AS == AddressSpace::Private || AS == AddressSpace::ModuleScopePrivate ||
        AS == AddressSpace::Local);
   auto ptr_id = getSPIRVPointerType(Ty, GV.getValueType());
-  SPIRVID var_id =
-      addSPIRVGlobalVariable(ptr_id, spvSC, InitializerID, interface);
 
-  VMap[&GV] = var_id;
+  if (!(module_scope_constant_external_init &&
+        clspv::Option::PhysicalStorageBuffers())) {
+    SPIRVID var_id =
+        addSPIRVGlobalVariable(ptr_id, spvSC, InitializerID, interface);
+    VMap[&GV] = var_id;
+  }
 
   auto IsOpenCLBuiltin = [](spv::BuiltIn builtin) {
     return builtin == spv::BuiltInWorkDim ||
@@ -2856,35 +2860,67 @@ void SPIRVProducerPassImpl::GenerateGlobalVar(GlobalVariable &GV) {
 
     addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
   } else if (module_scope_constant_external_init) {
-    // This module scope constant is initialized from a storage buffer with data
-    // provided by the host at binding 0 of the next descriptor set.
-    const uint32_t descriptor_set = TakeDescriptorIndex(module);
-
     // Emit the intializer as a reflection instruction.
-    // Use "kind,buffer" to indicate storage buffer. We might want to expand
-    // that later to other types, like uniform buffer.
     std::string hexbytes;
     llvm::raw_string_ostream str(hexbytes);
     clspv::ConstantEmitter(DL, str).Emit(GV.getInitializer());
-
-    // Reflection instruction for constant data.
-    SPIRVOperandVec Ops;
     auto data_id = addSPIRVInst<kDebug>(spv::OpString, str.str().c_str());
-    Ops << getSPIRVType(Type::getVoidTy(module->getContext()))
-        << getReflectionImport() << reflection::ExtInstConstantDataStorageBuffer
-        << getSPIRVInt32Constant(descriptor_set) << getSPIRVInt32Constant(0)
-        << data_id;
-    addSPIRVInst<kReflection>(spv::OpExtInst, Ops);
+    SPIRVOperandVec Ops;
+    // If using physical storage buffers, lower the constants GV as a push
+    // constant containing a pointer, otherwise use a storage buffer
+    if (clspv::Option::PhysicalStorageBuffers()) {
+      std::string hexbytes;
+      llvm::raw_string_ostream str(hexbytes);
+      clspv::ConstantEmitter(DL, str).Emit(GV.getInitializer());
 
-    // OpDecorate %var DescriptorSet <descriptor_set>
-    Ops.clear();
-    Ops << var_id << spv::DecorationDescriptorSet << descriptor_set;
-    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+      auto PushConstGV =
+          module->getGlobalVariable(clspv::PushConstantsVariableName());
+      auto STy = cast<StructType>(PushConstGV->getValueType());
+      auto MD = PushConstGV->getMetadata(clspv::PushConstantsMetadataName());
+      bool Found = false;
+      uint32_t Offset = 0;
 
-    // OpDecorate %var Binding <binding>
-    Ops.clear();
-    Ops << var_id << spv::DecorationBinding << 0;
-    addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+      // Find the push constant offset for the module constants pointer
+      for (unsigned i = 0; i < STy->getNumElements(); i++) {
+        auto pc = static_cast<clspv::PushConstant>(
+            mdconst::extract<ConstantInt>(MD->getOperand(i))->getZExtValue());
+
+        if (pc == clspv::PushConstant::ModuleConstantsPointer) {
+          Found = true;
+          Offset = GetExplicitLayoutStructMemberOffset(STy, i, DL);
+        }
+      }
+      assert(Found);
+
+      Ops << getSPIRVType(Type::getVoidTy(module->getContext()))
+          << getReflectionImport()
+          << reflection::ExtInstConstantDataPointerPushConstant
+          << getSPIRVInt32Constant(Offset) << getSPIRVInt32Constant(8)
+          << data_id;
+      addSPIRVInst<kReflection>(spv::OpExtInst, Ops);
+    } else {
+      // This module scope constant is initialized from a storage buffer with
+      // data provided by the host at binding 0 of the next descriptor set.
+      const uint32_t descriptor_set = TakeDescriptorIndex(module);
+
+      // Reflection instruction for constant data.
+      Ops << getSPIRVType(Type::getVoidTy(module->getContext()))
+          << getReflectionImport()
+          << reflection::ExtInstConstantDataStorageBuffer
+          << getSPIRVInt32Constant(descriptor_set) << getSPIRVInt32Constant(0)
+          << data_id;
+      addSPIRVInst<kReflection>(spv::OpExtInst, Ops);
+
+      // OpDecorate %var DescriptorSet <descriptor_set>
+      Ops.clear();
+      Ops << VMap[&GV] << spv::DecorationDescriptorSet << descriptor_set;
+      addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+
+      // OpDecorate %var Binding <binding>
+      Ops.clear();
+      Ops << VMap[&GV] << spv::DecorationBinding << 0;
+      addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+    }
   }
 }
 
@@ -3007,7 +3043,8 @@ void SPIRVProducerPassImpl::GenerateFuncPrologue(Function &F) {
       // PhysicalStorageBuffer args require a Restrict or Aliased decoration
       if (auto *PtrTy = dyn_cast<PointerType>(Arg.getType())) {
         if (clspv::Option::PhysicalStorageBuffers() &&
-            PtrTy->getAddressSpace() == clspv::AddressSpace::Global) {
+            (PtrTy->getAddressSpace() == clspv::AddressSpace::Global ||
+             PtrTy->getAddressSpace() == clspv::AddressSpace::Constant)) {
           Ops.clear();
           Ops << param_id
               << (Arg.hasNoAliasAttr() ? spv::DecorationRestrict
@@ -3116,7 +3153,8 @@ void SPIRVProducerPassImpl::GenerateModuleInfo() {
         }
       }
 
-      if (clspv::Option::ModuleConstantsInStorageBuffer()) {
+      if (clspv::Option::ModuleConstantsInStorageBuffer() &&
+          !clspv::Option::PhysicalStorageBuffers()) {
         auto *V = module->getGlobalVariable(
             clspv::ClusteredConstantsVariableName(), true);
         if (V) {
@@ -6544,7 +6582,8 @@ void SPIRVProducerPassImpl::GeneratePushConstantReflection() {
       auto pc = static_cast<clspv::PushConstant>(
           mdconst::extract<ConstantInt>(MD->getOperand(i))->getZExtValue());
       if (pc == PushConstant::KernelArgument ||
-          pc == PushConstant::ImageMetadata)
+          pc == PushConstant::ImageMetadata ||
+          pc == PushConstant::ModuleConstantsPointer)
         continue;
 
       auto memberType = STy->getElementType(i);
@@ -6773,7 +6812,7 @@ void SPIRVProducerPassImpl::GenerateKernelReflection() {
 
         // Generate the specific argument instruction.
         const uint32_t ordinal = static_cast<uint32_t>(old_index);
-        const uint32_t arg_offset = static_cast<uint32_t>(offset);
+        uint32_t arg_offset = static_cast<uint32_t>(offset);
         const uint32_t arg_size = static_cast<uint32_t>(size);
         uint32_t elem_size = 0;
         uint32_t descriptor_set = 0;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -6561,7 +6561,7 @@ SPIRVID SPIRVProducerPassImpl::getReflectionImport() {
       addSPIRVInst<kExtensions>(spv::OpExtension, "SPV_KHR_non_semantic_info");
     }
     ReflectionID = addSPIRVInst<kImports>(spv::OpExtInstImport,
-                                          "NonSemantic.ClspvReflection.4");
+                                          "NonSemantic.ClspvReflection.5");
   }
   return ReflectionID;
 }

--- a/test/KernelArgInfo/kernel-arg-info.cl
+++ b/test/KernelArgInfo/kernel-arg-info.cl
@@ -5,7 +5,7 @@
 
 void kernel foo(global int4 *A, local float* SEC, constant short2* TER, int QUA, read_only image2d_t im0, write_only image2d_t im1, const volatile global int * restrict ptr){}
 
-// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 
 // CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "A"

--- a/test/PhysicalStorageBuffers/physical_constant_module_scope.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_module_scope.cl
@@ -11,7 +11,7 @@ kernel void test(global int *result) {
 }
 
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
-// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64
 // CHECK: [[Initializer:%[a-zA-Z0-9_]+]] = OpString "0000000000000000000000000000000000000000"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid

--- a/test/PhysicalStorageBuffers/physical_constant_module_scope.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_module_scope.cl
@@ -1,0 +1,36 @@
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+constant int myconst[5] = { 0 };
+
+kernel void test(global int *result) {
+  size_t tid = get_global_id(0);
+  result[tid] = myconst[tid];
+}
+
+// CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK: OpMemoryModel PhysicalStorageBuffer64
+// CHECK: [[Initializer:%[a-zA-Z0-9_]+]] = OpString "0000000000000000000000000000000000000000"
+// CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32
+// CHECK-DAG: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 8
+// CHECK-DAG: [[arr_int_5:%[a-zA-Z0-9_]+]] = OpTypeArray [[uint]] [[uint_5]]
+// CHECK-DAG: [[arr_int_5_struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[arr_int_5]]
+// CHECK-DAG: [[module_consts_pc_ptr_type:%[a-zA-Z0-9_]+]] = OpTypePointer PushConstant %ulong
+// CHECK-DAG: [[module_consts_type:%[a-zA-Z0-9_]+]] = OpTypePointer PhysicalStorageBuffer [[arr_int_5_struct]]
+// CHECK-DAG: [[physical_int_ptr_type0:%[a-zA-Z0-9_]+]] = OpTypePointer PhysicalStorageBuffer [[uint]]
+// CHECK-DAG: [[physical_int_ptr_type1:%[a-zA-Z0-9_]+]] = OpTypePointer PhysicalStorageBuffer [[uint]]
+
+// CHECK: [[module_consts_pc_ptr:%[a-zA-Z0-9_]+]] = OpAccessChain [[module_consts_pc_ptr_type]]
+// CHECK: [[module_consts_ptr:%[a-zA-Z0-9_]+]] = OpLoad [[ulong]] [[module_consts_pc_ptr]] Aligned 8
+// CHECK: [[module_consts_ptr_converted:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[module_consts_type]] [[module_consts_ptr]]
+// CHECK: [[module_consts_gep:%[a-zA-Z0-9_]+]] = OpAccessChain [[physical_int_ptr_type1]] [[module_consts_ptr_converted]]
+// CHECK: OpLoad [[uint]] [[module_consts_gep]] Aligned 4
+
+// CHECK: OpExtInst [[void]] [[ClspvReflection]] ConstantDataPointerPushConstant [[uint_0]] [[uint_8]] [[Initializer]]

--- a/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
@@ -14,7 +14,7 @@ kernel void copy(constant short *a, global int *b, int x, int y) {
 }
 
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
-// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64
 // CHECK-DAG: OpDecorate [[ptr_physical_ushort:%[a-zA-Z0-9_]+]] ArrayStride 2
 // CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4

--- a/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
@@ -1,0 +1,45 @@
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-pushconstant
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-PC
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-ubo
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-UBO
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void copy(constant short *a, global int *b, int x, int y) {
+    size_t gid = get_global_id(0);
+    b[gid] = (int) a[gid] + x + y;
+}
+
+// CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK: OpMemoryModel PhysicalStorageBuffer64
+// CHECK-DAG: OpDecorate [[ptr_physical_ushort:%[a-zA-Z0-9_]+]] ArrayStride 2
+// CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK-DAG: [[ushort:%[a-zA-Z0-9_]+]] = OpTypeInt 16
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32
+// CHECK-DAG: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64
+// CHECK-DAG: [[pod_struct_ty:%[a-zA-Z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]] [[uint]] [[uint]]
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 8
+// CHECK-DAG: [[ptr_physical_ushort]] = OpTypePointer PhysicalStorageBuffer [[ushort]]
+// CHECK-DAG: [[ptr_physical_uint]] = OpTypePointer PhysicalStorageBuffer [[uint]]
+
+// CHECK: [[pod_struct:%[a-zA-Z0-9_]+]] = OpLoad [[pod_struct_ty]]
+// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 0
+// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 1
+// CHECK: [[ptr_a:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_ushort]] [[ptr_int_a]]
+// CHECK: [[ptr_b:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_uint]] [[ptr_int_b]]
+// CHECK: [[ptr_a_access_chain:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_ushort]] [[ptr_a]]
+// CHECK: OpLoad [[ushort]] [[ptr_a_access_chain]] Aligned 2
+// CHECK: [[ptr_b_access_chain:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_uint]] [[ptr_b]]
+// CHECK: OpStore [[ptr_b_access_chain]] %{{[a-zA-Z0-9_]+}} Aligned 4
+
+// CHECK: [[KernelReflection:%[a-zA-Z0-9_]+]] = OpExtInst %void [[ClspvReflection]] Kernel
+// CHECK-PC: OpExtInst %void [[ClspvReflection]] ArgumentPointerPushConstant [[KernelReflection]] [[uint_0]] [[uint_0]] [[uint_8]]
+// CHECK-PC: OpExtInst %void [[ClspvReflection]] ArgumentPointerPushConstant [[KernelReflection]] [[uint_1]] [[uint_8]] [[uint_8]]
+// CHECK-UBO: OpExtInst %void [[ClspvReflection]] ArgumentPointerUniform [[KernelReflection]] [[uint_0]] %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} [[uint_0]] [[uint_8]]
+// CHECK-UBO: OpExtInst %void [[ClspvReflection]] ArgumentPointerUniform [[KernelReflection]] [[uint_1]] %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} [[uint_8]] [[uint_8]]

--- a/test/PhysicalStorageBuffers/physical_constant_ptrtoint.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_ptrtoint.cl
@@ -12,7 +12,7 @@ kernel void test(global ulong *a, constant int *b)
     a[tid + 1] = (ulong) &myconst[tid];
 }
 
-// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
 // CHECK-DAG: OpDecorate [[ptr_physical_ulong:%[a-zA-Z0-9_]+]] ArrayStride 8
 // CHECK-DAG: OpDecorate [[global_id:%[a-zA-Z0-9_]+]] BuiltIn GlobalInvocationId

--- a/test/PhysicalStorageBuffers/physical_constant_ptrtoint.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_ptrtoint.cl
@@ -1,0 +1,43 @@
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+constant char myconst[5] = { 42 };
+
+kernel void test(global ulong *a, constant int *b)
+{
+    size_t tid = get_global_id(0);
+    a[tid] = (ulong) &b[tid];
+    a[tid + 1] = (ulong) &myconst[tid];
+}
+
+// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.2"
+// CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
+// CHECK-DAG: OpDecorate [[ptr_physical_ulong:%[a-zA-Z0-9_]+]] ArrayStride 8
+// CHECK-DAG: OpDecorate [[global_id:%[a-zA-Z0-9_]+]] BuiltIn GlobalInvocationId
+// CHECK-DAG: [[uchar:%[a-zA-Z0-9_]+]] = OpTypeInt 8
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32
+// CHECK-DAG: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64
+// CHECK-DAG: [[ulong_0:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 0
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[arr_uchar_5:%[a-zA-Z0-9_]+]] = OpTypeArray [[uchar]] [[uint_5]]
+// CHECK-DAG: [[arr_uchar_5_struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[arr_uchar_5]]
+// CHECK-DAG: [[ptr_physical_arr_uchar_5:%[a-zA-Z0-9_]+]] = OpTypePointer PhysicalStorageBuffer [[arr_uchar_5_struct]]
+// CHECK-DAG: [[ptr_physical_uchar:%[a-zA-Z0-9_]+]] = OpTypePointer PhysicalStorageBuffer [[uchar]]
+// CHECK-DAG: [[ptr_physical_uint]] = OpTypePointer PhysicalStorageBuffer [[uint]]
+// CHECK-DAG: [[ptr_physical_ulong]] = OpTypePointer PhysicalStorageBuffer [[ulong]]
+
+// CHECK: [[ptr_a:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_ulong]]
+// CHECK: [[ptr_b:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_uint]]
+// CHECK: [[gid_x_ptr:%[a-zA-Z0-9_]+]] = OpAccessChain %{{[a-zA-Z0-9_]+}} [[global_id]] [[ulong_0]]
+// CHECK: [[gid_x_load:%[a-zA-Z0-9_]+]] = OpLoad [[uint]] [[gid_x_ptr]]
+// CHECK: [[gid_x:%[a-zA-Z0-9_]+]] = OpUConvert [[ulong]] [[gid_x_load]]
+// CHECK: [[ptr_b_offset:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_uint]] [[ptr_b]] [[gid_x]]
+// CHECK: [[ptr_b_offset_int:%[a-zA-Z0-9_]+]] = OpConvertPtrToU [[ulong]] [[ptr_b_offset]]
+// CHECK: [[ptr_a_offset:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_ulong]] [[ptr_a]] [[gid_x]]
+// CHECK: OpStore [[ptr_a_offset]] [[ptr_b_offset_int]] Aligned 8
+// CHECK: [[ptr_consts:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_arr_uchar_5]]
+// CHECK: [[ptr_consts_offset:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr_physical_uchar]] [[ptr_consts]]
+// CHECK: [[ptr_consts_offset_int:%[a-zA-Z0-9_]+]] = OpConvertPtrToU [[ulong]] [[ptr_consts_offset]]
+// CHECK: OpStore {{%[a-zA-Z0-9_]+}} [[ptr_consts_offset_int]] Aligned 8

--- a/test/PhysicalStorageBuffers/physical_global_exclude_image.cl
+++ b/test/PhysicalStorageBuffers/physical_global_exclude_image.cl
@@ -15,7 +15,7 @@ kernel void test(read_only image2d_t srcimg, global float4 *dst, sampler_t sampl
     dst[indx] = read_imagef(srcimg, sampler, (int2)(tid_x, tid_y));
 }
 
-// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: [[void:%[0-9a-zA-Z_]+]] = OpTypeVoid
 // CHECK-DAG: OpExtInst [[void]] [[clspv_reflection]] ArgumentSampledImage
 // CHECK-DAG: OpExtInst [[void]] [[clspv_reflection]] ArgumentSampler

--- a/test/PhysicalStorageBuffers/physical_global_pointer_args.cl
+++ b/test/PhysicalStorageBuffers/physical_global_pointer_args.cl
@@ -14,7 +14,7 @@ kernel void copy(global short *a, global int *b, int x, int y) {
 }
 
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
-// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64
 // CHECK-DAG: OpDecorate [[ptr_physical_ushort:%[a-zA-Z0-9_]+]] ArrayStride 2
 // CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4

--- a/test/PhysicalStorageBuffers/physical_global_ptrtoint.cl
+++ b/test/PhysicalStorageBuffers/physical_global_ptrtoint.cl
@@ -9,7 +9,7 @@ kernel void test(global ulong *a, global int *b)
     a[tid] = (ulong) &b[tid];
 }
 
-// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[clspv_reflection:%[0-9a-zA-Z_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: OpDecorate [[ptr_physical_uint:%[a-zA-Z0-9_]+]] ArrayStride 4
 // CHECK-DAG: OpDecorate [[ptr_physical_ulong:%[a-zA-Z0-9_]+]] ArrayStride 8
 // CHECK-DAG: OpDecorate [[global_id:%[a-zA-Z0-9_]+]] BuiltIn GlobalInvocationId

--- a/test/Reflection/constant_data_storage_buffer.cl
+++ b/test/Reflection/constant_data_storage_buffer.cl
@@ -9,7 +9,7 @@ kernel void foo(global int* data) {
   *data = x[get_global_id(0)];
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: [[x_data:%[a-zA-Z0-9_]+]] = OpString "01000000020000000300000004000000"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0

--- a/test/Reflection/different_reqd_work_group_sizes.cl
+++ b/test/Reflection/different_reqd_work_group_sizes.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[bar_name:%[a-zA-Z0-9_]+]] = OpString "bar"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid

--- a/test/Reflection/global_offset_spec_constant.cl
+++ b/test/Reflection/global_offset_spec_constant.cl
@@ -7,7 +7,7 @@ kernel void foo(global int* data) {
   *data = get_global_offset(0);
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3

--- a/test/Reflection/global_push_constants.cl
+++ b/test/Reflection/global_push_constants.cl
@@ -9,7 +9,7 @@ kernel void foo(global int* data) {
           get_group_id(0);
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0

--- a/test/Reflection/global_size_and_work_dim.cl
+++ b/test/Reflection/global_size_and_work_dim.cl
@@ -7,7 +7,7 @@ kernel void foo(global int* data) {
   *data = get_global_size(0) + get_work_dim();
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0

--- a/test/Reflection/literal_sampler.cl
+++ b/test/Reflection/literal_sampler.cl
@@ -19,7 +19,7 @@ kernel void foo(global float4* data, read_only image2d_t im) {
   data[3] = read_imagef(im, s4, (float2)(0.0f, 0.0f));
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: OpDecorate [[s1:%[a-zA-Z0-9_]+]] Binding 3
 // CHECK-DAG: OpDecorate [[s1]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[s2:%[a-zA-Z0-9_]+]] Binding 2

--- a/test/Reflection/mixed_reqd_workgroup_sizes.cl
+++ b/test/Reflection/mixed_reqd_workgroup_sizes.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[bar_name:%[a-zA-Z0-9_]+]] = OpString "bar"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid

--- a/test/Reflection/multiple_arguments.cl
+++ b/test/Reflection/multiple_arguments.cl
@@ -6,7 +6,7 @@
 kernel void foo(global int* data, global int* out) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/multiple_kernel_decls.cl
+++ b/test/Reflection/multiple_kernel_decls.cl
@@ -9,7 +9,7 @@ kernel void bar() { }
 
 kernel void baz() { }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: OpEntryPoint GLCompute [[bar:%[a-zA-Z0-9_]+]] "bar"
 // CHECK-DAG: OpEntryPoint GLCompute [[baz:%[a-zA-Z0-9_]+]] "baz"

--- a/test/Reflection/pod_push_constant_argument.cl
+++ b/test/Reflection/pod_push_constant_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(short data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/pod_storage_buffer_argument.cl
+++ b/test/Reflection/pod_storage_buffer_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(short data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/pod_uniform_buffer_argument.cl
+++ b/test/Reflection/pod_uniform_buffer_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(short data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/property_required_workgroup_size.cl
+++ b/test/Reflection/property_required_workgroup_size.cl
@@ -7,7 +7,7 @@ __attribute__((reqd_work_group_size(1,2,3)))
 kernel void foo(global int* data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid

--- a/test/Reflection/readwrite_image_argument.cl
+++ b/test/Reflection/readwrite_image_argument.cl
@@ -5,7 +5,7 @@
 
 kernel void foo(read_write image2d_t im) { }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[im_name:%[a-zA-Z0-9_]+]] = OpString "im"

--- a/test/Reflection/sampled_image_argument.cl
+++ b/test/Reflection/sampled_image_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(read_only image2d_t data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/sampler_argument.cl
+++ b/test/Reflection/sampler_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(sampler_t data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/storage_buffer_argument.cl
+++ b/test/Reflection/storage_buffer_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(global int* data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/storage_image_argument.cl
+++ b/test/Reflection/storage_image_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(write_only image2d_t data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/uniform_buffer_argument.cl
+++ b/test/Reflection/uniform_buffer_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(constant int4* data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/work_dim_spec_constant.cl
+++ b/test/Reflection/work_dim_spec_constant.cl
@@ -7,7 +7,7 @@ kernel void foo(global int* data) {
   *data = get_work_dim();
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3

--- a/test/Reflection/workgroup_argument.cl
+++ b/test/Reflection/workgroup_argument.cl
@@ -6,7 +6,7 @@
 kernel void foo(local int* data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpEntryPoint GLCompute [[foo:%[a-zA-Z0-9_]+]] "foo"
 // CHECK-DAG: [[foo_name:%[a-zA-Z0-9_]+]] = OpString "foo"
 // CHECK-DAG: [[data_name:%[a-zA-Z0-9_]+]] = OpString "data"

--- a/test/Reflection/workgroup_size_spec_constant.cl
+++ b/test/Reflection/workgroup_size_spec_constant.cl
@@ -6,7 +6,7 @@
 kernel void foo(global int* data) {
 }
 
-// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[import:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0

--- a/test/SubGroup/get_sub_group_max_size.cl
+++ b/test/SubGroup/get_sub_group_max_size.cl
@@ -10,7 +10,7 @@ void kernel test(global uint *c)
   *c = get_max_sub_group_size();
 }
 
-// CHECK: [[extinst:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.4"
+// CHECK: [[extinst:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
 // CHECK: OpDecorate [[max_subgroup_size_constant:%[a-zA-Z0-9_]+]] SpecId 3
 // CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[void:%[a-zA-Z0-9_]+]] = OpTypeVoid


### PR DESCRIPTION
This depends on an update to the ClspvReflection instructions, to allow the device address for module-scope constants to be passed:
https://github.com/KhronosGroup/SPIRV-Headers/pull/308
https://github.com/KhronosGroup/SPIRV-Registry/pull/178

This also fixes a problem with ClusterPodKernelArgumentsPass, where it used the size of the global push constant struct so far as the offset for the kernel args, but this wasn't taking into account padding elements. Now it gets the offset from the struct type directly.

This contribution is being made by Codeplay on behalf of Samsung.