### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "50882b4daf77b9d93e025f804b0855c94a83f237"
+      "commit" : "9883ee6816dca80adcdf806e38530c25d9443a29"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -587,7 +587,8 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
 
     // SROA pass is run because it will fold structs/unions that are
     // problematic on Vulkan SPIR-V away.
-    pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::SROAPass()));
+    pm.addPass(llvm::createModuleToFunctionPassAdaptor(
+        llvm::SROAPass(llvm::SROAOptions::PreserveCFG)));
 
     // InstructionCombining pass folds bitcast and gep instructions which are
     // not supported by Vulkan SPIR-V.

--- a/test/Structs/insert_value_issue_14.cl
+++ b/test/Structs/insert_value_issue_14.cl
@@ -30,20 +30,18 @@ kernel void foo(global S* A, global uchar4* B, int n) {
 // CHECK-DAG: [[uint:%[_a-zA-Z0-9]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[struct:%[_a-zA-Z0-9]+]] = OpTypeStruct [[uint]] [[uint]] [[uint]]
 
-// With undef mapping to 0 byte, (undef,1,2,3) maps to 66051.
+ 
+// With undef mapping to a 0 byte sequence, (undef,1,2,3) maps to 66051.
 // CHECK-DAG: [[theconst:%[_a-zA-Z0-9]+]] = OpConstant [[uint]] 66051
-// CHECK-DAG: [[int_65280:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 65280
-// CHECK-DAG: [[int_16711680:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 16711680
-// CHECK-DAG: [[int_4278190080:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4278190080
 // CHECK-DAG: [[int_255:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 255
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
 
 // no longer checked: [[undef_struct:%[_a-zA-Z0-9]+]] = OpUndef [[struct]]
 
 // CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] %{{.*}} [[int_255]]
-// CHECK: [[or1:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] %{{.*}} [[and]]
-// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_65280]]
-// CHECK: [[or2:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] [[or1]] [[and]]
-// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_16711680]]
-// CHECK: [[or3:%[a-zA-Z0-9_]+]] = OpBitwiseOr [[uint]] [[or2]] [[and]]
-// CHECK: [[and:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[uint]] [[theconst]] [[int_4278190080]]
-// CHECK: OpBitwiseOr [[uint]] [[or3]] [[and]]
+// CHECK: [[mask_255:%[a-zA-Z0-9_]+]] = OpShiftLeftLogical %uint [[int_255]] [[int_0]]
+// CHECK: [[mask:%[a-zA-Z0-9_]+]] = OpNot %uint [[mask_255]]
+// CHECK: [[otherelems:%[a-zA-Z0-9_]+]] = OpBitwiseAnd %uint [[theconst]] [[mask]]
+// CHECK: [[firstelem:%[a-zA-Z0-9_]+]] = OpShiftLeftLogical %uint [[and]] [[int_0]]
+
+// CHECK: OpBitwiseOr [[uint]] [[otherelems]] [[firstelem]]

--- a/tools/clspv-opt/main.cpp
+++ b/tools/clspv-opt/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 
   llvm::PassInstrumentationCallbacks PIC;
   clspv::RegisterClspvPasses(&PIC);
-  llvm::PassBuilder PB(nullptr, llvm::PipelineTuningOptions(), llvm::None,
+  llvm::PassBuilder PB(nullptr, llvm::PipelineTuningOptions(), std::nullopt,
                        &PIC);
   clspv::RegisterClspvPassBuilderCallback(&PB);
 


### PR DESCRIPTION
Fix two constructors to accommodate a few changes in the LLVM API. Update test to take into account a different way to construct a value using masks. From what I can tell, the output is still correct.