### PR TITLE
Better handling for opaque pointers in replace bitcasts

### DIFF
--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -535,8 +535,6 @@ PreservedAnalyses
 clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
   PreservedAnalyses PA;
 
-  errs() << M << "\n";
-
   WeakInstructions ToBeDeleted;
   SmallVector<Instruction *, 16> WorkList;
   SmallVector<User *, 16> UserWorkList;

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -534,6 +535,8 @@ PreservedAnalyses
 clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
   PreservedAnalyses PA;
 
+  errs() << M << "\n";
+
   WeakInstructions ToBeDeleted;
   SmallVector<Instruction *, 16> WorkList;
   SmallVector<User *, 16> UserWorkList;
@@ -702,7 +705,6 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
     }
   }
 
-
   for (Instruction *Inst : WorkList) {
     LLVM_DEBUG(dbgs() << "## Inst: "; Inst->dump());
     Value *Src = nullptr;
@@ -746,17 +748,21 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
 
     // Investigate pointer bitcast's users.
     // TODO(#816): remove after final transition.
-    Value *start = isa<BitCastInst>(Inst) ? Inst : Src;
-    for (User *BitCastUser : start->users()) {
+    // For implicit pointer casts we only want to examine |Inst| because other
+    // uses of |Src| might be casts to different types than |DstTy| or not
+    // pointer casts at all.
+    SmallVector<User *, 4> Users;
+    if (isa<BitCastInst>(Inst)) {
+      for (auto *U : Inst->users()) {
+        Users.push_back(U);
+      }
+    } else {
+      Users.push_back(Inst);
+    }
+    for (User *BitCastUser : Users) {
       if (ImplicitCasts.count(BitCastUser)) {
         // If this user was queued on the worklist as an implicit cast
         // separately, don't handle it now.
-        continue;
-      }
-      if (SrcTy->isOpaquePointerTy() &&
-          clspv::InferType(start, M.getContext(), &type_cache) ==
-              clspv::InferType(BitCastUser, M.getContext(), &type_cache)) {
-        // This user is not a bitcast.
         continue;
       }
 

--- a/test/PointerCasts/opaque_cast_and_no_cast.ll
+++ b/test/PointerCasts/opaque_cast_and_no_cast.ll
@@ -2,8 +2,8 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; CHECK: for.body:
-; CHECK: getelementptr <2 x i8>,
-; CHECK: getelementptr <2 x i8>,
+; CHECK: getelementptr inbounds <2 x i8>,
+; CHECK: getelementptr inbounds <2 x i8>,
 ; CHECK: for.inc:
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/PointerCasts/opaque_different_casts_same_source.ll
+++ b/test/PointerCasts/opaque_different_casts_same_source.ll
@@ -1,0 +1,44 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: block1:
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i32 %x, 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[shl]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[shl]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[add]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+
+; CHECK: block2:
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i32 %y, 2
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[shl]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 [[shl]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[add1]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+; CHECK: [[add2:%[a-zA-Z0-9_.]+]] = add i32 [[add1]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[add2]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+; CHECK: [[add3:%[a-zA-Z0-9_.]+]] = add i32 [[add2]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i32, ptr addrspace(1) %base_gep, i32 [[add3]]
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+; CHECK: bitcast <4 x i32> %{{.*}} to <4 x float>
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test(ptr addrspace(1) %in, i32 %n, i32 %x, i32 %y) {
+entry:
+  %base_gep = getelementptr i32, ptr addrspace(1) %in, i32 %n
+  br label %block1
+
+block1:
+  %gep1 = getelementptr <2 x i32>, ptr addrspace(1) %base_gep, i32 %x
+  %ld1 = load <2 x i32>, ptr addrspace(1) %gep1
+  br label %block2
+
+block2:
+  %gep2 = getelementptr <4 x float>, ptr addrspace(1) %base_gep, i32 %y
+  %ld2 = load <4 x float>, ptr addrspace(1) %gep2
+  ret void
+}


### PR DESCRIPTION
Contributes to #816

* Further generalizes the fix from #973 to only operate on a single implicit bitcast at a time instead of all bitcasts from the same source
  * properly handles both non-casts cases (previous PR) and when there are multiple different types of casts from the same source