### PR TITLE
fixed 404 error to  llvm-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ copyrights.
 
 #### Required Tools
 
-You will need a pre-built version of [LLVM](github.com/llvm/llvm-project) for
+You will need a pre-built version of [LLVM](https://github.com/llvm/llvm-project) for
 your system, CMake, and (optionally) Ninja.
 
 #### Build


### PR DESCRIPTION
Included `https://` preffix to `llvm-project` URL as the current URL redirects to a 404 repository 