### PR TITLE
Update calling convention for users of copied functions in ClusterPodArgs

### DIFF
--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -225,6 +225,11 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
     NewFunc->setCallingConv(F->getCallingConv());
     F->setCallingConv(CallingConv::SPIR_FUNC);
 
+    for (auto user : F->users()) {
+      if (auto call = dyn_cast<CallInst>(user))
+        call->setCallingConv(CallingConv::SPIR_FUNC);
+    }
+
     // Transfer attributes that don't apply to the POD arguments
     // to the new functions.
     auto Attributes = F->getAttributes();

--- a/test/cluster_pod_args_retain_kernel_calls.cl
+++ b/test/cluster_pod_args_retain_kernel_calls.cl
@@ -1,0 +1,32 @@
+// RUN: clspv --cluster-pod-kernel-args %target %s -o %t.spv -arch=spir
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void test_kernel_to_call(__global int *output, __global int *input, int where)
+{
+  for (int i=0; i<where; i++)
+    output[get_global_id(0)] += input[i];
+}
+
+__kernel void test_call_kernel(__global int *src, __global int *dst, int c)
+{
+  int tid = get_global_id(0);
+  test_kernel_to_call(dst, src, tid+c);
+}
+
+// Check that both the kernels still exist as entry points, and that they have
+// some of the operations we'd expect in them (the fail state we're testing for
+// is that the second entry point is completely empty save for an
+// OpUnreachable).
+// CHECK: OpEntryPoint GLCompute %[[first_kernel:[0-9a-zA-Z_]+]] "test_kernel_to_call"
+// CHECK: OpEntryPoint GLCompute %[[second_kernel:[0-9a-zA-Z_]+]] "test_call_kernel"
+// CHECK: %[[first_kernel]] = OpFunction %void
+// CHECK: OpLoad
+// CHECK: OpBranchConditional
+// CHECK: OpStore
+// CHECK: %[[second_kernel]] = OpFunction %void
+// CHECK-NOT: OpUnreachable
+// CHECK: OpLoad
+// CHECK: OpBranchConditional
+// CHECK: OpStore


### PR DESCRIPTION
ClusterPodKernelArgumentsPass creates copies of kernels and changes the original kernel to have the SPIR_FUNC calling convention. We need to update the calling convention of any call instructions that used the original function as well or the mismach causes InstCombine to consider the call invalid and optimize it out.

This contribution is being made by Codeplay on behalf of Samsung.