### PR TITLE
Infer types for some SPIRVOps

### DIFF
--- a/lib/SPIRVOp.h
+++ b/lib/SPIRVOp.h
@@ -37,6 +37,10 @@ using namespace llvm;
 // Since this function may modify the symbol table of the module containing
 // Insert, it shouldn't be used while iterating over the symbols of that module
 // unless the caller knows that no new function will be created.
+//
+// If using this function to insert an instruction that has pointer operands
+// ensure that InferType also handles type inference for that instruction (see
+// lib/Types.cpp).
 Instruction *
 InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
               ArrayRef<Attribute::AttrKind> Attributes, Type *RetType,

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -166,6 +166,23 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
         else
           return CacheType(int32Ty);
       }
+      case clspv::Builtins::kSpirvOp: {
+        auto *op_param = call->getArgOperand(0);
+        auto op =
+            static_cast<spv::Op>(cast<ConstantInt>(op_param)->getZExtValue());
+        switch (op) {
+        case spv::Op::OpAtomicIIncrement:
+        case spv::Op::OpAtomicIDecrement:
+        case spv::Op::OpAtomicCompareExchange:
+          // Data type is return type.
+          return CacheType(call->getType());
+          break;
+        default:
+          // No other current uses of SPIRVOp deal with pointers, but this
+          // code should be expanded if any are added.
+          break;
+        }
+      }
       case clspv::Builtins::kBuiltinNone:
         if (!call->getCalledFunction()->isDeclaration()) {
           // See if the type can be inferred from the use in the called

--- a/test/AllocateDescriptors/atomic_inc_dec.ll
+++ b/test/AllocateDescriptors/atomic_inc_dec.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt -opaque-pointers %s -o %t.ll --passes=allocate-descriptors
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+; CHECK: call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
+; CHECK: call ptr addrspace(1) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i32] } zeroinitializer)
+; CHECK: call ptr addrspace(1) @_Z14clspv.resource.3(i32 0, i32 3, i32 0, i32 3, i32 3, i32 0, { [0 x i32] } zeroinitializer)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) align 4 %a, ptr addrspace(1) align 4 %b, ptr addrspace(1) align 8 %c, ptr addrspace(1) align 8 %d) !clspv.pod_args_impl !8 {
+entry:
+  %inci = tail call i32 @_Z8spirv.op.232.PU3AS1jj(i32 232, ptr addrspace(1) %a, i32 1, i32 80)
+  %incj = tail call i32 @_Z8spirv.op.232.PU3AS1jj(i32 232, ptr addrspace(1) %b, i32 1, i32 80)
+  %deci = tail call i32 @_Z8spirv.op.233.PU3AS1jj(i32 233, ptr addrspace(1) %c, i32 1, i32 80)
+  %decj = tail call i32 @_Z8spirv.op.233.PU3AS1jj(i32 233, ptr addrspace(1) %d, i32 1, i32 80)
+  ret void
+}
+
+declare i32 @_Z8spirv.op.232.PU3AS1jj(i32, ptr addrspace(1), i32, i32) local_unnamed_addr
+declare i32 @_Z8spirv.op.232.PU3AS1ii(i32, ptr addrspace(1), i32, i32) local_unnamed_addr
+declare i32 @_Z8spirv.op.233.PU3AS1jj(i32, ptr addrspace(1), i32, i32) local_unnamed_addr
+declare i32 @_Z8spirv.op.233.PU3AS1ii(i32, ptr addrspace(1), i32, i32) local_unnamed_addr
+
+!8 = !{i32 1}


### PR DESCRIPTION
Contributes to #816

* Add type inference for current SPIRVOps that are generated that use pointer operands
  * fixes atomic cts tests atomic_dec and atomic_inc with opaque pointers