### PR TITLE
Identify another implicit GEP case

### DIFF
--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -578,9 +578,11 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
 
         if (source_ty && dest_ty && source_ty != dest_ty) {
           int Steps = 0;
-          if (!isa<GetElementPtrInst>(I) &&
-              FindAliasingContainedType(source_ty, dest_ty, Steps)) {
-            if (Steps > 0) {
+          if (FindAliasingContainedType(source_ty, dest_ty, Steps)) {
+            // Single level GEP is ok to transform, but beyond that the address
+            // math must be divided among other entries.
+            if ((Steps > 0 && !isa<GetElementPtrInst>(I)) ||
+                (Steps == 1)) {
               ImplicitGEPs.insert({&I, Steps});
               continue;
             }

--- a/test/PointerCasts/opaque_single_array_cast.ll
+++ b/test/PointerCasts/opaque_single_array_cast.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt %s -o %t.ll --passes="replace-pointer-bitcast,simplify-pointer-bitcast"
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr [8 x i32], ptr addrspace(2) @global, i32 0, i32 %n
+; CHECK: load i32, ptr addrspace(2) [[gep]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@global = private addrspace(2) constant [8 x i32] zeroinitializer 
+
+define void @foo(ptr addrspace(1) %a, i32 %n) {
+entry:
+  %gep = getelementptr i32, ptr addrspace(2) @global, i32 %n
+  %ld = load i32, ptr addrspace(2) %gep
+  store i32 %ld, ptr addrspace(1) %a
+  ret void
+}
+


### PR DESCRIPTION
Contributes to #816

* Identify an implicit gep when there is a single step to find the aliased type even if the target is another GEP
  * fixes the basic cts test kernel_preprocessor_macros with opaque pointers