### PR TITLE
Long vector lowering improvements with opaque pointers

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -537,13 +537,6 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(clspv::FixupBuiltinsPass());
     pm.addPass(clspv::ThreeElementVectorLoweringPass());
 
-    // Lower longer vectors when requested. Note that this pass depends on
-    // ReplaceOpenCLBuiltinPass and expects DeadCodeEliminationPass to be run
-    // afterwards.
-    if (clspv::Option::LongVectorSupport()) {
-      pm.addPass(clspv::LongVectorLoweringPass());
-    }
-
     // We need to run mem2reg and inst combine early because our
     // createInlineFuncWithPointerBitCastArgPass pass cannot handle the
     // pattern
@@ -552,6 +545,13 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     //   %2 = bitcast float* %1
     //   %3 = load float %2
     pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::PromotePass()));
+
+    // Lower longer vectors when requested. Note that this pass depends on
+    // ReplaceOpenCLBuiltinPass and expects DeadCodeEliminationPass to be run
+    // afterwards.
+    if (clspv::Option::LongVectorSupport()) {
+      pm.addPass(clspv::LongVectorLoweringPass());
+    }
 
     // Try to deal with pointer bitcasts early. This can prevent problems like
     // issue #409 where LLVM is looser about access chain addressing than

--- a/test/LongVectorLowering/opaque_global_gep.ll
+++ b/test/LongVectorLowering/opaque_global_gep.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gv:@[a-zA-Z0-9_.]+]] = internal global [4 x [8 x i32]] zeroinitializer
+; CHECK: getelementptr [4 x [8 x i32]], ptr [[gv]], i32 0, i32 %n, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@gv = internal global [4 x <8 x i32>] zeroinitializer
+
+define void @test(i32 %n) {
+entry:
+  %gep = getelementptr [4 x <8 x i32>], ptr @gv, i32 0, i32 %n, i32 0
+  store i32 1, ptr %gep
+  ret void
+}
+

--- a/test/LongVectorLowering/opaque_global_load.ll
+++ b/test/LongVectorLowering/opaque_global_load.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gv:@[a-zA-Z0-9_.]+]] = internal global [8 x i32] zeroinitializer
+; CHECK: load [8 x i32], ptr [[gv]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@gv = internal global <8 x i32> zeroinitializer
+
+define void @test() {
+entry:
+  %ld = load <8 x i32>, ptr @gv
+  ret void
+}

--- a/test/LongVectorLowering/opaque_global_store.ll
+++ b/test/LongVectorLowering/opaque_global_store.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gv:@[a-zA-Z0-9_.]+]] = internal global [8 x i32] undef
+; CHECK: store [8 x i32] zeroinitializer, ptr [[gv]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@gv = internal global <8 x i32> undef
+
+define void @test() {
+entry:
+  store <8 x i32> zeroinitializer, ptr @gv
+  ret void
+}
+


### PR DESCRIPTION
Contributes to #816

* Run promote pass before long vector lowering to handle easy cases
* Check for handled values and global variables on opaque pointer values in gep, load and store visits