### PR TITLE
Support limited uses of ptrtoint on logical address spaces

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -82,6 +82,10 @@ bool HackClampWidth();
 // around a driver bug.
 bool HackMulExtended();
 
+// Returns true if ptrtoint on logical address spaces should be emulated using
+// compile-time constants when it is safe to do so.
+bool HackLogicalPtrtoint();
+
 // Returns true if module-scope constants are to be collected into a single
 // storage buffer.  The binding for that buffer, and its intialization data
 // are given in the descriptor map file.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerToFunctionArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Layout.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/LogicalPointerToIntPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/LongVectorLoweringPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SetImageChannelMetadataPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ThreeElementVectorLoweringPass.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -539,6 +539,11 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(clspv::FixupBuiltinsPass());
     pm.addPass(clspv::ThreeElementVectorLoweringPass());
 
+    if (clspv::Option::HackLogicalPtrtoint()) {
+      pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::PromotePass()));
+      pm.addPass(clspv::LogicalPointerToIntPass());
+    }
+
     // We need to run mem2reg and inst combine early because our
     // createInlineFuncWithPointerBitCastArgPass pass cannot handle the
     // pattern

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -786,7 +786,8 @@ public:
               }
               auto array_type = FD->getASTContext().getIncompleteArrayType(
                   type->getPointeeType(), clang::ArrayType::Normal, 0);
-              if (!IsSupportedLayout(array_type, 0, layout, FD->getASTContext(),
+              if (!clspv::Option::RewritePackedStructs() &&
+                  !IsSupportedLayout(array_type, 0, layout, FD->getASTContext(),
                                      P->getSourceRange(),
                                      P->getSourceRange())) {
                 return false;

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -1,0 +1,161 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instructions.h"
+
+#include "clspv/AddressSpace.h"
+
+#include "BitcastUtils.h"
+
+#include "LogicalPointerToIntPass.h"
+
+using namespace llvm;
+
+// Support limited uses of PtrToInt on logical address spaces, in particular
+// uses where a pointer is converted to an integer but not used to form an
+// integer which is converted back to a pointer.
+//
+// This is safe to do because:
+// * Private and local addresses are meaningless on the host, and cannot be
+//   dereferenced by any subsequent kernels.
+// * The actual numeric ranges of the address spaces may overlap, so we do not
+//   need to consider the physical address range of global and constant memory.
+//
+// The primary use of this limited functionality is to inspect the memory layout
+// of struct types.
+
+// Arbitrary 'large enough' size. We have a 64-bit range to use and in practice
+// the amount of private and local memory will be quite small.
+constexpr uint64_t MaxAllocSize = 0x0000100000000000;
+
+bool IsTargetAddrSpace(unsigned AS) {
+  return AS == clspv::AddressSpace::Private || AS == clspv::AddressSpace::Local;
+}
+
+PreservedAnalyses
+clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
+  PreservedAnalyses PA;
+
+  // If a kernel is called from another function, local pointer arguments
+  // cannot be guaranteed to the 'base' address of the allocation, track these
+  // kernels so we can skip them if needed
+  for (auto &F : M) {
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        if (auto *Call = dyn_cast<CallInst>(&I)) {
+          if (auto *CalledFunc = Call->getCalledFunction()) {
+            calledFuncs.insert(CalledFunc);
+          }
+        }
+      }
+    }
+  }
+
+  SmallVector<Instruction *, 8> InstrsToProcess;
+  for (auto &F : M) {
+    BitcastUtils::RemovedCstExprFromFunction(&F);
+
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        if (auto *Cast = dyn_cast<CastInst>(&I)) {
+          if (Cast->getOpcode() == Instruction::PtrToInt) {
+            if (auto *PtrTy =
+                    cast<PointerType>(Cast->getOperand(0)->getType())) {
+              if (IsTargetAddrSpace(PtrTy->getAddressSpace())) {
+                InstrsToProcess.push_back(Cast);
+              }
+            }
+          } else if (Cast->getOpcode() == Instruction::IntToPtr) {
+            if (auto *PtrTy = cast<PointerType>(Cast->getType())) {
+              if (IsTargetAddrSpace(PtrTy->getAddressSpace())) {
+                // Bail out if we see a relevant IntToPtr anywhere, as it means
+                // we cannot guarantee a generated address won't be dereferenced
+                return PA;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (auto *Instr : InstrsToProcess) {
+    auto *IntTy = cast<IntegerType>(Instr->getType());
+
+    auto *PtrOp = Instr->getOperand(0);
+    APInt Offset(64, 0);
+    Value *MemBase = nullptr;
+
+    if (processValue(M.getDataLayout(), PtrOp, Offset, MemBase)) {
+      auto BaseAddr = getMemBaseAddr(MemBase);
+      auto *Replacement =
+          ConstantInt::get(IntTy, BaseAddr + Offset.getZExtValue());
+      Instr->replaceAllUsesWith(Replacement);
+    }
+  }
+
+  return PA;
+}
+
+bool clspv::LogicalPointerToIntPass::processValue(const DataLayout &DL,
+                                                  Value *Val, APInt &Offset,
+                                                  Value *&MemBase) {
+  if (auto *GEP = dyn_cast<GetElementPtrInst>(Val)) {
+    // Convert GEP indices to byte offset
+    if (GEP->hasAllConstantIndices() && isMemBase(GEP->getPointerOperand())) {
+      if (GEP->accumulateConstantOffset(DL, Offset)) {
+        MemBase = GEP->getPointerOperand();
+        return true;
+      }
+    }
+  } else if (auto *Bitcast = dyn_cast<BitCastInst>(Val)) {
+    return processValue(DL, Bitcast->getOperand(0), Offset, MemBase);
+  } else if (isMemBase(Val)) {
+    MemBase = Val;
+    return true;
+  }
+
+  return false;
+}
+
+bool clspv::LogicalPointerToIntPass::isMemBase(Value *Val) {
+  if (isa<AllocaInst>(Val)) {
+    return true;
+  } else if (auto *Arg = dyn_cast<Argument>(Val)) {
+    auto *F = Arg->getParent();
+    // Local memory args are only allowed in actual kernels, pointers passed
+    // to regular functions might not be the base of the actual allocation
+    if (F->getCallingConv() == llvm::CallingConv::SPIR_KERNEL &&
+        !calledFuncs.contains(F) && Arg->getType()->isPointerTy() &&
+        IsTargetAddrSpace(Arg->getType()->getPointerAddressSpace())) {
+      return true;
+    }
+  } else if (auto *GV = dyn_cast<GlobalVariable>(Val)) {
+    if (IsTargetAddrSpace(GV->getAddressSpace())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+uint64_t clspv::LogicalPointerToIntPass::getMemBaseAddr(llvm::Value *MemBase) {
+  auto InsertInfo = baseAddressMap.insert({MemBase, nextBaseAddress});
+  if (InsertInfo.second) {
+    nextBaseAddress += MaxAllocSize;
+  }
+  return InsertInfo.first->second;
+}

--- a/lib/LogicalPointerToIntPass.h
+++ b/lib/LogicalPointerToIntPass.h
@@ -1,0 +1,44 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unordered_map>
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+#ifndef _CLSPV_LIB_LOGICAL_POINTER_TO_INT_PASS_H
+#define _CLSPV_LIB_LOGICAL_POINTER_TO_INT_PASS_H
+
+namespace clspv {
+struct LogicalPointerToIntPass
+    : llvm::PassInfoMixin<LogicalPointerToIntPass> {
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+
+private:
+  bool isMemBase(llvm::Value* Val);
+  bool processValue(const llvm::DataLayout &DL, llvm::Value *Value,
+                  llvm::APInt &Offset, llvm::Value *&MemBase);
+  uint64_t getMemBaseAddr(llvm::Value *MemBase);
+
+
+// Arbitrary initial base address for allocations. Don't use 0x0 in case of
+// problems with NULL.
+  uint64_t nextBaseAddress = 0X1000000000000000;
+
+  std::unordered_map<llvm::Value*, uint64_t> baseAddressMap;
+  llvm::SmallPtrSet<llvm::Function*, 8> calledFuncs;
+};
+} // namespace clspv
+
+#endif // _CLSPV_LIB_LOGICAL_POINTER_TO_INT_PASS_H

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -1075,11 +1075,13 @@ void clspv::LongVectorLoweringPass::reworkIndices(
   Indices.push_back(Idxs[0]);
   for (unsigned i = 1; i < Idxs.size(); i++) {
     Indices.push_back(Idxs[i]);
-    auto IndexedTy = GetElementPtrInst::getIndexedType(Ty, Indices);
+    // Get original indices up to ith element for below:
+    auto CumulativeOldIdxs = ArrayRef<Value*>(Idxs.begin(), Idxs.begin() + i);
+    auto IndexedTy = GetElementPtrInst::getIndexedType(Ty, CumulativeOldIdxs);
     if (getEquivalentType(IndexedTy)) {
       auto Idx = Indices.pop_back_val();
       if (auto STy = dyn_cast<StructType>(
-              GetElementPtrInst::getIndexedType(Ty, Indices))) {
+              GetElementPtrInst::getIndexedType(Ty, CumulativeOldIdxs))) {
         auto Cst = dyn_cast<ConstantInt>(Idx);
         if (!Cst) {
           llvm_unreachable("unexpected index for gep on struct type");

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -394,6 +394,12 @@ static llvm::cl::opt<bool> physical_storage_buffers(
     "physical-storage-buffers", llvm::cl::init(false),
     llvm::cl::desc("Use physical storage buffers instead of storage buffers"));
 
+static llvm::cl::opt<bool> hack_logical_ptrtoint(
+    "hack-logical-ptrtoint", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Allow ptrtoint on logical address spaces when it can be "
+        "guaranteed that they won't be converted back to pointers."));
+
 } // namespace
 
 namespace clspv {
@@ -414,6 +420,7 @@ bool HackPhis() { return hack_phis; }
 bool HackBlockOrder() { return hack_block_order; }
 bool HackClampWidth() { return hack_clamp_width; }
 bool HackMulExtended() { return hack_mul_extended; }
+bool HackLogicalPtrtoint() { return hack_logical_ptrtoint; }
 bool ModuleConstantsInStorageBuffer() {
   return module_constants_in_storage_buffer;
 }

--- a/lib/PassRegistry.def
+++ b/lib/PassRegistry.def
@@ -33,6 +33,7 @@ MODULE_PASS("inline-func-with-image-metadata-getter", clspv::InlineFuncWithImage
 MODULE_PASS("inline-func-with-pointer-cast-arg", clspv::InlineFuncWithPointerBitCastArgPass)
 MODULE_PASS("inline-func-with-pointer-function-arg", clspv::InlineFuncWithPointerToFunctionArgPass)
 MODULE_PASS("inline-func-with-single-call-site", clspv::InlineFuncWithSingleCallSitePass)
+MODULE_PASS("logical-pointer-to-int", clspv::LogicalPointerToIntPass)
 MODULE_PASS("long-vector-lowering", clspv::LongVectorLoweringPass)
 MODULE_PASS("set-image-channel-metadata", clspv::SetImageChannelMetadataPass)
 MODULE_PASS("multi-version-ubo-functions", clspv::MultiVersionUBOFunctionsPass)

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -32,6 +32,7 @@
 #include "InlineFuncWithPointerBitCastArgPass.h"
 #include "InlineFuncWithPointerToFunctionArgPass.h"
 #include "InlineFuncWithSingleCallSitePass.h"
+#include "LogicalPointerToIntPass.h"
 #include "LongVectorLoweringPass.h"
 #include "MultiVersionUBOFunctionsPass.h"
 #include "NativeMathPass.h"

--- a/lib/PhysicalPointerArgsPass.cpp
+++ b/lib/PhysicalPointerArgsPass.cpp
@@ -30,6 +30,7 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
 
   PreservedAnalyses PA;
   DenseMap<Value *, Type *> TypeCache;
+  SmallVector<Function *, 8> FuncsToDelete;
 
   for (auto &F : M) {
     if (F.getCallingConv() != CallingConv::SPIR_KERNEL)
@@ -121,7 +122,12 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
 
     // Inline the function into the wrapper
     InlineFunctionInfo info;
-    InlineFunction(*CallInst, info);
+    if (InlineFunction(*CallInst, info).isSuccess())
+      FuncsToDelete.push_back(&F);
+  }
+
+  for (auto *F : FuncsToDelete) {
+    F->eraseFromParent();
   }
 
   return PA;

--- a/test/LogicalPtrToInt/disallow_inttoptr.cl
+++ b/test/LogicalPtrToInt/disallow_inttoptr.cl
@@ -1,0 +1,18 @@
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: not spirv-val --target-env vulkan1.0 %t.spv
+
+// Check that a virtual address (which would be 0x1000000000000000) is not
+// generated. We also expect spitv-val to fail.
+// CHECK: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK-NOT: [[addr_var0:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152921504606846976
+
+__kernel void test(__global long *dest, int offset)
+{
+    size_t gid = get_global_id(0);
+    __local uint var0[10];
+    long var0_addr = (long) var0;
+    __local long* ptr = (__local long *) (var0_addr + offset);
+    dest[gid] = *ptr;
+}

--- a/test/LogicalPtrToInt/local_args_ptrtoint.cl
+++ b/test/LogicalPtrToInt/local_args_ptrtoint.cl
@@ -1,0 +1,25 @@
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check virtual addresses 0x1000000000000000, 0x1000100000000000, and
+// 0x1000200000000008 are stored.
+// CHECK: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[addr_var0:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152921504606846976
+// CHECK: [[addr_var1:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152939096792891392
+// CHECK: [[addr_var2:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152956688978935816
+
+// CHECK-DAG: OpStore %{{.*}} [[addr_var0]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var1]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var2]]
+
+__kernel void test(__local uint *var0, __local uint *var1, __local uint *var2,
+    __global long *dest_a, __global long *dest_b, __global long *dest_c)
+{
+    size_t gid = get_global_id(0);
+    
+    dest_a[gid] = (long) &var0;
+    dest_b[gid] = (long) &var1;
+    dest_c[gid] = (long) &(var2[2]);
+}

--- a/test/LogicalPtrToInt/local_ptrtoint.cl
+++ b/test/LogicalPtrToInt/local_ptrtoint.cl
@@ -1,0 +1,28 @@
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check virtual addresses 0x1000000000000000, 0x1000100000000000, and
+// 0x1000200000000008 are stored.
+// CHECK: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[addr_var0:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152921504606846976
+// CHECK: [[addr_var1:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152939096792891392
+// CHECK: [[addr_var2:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152956688978935816
+
+// CHECK-DAG: OpStore %{{.*}} [[addr_var0]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var1]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var2]]
+
+__kernel void test(__global long *dest_a, __global long *dest_b,
+    __global long *dest_c)
+{
+    size_t gid = get_global_id(0);
+    __local uint var0;
+    __local uint var1;
+    __local uint var2[10];
+    
+    dest_a[gid] = (long) &var0;
+    dest_b[gid] = (long) &var1;
+    dest_c[gid] = (long) &(var2[2]);
+}

--- a/test/LogicalPtrToInt/private_ptrtoint.cl
+++ b/test/LogicalPtrToInt/private_ptrtoint.cl
@@ -1,0 +1,28 @@
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// Check virtual addresses 0x1000000000000000, 0x1000100000000000, and
+// 0x1000200000000008 are stored.
+// CHECK: [[ulong:%[a-zA-Z0-9_]+]] = OpTypeInt 64 0
+// CHECK: [[addr_var0:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152921504606846976
+// CHECK: [[addr_var1:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152939096792891392
+// CHECK: [[addr_var2:%[a-zA-Z0-9_]+]] = OpConstant [[ulong]] 1152956688978935816
+
+// CHECK-DAG: OpStore %{{.*}} [[addr_var0]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var1]]
+// CHECK-DAG: OpStore %{{.*}} [[addr_var2]]
+
+__kernel void test(__global long *dest_a, __global long *dest_b,
+    __global long *dest_c)
+{
+    size_t gid = get_global_id(0);
+    __private uint var0 = 42;
+    __private uint var1 = 21;
+    __private uint var2[10];
+    
+    dest_a[gid] = (long) &var0;
+    dest_b[gid] = (long) &var1;
+    dest_c[gid] = (long) &(var2[2]);
+}


### PR DESCRIPTION
This effectively creates a compile-time virtual address space for function and workgroup storage. The only practical use of this support is for inspecting the layout of composite types in memory. In anything but this narrow scenario the behavior will be unchanged. This is enough for the CTS vector alignment tests to pass.

This is a less-than-ideal hack but I think it's the best solution to unblock these CTS tests with the current state of SPIR-V and Vulkan.

This also fixes a bug in LongVectorLowering where updated GEP indices were being used to refer to the original type, rather than the cumulative old indices up to the original index being looked at.

This contribution is being made by Codeplay on behalf of Samsung.
