### PR TITLE
Change how the conditionality of inlining works

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -715,7 +715,7 @@ void ConvertInto(Type *Ty, IRBuilder<> &Builder,
   }
 }
 
-bool RemovedCstExprFromFunction(Function *F) {
+bool RemoveCstExprFromFunction(Function *F) {
   SmallVector<std::pair<Instruction *, unsigned>, 16> WorkList;
 
   auto CheckInstruction = [&WorkList](Instruction *I) {

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -38,7 +38,7 @@ void BitcastIntoVector(IRBuilder<> &Builder, SmallVector<Value *, 8> &Values,
 void ConvertInto(Type *Ty, IRBuilder<> &Builder,
                  SmallVector<Value *, 8> &Values);
 
-bool RemovedCstExprFromFunction(Function *F);
+bool RemoveCstExprFromFunction(Function *F);
 } // namespace BitcastUtils
 
 #endif // _CLSPV_LIB_BITCAST_UTILS_PASS_H

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -578,14 +578,11 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(
         llvm::createModuleToFunctionPassAdaptor(llvm::InstCombinePass()));
 
-    if (clspv::Option::InlineEntryPoints()) {
-      pm.addPass(clspv::InlineEntryPointsPass());
-    } else {
-      pm.addPass(clspv::InlineFuncWithImageMetadataGetterPass());
-      pm.addPass(clspv::InlineFuncWithPointerBitCastArgPass());
-      pm.addPass(clspv::InlineFuncWithPointerToFunctionArgPass());
-      pm.addPass(clspv::InlineFuncWithSingleCallSitePass());
-    }
+    pm.addPass(clspv::InlineEntryPointsPass());
+    pm.addPass(clspv::InlineFuncWithImageMetadataGetterPass());
+    pm.addPass(clspv::InlineFuncWithPointerBitCastArgPass());
+    pm.addPass(clspv::InlineFuncWithPointerToFunctionArgPass());
+    pm.addPass(clspv::InlineFuncWithSingleCallSitePass());
 
     // Mem2Reg pass should be run early because O0 level optimization leaves
     // redundant alloca, load and store instructions from function arguments.
@@ -602,10 +599,8 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(
         llvm::createModuleToFunctionPassAdaptor(llvm::InstCombinePass()));
 
-    if (clspv::Option::LanguageUsesGenericAddressSpace()) {
-      pm.addPass(llvm::createModuleToFunctionPassAdaptor(
-          llvm::InferAddressSpacesPass(clspv::AddressSpace::Generic)));
-    }
+    pm.addPass(llvm::createModuleToFunctionPassAdaptor(
+        llvm::InferAddressSpacesPass(clspv::AddressSpace::Generic)));
   });
 
   // Run the following passes after the default LLVM pass pipeline.

--- a/lib/InlineEntryPointsPass.h
+++ b/lib/InlineEntryPointsPass.h
@@ -24,6 +24,7 @@ struct InlineEntryPointsPass : llvm::PassInfoMixin<InlineEntryPointsPass> {
 
 private:
   bool InlineFunctions(llvm::Module &M);
+  bool RequiresInlining(llvm::Module &M);
 };
 } // namespace clspv
 

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -66,7 +66,7 @@ clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
   SmallVector<Instruction *, 8> InstrsToProcess;
   for (auto &F : M) {
-    BitcastUtils::RemovedCstExprFromFunction(&F);
+    BitcastUtils::RemoveCstExprFromFunction(&F);
 
     for (auto &BB : F) {
       for (auto &I : BB) {

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -537,7 +537,7 @@ Function *createFunctionWithMappedTypes(Function &F,
 
   // Inlining a function can introduce constant expression that we could not
   // handle afterwards.
-  BitcastUtils::RemovedCstExprFromFunction(Wrapper);
+  BitcastUtils::RemoveCstExprFromFunction(Wrapper);
 
   return Wrapper;
 }
@@ -667,7 +667,7 @@ PreservedAnalyses clspv::LongVectorLoweringPass::run(Module &M,
   runOnGlobals(M);
 
   for (auto &F : M.functions()) {
-    BitcastUtils::RemovedCstExprFromFunction(&F);
+    BitcastUtils::RemoveCstExprFromFunction(&F);
     runOnFunction(F);
   }
 

--- a/lib/RewritePackedStructs.cpp
+++ b/lib/RewritePackedStructs.cpp
@@ -123,7 +123,7 @@ Function *createFunctionWithMappedTypes(Function &F,
 
   // Inlining a function can introduce constant expression that we could not
   // handle afterwards.
-  BitcastUtils::RemovedCstExprFromFunction(Wrapper);
+  BitcastUtils::RemoveCstExprFromFunction(Wrapper);
 
   return Wrapper;
 }

--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -54,7 +54,7 @@ clspv::SimplifyPointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
 // TODO(#816): remove function after final transition.
 void clspv::SimplifyPointerBitcastPass::runOnInstFromCstExpr(Module &M) const {
   for (Function &F : M) {
-    BitcastUtils::RemovedCstExprFromFunction(&F);
+    BitcastUtils::RemoveCstExprFromFunction(&F);
   }
 }
 

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -200,7 +200,7 @@ Function *createFunctionWithMappedTypes(Function &F,
 
   // Inlining a function can introduce constant expression that we could not
   // handle afterwards.
-  BitcastUtils::RemovedCstExprFromFunction(Wrapper);
+  BitcastUtils::RemoveCstExprFromFunction(Wrapper);
 
   return Wrapper;
 }
@@ -242,7 +242,7 @@ clspv::ThreeElementVectorLoweringPass::run(Module &M, ModuleAnalysisManager &) {
 
   runOnGlobals(M);
   for (auto &F : M.functions()) {
-    BitcastUtils::RemovedCstExprFromFunction(&F);
+    BitcastUtils::RemoveCstExprFromFunction(&F);
     runOnFunction(F);
   }
 

--- a/test/always_strip_generic.ll
+++ b/test/always_strip_generic.ll
@@ -1,0 +1,26 @@
+; RUN: clspv -x ir %s -o %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; CHECK: = OpFunction
+; CHECK-NOT: = OpFunction
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@local_data = internal addrspace(3) global [1024 x i32] undef, align 4
+
+define spir_kernel void @test() {
+entry:
+  call void @bar(i32 addrspace(4)* addrspacecast (i32 addrspace(3)* getelementptr ([1024 x i32], [1024 x i32] addrspace(3)* @local_data, i32 0, i32 0) to i32 addrspace(4)*))
+  ret void
+}
+
+define spir_func void @bar(i32 addrspace(4)* %data) {
+entry:
+  call spir_func void @_Z7vstore4Dv4_iiPU3AS4i(<4 x i32> zeroinitializer, i32 0, i32 addrspace(4)* %data)
+  ret void
+}
+
+declare spir_func void @_Z7vstore4Dv4_iiPU3AS4i(<4 x i32>, i32, i32 addrspace(4)*)


### PR DESCRIPTION
Fixes #999

* Make all inlining passes unconditional
* Make generic address space inference unconditional
* Add functionality to inline entry points to look for generic address space and inline in that case
  * also strips constexprs
* Rename `RemovedCstExprFromFunction` to `RemoveCstExprFromFunction`