### PR TITLE
Update deps

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,13 +6,13 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "89ada6c51fbdf59dcab8a1e479f60196d29bd4d3"
+      "commit" : "944f4b2805852072022293678fddd65dc450e0f2"
     },
     {
       "name" : "SPIRV-Headers",
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Headers",
-      "branch" : "master",
+      "branch" : "main",
       "subdir" : "third_party/SPIRV-Headers",
       "commit" : "d13b52222c39a7e9a401b44646f0ca3a640fbd47"
     },
@@ -20,9 +20,9 @@
       "name" : "SPIRV-Tools",
       "site" : "github",
       "subrepo" : "KhronosGroup/SPIRV-Tools",
-      "branch" : "master",
+      "branch" : "main",
       "subdir" : "third_party/SPIRV-Tools",
-      "commit" : "9a6f4121f4a49fa3b3d8ddafc43cb519f7a6e1fc"
+      "commit" : "7e8813bb4cf32fd9c4d696c09d4e68e17a8f57f1"
     }
   ]
 }

--- a/test/CommonBuiltins/clamp/half2_clamp_splat.ll
+++ b/test/CommonBuiltins/clamp/half2_clamp_splat.ll
@@ -1,9 +1,9 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
-; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %y, i32 0
+; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %y, i64 0
 ; CHECK: [[y_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[y_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z5clampDv2_DhS_S_(<2 x half> %in, <2 x half> [[x_shuffle]], <2 x half> [[y_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/clamp/half3_clamp_splat.ll
+++ b/test/CommonBuiltins/clamp/half3_clamp_splat.ll
@@ -1,9 +1,9 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
-; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %y, i32 0
+; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %y, i64 0
 ; CHECK: [[y_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[y_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z5clampDv2_DhS_S_(<3 x half> %in, <3 x half> [[x_shuffle]], <3 x half> [[y_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/clamp/half4_clamp_splat.ll
+++ b/test/CommonBuiltins/clamp/half4_clamp_splat.ll
@@ -1,9 +1,9 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
-; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %y, i32 0
+; CHECK: [[y_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %y, i64 0
 ; CHECK: [[y_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[y_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z5clampDv2_DhS_S_(<4 x half> %in, <4 x half> [[x_shuffle]], <4 x half> [[y_shuffle]])
 ; CHECK: ret <4 x half> [[call]]

--- a/test/CommonBuiltins/max/half2_fmax_splat.ll
+++ b/test/CommonBuiltins/max/half2_fmax_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z4fmaxDv2_DhS_(<2 x half> %in, <2 x half> [[x_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/max/half2_max_splat.ll
+++ b/test/CommonBuiltins/max/half2_max_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z3maxDv2_DhS_(<2 x half> %in, <2 x half> [[x_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/max/half3_fmax_splat.ll
+++ b/test/CommonBuiltins/max/half3_fmax_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z4fmaxDv3_DhS_(<3 x half> %in, <3 x half> [[x_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/max/half3_max_splat.ll
+++ b/test/CommonBuiltins/max/half3_max_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z3maxDv3_DhS_(<3 x half> %in, <3 x half> [[x_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/max/half4_fmax_splat.ll
+++ b/test/CommonBuiltins/max/half4_fmax_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z4fmaxDv4_DhS_(<4 x half> %in, <4 x half> [[x_shuffle]])
 ; CHECK: ret <4 x half> [[call]]

--- a/test/CommonBuiltins/max/half4_max_splat.ll
+++ b/test/CommonBuiltins/max/half4_max_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z3maxDv4_DhS_(<4 x half> %in, <4 x half> [[x_shuffle]])
 ; CHECK: ret <4 x half> [[call]]

--- a/test/CommonBuiltins/min/half2_fmin_splat.ll
+++ b/test/CommonBuiltins/min/half2_fmin_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z4fminDv2_DhS_(<2 x half> %in, <2 x half> [[x_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/min/half2_min_splat.ll
+++ b/test/CommonBuiltins/min/half2_min_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z3minDv2_DhS_(<2 x half> %in, <2 x half> [[x_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/min/half3_fmin_splat.ll
+++ b/test/CommonBuiltins/min/half3_fmin_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z4fminDv3_DhS_(<3 x half> %in, <3 x half> [[x_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/min/half3_min_splat.ll
+++ b/test/CommonBuiltins/min/half3_min_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z3minDv3_DhS_(<3 x half> %in, <3 x half> [[x_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/min/half4_fmin_splat.ll
+++ b/test/CommonBuiltins/min/half4_fmin_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z4fminDv4_DhS_(<4 x half> %in, <4 x half> [[x_shuffle]])
 ; CHECK: ret <4 x half> [[call]]

--- a/test/CommonBuiltins/min/half4_min_splat.ll
+++ b/test/CommonBuiltins/min/half4_min_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z3minDv4_DhS_(<4 x half> %in, <4 x half> [[x_shuffle]])
 ; CHECK: ret <4 x half> [[call]]

--- a/test/CommonBuiltins/mix/half2_mix_splat.ll
+++ b/test/CommonBuiltins/mix/half2_mix_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <2 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <2 x half> [[x_in0]], <2 x half> {{.*}}, <2 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <2 x half> @_Z3mixDv2_DhS_S_(<2 x half> %in1, <2 x half> %in2, <2 x half> [[x_shuffle]])
 ; CHECK: ret <2 x half> [[call]]

--- a/test/CommonBuiltins/mix/half3_mix_splat.ll
+++ b/test/CommonBuiltins/mix/half3_mix_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <3 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <3 x half> [[x_in0]], <3 x half> {{.*}}, <3 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <3 x half> @_Z3mixDv3_DhS_S_(<3 x half> %in1, <3 x half> %in2, <3 x half> [[x_shuffle]])
 ; CHECK: ret <3 x half> [[call]]

--- a/test/CommonBuiltins/mix/half4_mix_splat.ll
+++ b/test/CommonBuiltins/mix/half4_mix_splat.ll
@@ -1,7 +1,7 @@
 ; RUN: clspv-opt --passes=splat-arg %s -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i32 0
+; CHECK: [[x_in0:%[a-zA-Z0-9_.]+]] = insertelement <4 x half> {{.*}}, half %x, i64 0
 ; CHECK: [[x_shuffle:%[a-zA-Z0-9_.]+]] = shufflevector <4 x half> [[x_in0]], <4 x half> {{.*}}, <4 x i32> zeroinitializer
 ; CHECK: [[call:%[a-zA-Z0-9_.]+]] = call spir_func <4 x half> @_Z3mixDv4_DhS_S_(<4 x half> %in1, <4 x half> %in2, <4 x half> [[x_shuffle]])
 ; CHECK: ret <4 x half> [[call]]


### PR DESCRIPTION
* SPIRV-Tools and SPIRV-Headers switched to track main
* IRBuilder::CreateVectorSplat now uses i64 for indices so updated some tests as a result