### PR TITLE
Remove optnone attribute

### DIFF
--- a/lib/AddFunctionAttributesPass.cpp
+++ b/lib/AddFunctionAttributesPass.cpp
@@ -25,6 +25,11 @@ PreservedAnalyses
 clspv::AddFunctionAttributesPass::run(Module &M, ModuleAnalysisManager &) {
   PreservedAnalyses PA;
 
+  // Clspv can't respect the optnone attribute.
+  for (auto &F : M) {
+    F.removeFnAttr(Attribute::AttrKind::OptimizeNone);
+  }
+
   // Add ReadNone and Speculatable to literal sampler functions to avoid loop
   // optimizations producing phis with them.
   if (auto F = M.getFunction(clspv::TranslateSamplerInitializerFunction())) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1805,6 +1805,13 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
     // Ops[1] = Element Type ID
     SPIRVOperandVec Ops;
 
+    SPIRVID pointee_id;
+    // TODO(#816): no way to infer the data type here.
+    if (PointeeTy->isPointerTy()) {
+      pointee_id = getSPIRVType(PointeeTy);
+    } else {
+      pointee_id = getSPIRVType(PointeeTy, needs_layout);
+    }
     Ops << GetStorageClass(AddrSpace) << getSPIRVType(PointeeTy, needs_layout);
 
     RID = addSPIRVInst<kTypes>(spv::OpTypePointer, Ops);


### PR DESCRIPTION
* Clspv cannot generate correct code without optimizations so remove any functions with the optnone attribute
* When generating a pointer type, if the data type is a pointer then the layout is based on that storage class
