### PR TITLE
Fix definition of get_global_offset() when push constants are used

### DIFF
--- a/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
@@ -426,19 +426,19 @@ bool DefineOpenCLWorkItemBuiltinsPass::defineGlobalOffsetBuiltin(Module &M) {
   if (isSupportEnabled) {
     auto Dim = &*F->arg_begin();
     auto InBoundsDim = inBoundsDimensionIndex(Builder, Dim);
-    Value *Indices[] = {Builder.getInt32(0), InBoundsDim};
     Value *gep = nullptr;
     auto *VecTy = FixedVectorType::get(Int32Ty, 3);
     const bool uses_push_constant =
         clspv::ShouldDeclareGlobalOffsetPushConstant(M);
     if (uses_push_constant) {
-      auto GoffPtr =
-          GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset);
-      gep = Builder.CreateInBoundsGEP(VecTy, GoffPtr, Indices);
+      Value *Indices[] = {InBoundsDim};
+      gep = GetPushConstantPointer(BB, clspv::PushConstant::GlobalOffset,
+                                   Indices);
     } else {
       StringRef name = "__spirv_GlobalOffset";
       auto offset_var = createGlobalVariable(M, name, VecTy,
                                              AddressSpace::ModuleScopePrivate);
+      Value *Indices[] = {Builder.getInt32(0), InBoundsDim};
       gep = Builder.CreateInBoundsGEP(VecTy, offset_var, Indices);
     }
     auto load = Builder.CreateLoad(Int32Ty, gep);

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -287,7 +287,12 @@ void RedeclareGlobalPushConstants(Module &M, StructType *mangled_struct_ty,
         auto new_gep = ConstantExpr::getGetElementPtr(
             push_constant_ty, new_GV, indices, gep_operator->isInBounds());
         user->replaceAllUsesWith(new_gep);
+      } else if (auto load = dyn_cast<LoadInst>(user)) {
+        auto new_load = new LoadInst(load->getType(), new_GV, "", load);
+        load->replaceAllUsesWith(new_load);
+        load->eraseFromParent();
       } else {
+        user->print(errs());
         assert(false && "unexpected global use");
       }
     }

--- a/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.ll
+++ b/test/WorkItemBuiltins/get_global_offset-push-constant-non-constant-dim.ll
@@ -9,7 +9,7 @@
 ; CHECK: define spir_func i32 @_Z17get_global_offsetj(i32 [[p:%[0-9]+]])
 ; CHECK: [[cmp:%[0-9]+]] = icmp ult i32 [[p]], 3
 ; CHECK: [[sel:%[0-9]+]] = select i1 [[cmp]], i32 [[p]], i32 0
-; CHECK: [[gep:%[0-9]+]] = getelementptr inbounds <3 x i32>, ptr addrspace(9) @__push_constants, i32 0, i32 [[sel]]
+; CHECK: [[gep:%[0-9]+]] = getelementptr inbounds [[type]], ptr addrspace(9) @__push_constants, i32 0, i32 0, i32 [[sel]]
 ; CHECK: [[ld:%[0-9]+]] = load i32, ptr addrspace(9) [[gep]]
 ; CHECK: [[sel:%[0-9]+]] = select i1 [[cmp]], i32 [[ld]], i32 0
 ; CHECK: ret i32 [[sel]]


### PR DESCRIPTION
GetPushConstantPointer is designed to return a GEP into the push constant variable. When there is a single push constant or when indexing into the first one (i.e. the global offset), this leads to a GEP with all zero indices being created. With opaque pointers, this GEP is no longer created and CreateInBoundsGEP returns the original pointer. defineGlobalOffsetBuiltin was then assuming that the pointer returned pointed to a specific push constant rather than the global push constant variable itself which led to incorrect indices being used.

After this change, the extra indices are provided to GetPushConstantPointer so the full GEP into the global offset vector is created directly.

It seems that this is a generic issue and users who want to guard against this might now need to check whether CreateInBoundsGEP returned a GEP instruction or the original pointer to guarantee that a chained GEP uses the correct indices. This seems to break encapsulation.

Also support the case where the global push constant variable is used by a load instruction. This happens in a clvk unit test.