### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "a180344589cacac31276a0b26a1988ea0017728b"
+      "commit" : "48fb6659610a3177e8606681046dfa0d19f67203"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -95,20 +95,26 @@ bool clspv::AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(
 
   // Generate the function type for clspv::LiteralSamplerFunction()
   IRBuilder<> Builder(M.getContext());
-  auto *sampler_struct_ty =
-      StructType::getTypeByName(M.getContext(), "opencl.sampler_t");
-  if (!sampler_struct_ty) {
-    sampler_struct_ty = StructType::create(M.getContext(), "opencl.sampler_t");
-  }
-  // TODO: #816 remove after final switch.
   Type *sampler_ty = nullptr;
-  if (init_fn->getType()->isOpaquePointerTy()) {
-    sampler_ty = PointerType::get(M.getContext(), clspv::AddressSpace::Constant);
+  Type *sampler_data_ty = nullptr;;
+  if (init_fn->getReturnType()->isTargetExtTy()) {
+    sampler_ty = init_fn->getReturnType();
+    sampler_data_ty = init_fn->getReturnType();
   } else {
-    sampler_ty = sampler_struct_ty->getPointerTo(clspv::AddressSpace::Constant);
+    sampler_data_ty =
+        StructType::getTypeByName(M.getContext(), "opencl.sampler_t");
+    if (!sampler_data_ty) {
+      sampler_data_ty = StructType::create(M.getContext(), "opencl.sampler_t");
+    }
+    // TODO: #816 remove after final switch.
+    if (init_fn->getType()->isOpaquePointerTy()) {
+      sampler_ty = PointerType::get(M.getContext(), clspv::AddressSpace::Constant);
+    } else {
+      sampler_ty = sampler_data_ty->getPointerTo(clspv::AddressSpace::Constant);
+    }
   }
   Type *i32 = Builder.getInt32Ty();
-  FunctionType *fn_ty = FunctionType::get(sampler_ty, {i32, i32, i32, sampler_struct_ty}, false);
+  FunctionType *fn_ty = FunctionType::get(sampler_ty, {i32, i32, i32, sampler_data_ty}, false);
 
   auto var_fn = M.getOrInsertFunction(clspv::LiteralSamplerFunction(), fn_ty);
 
@@ -148,7 +154,7 @@ bool clspv::AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(
         SmallVector<Value *, 3> args = {
             Builder.getInt32(descriptor_set), Builder.getInt32(binding),
             Builder.getInt32(third_param),
-            Constant::getNullValue(sampler_struct_ty)};
+            Constant::getNullValue(sampler_data_ty)};
         if (ShowDescriptors) {
           outs() << "  translate literal sampler " << *const_val << " to ("
                  << descriptor_set << "," << binding << ")\n";
@@ -156,7 +162,7 @@ bool clspv::AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(
         auto *new_call =
             CallInst::Create(var_fn, args, "", dyn_cast<Instruction>(call));
         assert(clspv::InferType(new_call, M.getContext(), &type_cache_) ==
-               sampler_struct_ty);
+               sampler_data_ty);
         call->replaceAllUsesWith(new_call);
         call->eraseFromParent();
       }
@@ -620,11 +626,13 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         if (!var_fn) {
           // Make the function
           // TODO: #816 remove after final transition.
-          PointerType *ptrTy = nullptr;
-          if (Arg.getType()->isOpaquePointerTy()) {
-            ptrTy = PointerType::get(M.getContext(), addr_space);
+          Type *ret_ty = nullptr;
+          if (Arg.getType()->isTargetExtTy()) {
+            ret_ty = Arg.getType();
+          } else if (Arg.getType()->isOpaquePointerTy()) {
+            ret_ty = PointerType::get(M.getContext(), addr_space);
           } else {
-            ptrTy = resource_type->getPointerTo(addr_space);
+            ret_ty = resource_type->getPointerTo(addr_space);
           }
           // The parameters are:
           //  descriptor set
@@ -636,7 +644,7 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           //  data_type
           Type *i32 = Builder.getInt32Ty();
           FunctionType *fnTy =
-              FunctionType::get(ptrTy, {i32, i32, i32, i32, i32, i32, resource_type}, false);
+              FunctionType::get(ret_ty, {i32, i32, i32, i32, i32, i32, resource_type}, false);
           var_fn =
               cast<Function>(M.getOrInsertFunction(fn_name, fnTy).getCallee());
         }

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -97,6 +97,7 @@ bool clspv::AllocateDescriptorsPass::AllocateLiteralSamplerDescriptors(
   IRBuilder<> Builder(M.getContext());
   Type *sampler_ty = nullptr;
   Type *sampler_data_ty = nullptr;;
+  // TODO(#1036): remove opaque struct support
   if (init_fn->getReturnType()->isTargetExtTy()) {
     sampler_ty = init_fn->getReturnType();
     sampler_data_ty = init_fn->getReturnType();

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -42,6 +42,7 @@ clspv::ArgKind GetArgKindForType(Type *type, Type *data_type) {
     Type *inner_type = ptrTy->isOpaquePointerTy()
                            ? data_type
                            : ptrTy->getNonOpaquePointerElementType();
+    // TODO(#1036): remove opaque struct support
     if (clspv::IsSamplerType(inner_type)) {
       return clspv::ArgKind::Sampler;
     }

--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -28,6 +28,7 @@
 #include "Constants.h"
 #include "Layout.h"
 #include "PushConstant.h"
+#include "Types.h"
 
 using namespace llvm;
 
@@ -96,11 +97,8 @@ void clspv::AutoPodArgsPass::runOnFunction(Function &F) {
       arg_type = Arg.getParamByValType();
     }
 
-    if (auto *ptr_ty = dyn_cast<PointerType>(arg_type)) {
-      if (!(clspv::Option::PhysicalStorageBuffers() &&
-            (ptr_ty->getAddressSpace() == clspv::AddressSpace::Global ||
-             ptr_ty->getAddressSpace() == clspv::AddressSpace::Constant)))
-        continue;
+    if (IsResourceType(arg_type) && !IsPhysicalSSBOType(arg_type)) {
+      continue;
     }
 
     pod_types.push_back(arg_type);

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -72,7 +72,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
       continue;
     }
     for (Argument &Arg : F.args()) {
-      if (!isa<PointerType>(Arg.getType())) {
+      if (!clspv::IsResourceType(Arg.getType())) {
         WorkList.push_back(&F);
         break;
       }
@@ -130,7 +130,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
     unsigned pod_index = 0;
     for (Argument &Arg : F->args()) {
       Type *ArgTy = Arg.getType();
-      if (isa<PointerType>(ArgTy)) {
+      if (clspv::IsResourceType(ArgTy)) {
         PtrArgTys.push_back(ArgTy);
         // The kind only matter if the argument is used, otherwise we just need
         // to track that there was an argument.
@@ -162,7 +162,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
       unsigned pod_index = 0;
       for (auto &Arg : F->args()) {
         auto arg_type = Arg.getType();
-        if (arg_type->isPointerTy())
+        if (clspv::IsResourceType(arg_type))
           continue;
 
         // The frontend has validated individual POD arguments. When the
@@ -219,7 +219,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
       arg_index = 0;
       for (Argument &Arg : F->args()) {
         Type *ArgTy = Arg.getType();
-        if (!isa<PointerType>(ArgTy)) {
+        if (!clspv::IsResourceType(ArgTy)) {
           auto pod_arg_kind = clspv::GetArgKind(Arg, ArgTy);
           unsigned arg_size = DL.getTypeStoreSize(ArgTy);
           unsigned offset = StructLayout->getElementOffset(PodIndexMap[&Arg]);
@@ -370,7 +370,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
     unsigned podCount = 0;
     unsigned ptrIndex = 0;
     for (Argument &Arg : F->args()) {
-      if (isa<PointerType>(Arg.getType())) {
+      if (clspv::IsResourceType(Arg.getType())) {
         CalleeArgs.push_back(CallerArgs[ptrIndex++]);
       } else {
         podCount++;
@@ -423,7 +423,7 @@ clspv::ClusterPodKernelArgumentsPass::GetTypeMangledPodArgsStruct(Module &M) {
 
     SmallVector<Type *, 8> PodArgTys;
     for (auto &Arg : F.args()) {
-      if (!Arg.getType()->isPointerTy()) {
+      if (!clspv::IsResourceType(Arg.getType())) {
         PodArgTys.push_back(Arg.getType());
       }
     }

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -38,7 +38,6 @@
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar/DCE.h"
 #include "llvm/Transforms/Scalar/InferAddressSpaces.h"

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -44,6 +44,20 @@ enum ClspvOperand {
   kSamplerDataType = 3,
 };
 
+// Operands for "spirv.Image" target ext type.
+// Except for kClspvUnsigned they match SPIR-V image operands after the sampled
+// type.
+enum SpvImageTypeOperand {
+  kDim = 0,
+  kDepth = 1,
+  kArrayed = 2,
+  kMS = 3,
+  kSampled = 4,
+  kImageFormat = 5,
+  kAccessQualifier = 6,
+  kClspvUnsigned = 7, // Not a SPIR-V image operand
+};
+
 // Base name for workgroup variable accessor function.
 const std::string &WorkgroupAccessorFunction();
 

--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -3468,8 +3468,7 @@ bool ReplaceOpenCLBuiltinPass::replaceSampledReadImageWithIntCoords(
     // The coordinate (integer type that we can't handle).
     auto Arg2 = CI->getOperand(2);
 
-    auto *image_ty =
-        cast<StructType>(InferType(Arg0, M.getContext(), &InferredTypeCache));
+    auto *image_ty = InferType(Arg0, M.getContext(), &InferredTypeCache);
     uint32_t dim = clspv::ImageNumDimensions(image_ty);
     uint32_t components = dim + (clspv::IsArrayImageType(image_ty) ? 1 : 0);
     Type *float_ty = nullptr;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -704,7 +704,8 @@ private:
         : index(index_arg), descriptor_set(set_arg), binding(binding_arg),
           var_fn(fn), arg_kind(arg_kind_arg), coherent(coherent_arg),
           data_type(type),
-          addr_space(fn->getReturnType()->getPointerAddressSpace()) {}
+          addr_space(type->isPointerTy() ? type->getPointerAddressSpace() : 0) {
+    }
     const int index; // Index into ResourceVarInfoList
     const unsigned descriptor_set;
     const unsigned binding;
@@ -1532,6 +1533,8 @@ Type *SPIRVProducerPassImpl::CanonicalType(Type *type) {
         return GlobalTy;
       }
     }
+  } else if (type->isTargetExtTy()) {
+    // Nothing
   } else if (type->getNumContainedTypes() != 0) {
     switch (type->getTypeID()) {
     case Type::StructTyID: {
@@ -1815,6 +1818,123 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
     Ops << GetStorageClass(AddrSpace) << getSPIRVType(PointeeTy, needs_layout);
 
     RID = addSPIRVInst<kTypes>(spv::OpTypePointer, Ops);
+    break;
+  }
+  case Type::TargetExtTyID: {
+    auto *ext_ty = cast<TargetExtType>(Canonical);
+    if (IsImageType(ext_ty)) {
+      const auto dim = ImageDimensionality(ext_ty);
+      const auto sampled = IsSampledImageType(ext_ty);
+      switch (dim) {
+        case spv::Dim1D:
+          if (sampled) {
+            addCapability(spv::CapabilitySampled1D);
+          } else {
+            addCapability(spv::CapabilityImage1D);
+          }
+          break;
+        case spv::DimBuffer:
+          if (sampled) {
+            addCapability(spv::CapabilitySampledBuffer);
+          } else {
+            addCapability(spv::CapabilityImageBuffer);
+          }
+          break;
+        default:
+          break;
+      }
+
+      //
+      // Generate OpTypeImage
+      //
+      // Ops[0] = Sampled Type ID
+      // Ops[1] = Dim ID
+      // Ops[2] = Depth (Literal Number)
+      // Ops[3] = Arrayed (Literal Number)
+      // Ops[4] = MS (Literal Number)
+      // Ops[5] = Sampled (Literal Number)
+      // Ops[6] = Image Format ID
+      //
+      SPIRVOperandVec Ops;
+
+      SPIRVID SampledTyID;
+      // None of the sampled types have a layout.
+      if (IsFloatImageType(ext_ty)) {
+          SampledTyID =
+              getSPIRVType(Type::getFloatTy(Canonical->getContext()), false);
+      } else if (IsUintImageType(ext_ty)) {
+          SampledTyID =
+              getSPIRVType(Type::getInt32Ty(Canonical->getContext()), false);
+      } else if (IsIntImageType(ext_ty)) {
+          // Generate a signed 32-bit integer if necessary.
+          if (int32ID == 0) {
+            SPIRVOperandVec intOps;
+            intOps << 32 << 1;
+            int32ID = addSPIRVInst<kTypes>(spv::OpTypeInt, intOps);
+          }
+          SampledTyID = int32ID;
+
+          // Generate a vec4 of the signed int if necessary.
+          if (v4int32ID == 0) {
+            SPIRVOperandVec vecOps;
+            vecOps << int32ID << 4;
+            v4int32ID = addSPIRVInst<kTypes>(spv::OpTypeVector, vecOps);
+          }
+      } else {
+          // This was likely an UndefValue.
+          SampledTyID =
+              getSPIRVType(Type::getFloatTy(Canonical->getContext()), false);
+      }
+      Ops << SampledTyID;
+
+      spv::Dim DimID = ImageDimensionality(ext_ty);
+      Ops << DimID;
+
+      // TODO: Set up Depth.
+      Ops << 0;
+
+      uint32_t arrayed = IsArrayImageType(ext_ty) ? 1 : 0;
+      Ops << arrayed;
+
+      // TODO: Set up MS.
+      Ops << 0;
+
+      // Set up Sampled.
+      //
+      // From Spec
+      //
+      // 0 indicates this is only known at run time, not at compile time
+      // 1 indicates will be used with sampler
+      // 2 indicates will be used without a sampler (a storage image)
+      uint32_t Sampled = 1;
+      if (!IsSampledImageType(ext_ty)) {
+          Sampled = 2;
+      }
+      Ops << Sampled;
+
+      // TODO: Set up Image Format.
+      Ops << spv::ImageFormatUnknown;
+      RID = addSPIRVInst<kTypes>(spv::OpTypeImage, Ops);
+
+      // Only need a sampled version of the type if it is used with a sampler.
+      if (Sampled == 1 && ImageDimensionality(ext_ty) != spv::DimBuffer) {
+          Ops.clear();
+          Ops << RID;
+          getImageTypeMap()[Canonical] =
+              addSPIRVInst<kTypes>(spv::OpTypeSampledImage, Ops);
+      }
+      break;
+    } else if (IsSamplerType(ext_ty)) {
+      //
+      // Generate OpTypeSampler
+      //
+      // Empty Ops.
+
+      RID = addSPIRVInst<kTypes>(spv::OpTypeSampler);
+      break;
+    } else {
+      llvm_unreachable("Unknown target ext type");
+    }
     break;
   }
   case Type::StructTyID: {
@@ -2565,10 +2685,9 @@ void SPIRVProducerPassImpl::GenerateResourceVars() {
       }
       break;
     case clspv::ArgKind::StorageImage: {
-      auto *struct_ty = cast<StructType>(info->data_type);
       // TODO(alan-baker): This is conservative. If compiling for OpenCL 2.0 or
       // above, the compiler treats all write_only images as read_write images.
-      if (struct_ty->getName().contains("_wo")) {
+      if (IsWriteOnlyImageType(info->data_type)) {
         Ops.clear();
         Ops << info->var_id << spv::DecorationNonReadable;
         addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
@@ -3667,8 +3786,8 @@ SPIRVProducerPassImpl::GenerateImageInstruction(CallInst *Call,
     return 0;
   };
 
-  auto *image_ty = cast<StructType>(InferType(
-      Call->getArgOperand(0), module->getContext(), &InferredTypeCache));
+  auto *image_ty = InferType(Call->getArgOperand(0), module->getContext(),
+                             &InferredTypeCache);
   LLVMContext &Context = module->getContext();
   switch (FuncInfo.getType()) {
   case Builtins::kReadImagef:

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1941,6 +1941,7 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
     StructType *STy = cast<StructType>(Canonical);
 
     // Handle sampler type.
+    // TODO(#1036): remove image and sampler opaque struct support
     if (STy->isOpaque()) {
       if (IsSamplerType(STy)) {
         //

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -53,6 +53,7 @@ PreservedAnalyses SpecializeImageTypesPass::run(Module &M,
         if (res == kNotSpecialized) {
           // Argument is an image, but no specializing information was found.
           // Assume the image is sampled with a float type.
+          // TODO(#1036): remove opaque struct support
           if (auto *ext_ty = dyn_cast<TargetExtType>(new_ty)) {
             SmallVector<Type *, 1> types(1, Type::getFloatTy(M.getContext()));
             SmallVector<uint32_t, 8> ints(ext_ty->int_params());

--- a/lib/SpecializeImageTypes.h
+++ b/lib/SpecializeImageTypes.h
@@ -45,7 +45,7 @@ private:
   // |type|.
   llvm::Function *ReplaceImageBuiltin(llvm::Function *f,
                                       Builtins::FunctionInfo info,
-                                      llvm::StructType *type);
+                                      llvm::Type *type);
 
   // Rewrites |f| using the |remapped_args_| to determine to updated types.
   void RewriteFunction(llvm::Function *f);

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -910,7 +910,8 @@ Type *clspv::ThreeElementVectorLoweringPass::getEquivalentType(Type *Ty) {
 
 Type *clspv::ThreeElementVectorLoweringPass::getEquivalentTypeImpl(Type *Ty) {
   if (Ty->isIntegerTy() || Ty->isFloatingPointTy() || Ty->isVoidTy() ||
-      Ty->isLabelTy() || Ty->isMetadataTy() || Ty->isOpaquePointerTy()) {
+      Ty->isLabelTy() || Ty->isMetadataTy() || Ty->isOpaquePointerTy() ||
+      Ty->isTargetExtTy()) {
     // No lowering required.
     return nullptr;
   }

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -32,42 +32,53 @@ namespace clspv {
 llvm::Type *InferType(llvm::Value *v, llvm::LLVMContext &context,
                       llvm::DenseMap<llvm::Value *, llvm::Type *> *cache);
 
-// Returns true if the given struct type is a sampler type.
-bool IsSamplerType(llvm::StructType *type);
+// Returns true if the given type is descriptor resource.
+// Slight nuance with physical storage buffers.
+bool IsResourceType(llvm::Type *type);
 
-// Returns true if the given struct type is an image type.
-bool IsImageType(llvm::StructType *type);
+// Returns true if the given type is a physical storage buffer.
+bool IsPhysicalSSBOType(llvm::Type *type);
 
-// Returns the dimensionality of the image struct type. If |type| is not an
+// Returns true if the given type is a sampler type.
+bool IsSamplerType(llvm::Type *type);
+
+// Returns true if the given type is an image type.
+bool IsImageType(llvm::Type *type);
+
+// Returns the dimensionality of the image type. If |type| is not an
 // image, returns spv::DimMax.
-spv::Dim ImageDimensionality(llvm::StructType *type);
+spv::Dim ImageDimensionality(llvm::Type *type);
 
-// Returns the dimensionality of the image struct type. If |type| is not an
+// Returns the dimensionality of the image type. If |type| is not an
 // image, returns 0.
-uint32_t ImageNumDimensions(llvm::StructType *type);
+uint32_t ImageNumDimensions(llvm::Type *type);
 
 // Returns true if the given type is an array image type.
-bool IsArrayImageType(llvm::StructType *type);
+bool IsArrayImageType(llvm::Type *type);
 
-// Returns true if the given struct type is a sampled image type. Can only
+// Returns true if the given type is a sampled image type. Can only
 // return true after image specialization.
-bool IsSampledImageType(llvm::StructType *type);
+bool IsSampledImageType(llvm::Type *type);
 
 // Returns true if the given type is a storage image type. This is the case
 // for read_write and write_only images.
-bool IsStorageImageType(llvm::StructType *type);
+bool IsStorageImageType(llvm::Type *type);
 
 // Returns true if the given type is a float image type.
 // Before image specialization, all images are considered float images.
-bool IsFloatImageType(llvm::StructType *type);
+bool IsFloatImageType(llvm::Type *type);
 
 // Returns true if the given type is an int image type.
 // Can only return true after image specialization.
-bool IsIntImageType(llvm::StructType *type);
+bool IsIntImageType(llvm::Type *type);
 
 // Returns true if the given type is an uint image type.
 // Can only return true after image specialization.
-bool IsUintImageType(llvm::StructType *type);
+bool IsUintImageType(llvm::Type *type);
+
+// Returns true if the given type is a write only image type.
+// Only reliable after image specialization.
+bool IsWriteOnlyImageType(llvm::Type *type);
 
 // Returns true if pointers in the module are 64-bit.
 bool PointersAre64Bit(llvm::Module &m);

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -66,7 +66,8 @@ PreservedAnalyses clspv::UBOTypeTransformPass::run(Module &M,
       // specified in the function signature. This also works for non opaque
       // pointers, so the same solution is used.
       const auto *return_ty = F.getReturnType();
-      assert(return_ty->isPointerTy());
+      if (!return_ty->isPointerTy())
+        continue;
       if (clspv::Option::ConstantArgsInUniformBuffer() &&
           return_ty->getPointerAddressSpace() ==
               clspv::AddressSpace::Constant) {

--- a/test/AllocateDescriptors/images.ll
+++ b/test/AllocateDescriptors/images.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes="allocate-descriptors"
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+; CHECK-DAG: [[sampler:target\(\"spirv.Sampler\"\)]]
+; CHECK-DAG: [[image1df:target\(\"spirv.Image\", float, 0, 0, 0, 0, 1, 0, 0, 0\)]]
+; CHECK-DAG: [[image2di:target\(\"spirv.Image\", i32, 1, 0, 0, 0, 2, 0, 1, 0\)]]
+; CHECK-DAG: [[image3du:target\(\"spirv.Image\", i32, 2, 0, 0, 0, 1, 0, 0, 1\)]]
+; CHECK-DAG: [[image1dbufferf:target\(\"spirv.Image\", float, 5, 0, 0, 0, 2, 0, 1, 0\)]]
+; CHECK-DAG: [[image2darrayi:target\(\"spirv.Image\", i32, 1, 0, 1, 0, 1, 0, 0, 0\)]]
+
+declare spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32)
+declare spir_func <4 x float> @_Z11read_imagef30ocl_image1d_ro_t.float.sampled11ocl_samplerf(target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0), target("spirv.Sampler"), float)
+declare spir_func void @_Z12write_imagei20ocl_image2d_wo_t.intDv2_iDv4_i(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0), <2 x i32>, <4 x i32>)
+declare spir_func <4 x i32> @_Z12read_imageui29ocl_image3d_ro_t.uint.sampledDv4_i(target("spirv.Image", i32, 2, 0, 0, 0, 1, 0, 0, 1), <4 x i32>)
+declare spir_func void @_Z12write_imagef29ocl_image1d_buffer_wo_t.floatiDv4_f(target("spirv.Image", float, 5, 0, 0, 0, 2, 0, 1, 0), i32, <4 x float>)
+declare <4 x i32> @_Z11read_imagei34ocl_image2d_array_ro_t.int.sampled11ocl_samplerDv4_f(target("spirv.Image", i32, 1, 0, 1, 0, 1, 0, 0, 0), target("spirv.Sampler"), <4 x float>)
+
+; CHECK-LABEL: @test1
+; CHECK: call [[sampler]] @_Z14clspv.resource.0(i32 1, i32 0, i32 8, i32 0, i32 0, i32 0, [[sampler]]
+; CHECK: call [[image1df]] @_Z14clspv.resource.1(i32 1, i32 1, i32 6, i32 1, i32 1, i32 0, [[image1df]]
+define spir_kernel void @test1(target("spirv.Sampler") %s, target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) %f_im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %call = tail call spir_func <4 x float> @_Z11read_imagef30ocl_image1d_ro_t.float.sampled11ocl_samplerf(target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) %f_im, target("spirv.Sampler") %s, float 0.000000e+00)
+  store <4 x float> %call, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+; CHECK-LABEL: @test2
+; CHECK: call [[image2di]] @_Z14clspv.resource.3(i32 1, i32 0, i32 7, i32 0, i32 3, i32 0, [[image2di]]
+define spir_kernel void @test2(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) %i_im, ptr addrspace(1) nocapture readonly align 16 %data) !clspv.pod_args_impl !10 {
+entry:
+  %0 = load <4 x i32>, ptr addrspace(1) %data, align 16
+  tail call spir_func void @_Z12write_imagei20ocl_image2d_wo_t.intDv2_iDv4_i(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) %i_im, <2 x i32> zeroinitializer, <4 x i32> %0)
+  ret void
+}
+
+; CHECK-LABEL: @test3
+; CHECK: call [[image3du]] @_Z14clspv.resource.5(i32 1, i32 0, i32 6, i32 0, i32 5, i32 0, [[image3du]]
+define spir_kernel void @test3(target("spirv.Image", i32, 2, 0, 0, 0, 1, 0, 0, 1) %u_im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui29ocl_image3d_ro_t.uint.sampledDv4_i(target("spirv.Image", i32, 2, 0, 0, 0, 1, 0, 0, 1) %u_im, <4 x i32> zeroinitializer)
+  store <4 x i32> %call, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+; CHECK-LABEL: @test4
+; CHECK: call [[image1dbufferf]] @_Z14clspv.resource.6(i32 1, i32 0, i32 7, i32 0, i32 6, i32 0, [[image1dbufferf]]
+define spir_kernel void @test4(target("spirv.Image", float, 5, 0, 0, 0, 2, 0, 1, 0) %im, ptr addrspace(1) nocapture readonly align 16 %data) !clspv.pod_args_impl !10 {
+entry:
+  %0 = load <4 x float>, ptr addrspace(1) %data, align 16
+  tail call spir_func void @_Z12write_imagef29ocl_image1d_buffer_wo_t.floatiDv4_f(target("spirv.Image", float, 5, 0, 0, 0, 2, 0, 1, 0) %im, i32 0, <4 x float> %0)
+  ret void
+}
+
+; CHECK-LABEL: @test5
+; CHECK: call [[image2darrayi]] @_Z14clspv.resource.8(i32 1, i32 0, i32 6, i32 0, i32 8, i32 0, [[image2darrayi]]
+; CHECK: call [[sampler]] @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 18, [[sampler]]
+define spir_kernel void @test5(target("spirv.Image", i32, 1, 0, 1, 0, 1, 0, 0, 0) %im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %0 = tail call spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32 18)
+  %1 = tail call <4 x i32> @_Z11read_imagei34ocl_image2d_array_ro_t.int.sampled11ocl_samplerDv4_f(target("spirv.Image", i32, 1, 0, 1, 0, 1, 0, 0, 0) %im, target("spirv.Sampler") %0, <4 x float> zeroinitializer)
+  store <4 x i32> %1, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+
+!10 = !{i32 2}
+

--- a/test/FixupStructuredCFG/conditional_loop_header.cl
+++ b/test/FixupStructuredCFG/conditional_loop_header.cl
@@ -1,0 +1,37 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-val %t.spv --target-env vulkan1.0
+
+__kernel void compute_sum_with_localmem(__global int *a, int n, __local int *tmp_sum, __global int *sum)
+{
+    int  tid = get_local_id(0);
+    int  lsize = get_local_size(0);
+    int  i;
+
+    tmp_sum[tid] = 0;
+    for (i=tid; i<n; i+=lsize)
+         tmp_sum[tid] += a[i];
+
+    if( lsize == 1 )
+    {
+       if( tid == 0 )
+           *sum = tmp_sum[0];
+       return;
+    }
+
+    do
+    {
+       barrier(CLK_LOCAL_MEM_FENCE);
+       if (tid < lsize/2)
+       {
+           int sum = tmp_sum[tid];
+           if( (lsize & 1) && tid == 0 )
+               sum += tmp_sum[tid + lsize - 1];
+           tmp_sum[tid] = sum + tmp_sum[tid + lsize/2];
+       }
+       lsize = lsize/2; 
+    }while( lsize );
+
+    if( tid == 0 )
+       *sum = tmp_sum[0];
+}
+

--- a/test/SpecializeImageTypes/images.ll
+++ b/test/SpecializeImageTypes/images.ll
@@ -1,0 +1,78 @@
+; RUN: clspv-opt %s -o %t.ll --passes=specialize-image-types
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+; CHECK-DAG: [[image1df:target\(\"spirv.Image\", float, 0, 0, 0, 0, 1, 0, 0, 0\)]]
+; CHECK-DAG: [[image2di:target\(\"spirv.Image\", i32, 1, 0, 0, 0, 2, 0, 1, 0\)]]
+; CHECK-DAG: [[image3du:target\(\"spirv.Image\", i32, 2, 0, 0, 0, 1, 0, 0, 1\)]]
+; CHECK-DAG: [[image1dbufferf:target\(\"spirv.Image\", float, 5, 0, 0, 0, 2, 0, 1, 0\)]]
+; CHECK-DAG: [[image2darrayi:target\(\"spirv.Image\", i32, 1, 0, 1, 0, 1, 0, 0, 0\)]]
+
+; CHECK-LABEL: @test1
+; CHECK: [[image1df]] %f_im
+; CHECK: @{{[a-zA-Z0-9_]+}}read_imagef{{[a-zA-Z0-9_.]+}}([[image1df]] %f_im
+define dso_local spir_kernel void @test1(target("spirv.Sampler") %s, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %f_im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image1d_ro11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %f_im, target("spirv.Sampler") %s, float 0.000000e+00)
+  store <4 x float> %call, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image1d_ro11ocl_samplerf(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), target("spirv.Sampler"), float)
+
+; CHECK-LABEL: @test2
+; CHECK: [[image2di]] %i_im
+; CHECK: @{{[a-zA-Z0-9_]+}}write_imagei{{[a-zA-Z0-9_.]+}}([[image2di]] %i_im
+define dso_local spir_kernel void @test2(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %i_im, ptr addrspace(1) nocapture readonly align 16 %data) !clspv.pod_args_impl !10 {
+entry:
+  %0 = load <4 x i32>, ptr addrspace(1) %data, align 16
+  tail call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %i_im, <2 x i32> zeroinitializer, <4 x i32> %0)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, <4 x i32>)
+
+; CHECK-LABEL: @test3
+; CHECK: [[image3du]] %u_im
+; CHECK: @{{[a-zA-Z0-9_]+}}read_imageui{{[a-zA-Z0-9_.]+}}([[image3du]] %u_im
+define dso_local spir_kernel void @test3(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %u_im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %call = tail call spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_roDv4_i(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %u_im, <4 x i32> zeroinitializer)
+  store <4 x i32> %call, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+declare spir_func <4 x i32> @_Z12read_imageui14ocl_image3d_roDv4_i(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), <4 x i32>)
+
+; CHECK-LABEL: @test4
+; CHECK: [[image1dbufferf]] %im
+; CHECK: @{{[a-zA-Z0-9_]+}}write_imagef{{[a-zA-Z0-9_.]+}}([[image1dbufferf]] %im
+define dso_local spir_kernel void @test4(target("spirv.Image", void, 5, 0, 0, 0, 0, 0, 1) %im, ptr addrspace(1) nocapture readonly align 16 %data) !clspv.pod_args_impl !10 {
+entry:
+  %0 = load <4 x float>, ptr addrspace(1) %data, align 16
+  tail call spir_func void @_Z12write_imagef21ocl_image1d_buffer_woiDv4_f(target("spirv.Image", void, 5, 0, 0, 0, 0, 0, 1) %im, i32 0, <4 x float> %0)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef21ocl_image1d_buffer_woiDv4_f(target("spirv.Image", void, 5, 0, 0, 0, 0, 0, 1), i32, <4 x float>)
+
+; CHECK-LABEL: @test5
+; CHECK: [[image2darrayi]] %im
+; CHECK: @{{[a-zA-Z0-9_]+}}read_imagei{{[a-zA-Z0-9_.]+}}([[image2darrayi]] %im
+define dso_local spir_kernel void @test5(target("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0) %im, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
+entry:
+  %0 = tail call spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32 18)
+  %1 = tail call <4 x i32> @_Z11read_imagei20ocl_image2d_array_ro11ocl_samplerDv4_f(target("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0) %im, target("spirv.Sampler") %0, <4 x float> zeroinitializer)
+  store <4 x i32> %1, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+declare spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32)
+
+declare <4 x i32> @_Z11read_imagei20ocl_image2d_array_ro11ocl_samplerDv4_f(target("spirv.Image", void, 1, 0, 1, 0, 0, 0, 0), target("spirv.Sampler"), <4 x float>)
+
+!10 = !{i32 2}


### PR DESCRIPTION
* Remove PassManagerBuilder.h include
* Support samplers and images as target ext types
  * Many updates for interfaces and resources
  * Many query functions updated
* new tests

See #1036 for cleanup.