### PR TITLE
Revert "reenable unsafe-buffer-usage warning"

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -311,6 +311,8 @@ int SetCompilerInstanceOptions(
   instance.getCodeGenOpts().DisableO0ImplyOptNone = true;
   instance.getCodeGenOpts().OpaquePointers = clspv::Option::OpaquePointers();
   instance.getDiagnosticOpts().IgnoreWarnings = IgnoreWarnings;
+  // TODO(#995): Re-enable this warning.
+  instance.getDiagnosticOpts().Warnings.push_back("no-unsafe-buffer-usage");
 
   instance.getLangOpts().SinglePrecisionConstants =
       cl_single_precision_constants;


### PR DESCRIPTION
Reverts google/clspv#1043

Noticed failures on compiler/options_build_optimizations for swiftshader and nvidia when importing this change.