### PR TITLE
fix Rewrite Packed Structs pass for opaque pointers

### DIFF
--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -45,8 +45,7 @@ bool IsImplicitCasts(Module &M, DenseMap<Value *, Type *> &type_cache,
                      Type *&dest_ty, bool ReplacePhysicalPointerBitcasts);
 
 SmallVector<size_t, 4> getEleTypesBitWidths(Type *Ty, const DataLayout &DL,
-                                            Type *BaseTy);
-SmallVector<size_t, 4> getEleTypesBitWidths(Type *Ty, const DataLayout &DL);
+                                            Type *BaseTy = nullptr);
 
 Type *GetIndexTy(IRBuilder<> &Builder);
 ConstantInt *GetIndexTyConst(IRBuilder<> &Builder, uint64_t C);
@@ -57,6 +56,15 @@ Value *CreateRem(IRBuilder<> &Builder, unsigned rem, Value *Val);
 
 bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
                                bool &PerfectMatch, const DataLayout &DL);
+
+void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
+                          GetElementPtrInst *GEP, uint64_t &CstVal,
+                          Value *&DynVal, size_t &SmallerBitWidths);
+
+SmallVector<Value *, 2>
+GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
+                       Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
+                       size_t SmallerBitWidths, bool IsPrivate);
 } // namespace BitcastUtils
 
 #endif // _CLSPV_LIB_BITCAST_UTILS_PASS_H

--- a/lib/RewritePackedStructs.h
+++ b/lib/RewritePackedStructs.h
@@ -52,6 +52,8 @@ private:
   /// buffers.
   llvm::Function *convertUserDefinedFunction(llvm::Function &F);
 
+  bool structsShouldBeLowered(llvm::Function &F);
+
 private:
   /// A map between struct types and their equivalent representation.
   llvm::DenseMap<llvm::Type *, llvm::Type *> TypeMap;

--- a/test/PointerCasts/opaque_trivial_casts.ll
+++ b/test/PointerCasts/opaque_trivial_casts.ll
@@ -80,9 +80,8 @@ entry:
 
 ; CHECK-LABEL: define void @test6(ptr %in) {
 ; CHECK: entry:
-; CHECK:   %gep1 = getelementptr float, ptr %in, i32 1
-; CHECK:   %gep2 = getelementptr i32, ptr %gep1, i32 1
-; CHECK:   ret void
+; CHECK:   getelementptr float, ptr %in, i32 1
+; CHECK-NEXT: ret void
 ; CHECK: }
 
 define void @test6(ptr %in) {

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
@@ -6,21 +6,20 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
+; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 2
+; CHECK: [[gep_src:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <4 x i8>
 ; CHECK: [[trunc0:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 0
 ; CHECK: [[trunc1:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 1
 ; CHECK: [[trunc2:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 2
 ; CHECK: [[trunc3:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 3
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %cast, i32
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 0
 ; CHECK: store i8 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 %{{.*}}, 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %cast, i32 [[add1]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 1
 ; CHECK: store i8 [[trunc1]], ptr addrspace(1) [[gep]]
-; CHECK: [[add2:%[a-zA-Z0-9_.]+]] = add i32 [[add1]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %cast, i32 [[add2]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 2
 ; CHECK: store i8 [[trunc2]], ptr addrspace(1) [[gep]]
-; CHECK: [[add3:%[a-zA-Z0-9_.]+]] = add i32 [[add2]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %cast, i32 [[add3]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 3
 ; CHECK: store i8 [[trunc3]], ptr addrspace(1) [[gep]]
 
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
@@ -6,13 +6,14 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
+; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 1
+; CHECK: [[gep_src:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <2 x i16>
 ; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 0
 ; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %cast, i32
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 0
 ; CHECK: store i16 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 %{{.*}}, 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %cast, i32 [[add1]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 1
 ; CHECK: store i16 [[trunc1]], ptr addrspace(1) [[gep]]
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {
 entry:

--- a/test/RewritePackedStructs/packed_struct.cl
+++ b/test/RewritePackedStructs/packed_struct.cl
@@ -2,8 +2,6 @@
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
-// TODO(#1005): pass needs fixed
-// XFAIL: *
 
 struct S1{
     int x;
@@ -30,20 +28,20 @@ struct S4{
     char y;
 } __attribute__((packed));
 
-__kernel void test1(__global struct S1 *a, __global struct S2* b) { 
+__kernel void test1(__global struct S1 *a, __global struct S2* b) {
   b[0].x = a[0].x;
   b[0].y = a[0].y;
 }
 
-__kernel void test2(__global struct S1 *a, __global struct S2* b, __global struct S3* c) { 
+__kernel void test2(__global struct S1 *a, __global struct S2* b, __global struct S3* c) {
   b[0].y = a[0].y + c[0].y;
   b[0].x = a[0].x + c[0].x;
-  
+
   c[0].a = a[0].y + b[0].y;
   c[0].b = c[0].a + c[0].y;
 }
 
-__kernel void test3(__global struct S3* a, __global struct S4* b) { 
+__kernel void test3(__global struct S3* a, __global struct S4* b) {
   a[0].a = b[0].a;
   a[0].b = b[0].b;
   a[0].x = b[0].x;
@@ -52,86 +50,49 @@ __kernel void test3(__global struct S3* a, __global struct S4* b) {
   b[0].c = b[0].a + b[0].b + b[0].y;
 }
 
-// CHECK: OpCapability Int8
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint5:%[^ ]+]] = OpConstant [[uint]] 5
+// CHECK-DAG: [[uint7:%[^ ]+]] = OpConstant [[uint]] 7
+// CHECK-DAG: [[uint8:%[^ ]+]] = OpConstant [[uint]] 8
+// CHECK-DAG: [[uchar:%[^ ]+]] = OpTypeInt 8 0
 
-// argument types with packed structs
+// CHECK-DAG: [[arr_uchar5:%[^ ]+]] = OpTypeArray [[uchar]] [[uint5]]
+// CHECK-DAG: [[struct_arr_uchar5:%[^ ]+]] = OpTypeStruct [[arr_uchar5]]
+// CHECK-DAG: [[arr_struct_arr_uchar5:%[^ ]+]] = OpTypeRuntimeArray [[struct_arr_uchar5]]
+// CHECK-DAG: [[S1:%[^ ]+]] = OpTypeStruct [[arr_struct_arr_uchar5]]
+// CHECK-DAG: [[S1_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[S1]]
 
-// CHECK: OpMemberDecorate [[S3_transformed:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[S3_buffer_runtime_arr:%[a-zA-Z0-9_]+]] ArrayStride 7
-// CHECK: OpMemberDecorate [[S3_buffer_runtime_arr_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK-DAG: [[arr_uchar8:%[^ ]+]] = OpTypeArray [[uchar]] [[uint8]]
+// CHECK-DAG: [[arr_arr_uchar8:%[^ ]+]] = OpTypeRuntimeArray [[arr_uchar8]]
+// CHECK-DAG: [[S2_4:%[^ ]+]] = OpTypeStruct [[arr_arr_uchar8]]
+// CHECK-DAG: [[S2_4_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[S2_4]]
 
-// CHECK: OpMemberDecorate [[S4:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[S4]] 1 Offset 4
-// CHECK: OpMemberDecorate [[S4]] 2 Offset 5
-// CHECK: OpMemberDecorate [[S4]] 3 Offset 6
-// CHECK: OpMemberDecorate [[S4]] 4 Offset 7
-// CHECK: OpDecorate [[S4_buffer_runtime_arr:%[a-zA-Z0-9_]+]] ArrayStride 8
-// CHECK: OpMemberDecorate [[S4_buffer_runtime_arr_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK-DAG: [[arr_uchar7:%[^ ]+]] = OpTypeArray [[uchar]] [[uint7]]
+// CHECK-DAG: [[struct_arr_uchar7:%[^ ]+]] = OpTypeStruct [[arr_uchar7]]
+// CHECK-DAG: [[arr_struct_arr_uchar7:%[^ ]+]] = OpTypeRuntimeArray [[struct_arr_uchar7]]
+// CHECK-DAG: [[S3:%[^ ]+]] = OpTypeStruct [[arr_struct_arr_uchar7]]
+// CHECK-DAG: [[S3_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[S3]]
 
-// CHECK: OpMemberDecorate [[S1_transformed:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpDecorate [[S1_buffer_runtime_arr:%[a-zA-Z0-9_]+]] ArrayStride 5
-// CHECK: OpMemberDecorate [[S1_buffer_runtime_arr_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK-DAG: OpDecorate [[arr_uchar5]] ArrayStride 1
+// CHECK-DAG: OpDecorate [[arr_uchar7]] ArrayStride 1
+// CHECK-DAG: OpDecorate [[arr_uchar8]] ArrayStride 1
 
-// CHECK: OpMemberDecorate [[S2:%[a-zA-Z0-9_]+]] 0 Offset 0
-// CHECK: OpMemberDecorate [[S2]] 1 Offset 4
-// CHECK: OpDecorate [[S2_buffer_runtime_arr:%[a-zA-Z0-9_]+]] ArrayStride 8
-// CHECK: OpMemberDecorate [[S2_buffer_runtime_arr_struct:%[a-zA-Z0-9_]+]] 0 Offset 0
+// CHECK-DAG: OpMemberDecorate [[struct_arr_uchar5]] 0 Offset 0
+// CHECK-DAG: OpDecorate [[arr_struct_arr_uchar5]] ArrayStride 5
+// CHECK-DAG: OpDecorate [[arr_arr_uchar8]] ArrayStride 8
+// CHECK-DAG: OpMemberDecorate [[struct_arr_uchar7]] 0 Offset 0
+// CHECK-DAG: OpDecorate [[arr_struct_arr_uchar7]] ArrayStride 7
 
-// declarations 
+// CHECK-DAG: [[a_S1:%[^ ]+]] = OpVariable [[S1_ptr]] StorageBuffer
+// CHECK-DAG: [[b_S2_4:%[^ ]+]] = OpVariable [[S2_4_ptr]] StorageBuffer
+// CHECK-DAG: [[c_S3:%[^ ]+]] = OpVariable [[S3_ptr]] StorageBuffer
+// CHECK-DAG: [[a_S3:%[^ ]+]] = OpVariable [[S3_ptr]] StorageBuffer
 
-// CHECK: OpDecorate [[arr_uchar_uint_7:%[a-zA-Z0-9_]+]] ArrayStride 1
-// CHECK: OpDecorate [[arr_uchar_uint_5:%[a-zA-Z0-9_]+]] ArrayStride 1
-
-// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
-// CHECK: [[uchar:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
-// CHECK: [[uint_7:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 7
-
-// CHECK: [[arr_uchar_uint_7]] = OpTypeArray [[uchar]] [[uint_7]]
-// CHECK: [[S3_transformed]] = OpTypeStruct [[arr_uchar_uint_7]]
-// CHECK: [[S3_buffer_runtime_arr]] = OpTypeRuntimeArray [[S3_transformed]]
-// CHECK: [[S3_buffer_runtime_arr_struct]] = OpTypeStruct [[S3_buffer_runtime_arr]]
-
-// CHECK: [[S4]] = OpTypeStruct [[uint]] [[uchar]] [[uchar]] [[uchar]] [[uchar]]
-// CHECK: [[S4_buffer_runtime_arr]] = OpTypeRuntimeArray [[S4]]
-// CHECK: [[S4_buffer_runtime_arr_struct]] = OpTypeStruct [[S4_buffer_runtime_arr]]
-
-// CHECK: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 5
-
-// CHECK: [[arr_uchar_uint_5]] = OpTypeArray [[uchar]] [[uint_5]]
-// CHECK: [[S1_transformed]] = OpTypeStruct [[arr_uchar_uint_5]]
-// CHECK: [[S1_buffer_runtime_arr]] = OpTypeRuntimeArray [[S1_transformed]]
-// CHECK: [[S1_buffer_runtime_arr_struct]] = OpTypeStruct [[S1_buffer_runtime_arr]]
-
-// CHECK: [[S2]] = OpTypeStruct [[uchar]] [[uint]]
-// CHECK: [[S2_buffer_runtime_arr]] = OpTypeRuntimeArray [[S2]]
-// CHECK: [[S2_buffer_runtime_arr_struct]] = OpTypeStruct [[S2_buffer_runtime_arr]]
-
-// CHECK: [[ptr_StorageBuffer_uchar:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uchar]]
-// CHECK: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
-// CHECK: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 1
-// CHECK: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 4
-// CHECK: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 2
-// CHECK: [[ptr_StorageBuffer_uint:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[uint]]
-// CHECK: [[v4uchar:%[a-zA-Z0-9_]+]] = OpTypeVector [[uchar]] 4
-// CHECK: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 3
-// CHECK: [[uint_6:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 6
-// CHECK: [[ptr_StorageBuffer_arr_uchar_uint_5:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[arr_uchar_uint_5]]
-// CHECK: [[ptr_StorageBuffer_arr_uchar_uint_7:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[arr_uchar_uint_7]]
-
-// In functions
-// CHECK: {{.*}} = OpFunction %void None {{.*}}
-// CHECK: {{.*}} = OpFunction %void None {{.*}}
-// CHECK: {{.*}} = OpFunction %void None {{.*}}
-// CHECK: [[a_0_x_new_type:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr_StorageBuffer_arr_uchar_uint_5]] {{.*}} [[uint_0]] [[uint_0]] [[uint_0]]
-// CHECK: [[a_0_x_loaded:%[a-zA-Z0-9_]+]] = OpLoad [[arr_uchar_uint_5]] [[a_0_x_new_type]]
-// CHECK: [[first_uchar_from_v4uchar:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uchar]] [[a_0_x_loaded]] 0
-// CHECK: [[second_uchar_from_v4uchar:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uchar]] [[a_0_x_loaded]] 1
-// CHECK: [[third_uchar_from_v4uchar:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uchar]] [[a_0_x_loaded]] 2
-// CHECK: [[forth_uchar_from_v4uchar:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[uchar]] [[a_0_x_loaded]] 3
-// CHECK: {{.*}} = OpCompositeInsert [[v4uchar]] [[first_uchar_from_v4uchar]] {{.*}} 0
-// CHECK: {{.*}} = OpCompositeInsert [[v4uchar]] [[second_uchar_from_v4uchar]] {{.*}} 1
-// CHECK: {{.*}} = OpCompositeInsert [[v4uchar]] [[third_uchar_from_v4uchar]] {{.*}} 2
-// CHECK: {{.*}} = OpCompositeInsert [[v4uchar]] [[forth_uchar_from_v4uchar]] {{.*}} 3
-// CHECK: [[a_0_x:%[a-zA-Z0-9_]+]] = OpBitcast [[uint]] {{.*}}
-// CHECK: [[b_0_x:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr_StorageBuffer_uint]] {{.*}} [[uint_0]] [[uint_0]] [[uint_1]]
-// CHECK: OpStore [[b_0_x]] [[a_0_x]]
+// CHECK-DAG: OpDecorate [[a_S1]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[a_S1]] Binding 0
+// CHECK-DAG: OpDecorate [[b_S2_4]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[b_S2_4]] Binding 1
+// CHECK-DAG: OpDecorate [[c_S3]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[c_S3]] Binding 2
+// CHECK-DAG: OpDecorate [[a_S3]] DescriptorSet 0
+// CHECK-DAG: OpDecorate [[a_S3]] Binding 0

--- a/test/RewritePackedStructs/packed_struct3.ll
+++ b/test/RewritePackedStructs/packed_struct3.ll
@@ -1,7 +1,5 @@
 ; RUN: clspv-opt --passes=rewrite-packed-structs %s -o %t
 ; RUN: FileCheck %s < %t
-; TODO(#1005): convert to opaque pointers when pass is fixed
-; XFAIL: *
 
 %struct = type <{ i32, float }>
 
@@ -14,4 +12,4 @@ define spir_kernel void @test(%struct addrspace(1)* nocapture %in) {
 
 declare spir_func i32 @_Z13get_global_idj(i32)
 
-; CHECK: define spir_kernel void @test(%struct addrspace(1)* nocapture %in) {
+; CHECK: define spir_kernel void @test(ptr addrspace(1) nocapture %in) {

--- a/test/RewritePackedStructs/packed_struct4.ll
+++ b/test/RewritePackedStructs/packed_struct4.ll
@@ -1,7 +1,5 @@
 ; RUN: clspv-opt --passes=rewrite-packed-structs %s -o %t
 ; RUN: FileCheck %s < %t
-; TODO(#1005): convert to opaque pointers when pass is fixed
-; XFAIL: *
 
 %struct = type <{ i8, float }>
 
@@ -14,8 +12,7 @@ define spir_kernel void @test(%struct addrspace(1)* nocapture %in) {
 
 declare spir_func i32 @_Z13get_global_idj(i32)
 
-; CHECK: define spir_kernel void @test(<{ [5 x i8] }> addrspace(1)* nocapture %in) {
-; CHECK: [[input_buffer_bitcast:%[_a-zA-Z0-9]+]] = bitcast <{ [5 x i8] }> addrspace(1)* %in to %struct addrspace(1)*
+; CHECK: define spir_kernel void @test(ptr addrspace(1) nocapture %in) {
 ; CHECK: [[idx:%[_a-zA-Z0-9]+]] = call spir_func i32 @_Z13get_global_idj(i32 0)
-; CHECK: [[struct:%[_a-zA-Z0-9]+]] = getelementptr inbounds %struct, %struct addrspace(1)* [[input_buffer_bitcast]], i32 [[idx]]
-; CHECK: store %struct <{ i8 127, float 0.000000e+00 }>, %struct addrspace(1)* %3, align 1
+; CHECK: [[gep:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 [[idx]]
+; CHECK: store %struct <{ i8 127, float 0.000000e+00 }>, ptr addrspace(1) [[gep]], align 1

--- a/test/RewritePackedStructs/packed_struct_opaque.ll
+++ b/test/RewritePackedStructs/packed_struct_opaque.ll
@@ -1,7 +1,5 @@
 ; RUN: clspv-opt --passes=rewrite-packed-structs --opaque-pointers %s -o %t
 ; RUN: FileCheck %s < %t
-; TODO(#1005): disabled for opaque pointers
-; XFAIL: *
 
 %struct = type <{ i32, i8 }>
 
@@ -15,31 +13,6 @@ define spir_kernel void @test(ptr addrspace(1) nocapture %in) {
 declare spir_func i32 @_Z13get_global_idj(i32)
 
 ; CHECK: define spir_kernel void @test(ptr addrspace(1) nocapture %in) {
-; CHECK: [[allocated_tmp_struct_ptr:%[_a-zA-Z0-9]+]] = alloca %struct, align 8, addrspace(1)
-; CHECK: store <{ [5 x i8] }> zeroinitializer, ptr addrspace(1) %in, align 1
 ; CHECK: [[idx:%[_a-zA-Z0-9]+]] = call spir_func i32 @_Z13get_global_idj(i32 0)
-; CHECK: [[tmp_struct_ptr:%[_a-zA-Z0-9]+]] = getelementptr inbounds %struct, ptr addrspace(1) [[allocated_tmp_struct_ptr]], i32 [[idx]]
-; CHECK: store %struct <{ i32 2100483600, i8 127 }>, ptr addrspace(1) [[tmp_struct_ptr]], align 1
-
-; CHECK: [[tmp_struct:%[_a-zA-Z0-9]+]] = load %struct, ptr addrspace(1) [[allocated_tmp_struct_ptr]], align 1
-
-; CHECK: [[tmp_struct_value1:%[_a-zA-Z0-9]+]] = extractvalue %struct [[tmp_struct]], 0
-; CHECK: [[tmp_struct_value1_vec:%[_a-zA-Z0-9]+]] = bitcast i32 [[tmp_struct_value1]] to <4 x i8>
-; CHECK: [[tmp_struct_value1_vec_element1:%[_a-zA-Z0-9]+]] = extractelement <4 x i8> [[tmp_struct_value1_vec]], i64 0
-; CHECK: [[input_buffer_struct_value1_ptr:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 0, i32 0, i32 0
-; CHECK: store i8 [[tmp_struct_value1_vec_element1]], ptr addrspace(1) [[input_buffer_struct_value1_ptr]], align 1
-; CHECK: [[tmp_struct_value1_vec_element2:%[_a-zA-Z0-9]+]] = extractelement <4 x i8> [[tmp_struct_value1_vec]], i64 1
-; CHECK: [[input_buffer_struct_value2_ptr:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 0, i32 0, i32 1
-; CHECK: store i8 [[tmp_struct_value1_vec_element2]], ptr addrspace(1) [[input_buffer_struct_value2_ptr]], align 1
-; CHECK: [[tmp_struct_value1_vec_element3:%[_a-zA-Z0-9]+]] = extractelement <4 x i8> [[tmp_struct_value1_vec]], i64 2
-; CHECK: [[input_buffer_struct_value3_ptr:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 0, i32 0, i32 2
-; CHECK: store i8 [[tmp_struct_value1_vec_element3]], ptr addrspace(1) [[input_buffer_struct_value3_ptr]], align 1
-; CHECK: [[tmp_struct_value1_vec_element4:%[_a-zA-Z0-9]+]] = extractelement <4 x i8> [[tmp_struct_value1_vec]], i64 3
-; CHECK: [[input_buffer_struct_value4_ptr:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 0, i32 0, i32 3
-; CHECK: store i8 [[tmp_struct_value1_vec_element4]], ptr addrspace(1) [[input_buffer_struct_value4_ptr]], align 1
-
-; CHECK: [[tmp_struct_value2:%[_a-zA-Z0-9]+]] = extractvalue %struct [[tmp_struct]], 1
-; CHECK: [[tmp_struct_value2_vec:%[_a-zA-Z0-9]+]] = bitcast i8 [[tmp_struct_value2]] to <1 x i8>
-; CHECK: [[tmp_struct_value2_vec_element1:%[_a-zA-Z0-9]+]] = extractelement <1 x i8> [[tmp_struct_value2_vec]], i64 0
-; CHECK: [[input_buffer_struct_value5_ptr:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 0, i32 0, i32 4
-; CHECK: store i8 [[tmp_struct_value2_vec_element1]], ptr addrspace(1) [[input_buffer_struct_value5_ptr]], align 1
+; CHECK: [[gep:%[_a-zA-Z0-9]+]] = getelementptr <{ [5 x i8] }>, ptr addrspace(1) %in, i32 [[idx]]
+; CHECK: store %struct <{ i32 2100483600, i8 127 }>, ptr addrspace(1) [[gep]], align 1


### PR DESCRIPTION
For opaque pointers, do not look for packed structure in kernel arguments.
Instead look for gep on packed structure or on structure with an implicit cast.
Lowering structure (even unpacked) in implicit cast gep is needed to avoid complicated issue (that I don't have a answer for) in replacepointerbitcastpass.

Lower all those GEPs using 2 new functions to rework GEP indices from a source type to a target type.
Also use those functions in Simplifypointerbitcastpass

SimplifyPointerBitcastPass needs to be updated with a new Map containing ImplicitCasts (between 2 GEPs) that can be lower in this pass. This is needed to avoid regression in the CTS.

Other minor fixes:
- ReplacePointerBitcastPass::ComputeLoad: CreateGEP might not create a GEP, use getIndexedType to get the Load Type.
- BitcastUtils::getEleTypesBitWidths: fix typo in struct size supported.

Fixes #1005
Fixes #1050

No regression on full cts with Swiftshader and Nvidia