### PR TITLE
Fix kernel arg info generation for unused arguments when opaque pointers are enabled

### DIFF
--- a/include/clspv/ArgKind.h
+++ b/include/clspv/ArgKind.h
@@ -31,6 +31,7 @@ enum class ArgKind : int {
   Sampler,
   PointerUBO,
   PointerPushConstant,
+  Unknown,
 };
 
 // Converts an ArgKind to its string name.

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -700,7 +700,8 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           replacement = call;
         } break;
         case clspv::ArgKind::Local:
-          llvm_unreachable("local is unhandled");
+        case clspv::ArgKind::Unknown:
+          llvm_unreachable("local/unknown are unhandled");
         }
 
         if (ShowDescriptors) {

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -103,7 +103,7 @@ clspv::ArgKind GetArgKindForType(Type *type, Type *data_type) {
 
 namespace clspv {
 
-PodArgImpl GetPodArgsImpl(Function &F) {
+PodArgImpl GetPodArgsImpl(const Function &F) {
   assert(F.hasMetadata(PodArgsImplMetadataName()));
   auto md = F.getMetadata(PodArgsImplMetadataName());
   auto impl = static_cast<PodArgImpl>(
@@ -113,7 +113,7 @@ PodArgImpl GetPodArgsImpl(Function &F) {
   return impl;
 }
 
-ArgKind GetArgKindForPodArgs(Function &F) {
+ArgKind GetArgKindForPodArgs(const Function &F) {
   auto impl = GetPodArgsImpl(F);
   switch (impl) {
   case kUBO:
@@ -188,6 +188,8 @@ const char *GetArgKindName(ArgKind kind) {
     return "pointer_pushconstant";
   case ArgKind::PointerUBO:
     return "pointer_ubo";
+  case ArgKind::Unknown:
+    return "unknown";
   }
   errs() << "Unhandled case in clspv::GetArgKindForType: " << int(kind) << "\n";
   llvm_unreachable("Unhandled case in clspv::GetArgKindForType");

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -35,10 +35,10 @@ enum PodArgImpl {
 };
 
 // Returns the style of pod args used by |F|. Note that |F| must be a kernel.
-PodArgImpl GetPodArgsImpl(llvm::Function &F);
+PodArgImpl GetPodArgsImpl(const llvm::Function &F);
 
 // Returns the ArgKind for pod args in kernel |F|.
-ArgKind GetArgKindForPodArgs(llvm::Function &F);
+ArgKind GetArgKindForPodArgs(const llvm::Function &F);
 
 // Returns the ArgKind for |Arg|.
 ArgKind GetArgKind(llvm::Argument &Arg, llvm::Type *data_type = nullptr);

--- a/test/KernelArgInfo/kernel-arg-info-unused-cluster-pod-args.cl
+++ b/test/KernelArgInfo/kernel-arg-info-unused-cluster-pod-args.cl
@@ -1,0 +1,66 @@
+// RUN: clspv %target %s -cl-std=CL2.0 -inline-entry-points -cl-kernel-arg-info -cluster-pod-kernel-args -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel foo(global int4 *A, local float* SEC, constant short2* TER, int QUA, read_only image2d_t im0, write_only image2d_t im1, read_write image2d_t im2, sampler_t smp) {
+}
+
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+
+// CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "foo"
+// CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "A"
+// CHECK-DAG: [[arg0typename:%[a-zA-Z0-9_]+]] = OpString "int4*"
+// CHECK-DAG: [[arg1name:%[a-zA-Z0-9_]+]] = OpString "SEC"
+// CHECK-DAG: [[arg1typename:%[a-zA-Z0-9_]+]] = OpString "float*"
+// CHECK-DAG: [[arg2name:%[a-zA-Z0-9_]+]] = OpString "TER"
+// CHECK-DAG: [[arg2typename:%[a-zA-Z0-9_]+]] = OpString "short2*"
+// CHECK-DAG: [[arg3name:%[a-zA-Z0-9_]+]] = OpString "im0"
+// CHECK-DAG: [[arg3typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg4name:%[a-zA-Z0-9_]+]] = OpString "im1"
+// CHECK-DAG: [[arg4typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg5name:%[a-zA-Z0-9_]+]] = OpString "im2"
+// CHECK-DAG: [[arg5typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg6name:%[a-zA-Z0-9_]+]] = OpString "smp"
+// CHECK-DAG: [[arg6typename:%[a-zA-Z0-9_]+]] = OpString "sampler_t"
+// CHECK-DAG: [[arg7name:%[a-zA-Z0-9_]+]] = OpString "QUA"
+// CHECK-DAG: [[arg7typename:%[a-zA-Z0-9_]+]] = OpString "int"
+
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant %uint 8
+// CHECK-DAG: [[aspace_global:%[a-zA-Z0-9_]+]] = OpConstant %uint 4507
+// CHECK-DAG: [[qual_access_none:%[a-zA-Z0-9_]+]] = OpConstant %uint 4515
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant %uint 0
+// CHECK-DAG: [[uint_m1:%[a-zA-Z0-9_]+]] = OpConstant %uint 4294967295
+// CHECK-DAG: [[aspace_local:%[a-zA-Z0-9_]+]] = OpConstant %uint 4508
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant %uint 1
+// CHECK-DAG: [[aspace_constant:%[a-zA-Z0-9_]+]] = OpConstant %uint 4509
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant %uint 2
+// CHECK-DAG: [[qual_access_read_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4512
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant %uint 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant %uint 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant %uint 5
+// CHECK-DAG: [[uint_6:%[a-zA-Z0-9_]+]] = OpConstant %uint 6
+// CHECK-DAG: [[uint_7:%[a-zA-Z0-9_]+]] = OpConstant %uint 7
+// CHECK-DAG: [[aspace_private:%[a-zA-Z0-9_]+]] = OpConstant %uint 4510
+// CHECK-DAG: [[qual_access_write_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4513
+// CHECK-DAG: [[qual_access_read_write:%[a-zA-Z0-9_]+]] = OpConstant %uint 4514
+
+// CHECK: [[kernelinfo:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] Kernel {{.*}} [[kernel_name]]
+// CHECK-NEXT: [[arg0info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg0name]] [[arg0typename]] [[aspace_global]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer [[kernelinfo]] [[uint_0]] [[uint_m1]] [[uint_m1]] [[arg0info]]
+// CHECK-NEXT: [[arg1info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg1name]] [[arg1typename]] [[aspace_local]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentWorkgroup  [[kernelinfo]] [[uint_1]] [[uint_m1]] [[uint_0]] [[arg1info]]
+// CHECK-NEXT: [[arg2info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg2name]] [[arg2typename]] [[aspace_constant]] [[qual_access_none]] [[uint_1]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer  [[kernelinfo]] [[uint_2]] [[uint_m1]] [[uint_m1]] [[arg2info]]
+// CHECK-NEXT: [[arg3info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg3name]] [[arg3typename]] [[aspace_global]] [[qual_access_read_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentSampledImage  [[kernelinfo]] [[uint_4]] [[uint_m1]] [[uint_m1]] [[arg3info]]
+// CHECK-NEXT: [[arg4info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg4name]] [[arg4typename]] [[aspace_global]] [[qual_access_write_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageImage  [[kernelinfo]] [[uint_5]] [[uint_m1]] [[uint_m1]] [[arg4info]]
+// CHECK-NEXT: [[arg5info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg5name]] [[arg5typename]] [[aspace_global]] [[qual_access_read_write]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageImage  [[kernelinfo]] [[uint_6]] [[uint_m1]] [[uint_m1]] [[arg5info]]
+// CHECK-NEXT: [[arg6info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg6name]] [[arg6typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentSampler  [[kernelinfo]] [[uint_7]] [[uint_m1]] [[uint_m1]] [[arg6info]]
+// CHECK-NEXT: [[arg7info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg7name]] [[arg7typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_3]] [[uint_0]] [[uint_4]] [[arg7info]]

--- a/test/KernelArgInfo/kernel-arg-info-unused.cl
+++ b/test/KernelArgInfo/kernel-arg-info-unused.cl
@@ -1,0 +1,66 @@
+// RUN: clspv %target %s -cl-std=CL2.0 -inline-entry-points -cl-kernel-arg-info -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel foo(global int4 *A, local float* SEC, constant short2* TER, int QUA, read_only image2d_t im0, write_only image2d_t im1, read_write image2d_t im2, sampler_t smp) {
+}
+
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+
+// CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "foo"
+// CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "A"
+// CHECK-DAG: [[arg0typename:%[a-zA-Z0-9_]+]] = OpString "int4*"
+// CHECK-DAG: [[arg1name:%[a-zA-Z0-9_]+]] = OpString "SEC"
+// CHECK-DAG: [[arg1typename:%[a-zA-Z0-9_]+]] = OpString "float*"
+// CHECK-DAG: [[arg2name:%[a-zA-Z0-9_]+]] = OpString "TER"
+// CHECK-DAG: [[arg2typename:%[a-zA-Z0-9_]+]] = OpString "short2*"
+// CHECK-DAG: [[arg3name:%[a-zA-Z0-9_]+]] = OpString "im0"
+// CHECK-DAG: [[arg3typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg4name:%[a-zA-Z0-9_]+]] = OpString "im1"
+// CHECK-DAG: [[arg4typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg5name:%[a-zA-Z0-9_]+]] = OpString "im2"
+// CHECK-DAG: [[arg5typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg6name:%[a-zA-Z0-9_]+]] = OpString "smp"
+// CHECK-DAG: [[arg6typename:%[a-zA-Z0-9_]+]] = OpString "sampler_t"
+// CHECK-DAG: [[arg7name:%[a-zA-Z0-9_]+]] = OpString "QUA"
+// CHECK-DAG: [[arg7typename:%[a-zA-Z0-9_]+]] = OpString "int"
+
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant %uint 8
+// CHECK-DAG: [[aspace_global:%[a-zA-Z0-9_]+]] = OpConstant %uint 4507
+// CHECK-DAG: [[qual_access_none:%[a-zA-Z0-9_]+]] = OpConstant %uint 4515
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant %uint 0
+// CHECK-DAG: [[uint_m1:%[a-zA-Z0-9_]+]] = OpConstant %uint 4294967295
+// CHECK-DAG: [[aspace_local:%[a-zA-Z0-9_]+]] = OpConstant %uint 4508
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant %uint 1
+// CHECK-DAG: [[aspace_constant:%[a-zA-Z0-9_]+]] = OpConstant %uint 4509
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant %uint 2
+// CHECK-DAG: [[qual_access_read_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4512
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant %uint 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant %uint 4
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant %uint 5
+// CHECK-DAG: [[uint_6:%[a-zA-Z0-9_]+]] = OpConstant %uint 6
+// CHECK-DAG: [[uint_7:%[a-zA-Z0-9_]+]] = OpConstant %uint 7
+// CHECK-DAG: [[aspace_private:%[a-zA-Z0-9_]+]] = OpConstant %uint 4510
+// CHECK-DAG: [[qual_access_write_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4513
+// CHECK-DAG: [[qual_access_read_write:%[a-zA-Z0-9_]+]] = OpConstant %uint 4514
+
+// CHECK: [[kernelinfo:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] Kernel {{.*}} [[kernel_name]]
+// CHECK-NEXT: [[arg0info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg0name]] [[arg0typename]] [[aspace_global]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer [[kernelinfo]] [[uint_0]] [[uint_m1]] [[uint_m1]] [[arg0info]]
+// CHECK-NEXT: [[arg1info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg1name]] [[arg1typename]] [[aspace_local]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentWorkgroup  [[kernelinfo]] [[uint_1]] [[uint_m1]] [[uint_0]] [[arg1info]]
+// CHECK-NEXT: [[arg2info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg2name]] [[arg2typename]] [[aspace_constant]] [[qual_access_none]] [[uint_1]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer  [[kernelinfo]] [[uint_2]] [[uint_m1]] [[uint_m1]] [[arg2info]]
+// CHECK-NEXT: [[arg3info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg3name]] [[arg3typename]] [[aspace_global]] [[qual_access_read_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentSampledImage  [[kernelinfo]] [[uint_4]] [[uint_m1]] [[uint_m1]] [[arg3info]]
+// CHECK-NEXT: [[arg4info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg4name]] [[arg4typename]] [[aspace_global]] [[qual_access_write_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageImage  [[kernelinfo]] [[uint_5]] [[uint_m1]] [[uint_m1]] [[arg4info]]
+// CHECK-NEXT: [[arg5info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg5name]] [[arg5typename]] [[aspace_global]] [[qual_access_read_write]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageImage  [[kernelinfo]] [[uint_6]] [[uint_m1]] [[uint_m1]] [[arg5info]]
+// CHECK-NEXT: [[arg6info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg6name]] [[arg6typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentSampler  [[kernelinfo]] [[uint_7]] [[uint_m1]] [[uint_m1]] [[arg6info]]
+// CHECK-NEXT: [[arg7info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg7name]] [[arg7typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_3]] [[uint_0]] [[uint_4]] [[arg7info]]

--- a/test/ptr_local_struct.cl
+++ b/test/ptr_local_struct.cl
@@ -13,12 +13,12 @@ kernel void foo(local float *L, global float* A, float f, S local* LS, constant 
  *A = *L + *C + f + g + LS->b;
 }
 
-//      MAP: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
+//      MAP: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
+// MAP-NEXT: kernel,foo,arg,A,argOrdinal,1,descriptorSet,0,binding,0,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,f,argOrdinal,2,descriptorSet,0,binding,1,offset,0,argKind,pod_ubo,argSize,4
+// MAP-NEXT: kernel,foo,arg,LS,argOrdinal,3,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NEXT: kernel,foo,arg,C,argOrdinal,4,descriptorSet,0,binding,2,offset,0,argKind,buffer
 // MAP-NEXT: kernel,foo,arg,g,argOrdinal,5,descriptorSet,0,binding,3,offset,0,argKind,pod_ubo,argSize,4
-// MAP-NEXT: kernel,foo,arg,L,argOrdinal,0,argKind,local,arrayElemSize,4,arrayNumElemSpecId,3
-// MAP-NEXT: kernel,foo,arg,LS,argOrdinal,3,argKind,local,arrayElemSize,8,arrayNumElemSpecId,4
 // MAP-NOT: kernel
 
 // CHECK:      OpDecorate [[_2:%[0-9a-zA-Z_]+]] SpecId 3


### PR DESCRIPTION
This is the pattern used by the CTS tests to validate clGetKernelArgInfo.

The information needed to report kernel arg info via the OpenCL API is carried by ArgumentInfo reflection instructions. These are made available via the last optional operand to Argument* reflection instructions which means those need to be produced for unused arguments too.

This changes relies on the metadata provided by Clang to deduce the argument type. Pseudo-resources are allocated to descriptor set -1 / binding -1 / local memory spec constant -1 for unused arguments and runtimes need to deal with this case (if the approach is accepted, this ought to be documented as part of the specification for the ClspvReflection instruction set).

This change also reinstates the ability of runtimes to correctly report errors when kernel parameters are set to the wrong type of object (though it forces the use of -cl-kernel-arg-info to do so).