### PR TITLE
return an error when using -enable-opaque-pointers=0

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -22,12 +22,8 @@ The following subjects are covered:
 
 Jan 2023:
 
-Transparent pointers are deprecated. Usage of opaque pointers in LLVM are
-enabled by default. Soon the option will be removed. If you encounter
-regressions in behaviour, please open an issue.
-
-You may use -enable-opaque-pointers=0 for now, but that option will be removed
-when LLVM removes support for transparent pointers.
+Transparent pointers are not supported anymore. clspv only supports opaque
+pointers. If you encounter regressions in behaviour, please open an issue.
 
 Older:
 

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -760,7 +760,8 @@ int ParseOptions(const int argc, const char *const argv[]) {
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
   if (!clspv::Option::OpaquePointers()) {
-    llvm::errs() << "warning: transparent pointer support is deprecated\n";
+    llvm::errs() << "transparent pointer is not supported anymore\n";
+    return -1;
   }
   if (clspv::Option::KeepUnusedArguments()) {
     llvm::errs() << "warning: -keep-unused-arguments has been removed\n";


### PR DESCRIPTION
transparent pointers are not supported anymore since we have updated the builtins library using opaque pointers.