### PR TITLE
Fix type inference from kernel arg info

### DIFF
--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -289,8 +289,10 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
     NewFunc->setAttributes(newAttributes);
 
     // Move OpenCL kernel named attributes.
-    // TODO(dneto): Attributes starting with kernel_arg_* should be rewritten
-    // to reflect change in the argument shape.
+    // Do not rewrite the kernel_arg_* metadata as all of it needs to be
+    // preserved intact so it can be reported via clGetKernelArgInfo.
+    // Users of this metadata need to be aware that it may not map directly
+    // to kernel arguments after this pass.
     auto pod_md_name = clspv::PodArgsImplMetadataName();
     std::vector<const char *> Metadatas{
         "reqd_work_group_size",   "kernel_arg_addr_space",

--- a/test/KernelArgInfo/unused-arg-changed-order.cl
+++ b/test/KernelArgInfo/unused-arg-changed-order.cl
@@ -1,0 +1,54 @@
+// RUN: clspv %target %s -cl-kernel-arg-info -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+typedef struct
+{
+    int i;
+    float f;
+} structArg;
+
+__kernel void clone_kernel_test0(int iarg, float farg, structArg sarg, __local int* localbuf, __global int* outbuf)
+{
+}
+
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+
+// CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "clone_kernel_test0"
+// CHECK-DAG: [[arg3name:%[a-zA-Z0-9_]+]] = OpString "localbuf"
+// CHECK-DAG: [[arg3typename:%[a-zA-Z0-9_]+]] = OpString "int*"
+// CHECK-DAG: [[arg4name:%[a-zA-Z0-9_]+]] = OpString "outbuf"
+// CHECK-DAG: [[arg4typename:%[a-zA-Z0-9_]+]] = OpString "int*"
+// CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "iarg"
+// CHECK-DAG: [[arg0typename:%[a-zA-Z0-9_]+]] = OpString "int"
+// CHECK-DAG: [[arg1name:%[a-zA-Z0-9_]+]] = OpString "farg"
+// CHECK-DAG: [[arg1typename:%[a-zA-Z0-9_]+]] = OpString "float"
+// CHECK-DAG: [[arg2name:%[a-zA-Z0-9_]+]] = OpString "sarg"
+// CHECK-DAG: [[arg2typename:%[a-zA-Z0-9_]+]] = OpString "structArg"
+
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant %uint 5
+// CHECK-DAG: [[aspace_local:%[a-zA-Z0-9_]+]] = OpConstant %uint 4508
+// CHECK-DAG: [[qual_access_none:%[a-zA-Z0-9_]+]] = OpConstant %uint 4515
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant %uint 0
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant %uint 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant %uint 4
+// CHECK-DAG: [[aspace_global:%[a-zA-Z0-9_]+]] = OpConstant %uint 4507
+// CHECK-DAG: [[aspace_private:%[a-zA-Z0-9_]+]] = OpConstant %uint 4510
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant %uint 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant %uint 2
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant %uint 8
+
+// CHECK: [[kernelinfo:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] Kernel {{.*}} [[kernel_name]]
+// CHECK-NEXT: [[arg3info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg3name]] [[arg3typename]] [[aspace_local]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentWorkgroup [[kernelinfo]] [[uint_3]] [[uint_3]] [[uint_4]] [[arg3info]]
+// CHECK-NEXT: [[arg4info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg4name]] [[arg4typename]] [[aspace_global]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer  [[kernelinfo]] [[uint_4]] [[uint_0]] [[uint_0]] [[arg4info]]
+// CHECK-NEXT: [[arg0info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg0name]] [[arg0typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_0]] [[uint_0]] [[uint_4]] [[arg0info]]
+// CHECK-NEXT: [[arg1info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg1name]] [[arg1typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_1]] [[uint_4]] [[uint_4]] [[arg1info]]
+// CHECK-NEXT: [[arg2info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg2name]] [[arg2typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_2]] [[uint_8]] [[uint_8]] [[arg2info]]

--- a/test/KernelArgInfo/unused-intptr_t.cl
+++ b/test/KernelArgInfo/unused-intptr_t.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %target %s -cl-kernel-arg-info -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+kernel void foo(global intptr_t* buf)
+{
+}
+
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+
+// CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "foo"
+// CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "buf"
+// CHECK-DAG: [[arg0typename:%[a-zA-Z0-9_]+]] = OpString "intptr_t*"
+
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+
+// CHECK-DAG: [[qual_access_none:%[a-zA-Z0-9_]+]] = OpConstant %uint 4515
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant %uint 0
+// CHECK-DAG: [[aspace_global:%[a-zA-Z0-9_]+]] = OpConstant %uint 4507
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant %uint 1
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant %uint 2
+
+// CHECK: [[kernelinfo:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] Kernel {{.*}} [[kernel_name]]
+// CHECK-NEXT: [[arg0info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg0name]] [[arg0typename]] [[aspace_global]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageBuffer  [[kernelinfo]] [[uint_0]] [[uint_0]] [[uint_0]] [[arg0info]]


### PR DESCRIPTION
Now passing a full CTS sweep.

- Default to int for unknown types.
- Do not generate empty structure types for structures. Those do not have a correct layout.
- Support user-defined types and types whose name starts with one of the base types we are recognising.
- Use the arg_map when pod arguments have been clustered to figure out the original index of arguments to look at the right kernel arg info metadata.
- Add tests covering all these cases.