### PR TITLE
Specialize unused image arguments

### DIFF
--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -105,6 +105,10 @@ SpecializeImageTypesPass::RemapType(Argument *arg) {
       final_res = res;
     }
   }
+  if (arg->use_empty() && IsImageType(arg->getType())) {
+    final_res = ResultType::kNotSpecialized;
+    new_ty = arg->getType();
+  }
 
   return std::make_pair(final_res, new_ty);
 }

--- a/test/SpecializeImageTypes/unused.cl
+++ b/test/SpecializeImageTypes/unused.cl
@@ -1,0 +1,6 @@
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points
+// RUN: spirv-val %t.spv
+
+kernel void foo(write_only image2d_t im1, read_write image2d_t im2) {
+    write_imagef(im1, (int2)(0,0), (float4)(0.f,1.f,2.f,3.f));
+}

--- a/test/SpecializeImageTypes/unused.cl
+++ b/test/SpecializeImageTypes/unused.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points
+// RUN: clspv %s -o %t.spv --cl-std=CL2.0 -inline-entry-points -cl-kernel-arg-info
 // RUN: spirv-val %t.spv
 
 kernel void foo(write_only image2d_t im1, read_write image2d_t im2) {

--- a/test/SpecializeImageTypes/unused.ll
+++ b/test/SpecializeImageTypes/unused.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt %s -o %t.ll --passes=specialize-image-types --cl-std=CL2.0
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: @foo(target("spirv.Image", float, 1, 0, 0, 0, 2, 0, 2, 0) %unused)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+define dso_local spir_kernel void @foo(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %unused) {
+entry:
+  ret void
+}
+
+!10 = !{i32 2}
+


### PR DESCRIPTION
Fixes #1068

* Specialize unused image arguments to prevent type duplication