### PR TITLE
Remove inferred type parameter from GetArgKind

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -260,7 +260,7 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
       auto *inferred_ty = clspv::InferType(&Arg, M.getContext(), &type_cache_);
       assert(inferred_ty && "failed to infer argument type");
       Type *argTy = Arg.getType();
-      const auto arg_kind = clspv::GetArgKind(Arg, inferred_ty);
+      const auto arg_kind = clspv::GetArgKind(Arg);
 
       int separation_token = 0;
       switch (arg_kind) {
@@ -358,13 +358,11 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         if (Arg.use_empty()) {
           continue;
         }
-        auto *inferred_ty = clspv::InferType(&Arg, M.getContext(), &type_cache_);
-        assert(inferred_ty && "failed to infer argument type");
         set_and_binding_list.emplace_back(kUnallocated, kUnallocated);
         if (discriminants_list[arg_index].index >= 0) {
-          if (clspv::GetArgKind(Arg, inferred_ty) !=
+          if (clspv::GetArgKind(Arg) !=
                   clspv::ArgKind::PodPushConstant &&
-              clspv::GetArgKind(Arg, inferred_ty) !=
+              clspv::GetArgKind(Arg) !=
                   clspv::ArgKind::PointerPushConstant) {
             // Don't assign a descriptor set to push constants.
             set_and_binding_list.back().first = set;
@@ -397,12 +395,10 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
           // This argument will map to a resource.
           unsigned set = kUnallocated;
           unsigned binding = kUnallocated;
-          auto *inferred_ty = clspv::InferType(&*f_ptr->getArg(arg_index), M.getContext(), &type_cache_);
-          assert(inferred_ty && "failed to infer argument type");
           const bool is_push_constant_arg =
-              clspv::GetArgKind(*f_ptr->getArg(arg_index), inferred_ty) ==
+              clspv::GetArgKind(*f_ptr->getArg(arg_index)) ==
                   clspv::ArgKind::PodPushConstant ||
-              clspv::GetArgKind(*f_ptr->getArg(arg_index), inferred_ty) ==
+              clspv::GetArgKind(*f_ptr->getArg(arg_index)) ==
                   clspv::ArgKind::PointerPushConstant;
           if (always_single_kernel_descriptor ||
               functions_used_by_discriminant[info.index].size() ==
@@ -496,7 +492,7 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
                  << " type " << *argTy << "\n";
         }
 
-        const auto arg_kind = clspv::GetArgKind(Arg, inferred_ty);
+        const auto arg_kind = clspv::GetArgKind(Arg);
 
         Type *resource_type = nullptr;
         unsigned addr_space = kUnallocated;
@@ -771,7 +767,7 @@ bool clspv::AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
       Type *argTy = Arg.getType();
       auto *inferred_ty = clspv::InferType(&Arg, M.getContext(), &type_cache_);
       assert(inferred_ty && "failed to infer argument type");
-      const auto arg_kind = clspv::GetArgKind(Arg, inferred_ty);
+      const auto arg_kind = clspv::GetArgKind(Arg);
       if (arg_kind == clspv::ArgKind::Local) {
         // Assign a SpecId to this argument.
         int spec_id = GetSpecId(inferred_ty);

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -360,10 +360,8 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
         }
         set_and_binding_list.emplace_back(kUnallocated, kUnallocated);
         if (discriminants_list[arg_index].index >= 0) {
-          if (clspv::GetArgKind(Arg) !=
-                  clspv::ArgKind::PodPushConstant &&
-              clspv::GetArgKind(Arg) !=
-                  clspv::ArgKind::PointerPushConstant) {
+          if (clspv::GetArgKind(Arg) != clspv::ArgKind::PodPushConstant &&
+              clspv::GetArgKind(Arg) != clspv::ArgKind::PointerPushConstant) {
             // Don't assign a descriptor set to push constants.
             set_and_binding_list.back().first = set;
           }

--- a/lib/ArgKind.cpp
+++ b/lib/ArgKind.cpp
@@ -37,7 +37,7 @@ namespace {
 
 // TODO(#816): the second argument is no longer needed.
 // Maps an LLVM type for a kernel argument to an argument kind.
-clspv::ArgKind GetArgKindForType(Type *type, Type *) {
+clspv::ArgKind GetArgKindForType(Type *type) {
   if (isa<PointerType>(type)) {
     switch (type->getPointerAddressSpace()) {
     // Pointer to constant and pointer to global are both in
@@ -120,10 +120,9 @@ ArgKind GetArgKindForPointerPodArgs(Function &F) {
   llvm_unreachable("Unhandled case in clspv::GetArgKindForPodArgs");
 }
 
-// TODO(#816): data_type is no longer necessary.
-ArgKind GetArgKind(Argument &Arg, Type *data_type) {
+ArgKind GetArgKind(Argument &Arg) {
   if (isa<TargetExtType>(Arg.getType())) {
-    return GetArgKindForType(Arg.getType(), data_type);
+    return GetArgKindForType(Arg.getType());
   } else if (!isa<PointerType>(Arg.getType()) &&
       Arg.getParent()->getCallingConv() == CallingConv::SPIR_KERNEL) {
 
@@ -138,7 +137,7 @@ ArgKind GetArgKind(Argument &Arg, Type *data_type) {
     return GetArgKindForPodArgs(*Arg.getParent());
   }
 
-  return GetArgKindForType(Arg.getType(), data_type);
+  return GetArgKindForType(Arg.getType());
 }
 
 const char *GetArgKindName(ArgKind kind) {

--- a/lib/ArgKind.h
+++ b/lib/ArgKind.h
@@ -41,7 +41,7 @@ PodArgImpl GetPodArgsImpl(llvm::Function &F);
 ArgKind GetArgKindForPodArgs(llvm::Function &F);
 
 // Returns the ArgKind for |Arg|.
-ArgKind GetArgKind(llvm::Argument &Arg, llvm::Type *data_type = nullptr);
+ArgKind GetArgKind(llvm::Argument &Arg);
 
 // Returns true if the given type is a pointer-to-local type.
 bool IsLocalPtr(llvm::Type *type);

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -136,9 +136,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
         // to track that there was an argument.
         auto kind = clspv::ArgKind::Buffer;
         if (!Arg.use_empty() || clspv::Option::KernelArgInfo()) {
-          auto *inferred_ty =
-              clspv::InferType(&Arg, M.getContext(), &type_cache);
-          kind = clspv::GetArgKind(Arg, inferred_ty);
+          kind = clspv::GetArgKind(Arg);
         }
         RemapInfo.push_back(
             {std::string(Arg.getName()), arg_index, new_index++, 0u, 0u, kind});
@@ -220,7 +218,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
       for (Argument &Arg : F->args()) {
         Type *ArgTy = Arg.getType();
         if (!clspv::IsResourceType(ArgTy)) {
-          auto pod_arg_kind = clspv::GetArgKind(Arg, ArgTy);
+          auto pod_arg_kind = clspv::GetArgKind(Arg);
           unsigned arg_size = DL.getTypeStoreSize(ArgTy);
           unsigned offset = StructLayout->getElementOffset(PodIndexMap[&Arg]);
           int remapped_index = new_index;

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -83,8 +83,7 @@ clspv::MultiVersionUBOFunctionsPass::run(Module &M, ModuleAnalysisManager &) {
 bool clspv::MultiVersionUBOFunctionsPass::AnalyzeCall(
     Function *fn, CallInst *user, std::vector<ResourceInfo> *resources) {
   for (auto &arg : fn->args()) {
-    auto *inferred_ty = clspv::InferType(&arg, fn->getContext(), &type_cache_);
-    if (clspv::GetArgKind(arg, inferred_ty) != clspv::ArgKind::BufferUBO)
+    if (clspv::GetArgKind(arg) != clspv::ArgKind::BufferUBO)
       continue;
 
     Value *arg_operand = user->getOperand(arg.getArgNo());

--- a/lib/RewritePackedStructs.cpp
+++ b/lib/RewritePackedStructs.cpp
@@ -150,7 +150,7 @@ PreservedAnalyses clspv::RewritePackedStructs::run(Module &M,
             clspv::InferType(&Arg, F.getParent()->getContext(), &type_cache_);
         auto StructTy = dyn_cast<StructType>(ArgType);
         if (StructTy && StructTy->isPacked()) {
-          const auto ArgKind = clspv::GetArgKind(Arg, Arg.getType());
+          const auto ArgKind = clspv::GetArgKind(Arg);
           if (ArgKind == clspv::ArgKind::Buffer ||
               ArgKind == clspv::ArgKind::BufferUBO) {
             needRewriting = true;


### PR DESCRIPTION
* Since switching to target ext type for samplers and images, the inferred type is no longer necessary