### PR TITLE
fix vstore/vload_half3 when 16bit storage is not supported

### DIFF
--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -2143,6 +2143,94 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F,
   llvm_unreachable("Unsupported vload_half vector size");
 }
 
+llvm::Value *ReplaceOpenCLBuiltinPass::createVloadHalf(llvm::Module &M,
+                                                       llvm::CallInst *CI,
+                                                       llvm::Value *index,
+                                                       llvm::Value *ptr) {
+  auto IntTy = Type::getInt32Ty(M.getContext());
+  auto Float2Ty = FixedVectorType::get(Type::getFloatTy(M.getContext()), 2);
+  auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
+
+  // Our intrinsic to unpack a float2 from an int.
+  auto SPIRVIntrinsic = clspv::UnpackFunction();
+
+  auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
+
+  Value *V = nullptr;
+
+  bool supports_16bit_storage = true;
+  switch (ptr->getType()->getPointerAddressSpace()) {
+  case clspv::AddressSpace::Global:
+    supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+        clspv::Option::StorageClass::kSSBO);
+    break;
+  case clspv::AddressSpace::Constant:
+    if (clspv::Option::ConstantArgsInUniformBuffer())
+      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+          clspv::Option::StorageClass::kUBO);
+    else
+      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+          clspv::Option::StorageClass::kSSBO);
+    break;
+  default:
+    // Clspv will emit the Float16 capability if the half type is
+    // encountered. That capability covers private and local addressspaces.
+    break;
+  }
+
+  if (supports_16bit_storage) {
+    auto ShortTy = Type::getInt16Ty(M.getContext());
+
+    // Index into the correct address of the casted pointer.
+    auto Index = GetElementPtrInst::Create(ShortTy, ptr, index, "", CI);
+
+    // Load from the short* we casted to.
+    auto Load = new LoadInst(ShortTy, Index, "", CI);
+
+    // ZExt the short -> int.
+    auto ZExt = CastInst::CreateZExtOrBitCast(Load, IntTy, "", CI);
+
+    // Get our float2.
+    auto Call = CallInst::Create(NewF, ZExt, "", CI);
+
+    // Extract out the bottom element which is our float result.
+    V = ExtractElementInst::Create(Call, ConstantInt::get(IntTy, 0), "", CI);
+  } else {
+    // Assume the pointer argument points to storage aligned to 32bits
+    // or more.
+    // TODO(dneto): Do more analysis to make sure this is true?
+    //
+    // Replace call vstore_half(i32 %index, half addrspace(1) %base)
+    // with:
+    //
+    //   %base_i32_ptr = bitcast half addrspace(1)* %base to i32
+    //   addrspace(1)* %index_is_odd32 = and i32 %index, 1 %index_i32 =
+    //   lshr i32 %index, 1 %in_ptr = getlementptr i32, i32
+    //   addrspace(1)* %base_i32_ptr, %index_i32 %value_i32 = load i32,
+    //   i32 addrspace(1)* %in_ptr %converted = call <2 x float>
+    //   @spirv.unpack.v2f16(i32 %value_i32) %value = extractelement <2
+    //   x float> %converted, %index_is_odd32
+
+    auto One = ConstantInt::get(IntTy, 1);
+    auto IndexIsOdd = BinaryOperator::CreateAnd(index, One, "", CI);
+    auto IndexIntoI32 = BinaryOperator::CreateLShr(index, One, "", CI);
+
+    // Index into the correct address of the casted pointer.
+    auto Ptr = GetElementPtrInst::Create(IntTy, ptr, IndexIntoI32, "", CI);
+
+    // Load from the int* we casted to.
+    auto Load = new LoadInst(IntTy, Ptr, "", CI);
+
+    // Get our float2.
+    auto Call = CallInst::Create(NewF, Load, "", CI);
+
+    // Extract out the float result, where the element number is
+    // determined by whether the original index was even or odd.
+    V = ExtractElementInst::Create(Call, IndexIsOdd, "", CI);
+  }
+  return V;
+}
+
 bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F) {
   Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) {
@@ -2152,88 +2240,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf(Function &F) {
     // The pointer argument from vload_half.
     auto Arg1 = CI->getOperand(1);
 
-    auto IntTy = Type::getInt32Ty(M.getContext());
-    auto Float2Ty = FixedVectorType::get(Type::getFloatTy(M.getContext()), 2);
-    auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
-
-    // Our intrinsic to unpack a float2 from an int.
-    auto SPIRVIntrinsic = clspv::UnpackFunction();
-
-    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-    Value *V = nullptr;
-
-    bool supports_16bit_storage = true;
-    switch (Arg1->getType()->getPointerAddressSpace()) {
-    case clspv::AddressSpace::Global:
-      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-          clspv::Option::StorageClass::kSSBO);
-      break;
-    case clspv::AddressSpace::Constant:
-      if (clspv::Option::ConstantArgsInUniformBuffer())
-        supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-            clspv::Option::StorageClass::kUBO);
-      else
-        supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-            clspv::Option::StorageClass::kSSBO);
-      break;
-    default:
-      // Clspv will emit the Float16 capability if the half type is
-      // encountered. That capability covers private and local addressspaces.
-      break;
-    }
-
-    if (supports_16bit_storage) {
-      auto ShortTy = Type::getInt16Ty(M.getContext());
-
-      // Index into the correct address of the casted pointer.
-      auto Index = GetElementPtrInst::Create(ShortTy, Arg1, Arg0, "", CI);
-
-      // Load from the short* we casted to.
-      auto Load = new LoadInst(ShortTy, Index, "", CI);
-
-      // ZExt the short -> int.
-      auto ZExt = CastInst::CreateZExtOrBitCast(Load, IntTy, "", CI);
-
-      // Get our float2.
-      auto Call = CallInst::Create(NewF, ZExt, "", CI);
-
-      // Extract out the bottom element which is our float result.
-      V = ExtractElementInst::Create(Call, ConstantInt::get(IntTy, 0), "", CI);
-    } else {
-      // Assume the pointer argument points to storage aligned to 32bits
-      // or more.
-      // TODO(dneto): Do more analysis to make sure this is true?
-      //
-      // Replace call vstore_half(i32 %index, half addrspace(1) %base)
-      // with:
-      //
-      //   %base_i32_ptr = bitcast half addrspace(1)* %base to i32
-      //   addrspace(1)* %index_is_odd32 = and i32 %index, 1 %index_i32 =
-      //   lshr i32 %index, 1 %in_ptr = getlementptr i32, i32
-      //   addrspace(1)* %base_i32_ptr, %index_i32 %value_i32 = load i32,
-      //   i32 addrspace(1)* %in_ptr %converted = call <2 x float>
-      //   @spirv.unpack.v2f16(i32 %value_i32) %value = extractelement <2
-      //   x float> %converted, %index_is_odd32
-
-      auto One = ConstantInt::get(IntTy, 1);
-      auto IndexIsOdd = BinaryOperator::CreateAnd(Arg0, One, "", CI);
-      auto IndexIntoI32 = BinaryOperator::CreateLShr(Arg0, One, "", CI);
-
-      // Index into the correct address of the casted pointer.
-      auto Ptr = GetElementPtrInst::Create(IntTy, Arg1, IndexIntoI32, "", CI);
-
-      // Load from the int* we casted to.
-      auto Load = new LoadInst(IntTy, Ptr, "", CI);
-
-      // Get our float2.
-      auto Call = CallInst::Create(NewF, Load, "", CI);
-
-      // Extract out the float result, where the element number is
-      // determined by whether the original index was even or odd.
-      V = ExtractElementInst::Create(Call, IndexIsOdd, "", CI);
-    }
-    return V;
+    return createVloadHalf(M, CI, Arg0, Arg1);
   });
 }
 
@@ -2278,11 +2285,8 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf3(Function &F) {
     auto IntTy = Type::getInt32Ty(M.getContext());
     auto IndexTy =
         clspv::PointersAre64Bit(M) ? Type::getInt64Ty(M.getContext()) : IntTy;
-    auto ShortTy = Type::getInt16Ty(M.getContext());
     auto FloatTy = Type::getFloatTy(M.getContext());
-    auto Float2Ty = FixedVectorType::get(FloatTy, 2);
     auto Float3Ty = FixedVectorType::get(FloatTy, 3);
-    auto NewFType = FunctionType::get(Float2Ty, IntTy, false);
 
     auto Int0 = ConstantInt::get(IndexTy, 0);
     auto Int1 = ConstantInt::get(IndexTy, 1);
@@ -2293,38 +2297,17 @@ bool ReplaceOpenCLBuiltinPass::replaceVloadHalf3(Function &F) {
         Instruction::Add,
         BinaryOperator::Create(Instruction::Shl, Arg0, Int1, "", CI), Arg0, "",
         CI);
-    auto GEP0 = GetElementPtrInst::Create(ShortTy, Arg1, Index0, "", CI);
-    auto Load0 = new LoadInst(ShortTy, GEP0, "", CI);
+    auto Y0 = createVloadHalf(M, CI, Index0, Arg1);
 
     // Load the second element
     auto Index1 =
         BinaryOperator::Create(Instruction::Add, Index0, Int1, "", CI);
-    auto GEP1 = GetElementPtrInst::Create(ShortTy, Arg1, Index1, "", CI);
-    auto Load1 = new LoadInst(ShortTy, GEP1, "", CI);
+    auto Y1 = createVloadHalf(M, CI, Index1, Arg1);
 
     // Load the third element
     auto Index2 =
         BinaryOperator::Create(Instruction::Add, Index1, Int1, "", CI);
-    auto GEP2 = GetElementPtrInst::Create(ShortTy, Arg1, Index2, "", CI);
-    auto Load2 = new LoadInst(ShortTy, GEP2, "", CI);
-
-    // Extend each short to int.
-    auto X0 = CastInst::Create(Instruction::ZExt, Load0, IntTy, "", CI);
-    auto X1 = CastInst::Create(Instruction::ZExt, Load1, IntTy, "", CI);
-    auto X2 = CastInst::Create(Instruction::ZExt, Load2, IntTy, "", CI);
-
-    // Our intrinsic to unpack a float2 from an int.
-    auto SPIRVIntrinsic = clspv::UnpackFunction();
-
-    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-    // Convert int to float2 and extract the uniq meaningful float
-    auto Y0 = ExtractElementInst::Create(CallInst::Create(NewF, X0, "", CI),
-                                         Int0, "", CI);
-    auto Y1 = ExtractElementInst::Create(CallInst::Create(NewF, X1, "", CI),
-                                         Int0, "", CI);
-    auto Y2 = ExtractElementInst::Create(CallInst::Create(NewF, X2, "", CI),
-                                         Int0, "", CI);
+    auto Y2 = createVloadHalf(M, CI, Index2, Arg1);
 
     // Create the final float3 to be returned
     auto Combine =
@@ -2694,6 +2677,150 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F, int vec_size,
   return false;
 }
 
+llvm::Value *ReplaceOpenCLBuiltinPass::createVstoreHalf(llvm::Module &M,
+                                                        llvm::CallInst *CI,
+                                                        llvm::Value *value,
+                                                        llvm::Value *index,
+                                                        llvm::Value *ptr) {
+  auto IntTy = Type::getInt32Ty(M.getContext());
+  auto Int64Ty = Type::getInt64Ty(M.getContext());
+  auto Float2Ty = FixedVectorType::get(Type::getFloatTy(M.getContext()), 2);
+  auto NewFType = FunctionType::get(IntTy, Float2Ty, false);
+
+  // Our intrinsic to pack a float2 to an int.
+  auto SPIRVIntrinsic = clspv::PackFunction();
+
+  auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
+
+  // Insert our value into a float2 so that we can pack it.
+  auto TempVec = InsertElementInst::Create(PoisonValue::get(Float2Ty), value,
+                                           ConstantInt::get(IntTy, 0), "", CI);
+
+  // Pack the float2 -> half2 (in an int).
+  auto X = CallInst::Create(NewF, TempVec, "", CI);
+
+  bool supports_16bit_storage = true;
+  switch (ptr->getType()->getPointerAddressSpace()) {
+  case clspv::AddressSpace::Global:
+    supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+        clspv::Option::StorageClass::kSSBO);
+    break;
+  case clspv::AddressSpace::Constant:
+    if (clspv::Option::ConstantArgsInUniformBuffer())
+      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+          clspv::Option::StorageClass::kUBO);
+    else
+      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
+          clspv::Option::StorageClass::kSSBO);
+    break;
+  default:
+    // Clspv will emit the Float16 capability if the half type is
+    // encountered. That capability covers private and local addressspaces.
+    break;
+  }
+
+  Value *V = nullptr;
+  if (supports_16bit_storage) {
+    auto ShortTy = Type::getInt16Ty(M.getContext());
+
+    // Truncate our i32 to an i16.
+    auto Trunc = CastInst::CreateTruncOrBitCast(X, ShortTy, "", CI);
+
+    // Index into the correct address of the casted pointer.
+    auto Index = GetElementPtrInst::Create(ShortTy, ptr, index, "", CI);
+
+    // Store to the int* we casted to.
+    V = new StoreInst(Trunc, Index, CI);
+  } else {
+    // We can only write to 32-bit aligned words.
+    //
+    // Assuming base is aligned to 32-bits, replace the equivalent of
+    //   vstore_half(value, index, base)
+    // with:
+    //   uint32_t* target_ptr = (uint32_t*)(base) + index / 2;
+    //   uint32_t write_to_upper_half = index & 1u;
+    //   uint32_t shift = write_to_upper_half << 4;
+    //
+    //   // Pack the float value as a half number in bottom 16 bits
+    //   // of an i32.
+    //   uint32_t packed = spirv.pack.v2f16((float2)(value, undef));
+    //
+    //   uint32_t xor_value =   (*target_ptr & (0xffff << shift))
+    //                        ^ ((packed & 0xffff) << shift)
+    //   // We only need relaxed consistency, but OpenCL 1.2 only has
+    //   // sequentially consistent atomics.
+    //   // TODO(dneto): Use relaxed consistency.
+    //   atomic_xor(target_ptr, xor_value)
+    auto IntPointerTy =
+        PointerType::get(IntTy, ptr->getType()->getPointerAddressSpace());
+
+    auto One =
+        ConstantInt::get(clspv::PointersAre64Bit(M) ? Int64Ty : IntTy, 1);
+    auto Four =
+        ConstantInt::get(clspv::PointersAre64Bit(M) ? Int64Ty : IntTy, 4);
+    auto FFFF = ConstantInt::get(IntTy, 0xffff);
+    auto IndexIsOdd =
+        BinaryOperator::CreateAnd(index, One, "index_is_odd_i32", CI);
+    // Compute index / 2
+    auto IndexIntoI32 =
+        BinaryOperator::CreateLShr(index, One, "index_into_i32", CI);
+
+    auto OutPtr =
+        GetElementPtrInst::Create(IntTy, ptr, IndexIntoI32, "base_i32_ptr", CI);
+    auto CurrentValue = new LoadInst(IntTy, OutPtr, "current_value", CI);
+    Value *Shift = BinaryOperator::CreateShl(IndexIsOdd, Four, "shift", CI);
+    // The shift is safe to truncate as it will definitely fit in a 32-bit int
+    if (Shift->getType() != IntTy) {
+      Shift = CastInst::Create(Instruction::CastOps::Trunc, Shift, IntTy,
+                               "shift_trunc", CI);
+    }
+    auto MaskBitsToWrite =
+        BinaryOperator::CreateShl(FFFF, Shift, "mask_bits_to_write", CI);
+    auto MaskedCurrent = BinaryOperator::CreateAnd(
+        MaskBitsToWrite, CurrentValue, "masked_current", CI);
+
+    auto XLowerBits =
+        BinaryOperator::CreateAnd(X, FFFF, "lower_bits_of_packed", CI);
+    auto NewBitsToWrite =
+        BinaryOperator::CreateShl(XLowerBits, Shift, "new_bits_to_write", CI);
+    auto ValueToXor = BinaryOperator::CreateXor(MaskedCurrent, NewBitsToWrite,
+                                                "value_to_xor", CI);
+
+    // Generate the call to atomi_xor.
+    SmallVector<Type *, 5> ParamTypes;
+    // The pointer type.
+    ParamTypes.push_back(IntPointerTy);
+    // The Types for memory scope, semantics, and value.
+    ParamTypes.push_back(IntTy);
+    ParamTypes.push_back(IntTy);
+    ParamTypes.push_back(IntTy);
+    auto NewFType = FunctionType::get(IntTy, ParamTypes, false);
+    auto NewF = M.getOrInsertFunction("spirv.atomic_xor", NewFType);
+
+    const auto ConstantScopeDevice = ConstantInt::get(IntTy, spv::ScopeDevice);
+    // Assume the pointee is in OpenCL global (SPIR-V Uniform) or local
+    // (SPIR-V Workgroup).
+    const auto AddrSpaceSemanticsBits =
+        IntPointerTy->getPointerAddressSpace() == 1
+            ? spv::MemorySemanticsUniformMemoryMask
+            : spv::MemorySemanticsWorkgroupMemoryMask;
+
+    // We're using relaxed consistency here.
+    const auto ConstantMemorySemantics = ConstantInt::get(
+        IntTy, spv::MemorySemanticsUniformMemoryMask | AddrSpaceSemanticsBits);
+
+    SmallVector<Value *, 5> Params{OutPtr, ConstantScopeDevice,
+                                   ConstantMemorySemantics, ValueToXor};
+    CallInst::Create(NewF, Params, "store_halfword_xor_trick", CI);
+
+    // Return a Nop so the old Call is removed
+    Function *donothing = Intrinsic::getDeclaration(&M, Intrinsic::donothing);
+    V = CallInst::Create(donothing, {}, "", CI);
+  }
+
+  return V;
+}
+
 bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F) {
   Module &M = *F.getParent();
   return replaceCallsWithValue(F, [&](CallInst *CI) {
@@ -2706,145 +2833,7 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf(Function &F) {
     // The pointer argument from vstore_half.
     auto Arg2 = CI->getOperand(2);
 
-    auto IntTy = Type::getInt32Ty(M.getContext());
-    auto Int64Ty = Type::getInt64Ty(M.getContext());
-    auto Float2Ty = FixedVectorType::get(Type::getFloatTy(M.getContext()), 2);
-    auto NewFType = FunctionType::get(IntTy, Float2Ty, false);
-
-    // Our intrinsic to pack a float2 to an int.
-    auto SPIRVIntrinsic = clspv::PackFunction();
-
-    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-    // Insert our value into a float2 so that we can pack it.
-    auto TempVec = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty), Arg0, ConstantInt::get(IntTy, 0), "", CI);
-
-    // Pack the float2 -> half2 (in an int).
-    auto X = CallInst::Create(NewF, TempVec, "", CI);
-
-    bool supports_16bit_storage = true;
-    switch (Arg2->getType()->getPointerAddressSpace()) {
-    case clspv::AddressSpace::Global:
-      supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-          clspv::Option::StorageClass::kSSBO);
-      break;
-    case clspv::AddressSpace::Constant:
-      if (clspv::Option::ConstantArgsInUniformBuffer())
-        supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-            clspv::Option::StorageClass::kUBO);
-      else
-        supports_16bit_storage = clspv::Option::Supports16BitStorageClass(
-            clspv::Option::StorageClass::kSSBO);
-      break;
-    default:
-      // Clspv will emit the Float16 capability if the half type is
-      // encountered. That capability covers private and local addressspaces.
-      break;
-    }
-
-    Value *V = nullptr;
-    if (supports_16bit_storage) {
-      auto ShortTy = Type::getInt16Ty(M.getContext());
-
-      // Truncate our i32 to an i16.
-      auto Trunc = CastInst::CreateTruncOrBitCast(X, ShortTy, "", CI);
-
-      // Index into the correct address of the casted pointer.
-      auto Index = GetElementPtrInst::Create(ShortTy, Arg2, Arg1, "", CI);
-
-      // Store to the int* we casted to.
-      V = new StoreInst(Trunc, Index, CI);
-    } else {
-      // We can only write to 32-bit aligned words.
-      //
-      // Assuming base is aligned to 32-bits, replace the equivalent of
-      //   vstore_half(value, index, base)
-      // with:
-      //   uint32_t* target_ptr = (uint32_t*)(base) + index / 2;
-      //   uint32_t write_to_upper_half = index & 1u;
-      //   uint32_t shift = write_to_upper_half << 4;
-      //
-      //   // Pack the float value as a half number in bottom 16 bits
-      //   // of an i32.
-      //   uint32_t packed = spirv.pack.v2f16((float2)(value, undef));
-      //
-      //   uint32_t xor_value =   (*target_ptr & (0xffff << shift))
-      //                        ^ ((packed & 0xffff) << shift)
-      //   // We only need relaxed consistency, but OpenCL 1.2 only has
-      //   // sequentially consistent atomics.
-      //   // TODO(dneto): Use relaxed consistency.
-      //   atomic_xor(target_ptr, xor_value)
-      auto IntPointerTy =
-          PointerType::get(IntTy, Arg2->getType()->getPointerAddressSpace());
-
-      auto One =
-          ConstantInt::get(clspv::PointersAre64Bit(M) ? Int64Ty : IntTy, 1);
-      auto Four =
-          ConstantInt::get(clspv::PointersAre64Bit(M) ? Int64Ty : IntTy, 4);
-      auto FFFF = ConstantInt::get(IntTy, 0xffff);
-      auto IndexIsOdd =
-          BinaryOperator::CreateAnd(Arg1, One, "index_is_odd_i32", CI);
-      // Compute index / 2
-      auto IndexIntoI32 =
-          BinaryOperator::CreateLShr(Arg1, One, "index_into_i32", CI);
-
-      auto OutPtr = GetElementPtrInst::Create(IntTy, Arg2, IndexIntoI32,
-                                              "base_i32_ptr", CI);
-      auto CurrentValue = new LoadInst(IntTy, OutPtr, "current_value", CI);
-      Value *Shift = BinaryOperator::CreateShl(IndexIsOdd, Four, "shift", CI);
-      // The shift is safe to truncate as it will definitely fit in a 32-bit int
-      if (Shift->getType() != IntTy) {
-        Shift = CastInst::Create(Instruction::CastOps::Trunc, Shift, IntTy,
-                                 "shift_trunc", CI);
-      }
-      auto MaskBitsToWrite =
-          BinaryOperator::CreateShl(FFFF, Shift, "mask_bits_to_write", CI);
-      auto MaskedCurrent = BinaryOperator::CreateAnd(
-          MaskBitsToWrite, CurrentValue, "masked_current", CI);
-
-      auto XLowerBits =
-          BinaryOperator::CreateAnd(X, FFFF, "lower_bits_of_packed", CI);
-      auto NewBitsToWrite =
-          BinaryOperator::CreateShl(XLowerBits, Shift, "new_bits_to_write", CI);
-      auto ValueToXor = BinaryOperator::CreateXor(MaskedCurrent, NewBitsToWrite,
-                                                  "value_to_xor", CI);
-
-      // Generate the call to atomi_xor.
-      SmallVector<Type *, 5> ParamTypes;
-      // The pointer type.
-      ParamTypes.push_back(IntPointerTy);
-      // The Types for memory scope, semantics, and value.
-      ParamTypes.push_back(IntTy);
-      ParamTypes.push_back(IntTy);
-      ParamTypes.push_back(IntTy);
-      auto NewFType = FunctionType::get(IntTy, ParamTypes, false);
-      auto NewF = M.getOrInsertFunction("spirv.atomic_xor", NewFType);
-
-      const auto ConstantScopeDevice =
-          ConstantInt::get(IntTy, spv::ScopeDevice);
-      // Assume the pointee is in OpenCL global (SPIR-V Uniform) or local
-      // (SPIR-V Workgroup).
-      const auto AddrSpaceSemanticsBits =
-          IntPointerTy->getPointerAddressSpace() == 1
-              ? spv::MemorySemanticsUniformMemoryMask
-              : spv::MemorySemanticsWorkgroupMemoryMask;
-
-      // We're using relaxed consistency here.
-      const auto ConstantMemorySemantics =
-          ConstantInt::get(IntTy, spv::MemorySemanticsUniformMemoryMask |
-                                      AddrSpaceSemanticsBits);
-
-      SmallVector<Value *, 5> Params{OutPtr, ConstantScopeDevice,
-                                     ConstantMemorySemantics, ValueToXor};
-      CallInst::Create(NewF, Params, "store_halfword_xor_trick", CI);
-
-      // Return a Nop so the old Call is removed
-      Function *donothing = Intrinsic::getDeclaration(&M, Intrinsic::donothing);
-      V = CallInst::Create(donothing, {}, "", CI);
-    }
-
-    return V;
+    return createVstoreHalf(M, CI, Arg0, Arg1, Arg2);
   });
 }
 
@@ -2895,58 +2884,28 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreHalf3(Function &F) {
     auto IntTy = Type::getInt32Ty(M.getContext());
     auto IndexTy =
         clspv::PointersAre64Bit(M) ? Type::getInt64Ty(M.getContext()) : IntTy;
-    auto ShortTy = Type::getInt16Ty(M.getContext());
-    auto FloatTy = Type::getFloatTy(M.getContext());
-    auto Float2Ty = FixedVectorType::get(FloatTy, 2);
-    auto NewFType = FunctionType::get(IntTy, Float2Ty, false);
 
     auto Int0 = ConstantInt::get(IndexTy, 0);
     auto Int1 = ConstantInt::get(IndexTy, 1);
     auto Int2 = ConstantInt::get(IndexTy, 2);
 
-    auto X0 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int0, "", CI), Int0, "", CI);
-    auto X1 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int1, "", CI), Int0, "", CI);
-    auto X2 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int2, "", CI), Int0, "", CI);
-
-    // Our intrinsic to pack a float2 to an int.
-    auto SPIRVIntrinsic = clspv::PackFunction();
-
-    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-    // Convert float2 into int and trunc to short to keep only the meaningful
-    // part of it
-    auto Y0 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X0, "", CI),
-                         ShortTy, "", CI);
-    auto Y1 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X1, "", CI),
-                         ShortTy, "", CI);
-    auto Y2 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X2, "", CI),
-                         ShortTy, "", CI);
+    auto X0 = ExtractElementInst::Create(Arg0, Int0, "", CI);
+    auto X1 = ExtractElementInst::Create(Arg0, Int1, "", CI);
+    auto X2 = ExtractElementInst::Create(Arg0, Int2, "", CI);
 
     auto Index0 = BinaryOperator::Create(
         Instruction::Add,
         BinaryOperator::Create(Instruction::Shl, Arg1, Int1, "", CI), Arg1, "",
         CI);
-    auto GEP0 = GetElementPtrInst::Create(ShortTy, Arg2, Index0, "", CI);
-    new StoreInst(Y0, GEP0, CI);
+    createVstoreHalf(M, CI, X0, Index0, Arg2);
 
     auto Index1 =
         BinaryOperator::Create(Instruction::Add, Index0, Int1, "", CI);
-    auto GEP1 = GetElementPtrInst::Create(ShortTy, Arg2, Index1, "", CI);
-    new StoreInst(Y1, GEP1, CI);
+    createVstoreHalf(M, CI, X1, Index1, Arg2);
 
     auto Index2 =
         BinaryOperator::Create(Instruction::Add, Index1, Int1, "", CI);
-    auto GEP2 = GetElementPtrInst::Create(ShortTy, Arg2, Index2, "", CI);
-    return new StoreInst(Y2, GEP2, CI);
+    return createVstoreHalf(M, CI, X2, Index2, Arg2);
   });
 }
 
@@ -2965,55 +2924,25 @@ bool ReplaceOpenCLBuiltinPass::replaceVstoreaHalf3(Function &F) {
     auto IntTy = Type::getInt32Ty(M.getContext());
     auto IndexTy =
         clspv::PointersAre64Bit(M) ? Type::getInt64Ty(M.getContext()) : IntTy;
-    auto ShortTy = Type::getInt16Ty(M.getContext());
-    auto FloatTy = Type::getFloatTy(M.getContext());
-    auto Float2Ty = FixedVectorType::get(FloatTy, 2);
-    auto NewFType = FunctionType::get(IntTy, Float2Ty, false);
 
     auto Int0 = ConstantInt::get(IndexTy, 0);
     auto Int1 = ConstantInt::get(IndexTy, 1);
     auto Int2 = ConstantInt::get(IndexTy, 2);
 
-    auto X0 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int0, "", CI), Int0, "", CI);
-    auto X1 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int1, "", CI), Int0, "", CI);
-    auto X2 = InsertElementInst::Create(
-        PoisonValue::get(Float2Ty),
-        ExtractElementInst::Create(Arg0, Int2, "", CI), Int0, "", CI);
-
-    // Our intrinsic to pack a float2 to an int.
-    auto SPIRVIntrinsic = clspv::PackFunction();
-
-    auto NewF = M.getOrInsertFunction(SPIRVIntrinsic, NewFType);
-
-    // Convert float2 into int and trunc to short to keep only the meaningful
-    // part of it
-    auto Y0 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X0, "", CI),
-                         ShortTy, "", CI);
-    auto Y1 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X1, "", CI),
-                         ShortTy, "", CI);
-    auto Y2 =
-        CastInst::Create(Instruction::Trunc, CallInst::Create(NewF, X2, "", CI),
-                         ShortTy, "", CI);
+    auto X0 = ExtractElementInst::Create(Arg0, Int0, "", CI);
+    auto X1 = ExtractElementInst::Create(Arg0, Int1, "", CI);
+    auto X2 = ExtractElementInst::Create(Arg0, Int2, "", CI);
 
     auto Index0 = BinaryOperator::Create(Instruction::Shl, Arg1, Int2, "", CI);
-    auto GEP0 = GetElementPtrInst::Create(ShortTy, Arg2, Index0, "", CI);
-    new StoreInst(Y0, GEP0, CI);
+    createVstoreHalf(M, CI, X0, Index0, Arg2);
 
     auto Index1 =
         BinaryOperator::Create(Instruction::Add, Index0, Int1, "", CI);
-    auto GEP1 = GetElementPtrInst::Create(ShortTy, Arg2, Index1, "", CI);
-    new StoreInst(Y1, GEP1, CI);
+    createVstoreHalf(M, CI, X1, Index1, Arg2);
 
     auto Index2 =
         BinaryOperator::Create(Instruction::Add, Index1, Int1, "", CI);
-    auto GEP2 = GetElementPtrInst::Create(ShortTy, Arg2, Index2, "", CI);
-    return new StoreInst(Y2, GEP2, CI);
+    return createVstoreHalf(M, CI, X2, Index2, Arg2);
   });
 }
 

--- a/lib/ReplaceOpenCLBuiltinPass.h
+++ b/lib/ReplaceOpenCLBuiltinPass.h
@@ -60,6 +60,8 @@ private:
   bool replaceStep(llvm::Function &F, bool is_smooth);
   bool replaceSignbit(llvm::Function &F, bool is_vec);
   bool replaceMul(llvm::Function &F, bool is_float, bool is_mad);
+  llvm::Value *createVloadHalf(llvm::Module &M, llvm::CallInst *CI,
+                               llvm::Value *index, llvm::Value *ptr);
   bool replaceVloadHalf(llvm::Function &F, const std::string &name,
                         int vec_size, bool aligned);
   bool replaceVloadHalf(llvm::Function &F);
@@ -71,6 +73,9 @@ private:
   bool replaceVloadHalf16(llvm::Function &F);
   bool replaceClspvVloadaHalf2(llvm::Function &F);
   bool replaceClspvVloadaHalf4(llvm::Function &F);
+  llvm::Value *createVstoreHalf(llvm::Module &M, llvm::CallInst *CI,
+                                llvm::Value *value, llvm::Value *index,
+                                llvm::Value *ptr);
   bool replaceVstoreHalf(llvm::Function &F, int vec_size, bool aligned);
   bool replaceVstoreHalf(llvm::Function &F);
   bool replaceVstoreHalf2(llvm::Function &F);

--- a/test/HalfStorage/vload_half3.cl
+++ b/test/HalfStorage/vload_half3.cl
@@ -40,23 +40,21 @@ __kernel void test(__global half *a, int b, __global float3 *dst) {
 // CHECK-32: [[bx3:%[^ ]+]] = OpIMul [[uint]] [[b]] [[uint_3]]
 // CHECK-32: [[addr0:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[bx3]]
 // CHECK: [[val0i16:%[^ ]+]] = OpLoad [[ushort]] [[addr0]]
+// CHECK: [[val0i32:%[^ ]+]] = OpUConvert [[uint]] [[val0i16]]
+// CHECK: [[val0:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[val0i32]]
 
 // CHECK-64: [[idx1:%[^ ]+]] = OpIAdd [[ulong]] [[bx3]] [[ulong_1]]
 // CHECK-32: [[idx1:%[^ ]+]] = OpIAdd [[uint]] [[bx3]] [[uint_1]]
 // CHECK: [[addr1:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[idx1]]
 // CHECK: [[val1i16:%[^ ]+]] = OpLoad [[ushort]] [[addr1]]
+// CHECK: [[val1i32:%[^ ]+]] = OpUConvert [[uint]] [[val1i16]]
+// CHECK: [[val1:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[val1i32]]
 
 // CHECK-64: [[idx2:%[^ ]+]] = OpIAdd [[ulong]] [[bx3]] [[ulong_2]]
 // CHECK-32: [[idx2:%[^ ]+]] = OpIAdd [[uint]] [[bx3]] [[uint_2]]
 // CHECK: [[addr2:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[idx2]]
 // CHECK: [[val2i16:%[^ ]+]] = OpLoad [[ushort]] [[addr2]]
-
-// CHECK: [[val0i32:%[^ ]+]] = OpUConvert [[uint]] [[val0i16]]
-// CHECK: [[val1i32:%[^ ]+]] = OpUConvert [[uint]] [[val1i16]]
 // CHECK: [[val2i32:%[^ ]+]] = OpUConvert [[uint]] [[val2i16]]
-
-// CHECK: [[val0:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[val0i32]]
-// CHECK: [[val1:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[val1i32]]
 // CHECK: [[val2:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[val2i32]]
 
 // CHECK: [[val0f3:%[^ ]+]] = OpVectorShuffle [[float3]] [[val2]] [[undef_float2]] 0 4294967295 4294967295

--- a/test/HalfStorage/vload_half3.ll
+++ b/test/HalfStorage/vload_half3.ll
@@ -16,21 +16,24 @@ declare spir_func <3 x float> @_Z11vload_half3jPU3AS1KDh(i32, ptr addrspace(1))
 ; CHECK:  [[idx0:%[^ ]+]] = add i32 [[bx2]], %b
 ; CHECK:  [[gep0:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx0]]
 ; CHECK:  [[val0i16:%[^ ]+]] = load i16, ptr addrspace(1) [[gep0]], align 2
+; CHECK:  [[val0i32:%[^ ]+]] = zext i16 [[val0i16]] to i32
+; CHECK:  [[val2f0:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[val0i32]])
+; CHECK:  [[val0:%[^ ]+]] = extractelement <2 x float> [[val2f0]], i32 0
+
 ; CHECK:  [[idx1:%[^ ]+]] = add i32 [[idx0]], 1
 ; CHECK:  [[gep1:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx1]]
 ; CHECK:  [[val1i16:%[^ ]+]] = load i16, ptr addrspace(1) [[gep1]], align 2
+; CHECK:  [[val1i32:%[^ ]+]] = zext i16 [[val1i16]] to i32
+; CHECK:  [[val2f1:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[val1i32]])
+; CHECK:  [[val1:%[^ ]+]] = extractelement <2 x float> [[val2f1]], i32 0
+
 ; CHECK:  [[idx2:%[^ ]+]] = add i32 [[idx1]], 1
 ; CHECK:  [[gep2:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx2]]
 ; CHECK:  [[val2i16:%[^ ]+]] = load i16, ptr addrspace(1) [[gep2]], align 2
-; CHECK:  [[val0i32:%[^ ]+]] = zext i16 [[val0i16]] to i32
-; CHECK:  [[val1i32:%[^ ]+]] = zext i16 [[val1i16]] to i32
 ; CHECK:  [[val2i32:%[^ ]+]] = zext i16 [[val2i16]] to i32
-; CHECK:  [[val2f0:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[val0i32]])
-; CHECK:  [[val0:%[^ ]+]] = extractelement <2 x float> [[val2f0]], i32 0
-; CHECK:  [[val2f1:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[val1i32]])
-; CHECK:  [[val1:%[^ ]+]] = extractelement <2 x float> [[val2f1]], i32 0
 ; CHECK:  [[val2f2:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[val2i32]])
 ; CHECK:  [[val2:%[^ ]+]] = extractelement <2 x float> [[val2f2]], i32 0
+
 ; CHECK:  [[ret0:%[^ ]+]] = insertelement <3 x float> poison, float [[val0]], i32 0
 ; CHECK:  [[ret01:%[^ ]+]] = insertelement <3 x float> [[ret0]], float [[val1]], i32 1
 ; CHECK:  [[ret:%[^ ]+]] = insertelement <3 x float> [[ret01]], float [[val2]], i32 2

--- a/test/HalfStorage/vload_half3_no_16bit_storage.ll
+++ b/test/HalfStorage/vload_half3_no_16bit_storage.ll
@@ -1,0 +1,42 @@
+; RUN: clspv-opt %s -o %t --passes=replace-opencl-builtin --no-16bit-storage=ssbo
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define <3 x float> @foo(ptr addrspace(1) %a, i32 %b) {
+entry:
+  %0 = call spir_func <3 x float> @_Z11vload_half3jPU3AS1KDh(i32 %b, ptr addrspace(1) %a)
+  ret <3 x float> %0
+}
+
+declare spir_func <3 x float> @_Z11vload_half3jPU3AS1KDh(i32, ptr addrspace(1))
+
+; CHECK:  [[shl:%[^ ]+]] = shl i32 %b, 1
+; CHECK:  [[add0:%[^ ]+]] = add i32 [[shl]], %b
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add0]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add0]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[unpack:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[load]])
+; CHECK:  [[val0:%[^ ]+]] = extractelement <2 x float> [[unpack]], i32 [[and]]
+
+; CHECK:  [[add1:%[^ ]+]] = add i32 [[add0]], 1
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add1]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add1]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[unpack:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[load]])
+; CHECK:  [[val1:%[^ ]+]] = extractelement <2 x float> [[unpack]], i32 [[and]]
+
+; CHECK:  [[add2:%[^ ]+]] = add i32 [[add1]], 1
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add2]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add2]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[unpack:%[^ ]+]] = call <2 x float> @_Z18spirv.unpack.v2f16(i32 [[load]])
+; CHECK:  [[val2:%[^ ]+]] = extractelement <2 x float> [[unpack]], i32 [[and]]
+
+; CHECK:  [[ret0:%[^ ]+]] = insertelement <3 x float> poison, float [[val0]], i32 0
+; CHECK:  [[ret01:%[^ ]+]] = insertelement <3 x float> [[ret0]], float [[val1]], i32 1
+; CHECK:  [[ret:%[^ ]+]] = insertelement <3 x float> [[ret01]], float [[val2]], i32 2

--- a/test/HalfStorage/vstore_half3.cl
+++ b/test/HalfStorage/vstore_half3.cl
@@ -26,25 +26,24 @@ __kernel void test(__global half *a, float3 b, int c) {
 // CHECK-32-DAG: [[uint3:%[^ ]+]] = OpConstant [[uint]] 3{{$}}
 // CHECK-64-DAG: [[ulong3:%[^ ]+]] = OpConstant [[ulong]] 3{{$}}
 
-// CHECK: [[val1i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val1i16:%[^ ]+]] = OpUConvert [[ushort]] [[val1i32]]
-// CHECK: [[val2i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val2i16:%[^ ]+]] = OpUConvert [[ushort]] [[val2i32]]
-// CHECK: [[val3i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val3i16:%[^ ]+]] = OpUConvert [[ushort]] [[val3i32]]
-
 // CHECK-64: [[cx3:%[^ ]+]] = OpIMul [[ulong]] {{.*}} [[ulong3]]
 // CHECK-32: [[cx3:%[^ ]+]] = OpIMul [[uint]] {{.*}} [[uint3]]
 
+// CHECK: [[val1i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val1i16:%[^ ]+]] = OpUConvert [[ushort]] [[val1i32]]
 // CHECK: [[addr1:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[cx3]]
 // CHECK: OpStore [[addr1]] [[val1i16]]
 
 // CHECK-64: [[idx1:%[^ ]+]] = OpIAdd [[ulong]] [[cx3]] [[ulong1]]
 // CHECK-32: [[idx1:%[^ ]+]] = OpIAdd [[uint]] [[cx3]] [[uint1]]
+// CHECK: [[val2i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val2i16:%[^ ]+]] = OpUConvert [[ushort]] [[val2i32]]
 // CHECK: [[addr2:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[idx1]]
 // CHECK: OpStore [[addr2]] [[val2i16]]
 
 // CHECK-64: [[idx2:%[^ ]+]] = OpIAdd [[ulong]] [[cx3]] [[ulong2]]
 // CHECK-32: [[idx2:%[^ ]+]] = OpIAdd [[uint]] [[cx3]] [[uint2]]
+// CHECK: [[val3i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val3i16:%[^ ]+]] = OpUConvert [[ushort]] [[val3i32]]
 // CHECK: [[addr3:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[idx2]]
 // CHECK: OpStore [[addr3]] [[val3i16]]

--- a/test/HalfStorage/vstore_half3.ll
+++ b/test/HalfStorage/vstore_half3.ll
@@ -14,24 +14,28 @@ declare spir_func void @_Z13vstore_half_3Dv3_fjPU3AS1Dh(<3 x float>, i32, ptr ad
 
 
 ; CHECK:  [[b0:%[^ ]+]] = extractelement <3 x float> %b, i32 0
-; CHECK:  [[b0f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
 ; CHECK:  [[b1:%[^ ]+]] = extractelement <3 x float> %b, i32 1
-; CHECK:  [[b1f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
 ; CHECK:  [[b2:%[^ ]+]] = extractelement <3 x float> %b, i32 2
-; CHECK:  [[b2f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+
+; CHECK:  [[cx2:%[^ ]+]] = shl i32 %c, 1
+
+; CHECK:  [[idx0:%[^ ]+]] = add i32 [[cx2]], %c
+; CHECK:  [[b0f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
 ; CHECK:  [[b0i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b0f2]])
 ; CHECK:  [[b0i16:%[^ ]+]] = trunc i32 [[b0i32]] to i16
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx0]]
+; CHECK:  store i16 [[b0i16]], ptr addrspace(1) [[gep0]], align 2
+
+; CHECK:  [[idx1:%[^ ]+]] = add i32 [[idx0]], 1
+; CHECK:  [[b1f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
 ; CHECK:  [[b1i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b1f2]])
 ; CHECK:  [[b1i16:%[^ ]+]] = trunc i32 [[b1i32]] to i16
-; CHECK:  [[b2i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b2f2]])
-; CHECK:  [[b2i16:%[^ ]+]] = trunc i32 [[b2i32]] to i16
-; CHECK:  [[cx2:%[^ ]+]] = shl i32 %c, 1
-; CHECK:  [[cx3:%[^ ]+]] = add i32 [[cx2]], %c
-; CHECK:  [[gep0:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[cx3]]
-; CHECK:  store i16 [[b0i16]], ptr addrspace(1) [[gep0]], align 2
-; CHECK:  [[idx1:%[^ ]+]] = add i32 [[cx3]], 1
 ; CHECK:  [[gep1:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx1]]
 ; CHECK:  store i16 [[b1i16]], ptr addrspace(1) [[gep1]], align 2
+
 ; CHECK:  [[idx2:%[^ ]+]] = add i32 [[idx1]], 1
+; CHECK:  [[b2f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+; CHECK:  [[b2i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b2f2]])
+; CHECK:  [[b2i16:%[^ ]+]] = trunc i32 [[b2i32]] to i16
 ; CHECK:  [[gep2:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx2]]
 ; CHECK:  store i16 [[b2i16]], ptr addrspace(1) [[gep2]], align 2

--- a/test/HalfStorage/vstore_half3_no_16bit_storage.ll
+++ b/test/HalfStorage/vstore_half3_no_16bit_storage.ll
@@ -1,0 +1,67 @@
+; RUN: clspv-opt %s -o %t --passes=replace-opencl-builtin --no-16bit-storage=ssbo
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, <3 x float> %b, i32 %c) {
+entry:
+  call spir_func void @_Z13vstore_half_3Dv3_fjPU3AS1Dh(<3 x float> %b, i32 %c, ptr addrspace(1) %a)
+  ret void
+}
+
+declare spir_func void @_Z13vstore_half_3Dv3_fjPU3AS1Dh(<3 x float>, i32, ptr addrspace(1))
+
+
+; CHECK:  [[b0:%[^ ]+]] = extractelement <3 x float> %b, i32 0
+; CHECK:  [[b1:%[^ ]+]] = extractelement <3 x float> %b, i32 1
+; CHECK:  [[b2:%[^ ]+]] = extractelement <3 x float> %b, i32 2
+
+; CHECK:  [[shl:%[^ ]+]] = shl i32 %c, 1
+; CHECK:  [[add0:%[^ ]+]] = add i32 [[shl]], %c
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add0]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add0]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()
+
+; CHECK:  [[add1:%[^ ]+]] = add i32 [[add0]], 1
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add1]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add1]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()
+
+; CHECK:  [[add2:%[^ ]+]] = add i32 [[add1]], 1
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add2]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add2]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()

--- a/test/HalfStorage/vstorea_half3.cl
+++ b/test/HalfStorage/vstorea_half3.cl
@@ -24,25 +24,24 @@ __kernel void test(__global half *a, float3 b, int c) {
 // CHECK-64-DAG: [[ulong1:%[^ ]+]] = OpConstant [[ulong]] 1{{$}}
 // CHECK-64-DAG: [[ulong2:%[^ ]+]] = OpConstant [[ulong]] 2{{$}}
 
-// CHECK: [[val1i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val1i16:%[^ ]+]] = OpUConvert [[ushort]] [[val1i32]]
-// CHECK: [[val2i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val2i16:%[^ ]+]] = OpUConvert [[ushort]] [[val2i32]]
-// CHECK: [[val3i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
-// CHECK: [[val3i16:%[^ ]+]] = OpUConvert [[ushort]] [[val3i32]]
-
 // CHECK-64: [[cx4:%[^ ]+]] = OpShiftLeftLogical [[ulong]] {{.*}} [[ulong2]]
 // CHECK-32: [[cx4:%[^ ]+]] = OpShiftLeftLogical [[uint]] {{.*}} [[uint2]]
 
+// CHECK: [[val1i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val1i16:%[^ ]+]] = OpUConvert [[ushort]] [[val1i32]]
 // CHECK: [[addr1:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[cx4]]
 // CHECK: OpStore [[addr1]] [[val1i16]]
 
 // CHECK-64: [[idx1:%[^ ]+]] = OpBitwiseOr [[ulong]] [[cx4]] [[ulong1]]
 // CHECK-32: [[idx1:%[^ ]+]] = OpBitwiseOr [[uint]] [[cx4]] [[uint1]]
+// CHECK: [[val2i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val2i16:%[^ ]+]] = OpUConvert [[ushort]] [[val2i32]]
 // CHECK: [[addr2:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[idx1]]
 // CHECK: OpStore [[addr2]] [[val2i16]]
 
 // CHECK-64: [[idx2:%[^ ]+]] = OpBitwiseOr [[ulong]] [[cx4]] [[ulong2]]
 // CHECK-32: [[idx2:%[^ ]+]] = OpBitwiseOr [[uint]] [[cx4]] [[uint2]]
+// CHECK: [[val3i32:%[^ ]+]] = OpExtInst [[uint]] {{.*}} PackHalf2x16
+// CHECK: [[val3i16:%[^ ]+]] = OpUConvert [[ushort]] [[val3i32]]
 // CHECK: [[addr3:%[^ ]+]] = OpAccessChain %{{.*}} %{{.*}} [[uint0]] [[idx2]]
 // CHECK: OpStore [[addr3]] [[val3i16]]

--- a/test/HalfStorage/vstorea_half3.ll
+++ b/test/HalfStorage/vstorea_half3.ll
@@ -14,23 +14,27 @@ declare spir_func void @_Z14vstorea_half_3Dv3_fjPU3AS1Dh(<3 x float>, i32, ptr a
 
 
 ; CHECK:  [[b0:%[^ ]+]] = extractelement <3 x float> %b, i32 0
-; CHECK:  [[b0f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
 ; CHECK:  [[b1:%[^ ]+]] = extractelement <3 x float> %b, i32 1
-; CHECK:  [[b1f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
 ; CHECK:  [[b2:%[^ ]+]] = extractelement <3 x float> %b, i32 2
-; CHECK:  [[b2f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+
+; CHECK:  [[idx0:%[^ ]+]] = shl i32 %c, 2
+
+; CHECK:  [[b0f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
 ; CHECK:  [[b0i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b0f2]])
 ; CHECK:  [[b0i16:%[^ ]+]] = trunc i32 [[b0i32]] to i16
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx0]]
+; CHECK:  store i16 [[b0i16]], ptr addrspace(1) [[gep0]], align 2
+
+; CHECK:  [[idx1:%[^ ]+]] = add i32 [[idx0]], 1
+; CHECK:  [[b1f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
 ; CHECK:  [[b1i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b1f2]])
 ; CHECK:  [[b1i16:%[^ ]+]] = trunc i32 [[b1i32]] to i16
-; CHECK:  [[b2i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b2f2]])
-; CHECK:  [[b2i16:%[^ ]+]] = trunc i32 [[b2i32]] to i16
-; CHECK:  [[cx4:%[^ ]+]] = shl i32 %c, 2
-; CHECK:  [[gep0:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[cx4]]
-; CHECK:  store i16 [[b0i16]], ptr addrspace(1) [[gep0]], align 2
-; CHECK:  [[idx1:%[^ ]+]] = add i32 [[cx4]], 1
 ; CHECK:  [[gep1:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx1]]
 ; CHECK:  store i16 [[b1i16]], ptr addrspace(1) [[gep1]], align 2
+
 ; CHECK:  [[idx2:%[^ ]+]] = add i32 [[idx1]], 1
+; CHECK:  [[b2f2:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+; CHECK:  [[b2i32:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[b2f2]])
+; CHECK:  [[b2i16:%[^ ]+]] = trunc i32 [[b2i32]] to i16
 ; CHECK:  [[gep2:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[idx2]]
 ; CHECK:  store i16 [[b2i16]], ptr addrspace(1) [[gep2]], align 2

--- a/test/HalfStorage/vstorea_half3_no_16bit_storage.ll
+++ b/test/HalfStorage/vstorea_half3_no_16bit_storage.ll
@@ -1,0 +1,66 @@
+; RUN: clspv-opt %s -o %t --passes=replace-opencl-builtin --no-16bit-storage=ssbo
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @foo(ptr addrspace(1) %a, <3 x float> %b, i32 %c) {
+entry:
+  call spir_func void @_Z14vstorea_half_3Dv3_fjPU3AS1Dh(<3 x float> %b, i32 %c, ptr addrspace(1) %a)
+  ret void
+}
+
+declare spir_func void @_Z14vstorea_half_3Dv3_fjPU3AS1Dh(<3 x float>, i32, ptr addrspace(1))
+
+
+; CHECK:  [[b0:%[^ ]+]] = extractelement <3 x float> %b, i32 0
+; CHECK:  [[b1:%[^ ]+]] = extractelement <3 x float> %b, i32 1
+; CHECK:  [[b2:%[^ ]+]] = extractelement <3 x float> %b, i32 2
+
+; CHECK:  [[idx0:%[^ ]+]] = shl i32 %c, 2
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b0]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[idx0]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[idx0]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()
+
+; CHECK:  [[add1:%[^ ]+]] = add i32 [[idx0]], 1
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b1]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add1]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add1]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()
+
+; CHECK:  [[add2:%[^ ]+]] = add i32 [[add1]], 1
+; CHECK:  [[insert:%[^ ]+]] = insertelement <2 x float> poison, float [[b2]], i32 0
+; CHECK:  [[pack:%[^ ]+]] = call i32 @_Z16spirv.pack.v2f16(<2 x float> [[insert]])
+; CHECK:  [[and:%[^ ]+]] = and i32 [[add2]], 1
+; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[add2]], 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) [[gep]], align 4
+; CHECK:  [[shl1:%[^ ]+]] = shl i32 [[and]], 4
+; CHECK:  [[shl2:%[^ ]+]] = shl i32 65535, [[shl1]]
+; CHECK:  [[and1:%[^ ]+]] = and i32 [[shl2]], [[load]]
+; CHECK:  [[and2:%[^ ]+]] = and i32 [[pack]], 65535
+; CHECK:  [[shl3:%[^ ]+]] = shl i32 [[and2]], [[shl1]]
+; CHECK:  [[zor:%[^ ]+]] = xor i32 [[and1]], [[shl3]]
+; CHECK:  call i32 @spirv.atomic_xor(ptr addrspace(1) [[gep]], i32 1, i32 64, i32 [[zor]])
+; CHECK:  call void @llvm.donothing()


### PR DESCRIPTION
we used to use 16bit storage even when not supported to implement vstore_half3 and vload_half3. Use vstore_half and vload_half implementation to implement those to make sure we do not use 16bit storage when not available