### PR TITLE
Replace deprecated LLVM functions with the suggested replacement

### DIFF
--- a/lib/AutoPodArgsPass.cpp
+++ b/lib/AutoPodArgsPass.cpp
@@ -137,7 +137,7 @@ void clspv::AutoPodArgsPass::runOnFunction(Function &F) {
                                    clspv::Option::StorageClass::kPushConstant);
   // Align to 4 to use i32s.
   const uint64_t pod_struct_size =
-      alignTo(DL.getTypeStoreSize(pod_struct_ty).getKnownMinSize(), 4);
+      alignTo(DL.getTypeStoreSize(pod_struct_ty).getKnownMinValue(), 4);
   const bool fits_push_constant =
       pod_struct_size <= clspv::Option::MaxPushConstantsSize();
   const bool satisfies_push_constant =
@@ -166,7 +166,7 @@ void clspv::AutoPodArgsPass::runOnFunction(Function &F) {
   // fallback to fit arguments depending on the performance cost.
   const auto global_pc_type = clspv::GlobalPushConstantsType(M);
   const auto global_pc_size =
-      DL.getTypeStoreSize(global_pc_type).getKnownMinSize();
+      DL.getTypeStoreSize(global_pc_type).getKnownMinValue();
   const auto global_size = global_pc_size + pod_struct_size;
   const auto fits_global_size =
       global_size <= clspv::Option::MaxPushConstantsSize();

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -87,7 +87,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
 #ifndef NDEBUG
   const auto &DL = M.getDataLayout();
   const uint64_t global_push_constant_size =
-      DL.getTypeStoreSize(global_push_constant_ty).getKnownMinSize();
+      DL.getTypeStoreSize(global_push_constant_ty).getKnownMinValue();
   assert(global_push_constant_size % 8 == 0 &&
          "Global push constants size changed");
 #endif

--- a/lib/ConstantEmitter.cpp
+++ b/lib/ConstantEmitter.cpp
@@ -27,7 +27,7 @@ using namespace llvm;
 namespace clspv {
 
 void ConstantEmitter::Emit(Constant *c) {
-  AlignTo(Layout.getABITypeAlignment(c->getType()));
+  AlignTo(Layout.getABITypeAlign(c->getType()).value());
   if (auto i = dyn_cast<ConstantInt>(c)) {
     EmitInt(i);
   } else if (auto f = dyn_cast<ConstantFP>(c)) {

--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -329,7 +329,7 @@ Value *ConvertToType(Module &M, StructType *pod_struct, unsigned index,
   const auto &DL = M.getDataLayout();
   const auto struct_layout = DL.getStructLayout(pod_struct);
   auto ele_ty = pod_struct->getElementType(index);
-  const auto ele_size = DL.getTypeStoreSize(ele_ty).getKnownMinSize();
+  const auto ele_size = DL.getTypeStoreSize(ele_ty).getKnownMinValue();
   auto ele_offset = struct_layout->getElementOffset(index);
   const auto ele_start_index = ele_offset / kIntBytes; // round down
   const auto ele_end_index =
@@ -357,7 +357,7 @@ Value *BuildFromElements(Module &M, IRBuilder<> &builder, Type *dst_type,
                          const std::vector<Value *> &elements) {
   auto int32_ty = IntegerType::get(M.getContext(), 32);
   const auto &DL = M.getDataLayout();
-  const auto dst_size = DL.getTypeStoreSize(dst_type).getKnownMinSize();
+  const auto dst_size = DL.getTypeStoreSize(dst_type).getKnownMinValue();
   auto dst_array_ty = dyn_cast<ArrayType>(dst_type);
   auto dst_vec_ty = dyn_cast<VectorType>(dst_type);
 
@@ -449,7 +449,7 @@ Value *BuildFromElements(Module &M, IRBuilder<> &builder, Type *dst_type,
       // General case, break into elements and construct the composite type.
       auto ele_ty = dst_vec_ty ? dst_vec_ty->getElementType()
                                : dst_array_ty->getElementType();
-      assert((DL.getTypeStoreSize(ele_ty).getKnownMinSize() < kIntBytes ||
+      assert((DL.getTypeStoreSize(ele_ty).getKnownMinValue() < kIntBytes ||
               base_offset == 0) &&
              "Unexpected packed data format");
       uint64_t ele_size = DL.getTypeStoreSize(ele_ty);

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -329,8 +329,10 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         auto Arg3 = dyn_cast<ConstantInt>(CI->getArgOperand(3));
 
         auto I32Ty = Type::getInt32Ty(M.getContext());
-        auto DstAlignment = cast<MemCpyInst>(CI)->getDestAlignment();
-        auto SrcAlignment = cast<MemCpyInst>(CI)->getSourceAlignment();
+        auto DstAlign = cast<MemCpyInst>(CI)->getDestAlign();
+        auto DstAlignment = DstAlign ? DstAlign->value() : 0;
+        auto SrcAlign = cast<MemCpyInst>(CI)->getSourceAlign();
+        auto SrcAlignment = SrcAlign ? SrcAlign->value() : 0;
         auto Volatile = ConstantInt::get(I32Ty, Arg3->getZExtValue());
 
         auto Dst = CI->getArgOperand(0);

--- a/lib/UndoTruncateToOddIntegerPass.cpp
+++ b/lib/UndoTruncateToOddIntegerPass.cpp
@@ -70,9 +70,8 @@ clspv::UndoTruncateToOddIntegerPass::ZeroExtend(Value *v,
     // restricted to the original bit width.
     result = BinaryOperator::Create(
         Instruction::And, tmp,
-        ConstantInt::get(
-            desired_int_ty,
-            (uint32_t)APInt::getAllOnesValue(bit_width).getZExtValue()),
+        ConstantInt::get(desired_int_ty,
+                         (uint32_t)APInt::getAllOnes(bit_width).getZExtValue()),
         "", trunc);
   } else if (auto *zext = dyn_cast<ZExtInst>(v)) {
     auto tmp = ZeroExtend(zext->getOperand(0), desired_bit_width);
@@ -119,7 +118,7 @@ clspv::UndoTruncateToOddIntegerPass::ZeroExtend(Value *v,
             Instruction::And, result,
             ConstantInt::get(
                 desired_int_ty,
-                (uint32_t)APInt::getAllOnesValue(bit_width).getZExtValue()),
+                (uint32_t)APInt::getAllOnes(bit_width).getZExtValue()),
             "", binop);
       }
     } else {


### PR DESCRIPTION
This takes care of all deprecation warnings except those that relate to getPointerElementType().