### PR TITLE
Fixes for Darktable kernels

### DIFF
--- a/lib/FixupStructuredCFGPass.cpp
+++ b/lib/FixupStructuredCFGPass.cpp
@@ -24,8 +24,9 @@ using namespace llvm;
 PreservedAnalyses
 clspv::FixupStructuredCFGPass::run(Function &F, FunctionAnalysisManager &FAM) {
   // Assumes CFG has been structurized.
-  breakConditionalHeader(F, FAM);
   isolateContinue(F, FAM);
+  // Run after isolateContinue since this can invalidate loop info.
+  breakConditionalHeader(F, FAM);
 
   PreservedAnalyses PA;
   return PA;

--- a/lib/InlineFuncWithPointerBitCastArgPass.cpp
+++ b/lib/InlineFuncWithPointerBitCastArgPass.cpp
@@ -100,73 +100,22 @@ bool clspv::InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
   for (auto &F : M) {
     for (auto &BB : F) {
       for (auto &I : BB) {
-        // All implicit casts of interest will be based on GEPs. There are two
-        // scenarios:
-        // 1. The GEP itself is the cast (e.g. source type doesn't
-        //    match the inferred input type).
-        // 2. The cast occurs through the call instruction (e.g. the inferred
-        //    argument type doesn't match the GEP result element type).
-        auto *gep = dyn_cast<GetElementPtrInst>(&I);
-        if (!gep)
-          continue;
+        if (auto *call = dyn_cast<CallInst>(&I)) {
+          auto *func = call->getCalledFunction();
+          if (func->isDeclaration())
+            continue;
 
-        const auto *source_inferred_ty = clspv::InferType(
-            gep->getPointerOperand(), M.getContext(), &type_cache);
-        const auto *source_ele_ty = gep->getSourceElementType();
-        const auto *result_ele_ty = gep->getResultElementType();
-        bool add_all = source_inferred_ty && source_ele_ty &&
-                       source_inferred_ty != source_ele_ty;
-        SmallVector<std::pair<User *, unsigned>, 8> to_check;
-        for (auto &use : gep->uses()) {
-          to_check.push_back(std::make_pair(use.getUser(), use.getOperandNo()));
-        }
-        SmallSet<User *, 8> checked_phis;
-        while (!to_check.empty()) {
-          auto *user = to_check.back().first;
-          auto operand = to_check.back().second;
-          to_check.pop_back();
-
-          if (auto *inst = dyn_cast<Instruction>(user)) {
-            switch (inst->getOpcode()) {
-            default:
-              break;
-            case Instruction::Call: {
-              auto *call = cast<CallInst>(inst);
-              if (add_all) {
+          // Inline the call if the argument's type is inferred to be different
+          // than the parameter's type.
+          for (unsigned i = 0; i < call->arg_size(); i++) {
+            if (call->getArgOperand(i)->getType()->isPointerTy()) {
+              auto *arg_ty = clspv::InferType(call->getArgOperand(i),
+                                              M.getContext(), &type_cache);
+              auto *param_ty = clspv::InferType(func->getArg(i), M.getContext(),
+                                                &type_cache);
+              if (arg_ty != param_ty) {
                 WorkList.insert(call);
-              } else {
-                const auto *arg_ty =
-                    clspv::InferType(call->getCalledFunction()->getArg(operand),
-                                     M.getContext(), &type_cache);
-                if (arg_ty != result_ele_ty) {
-                  WorkList.insert(call);
-                }
               }
-              break;
-            }
-            case Instruction::PHI:
-              if (checked_phis.count(user))
-                break;
-              checked_phis.insert(user);
-              for (auto &use : user->uses()) {
-                to_check.push_back(
-                    std::make_pair(use.getUser(), use.getOperandNo()));
-              }
-              break;
-            case Instruction::GetElementPtr: {
-              auto *next_gep = cast<GetElementPtrInst>(user);
-              if (result_ele_ty &&
-                  next_gep->getResultElementType() != result_ele_ty) {
-                // TODO: this is an over-approximation, but it is necessary
-                // unless we want to traverse phis multiple times.
-                add_all = true;
-              }
-              for (auto &use : user->uses()) {
-                to_check.push_back(
-                    std::make_pair(use.getUser(), use.getOperandNo()));
-              }
-              break;
-            }
             }
           }
         }

--- a/test/DirectResourceAccess/local_variable.cl
+++ b/test/DirectResourceAccess/local_variable.cl
@@ -13,8 +13,7 @@ void read_local(__global int* out, __local int* tmp, unsigned int id) {
   out[id] = tmp[id];
 }
 
-__kernel void local_memory(__global int* in, __global int* out) {
-  __local int temp[32];
+__kernel void local_memory(__global int* in, __global int* out, __local int *temp) {
   unsigned int gid = get_global_id(0);
   write_local(in, temp, gid);
   barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);

--- a/test/FixupStructuredCFG/split_and_isolate.ll
+++ b/test/FixupStructuredCFG/split_and_isolate.ll
@@ -1,0 +1,94 @@
+; RUN: clspv-opt --passes=fixup-structured-cfg %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: for.cond35.i.preheader:
+; CHECK-NEXT: br label %[[split1:[a-zA-Z0-9_.]+]]
+; CHECK: [[split1]]:
+; CHECK-NEXT: br label %for.body38.i
+; CHECK: interpolation_func_bicubic.exit27:
+; CHECK-NEXT: br i1 undef, label %[[split2:[a-zA-Z0-9_.]+]], label %[[split1]]
+; CHECK: [[split2]]:
+; CHECK-NEXT: br label %for.end.i
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test() {
+entry:
+  br i1 undef, label %if.end.i, label %Flow37
+
+if.end.i:
+  br i1 undef, label %if.then23.i, label %if.end24.i
+
+if.then23.i:
+  br label %if.end24.i
+
+Flow37:
+  br label %clip_rotate_bicubic.inner.exit
+
+if.end24.i:
+  br label %for.cond35.i.preheader
+
+for.cond35.i.preheader:
+  br label %for.body38.i
+
+for.body38.i:
+  br i1 undef, label %cond.false.i, label %Flow36
+
+cond.false.i:
+  br i1 undef, label %cond.false4.i, label %Flow35
+
+Flow35:
+  br i1 undef, label %cond.true2.i, label %cond.end.i
+
+cond.true2.i:
+  br label %cond.end.i
+
+cond.false4.i:
+  br label %Flow35
+
+Flow36:
+  br label %interpolation_func_bicubic.exit
+
+cond.end.i:
+  br label %Flow36
+
+interpolation_func_bicubic.exit:
+  br i1 undef, label %cond.false4.i15, label %Flow34
+
+cond.false4.i15:
+  br i1 undef, label %cond.false4.i22, label %Flow
+
+Flow:
+  br i1 undef, label %cond.true2.i19, label %cond.end.i25
+
+cond.true2.i19:
+  br label %cond.end.i25
+
+cond.false4.i22:
+  br label %Flow
+
+Flow34:
+  br label %interpolation_func_bicubic.exit27
+
+cond.end.i25:
+  br label %Flow34
+
+interpolation_func_bicubic.exit27:
+  br i1 undef, label %for.end.i, label %for.body38.i
+
+for.end.i:
+  br i1 undef, label %for.end56.i, label %for.cond35.i.preheader
+
+for.end56.i:
+  br i1 undef, label %cond.true67.i, label %cond.end72.i
+
+cond.true67.i:
+  br label %cond.end72.i
+
+cond.end72.i:
+  br label %Flow37
+
+clip_rotate_bicubic.inner.exit:
+  ret void
+}

--- a/test/PointerCasts/inline_implicit_cast_through_function.ll
+++ b/test/PointerCasts/inline_implicit_cast_through_function.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t.ll --passes=inline-func-with-pointer-cast-arg
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-NOT: call void @foo
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%s = type { [32 x float] }
+
+define void @bar(ptr addrspace(1) %p1, ptr addrspace(1) %p2) {
+entry:
+  %gep1 = getelementptr %s, ptr addrspace(1) %p1, i32 0, i32 0, i32 1
+  %ld = load float, ptr addrspace(1) %p2
+  ret void
+}
+
+define void @foo(ptr addrspace(1) %p) {
+entry:
+  call void @bar(ptr addrspace(1) %p, ptr addrspace(1) %p)
+  ret void
+}
+

--- a/test/ProgramScopeConstants/constant_array_with_function_call.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call.cl
@@ -33,5 +33,3 @@ void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
 // CHECK-DAG:  [[_20:%[0-9a-zA-Z_]+]] = OpConstantComposite [[__arr_uint_uint_4]] [[_uint_42]] [[_uint_13]] [[_uint_0]] [[_uint_5]]
 // CHECK-DAG:  [[_22:%[0-9a-zA-Z_]+]] = OpVariable [[__ptr_Private__arr_uint_uint_4]] Private [[_20]]
 // CHECK:  = OpFunction
-// CHECK:  [[_35:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_uint]] [[_24:%[0-9a-zA-Z_]+]]
-// CHECK:  [[_24]] = OpFunction [[_uint]] 

--- a/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
+++ b/test/ProgramScopeConstants/constant_array_with_function_call_module_constants_storage_buffer.cl
@@ -35,5 +35,3 @@ void kernel __attribute__((reqd_work_group_size(4, 1, 1))) foo(global uint* a)
 // CHECK-DAG:  [[__ptr_Input_uint:%[0-9a-zA-Z_]+]] = OpTypePointer Input [[_uint]]
 // CHECK-DAG:  [[_18]] = OpVariable [[__ptr_StorageBuffer__struct_10]] StorageBuffer
 // CHECK:  = OpFunction {{.*}}
-// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_uint]] [[bar:%[0-9a-zA-Z_]+]]
-// CHECK:  [[bar]] = OpFunction {{.*}}


### PR DESCRIPTION
Fixes #1095

* Perform structured cfg fixes in opposite order to preserve loop info
* Simplify (and catch more cases) of inlining a function due to an implicit cast
  * caused some miscellaneous test changes due to more inlining
* Add a debug option to emit OpName instructions for each basic block