### PR TITLE
Remove pointer parameter attributes when converting to physical SSBO

### DIFF
--- a/lib/PhysicalPointerArgsPass.cpp
+++ b/lib/PhysicalPointerArgsPass.cpp
@@ -78,6 +78,34 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
 
     NewFunc->setCallingConv(F.getCallingConv());
     NewFunc->copyAttributesFrom(&F);
+
+    // Remove all the pointer related parameter attributes for any parameter
+    // converted to an integer.
+    AttributeMask mask;
+    mask.addAttribute(Attribute::AttrKind::Alignment);
+    mask.addAttribute(Attribute::AttrKind::NoAlias);
+    mask.addAttribute(Attribute::AttrKind::ByVal);
+    mask.addAttribute(Attribute::AttrKind::ByRef);
+    mask.addAttribute(Attribute::AttrKind::StructRet);
+    mask.addAttribute(Attribute::AttrKind::ElementType);
+    mask.addAttribute(Attribute::AttrKind::InAlloca);
+    mask.addAttribute(Attribute::AttrKind::Preallocated);
+    mask.addAttribute(Attribute::AttrKind::NoCapture);
+    mask.addAttribute(Attribute::AttrKind::NoFree);
+    mask.addAttribute(Attribute::AttrKind::Nest);
+    mask.addAttribute(Attribute::AttrKind::NonNull);
+    mask.addAttribute(Attribute::AttrKind::Dereferenceable);
+    mask.addAttribute(Attribute::AttrKind::DereferenceableOrNull);
+    mask.addAttribute(Attribute::AttrKind::ReadOnly);
+    mask.addAttribute(Attribute::AttrKind::ReadNone);
+    mask.addAttribute(Attribute::AttrKind::WriteOnly);
+    for (unsigned i = 0; i < NewParamTypes.size(); i++) {
+      if (F.getArg(i)->getType()->isPointerTy() &&
+          !NewParamTypes[i]->isPointerTy()) {
+        NewFunc->removeParamAttrs(i, mask);
+      }
+    }
+
     F.setCallingConv(CallingConv::SPIR_FUNC);
     NewFunc->copyMetadata(&F, 0);
 

--- a/test/PhysicalStorageBuffers/parameter_attributes.ll
+++ b/test/PhysicalStorageBuffers/parameter_attributes.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt %s -o %t.ll --passes=physical-pointer-args
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: @test(target("spirv.Sampler") {{%[0-9a-zA-Z_.]+}}, i64 {{%[0-9a-zA-Z_.]+}}, i32 inreg {{%[0-9a-zA-Z_.]+}}, i64 inreg {{%[0-9a-zA-Z_.]+}})
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test(target("spirv.Sampler") %s, ptr addrspace(1) noalias %p1, i32 inreg %pod, ptr addrspace(1) readnone inreg align 64 %p2) !clspv.pod_args_impl !0 {
+entry:
+  %ld1 = load float, ptr addrspace(1) %p1
+  %ld2 = load float, ptr addrspace(1) %p2
+  ret void
+}
+
+!0 = !{i32 1 }


### PR DESCRIPTION
Fixes #1099

* Conversion of pointer arguments to physical SSBO references was copying all kernel function attributes
  * Instead it should not copy any pointer specific attributes for converted parameters