### PR TITLE
add support for inttoptr/ptrtoint in loweraddrspacecastpass

### DIFF
--- a/lib/LowerAddrSpaceCastPass.h
+++ b/lib/LowerAddrSpaceCastPass.h
@@ -42,6 +42,8 @@ private:
   llvm::Value *visitAddrSpaceCastInst(llvm::AddrSpaceCastInst &I);
   llvm::Value *visitICmpInst(llvm::ICmpInst &I);
   llvm::Value *visitCallInst(llvm::CallInst &I);
+  llvm::Value *visitIntToPtrInst(llvm::IntToPtrInst &I);
+  llvm::Value *visitPtrToIntInst(llvm::PtrToIntInst &I);
   llvm::Value *visitInstruction(llvm::Instruction &I);
 
   void runOnFunction(llvm::Function &F);

--- a/test/AddressSpaceCast/inttoptr.ll
+++ b/test/AddressSpaceCast/inttoptr.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  [[int:%[^ ]+]] = ptrtoint ptr addrspace(1) %out to i32
+; CHECK:  [[ptr:%[^ ]+]] = inttoptr i32 [[int]] to ptr addrspace(1)
+; CHECK:  getelementptr float, ptr addrspace(1) [[ptr]], i32 2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 4 %out) {
+entry:
+  %0 = ptrtoint ptr addrspace(1) %out to i32
+  %1 = inttoptr i32 %0 to ptr addrspace(4)
+  %2 = getelementptr float, ptr addrspace(4) %1, i32 2
+  %3 = addrspacecast ptr addrspace(4) %2 to ptr addrspace(1)
+  ret void
+}

--- a/test/AddressSpaceCast/issue-1107.cl
+++ b/test/AddressSpaceCast/issue-1107.cl
@@ -1,0 +1,10 @@
+// RUN: clspv -cl-std=CL2.0 -inline-entry-points -cl-single-precision-constant  -cl-kernel-arg-info   -fp16=0  -rewrite-packed-structs  -std430-ubo-layout  -decorate-nonuniform    -arch=spir64  -physical-storage-buffers  --use-native-builtins=acos,acosh,acospi,asin,asinh,asinpi,atan,atan2,atan2pi,atanh,atanpi,ceil,copysign,fabs,fdim,floor,fma,fmax,fmin,frexp,half_rsqrt,half_sqrt,isequal,isfinite,isgreater,isgreaterequal,isinf,isless,islessequal,islessgreater,isnan,isnormal,isnotequal,isordered,isunordered,ldexp,mad,rint,round,rsqrt,signbit,sqrt,tanh,trunc,  -spv-version=1.6  -max-pushconstant-size=256  -max-ubo-size=65536  -global-offset  -long-vector  -module-constants-in-storage-buffer  -cl-arm-non-uniform-work-group-size %s -o %t.spv
+// RUN: spirv-val --target-env spv1.6 %t.spv
+
+kernel void foo(global uintptr_t *dst, const global uintptr_t *src)
+{
+    const int gid = get_global_id(0);
+    const uchar *s = (uchar *)(src[gid]);
+    uchar *d = (uchar *)(dst[gid]);
+    *d = *s;
+}

--- a/test/AddressSpaceCast/ptrtoint.ll
+++ b/test/AddressSpaceCast/ptrtoint.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  [[gep:%[^ ]+]] = getelementptr float, ptr addrspace(1) %out, i32 2
+; CHECK:  ptrtoint ptr addrspace(1) [[gep]] to i32
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 4 %out) {
+entry:
+  %0 = addrspacecast ptr addrspace(1) %out to ptr addrspace(4)
+  %1 = getelementptr float, ptr addrspace(4) %0, i32 2
+  %2 = ptrtoint ptr addrspace(4) %1 to i32
+  ret void
+}


### PR DESCRIPTION
ptrtoint is quite simple.
But inttoptr can get quite complex like in #1107. In that case, use the global address space as it is the only one on which we will be able to perform a `OpConvertUToPtr`.

Fix #1107