### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "dc95245e69a1c1098a744a2c3af83ca48d9ba495"
+      "commit" : "62110aabc91d784b2a3a619e675c2830fa623c1e"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -313,6 +313,8 @@ int SetCompilerInstanceOptions(
   instance.getCodeGenOpts().DisableO0ImplyOptNone = true;
   instance.getCodeGenOpts().OpaquePointers = clspv::Option::OpaquePointers();
   instance.getDiagnosticOpts().IgnoreWarnings = IgnoreWarnings;
+  // We always undef __SPIR__ and __SPIRV__ (see below) so don't warn about it.
+  instance.getDiagnosticOpts().Warnings.push_back("no-builtin-macro-redefined");
   // TODO(#995): Re-enable this warning.
   instance.getDiagnosticOpts().Warnings.push_back("no-unsafe-buffer-usage");
 


### PR DESCRIPTION
* Disable builtin macro redefinition warning since it would always be issued