### PR TITLE
update LogicalPointerToIntPass to support more cases

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -564,11 +564,6 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(clspv::FixupBuiltinsPass());
     pm.addPass(clspv::ThreeElementVectorLoweringPass());
 
-    if (clspv::Option::HackLogicalPtrtoint()) {
-      pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::PromotePass()));
-      pm.addPass(clspv::LogicalPointerToIntPass());
-    }
-
     // Lower longer vectors when requested. Note that this pass depends on
     // ReplaceOpenCLBuiltinPass and expects DeadCodeEliminationPass to be run
     // afterwards.
@@ -598,6 +593,11 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(clspv::InlineFuncWithPointerBitCastArgPass());
     pm.addPass(clspv::InlineFuncWithPointerToFunctionArgPass());
     pm.addPass(clspv::InlineFuncWithSingleCallSitePass());
+
+    if (clspv::Option::HackLogicalPtrtoint()) {
+      pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::PromotePass()));
+      pm.addPass(clspv::LogicalPointerToIntPass());
+    }
 
     // Mem2Reg pass should be run early because O0 level optimization leaves
     // redundant alloca, load and store instructions from function arguments.

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -89,7 +89,7 @@ clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
   PreservedAnalyses PA;
 
   while (InlineFunctions(M))
-    ;
+    { }
 
   SmallVector<Instruction *, 8> InstrsToProcess;
   for (auto &F : M) {

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -88,8 +88,8 @@ PreservedAnalyses
 clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
   PreservedAnalyses PA;
 
-  while (InlineFunctions(M))
-    { }
+  while (InlineFunctions(M)) {
+  }
 
   SmallVector<Instruction *, 8> InstrsToProcess;
   for (auto &F : M) {

--- a/lib/LogicalPointerToIntPass.h
+++ b/lib/LogicalPointerToIntPass.h
@@ -21,23 +21,22 @@
 #define _CLSPV_LIB_LOGICAL_POINTER_TO_INT_PASS_H
 
 namespace clspv {
-struct LogicalPointerToIntPass
-    : llvm::PassInfoMixin<LogicalPointerToIntPass> {
+struct LogicalPointerToIntPass : llvm::PassInfoMixin<LogicalPointerToIntPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:
-  bool isMemBase(llvm::Value* Val);
+  bool isMemBase(llvm::Value *Val);
   bool processValue(const llvm::DataLayout &DL, llvm::Value *Value,
-                  llvm::APInt &Offset, llvm::Value *&MemBase);
+                    uint64_t &CstOffset, llvm::Value *&DynOffset,
+                    llvm::Value *&MemBase);
   uint64_t getMemBaseAddr(llvm::Value *MemBase);
+  bool InlineFunctions(llvm::Module &M);
 
-
-// Arbitrary initial base address for allocations. Don't use 0x0 in case of
-// problems with NULL.
+  // Arbitrary initial base address for allocations. Don't use 0x0 in case of
+  // problems with NULL.
   uint64_t nextBaseAddress = 0X1000000000000000;
 
-  std::unordered_map<llvm::Value*, uint64_t> baseAddressMap;
-  llvm::SmallPtrSet<llvm::Function*, 8> calledFuncs;
+  std::unordered_map<llvm::Value *, uint64_t> baseAddressMap;
 };
 } // namespace clspv
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -391,7 +391,7 @@ static llvm::cl::opt<bool> physical_storage_buffers(
     llvm::cl::desc("Use physical storage buffers instead of storage buffers"));
 
 static llvm::cl::opt<bool> hack_logical_ptrtoint(
-    "hack-logical-ptrtoint", llvm::cl::init(false),
+    "hack-logical-ptrtoint", llvm::cl::init(true),
     llvm::cl::desc(
         "Allow ptrtoint on logical address spaces when it can be "
         "guaranteed that they won't be converted back to pointers."));

--- a/test/LogicalPtrToInt/function_inlining.ll
+++ b/test/LogicalPtrToInt/function_inlining.ll
@@ -1,0 +1,27 @@
+; RUN: clspv-opt %s -o %t.ll --passes=logical-pointer-to-int
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_func i32 @get(ptr %pointer) {
+entry:
+  %call = ptrtoint ptr %pointer to i32
+  ret i32 %call
+}
+
+define dso_local spir_func i32 @bar(ptr %pointer) {
+entry:
+  %call = call spir_func i32 @get(ptr %pointer)
+  ret i32 %call
+}
+
+define dso_local spir_kernel void @foo(ptr %dst) {
+entry:
+  %call = call spir_func i32 @bar(ptr %dst)
+; CHECK:  store i32 0, ptr %dst, align 4
+  store i32 %call, ptr %dst, align 4
+  ret void
+}
+
+

--- a/test/LogicalPtrToInt/geps.ll
+++ b/test/LogicalPtrToInt/geps.ll
@@ -1,0 +1,24 @@
+; RUN: clspv-opt %s -o %t.ll --passes=logical-pointer-to-int
+; RUN: FileCheck %s < %t.ll
+
+; We expect a base of 1152921504606846976 (0x1000000000000000) plus an offset
+; of 4 x 4 + 4 + 8 * %i = 20 + (%i << 3) => 1152921504606846996 (0x1000000000000014)
+
+; CHECK:  [[shl0:%[^ ]+]] = shl i64 %i, 1
+; CHECK:  [[shl1:%[^ ]+]] = shl i64 [[shl0]], 2
+; CHECK:  [[add:%[^ ]+]] = add i64 1152921504606846996, [[shl1]]
+; CHECK:  store i64 [[add]], ptr %dst, align 4
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define dso_local spir_kernel void @foo(ptr %dst, i64 %i) {
+entry:
+  %gep = getelementptr i32, ptr %dst, i64 4
+  %gep2 = getelementptr <2 x i32>, ptr %gep, i64 %i, i64 1
+  %ptrtoint = ptrtoint ptr %gep2 to i64
+  store i64 %ptrtoint, ptr %dst, align 4
+  ret void
+}
+
+

--- a/test/LogicalPtrToInt/local_args_ptrtoint.cl
+++ b/test/LogicalPtrToInt/local_args_ptrtoint.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint --arch=spir64
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/LogicalPtrToInt/private_ptrtoint.cl
+++ b/test/LogicalPtrToInt/private_ptrtoint.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint
+// RUN: clspv %target %s -o %t.spv --hack-logical-ptrtoint --arch=spir64
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv


### PR DESCRIPTION
This PR is fixing the following CTS tests:
- vectors/vec_align_*
- basic/kernel_memory_alignment_*

This is done by:
- Support all GEPs, not just ones with constant offset.
- Support recursive GEPs.
- Inline function containing PtrToInt instead of skipping.
- If Physical Storage Buffers is not enable, consider every address space.
- Move pass later in the flow to make sure every needed inlining has been done and inst has been combine to remove as many IntToPtr and PtrToInt as possible.
- Enable to pass by default, I don't see a clear reason to have it disable by default.