### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "62110aabc91d784b2a3a619e675c2830fa623c1e"
+      "commit" : "3401a5f7584a2f12a90a7538aee2ae37038c82a9"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -311,7 +311,6 @@ int SetCompilerInstanceOptions(
   instance.getCodeGenOpts().SimplifyLibCalls = false;
   instance.getCodeGenOpts().EmitOpenCLArgMetadata = false;
   instance.getCodeGenOpts().DisableO0ImplyOptNone = true;
-  instance.getCodeGenOpts().OpaquePointers = clspv::Option::OpaquePointers();
   instance.getDiagnosticOpts().IgnoreWarnings = IgnoreWarnings;
   // We always undef __SPIR__ and __SPIRV__ (see below) so don't warn about it.
   instance.getDiagnosticOpts().Warnings.push_back("no-builtin-macro-redefined");


### PR DESCRIPTION
* LLVM no longer accepts the opaque pointer option (it was already a clspv error)