### PR TITLE
Add support clspv::Builtins::kSpirvOp instructions for the LowerAddrSpaceCastPass

### DIFF
--- a/lib/LowerAddrSpaceCastPass.cpp
+++ b/lib/LowerAddrSpaceCastPass.cpp
@@ -223,10 +223,23 @@ llvm::Value *clspv::LowerAddrSpaceCastPass::visitCallInst(llvm::CallInst &I) {
     }
     return Name;
   };
-  std::string Name = fixNameSuffix(clspv::Builtins::GetMangledFunctionName(
-      Info.getName().c_str(), FunctionTy));
 
-  Module *M = I.getParent()->getParent()->getParent();
+  std::string Name = Info.getName();
+  if (Info.getType() == clspv::Builtins::kSpirvOp) {
+    auto *opcode = dyn_cast<ConstantInt>(EquivalentArgs[0]);
+    Name = Builtins::GetMangledFunctionName(Name.c_str());
+    Name += ".";
+    Name += std::to_string(opcode->getZExtValue());
+    Name += ".";
+    for (auto i = 1; i < EquivalentTypes.size(); i++) {
+      Name += Builtins::GetMangledTypeName(EquivalentTypes[i]);
+    }
+  } else {
+    Name = fixNameSuffix(
+        clspv::Builtins::GetMangledFunctionName(Name.c_str(), FunctionTy));
+  }
+
+  Module *M = I.getModule();
   auto getEquivalentFunction = [&Name, &M, &FunctionTy, this, &F]() {
     Function *eqF = M->getFunction(Name);
     if (eqF != nullptr)

--- a/test/AddressSpaceCast/issue-1096.ll
+++ b/test/AddressSpaceCast/issue-1096.ll
@@ -1,10 +1,10 @@
 ; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: declare i32 @_Z8spirv.opjPU3AS3jjj(i32, ptr addrspace(3), i32, i32, i32)
+; CHECK: declare i32 @_Z8spirv.op.234.PU3AS3jjj(i32, ptr addrspace(3), i32, i32, i32)
 
 ; CHECK-NOT: addrspacecast
-; CHECK-COUNT-4: call i32 @_Z8spirv.opjPU3AS3jjj(i32 234, ptr addrspace(3)
+; CHECK-COUNT-4: call i32 @_Z8spirv.op.234.PU3AS3jjj(i32 234, ptr addrspace(3)
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"


### PR DESCRIPTION
Conflict between two passes.
ReplaceOpenCLBuiltinPass - this pass uses the InsertSPIRVOp function to generate a new instruction with an unusual naming style.
LowerAddrSpaceCastPass::visitCallInst() – create a new version of the instruction from the ReplaceOpenCLBuiltinPass pass with some patches but can't handle the name.