### PR TITLE
add hack option to prevent unwanted driver optimisation

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -86,6 +86,10 @@ bool HackMulExtended();
 // compile-time constants when it is safe to do so.
 bool HackLogicalPtrtoint();
 
+// Returns true if a dummy instruction should be inserted after conversion to
+// float to prevent driver optimisation getting rid of the conversion.
+bool HackConvertToFloat();
+
 // Returns true if module-scope constants are to be collected into a single
 // storage buffer.  The binding for that buffer, and its intialization data
 // are given in the descriptor map file.

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -165,6 +165,11 @@ llvm::cl::opt<bool> hack_mul_extended(
     "hack-mul-extended", llvm::cl::init(false),
     llvm::cl::desc("Avoid usage of OpSMulExtended and OpUMulExtended"));
 
+llvm::cl::opt<bool> hack_convert_to_float(
+    "hack-convert-to-float", llvm::cl::init(false),
+    llvm::cl::desc("Insert a dummy instruction after conversions to float to "
+                   "avoid driver optimization getting rid of the conversion"));
+
 llvm::cl::opt<bool>
     pod_ubo("pod-ubo", llvm::cl::init(false),
             llvm::cl::desc("POD kernel arguments are in uniform buffers"));
@@ -417,6 +422,7 @@ bool HackBlockOrder() { return hack_block_order; }
 bool HackClampWidth() { return hack_clamp_width; }
 bool HackMulExtended() { return hack_mul_extended; }
 bool HackLogicalPtrtoint() { return hack_logical_ptrtoint; }
+bool HackConvertToFloat() { return hack_convert_to_float; }
 bool ModuleConstantsInStorageBuffer() {
   return module_constants_in_storage_buffer;
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4527,7 +4527,16 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         }
         Ops << I.getOperand(0);
 
-        RID = addSPIRVInst(GetSPIRVCastOpcode(I), Ops);
+        auto Op = GetSPIRVCastOpcode(I);
+        RID = addSPIRVInst(Op, Ops);
+
+        if (clspv::Option::HackConvertToFloat() &&
+            (Op == spv::OpConvertSToF || Op == spv::OpConvertUToF)) {
+          Ops.clear();
+          Ops << I.getType() << RID
+              << getSPIRVConstant(Constant::getNullValue(I.getType()));
+          RID = addSPIRVInst(spv::OpFAdd, Ops);
+        }
       }
     } else if (isa<BinaryOperator>(I)) {
       //

--- a/test/ConvertBuiltins/hack_convert_to_float.ll
+++ b/test/ConvertBuiltins/hack_convert_to_float.ll
@@ -1,0 +1,55 @@
+; RUN: clspv-opt %s -hack-convert-to-float --passes=spirv-producer -o %t.ll -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: spirv-val --target-env spv1.0 %t.spv
+; RUN: FileCheck %s < %t.spvasm
+
+; CHECK: OpConvertSToF
+; CHECK-NEXT: OpFAdd
+; CHECK-NEXT: OpConvertFToS
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: nofree norecurse nosync nounwind memory(argmem: readwrite)
+define dso_local spir_kernel void @foo(ptr addrspace(1) nocapture readonly align 4 %src, ptr addrspace(1) nocapture writeonly align 4 %dest) local_unnamed_addr #0 !kernel_arg_addr_space !7 !kernel_arg_access_qual !8 !kernel_arg_type !9 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !clspv.pod_args_impl !11 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
+  %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
+  %3 = getelementptr { [0 x i32] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
+  %4 = load i32, ptr addrspace(1) %1, align 4
+  %5 = sitofp i32 %4 to float
+  %6 = fptosi float %5 to i32
+  store i32 %6, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+
+attributes #0 = { nofree norecurse nosync nounwind memory(argmem: readwrite) "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { nofree nosync memory(none) }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2}
+!opencl.ocl.version = !{!3}
+!opencl.spir.version = !{!3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3}
+!llvm.ident = !{!4, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5}
+!clspv.descriptor.index = !{!6}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"direct-access-external-data", i32 0}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{i32 1, i32 2}
+!4 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 40c90c8ea3e7af3fc1fabfbe5034a691227c05be)"}
+!5 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 3401a5f7584a2f12a90a7538aee2ae37038c82a9)"}
+!6 = !{i32 1}
+!7 = !{i32 1, i32 1}
+!8 = !{!"none", !"none"}
+!9 = !{!"int*", !"float*"}
+!10 = !{!"", !""}
+!11 = !{i32 2}
+


### PR DESCRIPTION
Some driver optimize pattern this pattern to completely remove the two
conversions, while libclc relies on this pattern to be executed to
perform rounded conversions.
```
%0 = OpConvertSToF %float %input
%1 = OpConvertFToS %int %0
```
The hack-convert-to-float option add a dummy instruction after
`OpConvertSToF` to prevent this optimisation.