### PR TITLE
Read kernel attributes and add them to non-semantic reflection information

### DIFF
--- a/lib/AnnotationToMetadataPass.cpp
+++ b/lib/AnnotationToMetadataPass.cpp
@@ -1,0 +1,87 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Constants.h"
+
+#include "AnnotationToMetadataPass.h"
+#include "Constants.h"
+
+using namespace llvm;
+
+PreservedAnalyses
+clspv::AnnotationToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
+  for (auto &GV : M.globals()) {
+    if (GV.getName() == "llvm.global.annotations") {
+      // metadata node to write to
+      auto &context = M.getContext();
+      NamedMDNode *md_node =
+          M.getOrInsertNamedMetadata(clspv::EntryPointAttributesMetadataName());
+
+      // list of processed strings to delete at the end
+      SmallPtrSet<GlobalValue *, 4> to_erase;
+      // TODO: #816 remove after final transition.
+      SmallPtrSet<Constant *, 4> constants_to_erase;
+
+      ConstantArray *annotations_array =
+          dyn_cast<ConstantArray>(GV.getOperand(0));
+      for (auto &annotation_entry : annotations_array->operands()) {
+        ConstantStruct *annotation_struct =
+            dyn_cast<ConstantStruct>(annotation_entry.get());
+
+        auto op0 = annotation_struct->getOperand(0);
+        Function *entry_point = dyn_cast<Function>(
+            op0->getType()->isOpaquePointerTy() ? op0 : op0->getOperand(0));
+
+        auto op1 = annotation_struct->getOperand(1);
+        GlobalVariable *annotation_gv = dyn_cast<GlobalVariable>(
+            op1->getType()->isOpaquePointerTy() ? op1 : op1->getOperand(0));
+        StringRef annotation =
+            dyn_cast<ConstantDataArray>(annotation_gv->getInitializer())
+                ->getAsCString();
+
+        const auto entry_point_name_md =
+            MDString::get(context, entry_point->getName());
+        const auto attrs_md = MDString::get(context, annotation);
+        llvm::errs() << entry_point->getName() << ": '" << annotation << "'\n";
+
+        MDTuple *entry =
+            MDTuple::get(M.getContext(), {entry_point_name_md, attrs_md});
+        md_node->addOperand(entry);
+
+        // clean up annotations so other passes don't try to use the value
+        to_erase.insert(annotation_gv);
+        // this isn't used so also clean up
+        auto op2 = annotation_struct->getOperand(2);
+        GlobalVariable *filename_gv = dyn_cast<GlobalVariable>(
+            op2->getType()->isOpaquePointerTy() ? op2 : op2->getOperand(0));
+        to_erase.insert(filename_gv);
+
+        // this constant stays after the global is erased, so kill it
+        // TODO: #816 remove after final transition.
+        if (!op1->getType()->isOpaquePointerTy())
+          constants_to_erase.insert(op0);
+      }
+
+      GV.eraseFromParent();
+      for (auto gv : to_erase) {
+        gv->eraseFromParent();
+      }
+      for (auto constant : constants_to_erase) {
+        constant->destroyConstant();
+      }
+      break;
+    }
+  }
+  return PreservedAnalyses::none();
+}

--- a/lib/AnnotationToMetadataPass.cpp
+++ b/lib/AnnotationToMetadataPass.cpp
@@ -30,8 +30,6 @@ clspv::AnnotationToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
 
       // list of processed strings to delete at the end
       SmallPtrSet<GlobalValue *, 4> to_erase;
-      // TODO: #816 remove after final transition.
-      SmallPtrSet<Constant *, 4> constants_to_erase;
 
       ConstantArray *annotations_array =
           dyn_cast<ConstantArray>(GV.getOperand(0));
@@ -40,12 +38,10 @@ clspv::AnnotationToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
             dyn_cast<ConstantStruct>(annotation_entry.get());
 
         auto op0 = annotation_struct->getOperand(0);
-        Function *entry_point = dyn_cast<Function>(
-            op0->getType()->isOpaquePointerTy() ? op0 : op0->getOperand(0));
+        Function *entry_point = dyn_cast<Function>(op0);
 
         auto op1 = annotation_struct->getOperand(1);
-        GlobalVariable *annotation_gv = dyn_cast<GlobalVariable>(
-            op1->getType()->isOpaquePointerTy() ? op1 : op1->getOperand(0));
+        GlobalVariable *annotation_gv = dyn_cast<GlobalVariable>(op1);
         StringRef annotation =
             dyn_cast<ConstantDataArray>(annotation_gv->getInitializer())
                 ->getAsCString();
@@ -63,22 +59,13 @@ clspv::AnnotationToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
         to_erase.insert(annotation_gv);
         // this isn't used so also clean up
         auto op2 = annotation_struct->getOperand(2);
-        GlobalVariable *filename_gv = dyn_cast<GlobalVariable>(
-            op2->getType()->isOpaquePointerTy() ? op2 : op2->getOperand(0));
+        GlobalVariable *filename_gv = dyn_cast<GlobalVariable>(op2);
         to_erase.insert(filename_gv);
-
-        // this constant stays after the global is erased, so kill it
-        // TODO: #816 remove after final transition.
-        if (!op1->getType()->isOpaquePointerTy())
-          constants_to_erase.insert(op0);
       }
 
       GV.eraseFromParent();
       for (auto gv : to_erase) {
         gv->eraseFromParent();
-      }
-      for (auto constant : constants_to_erase) {
-        constant->destroyConstant();
       }
       break;
     }

--- a/lib/AnnotationToMetadataPass.h
+++ b/lib/AnnotationToMetadataPass.h
@@ -1,0 +1,30 @@
+// Copyright 2022 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+#ifndef _CLSPV_LIB_ANNOTATION_TO_METADATA_PASS_H
+#define _CLSPV_LIB_ANNOTATION_TO_METADATA_PASS_H
+
+namespace clspv {
+struct AnnotationToMetadataPass
+    : llvm::PassInfoMixin<AnnotationToMetadataPass> {
+  // read the annotations produced by the PrintAttrsConsumer and store in the
+  // entry point annotations in metadata
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+};
+} // namespace clspv
+
+#endif // _CLSPV_LIB_ANNOTATION_TO_METADATA_PASS_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/AllocateDescriptorsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ArgKind.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/AutoPodArgsPass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/AnnotationToMetadataPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/BitcastUtils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Builtins.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphOrderedFunctions.cpp

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CodeGenAction.h"
@@ -81,6 +80,8 @@ enum class SPIRArch : uint32_t {
 static FrontendPluginRegistry::Add<clspv::ExtraValidationASTAction>
     X("extra-validation",
       "Perform extra validation on OpenCL C when targeting Vulkan");
+static FrontendPluginRegistry::Add<clspv::EntryPointAttrsASTAction>
+    Y("attr-information-getting", "get those attrs");
 
 static llvm::cl::opt<bool> cl_single_precision_constants(
     "cl-single-precision-constant", llvm::cl::init(false),
@@ -507,6 +508,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
                                         llvm::OptimizationLevel level) {
     pm.addPass(clspv::NativeMathPass());
     pm.addPass(clspv::ZeroInitializeAllocasPass());
+    pm.addPass(clspv::AnnotationToMetadataPass());
     pm.addPass(clspv::AddFunctionAttributesPass());
     pm.addPass(clspv::AutoPodArgsPass());
     pm.addPass(clspv::DeclarePushConstantsPass());

--- a/lib/Constants.cpp
+++ b/lib/Constants.cpp
@@ -17,6 +17,12 @@
 
 namespace clspv {
 
+const std::string &EntryPointAttributesMetadataName() {
+  static std::string func_name =
+      Builtins::GetMangledFunctionName("clspv.entry_point_attributes");
+  return func_name;
+}
+
 const std::string &LocalSpecIdMetadataName() {
   static std::string func_name =
       Builtins::GetMangledFunctionName("clspv.local_spec_ids");

--- a/lib/Constants.h
+++ b/lib/Constants.h
@@ -20,6 +20,10 @@
 
 namespace clspv {
 
+// Name for module level metadata storing annotations that were present on
+// entrypoints in the source OpenCL C
+const std::string &EntryPointAttributesMetadataName();
+
 // Name for module level metadata storing workgroup argument spec ids.
 const std::string &LocalSpecIdMetadataName();
 

--- a/lib/FrontendPlugin.h
+++ b/lib/FrontendPlugin.h
@@ -31,4 +31,18 @@ struct ExtraValidationASTAction final : public clang::PluginASTAction {
     return clang::PluginASTAction::AddBeforeMainAction;
   }
 };
+
+class EntryPointAttrsASTAction final : public clang::PluginASTAction {
+  virtual std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &CI,
+                    llvm::StringRef InFile) override;
+  virtual bool ParseArgs(const clang::CompilerInstance &CI,
+                         const std::vector<std::string> &arg) override {
+    // Parsing succeeded.
+    return true;
+  }
+  virtual clang::PluginASTAction::ActionType getActionType() override {
+    return clang::PluginASTAction::AddBeforeMainAction;
+  }
+};
 } // namespace clspv

--- a/lib/PassRegistry.def
+++ b/lib/PassRegistry.def
@@ -18,6 +18,7 @@
 #define MODULE_PASS(NAME, CREATE_PASS)
 #endif // MODULE_PASS
 MODULE_PASS("add-function-attributes", clspv::AddFunctionAttributesPass)
+MODULE_PASS("annotation-to-metadata", clspv::AnnotationToMetadataPass)
 MODULE_PASS("allocate-descriptors", clspv::AllocateDescriptorsPass)
 MODULE_PASS("auto-pod-args", clspv::AutoPodArgsPass)
 MODULE_PASS("cluster-constants", clspv::ClusterModuleScopeConstantVars)

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -17,6 +17,7 @@
 
 #include "AddFunctionAttributesPass.h"
 #include "AllocateDescriptorsPass.h"
+#include "AnnotationToMetadataPass.h"
 #include "AutoPodArgsPass.h"
 #include "ClusterConstants.h"
 #include "ClusterPodKernelArgumentsPass.h"

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1566,24 +1566,6 @@ Type *SPIRVProducerPassImpl::CanonicalType(Type *type) {
     // Nothing
   } else if (type->getNumContainedTypes() != 0) {
     switch (type->getTypeID()) {
-    case Type::PointerTyID: {
-      // For the purposes of our Vulkan SPIR-V type system, constant and global
-      // are conflated.
-      auto *ptr_ty = cast<PointerType>(type);
-      unsigned AddrSpace = ptr_ty->getAddressSpace();
-      if (AddressSpace::Constant == AddrSpace) {
-        if (!clspv::Option::ConstantArgsInUniformBuffer() &&
-            !clspv::Option::PhysicalStorageBuffers()) {
-          AddrSpace = AddressSpace::Global;
-          // The canonical type of __constant is __global unless constants are
-          // passed in uniform buffers.
-          auto *GlobalTy =
-              PointerType::getWithSamePointeeType(ptr_ty, AddrSpace);
-          return GlobalTy;
-        }
-      }
-      break;
-    }
     case Type::StructTyID: {
       SmallVector<Type *, 8> subtypes;
       bool changed = false;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -391,6 +391,8 @@ struct SPIRVProducerPassImpl {
   }
   StrideTypeList &getTypesNeedingArrayStride() { return TypesNeedingArrayStride; }
 
+  void ReadFunctionAttributes();
+
   void GenerateLLVMIRInfo();
   // Populate GlobalConstFuncTypeMap. Also, if module-scope __constant will
   // *not* be converted to a storage buffer, replace each such global variable
@@ -770,6 +772,8 @@ private:
   SPIRVID ReflectionID;
   DenseMap<Function *, SPIRVID> KernelDeclarations;
 
+  StringMap<std::string> functionAttrStrings;
+
 public:
   static SPIRVProducerPassImpl *Ptr;
 };
@@ -793,6 +797,18 @@ SPIRVOperandVec &operator<<(SPIRVOperandVec &list, Value *v) {
 }
 
 } // namespace
+
+void SPIRVProducerPassImpl::ReadFunctionAttributes() {
+  auto md_node =
+      module->getNamedMetadata(clspv::EntryPointAttributesMetadataName());
+  if (md_node) {
+    for (auto *operand : md_node->operands()) {
+      auto key = cast<MDString>(operand->getOperand(0).get())->getString();
+      auto value = cast<MDString>(operand->getOperand(1).get())->getString();
+      functionAttrStrings[key] = value;
+    }
+  }
+}
 
 PreservedAnalyses SPIRVProducerPass::run(Module &M,
                                          ModuleAnalysisManager &MAM) {
@@ -822,6 +838,7 @@ bool SPIRVProducerPassImpl::runOnModule(Module &M) {
 
   NonUniformPointers.clear();
 
+  ReadFunctionAttributes();
   PopulateUBOTypeMaps();
   PopulateStructuredCFGMaps();
 
@@ -1549,6 +1566,24 @@ Type *SPIRVProducerPassImpl::CanonicalType(Type *type) {
     // Nothing
   } else if (type->getNumContainedTypes() != 0) {
     switch (type->getTypeID()) {
+    case Type::PointerTyID: {
+      // For the purposes of our Vulkan SPIR-V type system, constant and global
+      // are conflated.
+      auto *ptr_ty = cast<PointerType>(type);
+      unsigned AddrSpace = ptr_ty->getAddressSpace();
+      if (AddressSpace::Constant == AddrSpace) {
+        if (!clspv::Option::ConstantArgsInUniformBuffer() &&
+            !clspv::Option::PhysicalStorageBuffers()) {
+          AddrSpace = AddressSpace::Global;
+          // The canonical type of __constant is __global unless constants are
+          // passed in uniform buffers.
+          auto *GlobalTy =
+              PointerType::getWithSamePointeeType(ptr_ty, AddrSpace);
+          return GlobalTy;
+        }
+      }
+      break;
+    }
     case Type::StructTyID: {
       SmallVector<Type *, 8> subtypes;
       bool changed = false;
@@ -6672,15 +6707,21 @@ void SPIRVProducerPassImpl::GenerateKernelReflection() {
       num_args = F.getFunctionType()->getNumParams();
     }
 
+    auto attributes_op_string = addSPIRVInst<kDebug>(
+        spv::OpString, functionAttrStrings[F.getName()].c_str());
+
     // Kernel declaration
     // Ops[0] = void type
     // Ops[1] = reflection ext import
     // Ops[2] = function id
     // Ops[3] = kernel name
     // Ops[4] = number of arguments
+    // Ops[5] = Flags
+    // Ops[6] = Attributes
     SPIRVOperandVec Ops;
     Ops << void_id << import_id << reflection::ExtInstKernel << ValueMap[&F]
-        << kernel_name << getSPIRVInt32Constant(num_args);
+        << kernel_name << getSPIRVInt32Constant(num_args)
+        << getSPIRVInt32Constant(0) << attributes_op_string;
     auto kernel_decl = addSPIRVInst<kReflection>(spv::OpExtInst, Ops);
 
     // Generate the required workgroup size property if it was specified.

--- a/test/kernel_attributes.cl
+++ b/test/kernel_attributes.cl
@@ -1,0 +1,11 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+
+// CHECK: [[attributes:%[^ ]+]] = OpString " __attribute__((work_group_size_hint(1, 1, 1))) __attribute__((reqd_work_group_size(1, 1, 1))) __attribute__((vec_type_hint(uchar2))) __kernel"
+// CHECK: OpExtInst %void {{.*}} Kernel {{.*}} {{.*}} {{.*}} {{.*}} [[attributes]]
+
+__attribute__((work_group_size_hint(1,1,1)))
+__attribute__((reqd_work_group_size(1,1,1)))
+__attribute__((vec_type_hint(uchar2)))
+__kernel void test_kernel(){}


### PR DESCRIPTION
reading the attrs
added kernel attrs as nonsemantic information
hacked kernel attribute information into nonsemantic information write annotations to metadata when possible
read attributes into spirv

This PR is just a clean rebase of #990

I have checked the implementation using a clean rebase of https://github.com/kpet/clvk/pull/489 on both swiftshader and nvidia. It fixes `test_api kernel_attributes`.