### PR TITLE
Fix generation of non-uniform any/all

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4064,7 +4064,7 @@ SPIRVProducerPassImpl::GenerateSubgroupInstruction(
     Operands << cmp;
     auto subgroup = addSPIRVInst(op, Operands);
     Ops << Call->getType() << subgroup << ConstantInt::get(Call->getType(), 1)
-        << ConstantInt::get(call->getType(), 0);
+        << ConstantInt::get(Call->getType(), 0);
     RID = addSPIRVInst(spv::OpSelect, Ops);
     break;
   }

--- a/test/SubGroup/subgroup_all.cl
+++ b/test/SubGroup/subgroup_all.cl
@@ -1,0 +1,21 @@
+// RUN: clspv -spv-version=1.3 %target -cl-std=CL2.0 -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.1 %t.spv
+
+// CHECK: OpCapability GroupNonUniformVote
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[subgroup:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 3
+// CHECK: [[cmp:%[a-zA-Z0-9_]+]] = OpINotEqual [[bool]] {{.*}} [[int_0]]
+// CHECK: [[any:%[a-zA-Z0-9_]+]] = OpGroupNonUniformAll [[bool]] [[subgroup]] [[cmp]]
+// CHECK: OpSelect [[int]] [[any]] [[int_1]] [[int_0]]
+
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+
+kernel void test(global int* out, global int *in) {
+  *out = sub_group_all(*in);
+}
+

--- a/test/SubGroup/subgroup_any.cl
+++ b/test/SubGroup/subgroup_any.cl
@@ -1,0 +1,20 @@
+// RUN: clspv -spv-version=1.3 %target -cl-std=CL2.0 -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.1 %t.spv
+
+// CHECK: OpCapability GroupNonUniformVote
+// CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+// CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[int_0:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+// CHECK-DAG: [[int_1:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+// CHECK-DAG: [[subgroup:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 3
+// CHECK: [[cmp:%[a-zA-Z0-9_]+]] = OpINotEqual [[bool]] {{.*}} [[int_0]]
+// CHECK: [[any:%[a-zA-Z0-9_]+]] = OpGroupNonUniformAny [[bool]] [[subgroup]] [[cmp]]
+// CHECK: OpSelect [[int]] [[any]] [[int_1]] [[int_0]]
+
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+
+kernel void test(global int* out, global int *in) {
+  *out = sub_group_any(*in);
+}


### PR DESCRIPTION
Fixes #1140

* Fix generation of OpGroupNonUniformAny/All
* convert input to bool by comparing not equal to 0
* convert subgroup result back to integer using a select