### PR TITLE
add kernel arg names to metadata pass

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerBitCastArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithPointerToFunctionArgPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/InlineFuncWithSingleCallSitePass.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/KernelArgNamesToMetadataPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Layout.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/LogicalPointerToIntPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/LongVectorLoweringPass.cpp

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -296,7 +296,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
         "reqd_work_group_size",   "kernel_arg_addr_space",
         "kernel_arg_access_qual", "kernel_arg_type",
         "kernel_arg_base_type",   "kernel_arg_type_qual",
-        pod_md_name.c_str()};
+        "kernel_arg_name",        pod_md_name.c_str()};
     for (auto name : Metadatas) {
       NewFunc->setMetadata(name, F->getMetadata(name));
       F->setMetadata(name, nullptr);

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -508,6 +508,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
                                         llvm::OptimizationLevel level) {
     pm.addPass(clspv::NativeMathPass());
     pm.addPass(clspv::ZeroInitializeAllocasPass());
+    pm.addPass(clspv::KernelArgNamesToMetadataPass());
     pm.addPass(clspv::AnnotationToMetadataPass());
     pm.addPass(clspv::AddFunctionAttributesPass());
     pm.addPass(clspv::AutoPodArgsPass());

--- a/lib/KernelArgNamesToMetadataPass.cpp
+++ b/lib/KernelArgNamesToMetadataPass.cpp
@@ -21,7 +21,7 @@ clspv::KernelArgNamesToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
   auto &context = M.getContext();
   for (Function &F : M.functions()) {
     SmallVector<Metadata *> MDs;
-    for (auto &arg: F.args()) {
+    for (auto &arg : F.args()) {
       MDs.push_back(MDString::get(context, arg.getName()));
     }
     F.addMetadata("kernel_arg_name", *MDNode::get(context, MDs));

--- a/lib/KernelArgNamesToMetadataPass.cpp
+++ b/lib/KernelArgNamesToMetadataPass.cpp
@@ -1,0 +1,30 @@
+// Copyright 2023 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "KernelArgNamesToMetadataPass.h"
+
+using namespace llvm;
+
+PreservedAnalyses
+clspv::KernelArgNamesToMetadataPass::run(Module &M, ModuleAnalysisManager &) {
+  auto &context = M.getContext();
+  for (Function &F : M.functions()) {
+    SmallVector<Metadata *> MDs;
+    for (auto &arg: F.args()) {
+      MDs.push_back(MDString::get(context, arg.getName()));
+    }
+    F.addMetadata("kernel_arg_name", *MDNode::get(context, MDs));
+  }
+  return PreservedAnalyses::none();
+}

--- a/lib/KernelArgNamesToMetadataPass.h
+++ b/lib/KernelArgNamesToMetadataPass.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+#ifndef _CLSPV_LIB_KERNEL_ARGNAMES_TO_METADATA_PASS_H
+#define _CLSPV_LIB_KERNEL_ARGNAMES_TO_METADATA_PASS_H
+
+namespace clspv {
+struct KernelArgNamesToMetadataPass
+    : llvm::PassInfoMixin<KernelArgNamesToMetadataPass> {
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+};
+} // namespace clspv
+
+#endif // _CLSPV_LIB_KERNEL_ARGNAMES_TO_METADATA_PASS_H

--- a/lib/PassRegistry.def
+++ b/lib/PassRegistry.def
@@ -34,6 +34,7 @@ MODULE_PASS("inline-func-with-image-metadata-getter", clspv::InlineFuncWithImage
 MODULE_PASS("inline-func-with-pointer-cast-arg", clspv::InlineFuncWithPointerBitCastArgPass)
 MODULE_PASS("inline-func-with-pointer-function-arg", clspv::InlineFuncWithPointerToFunctionArgPass)
 MODULE_PASS("inline-func-with-single-call-site", clspv::InlineFuncWithSingleCallSitePass)
+MODULE_PASS("kernel-argnames-to-metadata", clspv::KernelArgNamesToMetadataPass)
 MODULE_PASS("logical-pointer-to-int", clspv::LogicalPointerToIntPass)
 MODULE_PASS("long-vector-lowering", clspv::LongVectorLoweringPass)
 MODULE_PASS("set-image-channel-metadata", clspv::SetImageChannelMetadataPass)

--- a/lib/Passes.h
+++ b/lib/Passes.h
@@ -33,6 +33,7 @@
 #include "InlineFuncWithPointerBitCastArgPass.h"
 #include "InlineFuncWithPointerToFunctionArgPass.h"
 #include "InlineFuncWithSingleCallSitePass.h"
+#include "KernelArgNamesToMetadataPass.h"
 #include "LogicalPointerToIntPass.h"
 #include "LongVectorLoweringPass.h"
 #include "LowerAddrSpaceCastPass.h"

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -7035,7 +7035,18 @@ void SPIRVProducerPassImpl::AddArgumentReflection(
     uint32_t elem_size) {
   // Generate ArgumentInfo for this argument.
   auto import_id = getReflectionImport();
-  auto arg_name = addSPIRVInst<kDebug>(spv::OpString, name.c_str());
+  auto kernel_arg_name = kernelFn.getMetadata("kernel_arg_name");
+  SPIRVID arg_name;
+  if (kernel_arg_name) {
+    arg_name = addSPIRVInst<kDebug>(
+        spv::OpString, dyn_cast<MDString>(kernel_arg_name->getOperand(ordinal))
+                           ->getString()
+                           .str()
+                           .c_str());
+  } else {
+    // For legacy purpose
+    arg_name = addSPIRVInst<kDebug>(spv::OpString, name.c_str());
+  }
   auto void_id = getSPIRVType(Type::getVoidTy(module->getContext()));
   SPIRVOperandVec Ops;
   Ops << void_id << import_id << reflection::ExtInstArgumentInfo << arg_name;

--- a/test/KernelArgInfo/kernel-arg-info-physical-storage-buffers.cl
+++ b/test/KernelArgInfo/kernel-arg-info-physical-storage-buffers.cl
@@ -1,0 +1,70 @@
+// RUN: clspv %target %s -cl-kernel-arg-info -o %t.spv -physical-storage-buffers -arch=spir64 --print-after-all &> %t.ll
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+void kernel foo(global int4 *A, local float* SEC, constant short2* TER, int QUA, read_only image2d_t im0, write_only image2d_t im1, const volatile global int * restrict ptr) {
+  float4 tmp;
+  A[0] = (int4)(0,0,0,0);
+  *SEC = 0.0;
+  A[1] = (int4)((int)(*TER).x,0,0,0);
+  A[2] = (int4)QUA;
+  A[3] = (int4)(*ptr);
+  tmp = read_imagef(im0, (int2)(0, 0));
+  write_imagef(im1, (int2)(0, 0), tmp);
+}
+
+// CHECK: [[extinst:%[a-zA-A0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+
+// CHECK-DAG: [[kernel_name:%[a-zA-Z0-9_]+]] = OpString "foo"
+// CHECK-DAG: [[arg0name:%[a-zA-Z0-9_]+]] = OpString "A"
+// CHECK-DAG: [[arg0typename:%[a-zA-Z0-9_]+]] = OpString "int4*"
+// CHECK-DAG: [[arg1name:%[a-zA-Z0-9_]+]] = OpString "SEC"
+// CHECK-DAG: [[arg1typename:%[a-zA-Z0-9_]+]] = OpString "float*"
+// CHECK-DAG: [[arg2name:%[a-zA-Z0-9_]+]] = OpString "TER"
+// CHECK-DAG: [[arg2typename:%[a-zA-Z0-9_]+]] = OpString "short2*"
+// CHECK-DAG: [[arg3name:%[a-zA-Z0-9_]+]] = OpString "im0"
+// CHECK-DAG: [[arg3typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg4name:%[a-zA-Z0-9_]+]] = OpString "im1"
+// CHECK-DAG: [[arg4typename:%[a-zA-Z0-9_]+]] = OpString "image2d_t"
+// CHECK-DAG: [[arg5name:%[a-zA-Z0-9_]+]] = OpString "ptr"
+// CHECK-DAG: [[arg5typename:%[a-zA-Z0-9_]+]] = OpString "int*"
+// CHECK-DAG: [[arg6name:%[a-zA-Z0-9_]+]] = OpString "QUA"
+// CHECK-DAG: [[arg6typename:%[a-zA-Z0-9_]+]] = OpString "int"
+
+// CHECK: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+
+// CHECK-DAG: [[aspace_global:%[a-zA-Z0-9_]+]] = OpConstant %uint 4507
+// CHECK-DAG: [[qual_access_none:%[a-zA-Z0-9_]+]] = OpConstant %uint 4515
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant %uint 0
+// CHECK-DAG: [[aspace_local:%[a-zA-Z0-9_]+]] = OpConstant %uint 4508
+// CHECK-DAG: [[uint_1:%[a-zA-Z0-9_]+]] = OpConstant %uint 1
+// CHECK-DAG: [[uint_3:%[a-zA-Z0-9_]+]] = OpConstant %uint 3
+// CHECK-DAG: [[uint_4:%[a-zA-Z0-9_]+]] = OpConstant %uint 4
+// CHECK-DAG: [[aspace_constant:%[a-zA-Z0-9_]+]] = OpConstant %uint 4509
+// CHECK-DAG: [[uint_2:%[a-zA-Z0-9_]+]] = OpConstant %uint 2
+// CHECK-DAG: [[uint_5:%[a-zA-Z0-9_]+]] = OpConstant %uint 5
+// CHECK-DAG: [[uint_6:%[a-zA-Z0-9_]+]] = OpConstant %uint 6
+// CHECK-DAG: [[uint_7:%[a-zA-Z0-9_]+]] = OpConstant %uint 7
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant %uint 8
+// CHECK-DAG: [[uint_16:%[a-zA-Z0-9_]+]] = OpConstant %uint 16
+// CHECK-DAG: [[uint_24:%[a-zA-Z0-9_]+]] = OpConstant %uint 24
+// CHECK-DAG: [[aspace_private:%[a-zA-Z0-9_]+]] = OpConstant %uint 4510
+// CHECK-DAG: [[qual_access_read_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4512
+// CHECK-DAG: [[qual_access_write_only:%[a-zA-Z0-9_]+]] = OpConstant %uint 4513
+
+// CHECK: [[kernelinfo:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] Kernel {{.*}} [[kernel_name]]
+// CHECK-NEXT: [[arg1info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg1name]] [[arg1typename]] [[aspace_local]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentWorkgroup  [[kernelinfo]] [[uint_1]] [[uint_3]] [[uint_4]] [[arg1info]]
+// CHECK-NEXT: [[arg3info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg3name]] [[arg3typename]] [[aspace_global]] [[qual_access_read_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentSampledImage  [[kernelinfo]] [[uint_4]] [[uint_0]] [[uint_0]] [[arg3info]]
+// CHECK-NEXT: [[arg4info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg4name]] [[arg4typename]] [[aspace_global]] [[qual_access_write_only]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentStorageImage  [[kernelinfo]] [[uint_5]] [[uint_0]] [[uint_1]] [[arg4info]]
+// CHECK-NEXT: [[arg0info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg0name]] [[arg0typename]] [[aspace_global]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPointerPushConstant [[kernelinfo]] [[uint_0]] [[uint_0]] [[uint_8]] [[arg0info]]
+// CHECK-NEXT: [[arg2info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg2name]] [[arg2typename]] [[aspace_constant]] [[qual_access_none]] [[uint_1]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPointerPushConstant [[kernelinfo]] [[uint_2]] [[uint_8]] [[uint_8]] [[arg2info]]
+// CHECK-NEXT: [[arg6info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg6name]] [[arg6typename]] [[aspace_private]] [[qual_access_none]] [[uint_0]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPodPushConstant  [[kernelinfo]] [[uint_3]] [[uint_16]] [[uint_4]] [[arg6info]]
+// CHECK-NEXT: [[arg5info:%[a-zA-Z0-9_]+]] = OpExtInst %void [[extinst]] ArgumentInfo [[arg5name]] [[arg5typename]] [[aspace_global]] [[qual_access_none]] [[uint_7]]
+// CHECK-NEXT: OpExtInst %void [[extinst]] ArgumentPointerPushConstant [[kernelinfo]] [[uint_6]] [[uint_24]] [[uint_8]] [[arg5info]]

--- a/test/KernelArgInfo/kernel-arg-info.ll
+++ b/test/KernelArgInfo/kernel-arg-info.ll
@@ -1,0 +1,121 @@
+; RUN: clspv-opt %s -o %t.ll --passes=kernel-argnames-to-metadata
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: !kernel_arg_name [[id:![0-9]*]]
+; CHECK: [[id]] = !{!"A", !"SEC", !"TER", !"QUA", !"im0", !"im1", !"ptr"}
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+@.str = private unnamed_addr addrspace(2) constant [8 x i8] c" kernel\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr addrspace(2) constant [118 x i8] c"/usr/local/google/home/rjodin/work/clvk/external/clspv/test/KernelArgInfo/kernel-arg-info-physical-storage-buffers.cl\00", section "llvm.metadata"
+@llvm.global.annotations = appending global [1 x { ptr, ptr addrspace(2), ptr addrspace(2), i32, ptr addrspace(2) }] [{ ptr, ptr addrspace(2), ptr addrspace(2), i32, ptr addrspace(2) } { ptr @foo, ptr addrspace(2) @.str, ptr addrspace(2) @.str.1, i32 6, ptr addrspace(2) null }], section "llvm.metadata"
+
+; Function Attrs: convergent norecurse nounwind
+define dso_local spir_kernel void @foo(ptr addrspace(1) align 16 %A, ptr addrspace(3) align 4 %SEC, ptr addrspace(2) align 4 %TER, i32 %QUA, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %im0, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %im1, ptr addrspace(1) noalias align 4 %ptr) #0 !kernel_arg_addr_space !6 !kernel_arg_access_qual !7 !kernel_arg_type !8 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 {
+entry:
+  %A.addr = alloca ptr addrspace(1), align 8
+  store ptr addrspace(1) null, ptr %A.addr, align 8
+  %SEC.addr = alloca ptr addrspace(3), align 8
+  store ptr addrspace(3) null, ptr %SEC.addr, align 8
+  %TER.addr = alloca ptr addrspace(2), align 8
+  store ptr addrspace(2) null, ptr %TER.addr, align 8
+  %QUA.addr = alloca i32, align 4
+  store i32 0, ptr %QUA.addr, align 4
+  %im0.addr = alloca target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), align 8
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) zeroinitializer, ptr %im0.addr, align 8
+  %im1.addr = alloca target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), align 8
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) zeroinitializer, ptr %im1.addr, align 8
+  %ptr.addr = alloca ptr addrspace(1), align 8
+  store ptr addrspace(1) null, ptr %ptr.addr, align 8
+  %tmp = alloca <4 x float>, align 16
+  store <4 x float> zeroinitializer, ptr %tmp, align 16
+  %.compoundliteral = alloca <4 x i32>, align 16
+  store <4 x i32> zeroinitializer, ptr %.compoundliteral, align 16
+  %.compoundliteral1 = alloca <4 x i32>, align 16
+  store <4 x i32> zeroinitializer, ptr %.compoundliteral1, align 16
+  %.compoundliteral10 = alloca <2 x i32>, align 8
+  store <2 x i32> zeroinitializer, ptr %.compoundliteral10, align 8
+  %.compoundliteral11 = alloca <2 x i32>, align 8
+  store <2 x i32> zeroinitializer, ptr %.compoundliteral11, align 8
+  store ptr addrspace(1) %A, ptr %A.addr, align 8
+  store ptr addrspace(3) %SEC, ptr %SEC.addr, align 8
+  store ptr addrspace(2) %TER, ptr %TER.addr, align 8
+  store i32 %QUA, ptr %QUA.addr, align 4
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %im0, ptr %im0.addr, align 8
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %im1, ptr %im1.addr, align 8
+  store ptr addrspace(1) %ptr, ptr %ptr.addr, align 8
+  store <4 x i32> zeroinitializer, ptr %.compoundliteral, align 16
+  %0 = load <4 x i32>, ptr %.compoundliteral, align 16
+  %1 = load ptr addrspace(1), ptr %A.addr, align 8
+  %arrayidx = getelementptr inbounds <4 x i32>, ptr addrspace(1) %1, i64 0
+  store <4 x i32> %0, ptr addrspace(1) %arrayidx, align 16
+  %2 = load ptr addrspace(3), ptr %SEC.addr, align 8
+  store float 0.000000e+00, ptr addrspace(3) %2, align 4
+  %3 = load ptr addrspace(2), ptr %TER.addr, align 8
+  %4 = load <2 x i16>, ptr addrspace(2) %3, align 4
+  %5 = extractelement <2 x i16> %4, i64 0
+  %conv = sext i16 %5 to i32
+  %vecinit = insertelement <4 x i32> undef, i32 %conv, i32 0
+  %vecinit2 = insertelement <4 x i32> %vecinit, i32 0, i32 1
+  %vecinit3 = insertelement <4 x i32> %vecinit2, i32 0, i32 2
+  %vecinit4 = insertelement <4 x i32> %vecinit3, i32 0, i32 3
+  store <4 x i32> %vecinit4, ptr %.compoundliteral1, align 16
+  %6 = load <4 x i32>, ptr %.compoundliteral1, align 16
+  %7 = load ptr addrspace(1), ptr %A.addr, align 8
+  %arrayidx5 = getelementptr inbounds <4 x i32>, ptr addrspace(1) %7, i64 1
+  store <4 x i32> %6, ptr addrspace(1) %arrayidx5, align 16
+  %8 = load i32, ptr %QUA.addr, align 4
+  %splat.splatinsert = insertelement <4 x i32> poison, i32 %8, i64 0
+  %splat.splat = shufflevector <4 x i32> %splat.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %9 = load ptr addrspace(1), ptr %A.addr, align 8
+  %arrayidx6 = getelementptr inbounds <4 x i32>, ptr addrspace(1) %9, i64 2
+  store <4 x i32> %splat.splat, ptr addrspace(1) %arrayidx6, align 16
+  %10 = load ptr addrspace(1), ptr %ptr.addr, align 8
+  %11 = load volatile i32, ptr addrspace(1) %10, align 4
+  %splat.splatinsert7 = insertelement <4 x i32> poison, i32 %11, i64 0
+  %splat.splat8 = shufflevector <4 x i32> %splat.splatinsert7, <4 x i32> poison, <4 x i32> zeroinitializer
+  %12 = load ptr addrspace(1), ptr %A.addr, align 8
+  %arrayidx9 = getelementptr inbounds <4 x i32>, ptr addrspace(1) %12, i64 3
+  store <4 x i32> %splat.splat8, ptr addrspace(1) %arrayidx9, align 16
+  %13 = load target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), ptr %im0.addr, align 8
+  store <2 x i32> zeroinitializer, ptr %.compoundliteral10, align 8
+  %14 = load <2 x i32>, ptr %.compoundliteral10, align 8
+  %call = call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %13, <2 x i32> %14) #3
+  store <4 x float> %call, ptr %tmp, align 16
+  %15 = load target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), ptr %im1.addr, align 8
+  store <2 x i32> zeroinitializer, ptr %.compoundliteral11, align 8
+  %16 = load <2 x i32>, ptr %.compoundliteral11, align 8
+  %17 = load <4 x float>, ptr %tmp, align 16
+  call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %15, <2 x i32> %16, <4 x float> %17) #4
+  ret void
+}
+
+; Function Attrs: convergent nounwind willreturn memory(read)
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_roDv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>) #1
+
+; Function Attrs: convergent nounwind
+declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, <4 x float>) #2
+
+attributes #0 = { convergent norecurse nounwind "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { convergent nounwind willreturn memory(read) "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" }
+attributes #2 = { convergent nounwind "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" }
+attributes #3 = { convergent nobuiltin nounwind willreturn memory(read) "no-builtins" }
+attributes #4 = { convergent nobuiltin nounwind "no-builtins" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!opencl.ocl.version = !{!3}
+!opencl.spir.version = !{!3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3}
+!llvm.ident = !{!4, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5, !5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"direct-access-external-data", i32 0}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{i32 1, i32 2}
+!4 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project ab674234c440ed27302f58eeccc612c83b32c43f)"}
+!5 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 3401a5f7584a2f12a90a7538aee2ae37038c82a9)"}
+!6 = !{i32 1, i32 3, i32 2, i32 0, i32 1, i32 1, i32 1}
+!7 = !{!"none", !"none", !"none", !"none", !"read_only", !"write_only", !"none"}
+!8 = !{!"int4*", !"float*", !"short2*", !"int", !"image2d_t", !"image2d_t", !"int*"}
+!9 = !{!"int __attribute__((ext_vector_type(4)))*", !"float*", !"short __attribute__((ext_vector_type(2)))*", !"int", !"image2d_t", !"image2d_t", !"int*"}
+!10 = !{!"", !"", !"const", !"", !"", !"", !"restrict const volatile"}


### PR DESCRIPTION
This pass handle kernel arguments names through the metadata.

This is needed when running with physical storage buffers as all arguments are cluster in the push constant, and end up missing with the current implementation.