### PR TITLE
add missing header in Compiler.h

### DIFF
--- a/include/clspv/Compiler.h
+++ b/include/clspv/Compiler.h
@@ -15,6 +15,7 @@
 #ifndef CLSPV_INCLUDE_CLSPV_COMPILER_H_
 #define CLSPV_INCLUDE_CLSPV_COMPILER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Compiling on arch-linux with gcc-13 failed on this missing header