### PR TITLE
fix printf of literal string when pointers are 64bit

### DIFF
--- a/lib/PrintfPass.cpp
+++ b/lib/PrintfPass.cpp
@@ -288,7 +288,12 @@ PreservedAnalyses clspv::PrintfPass::run(Module &M, ModuleAnalysisManager &) {
     for (unsigned i = 1; i < CI->arg_size(); i++) {
       Value *Arg = CI->getArgOperand(i);
       Type *ArgType = Arg->getType();
-      unsigned ArgSize = GetPrintfStoreSize(DL, ArgType);
+
+      // Literal Arg are store using a 32bits identifier, which differs when
+      // using 64bits pointers from the size returned by GetPrintfStoreSize.
+      bool IsStringLiteral = GetStringLiteral(Arg) != "";
+      unsigned ArgSize = IsStringLiteral ? 4 : GetPrintfStoreSize(DL, ArgType);
+
       auto *ArgSizeConst = ConstantInt::get(Int32Ty, ArgSize);
       ArgMD.push_back(ConstantAsMetadata::get(ArgSizeConst));
     }

--- a/test/Printf/printf_string_64bit_ptr.ll
+++ b/test/Printf/printf_string_64bit_ptr.ll
@@ -1,0 +1,49 @@
+; RUN: clspv-opt %s -o %t.ll --passes=printf-pass
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-DAG: !clspv.printf_metadata = !{[[format:![0-9]*]], [[literal:![0-9]*]]}
+; CHECK-DAG: [[format]] = !{i32 0, !"%4s", [[size:![0-9]*]]}
+; CHECK-DAG: [[literal]] = !{i32 1, !"foo", {{.*}}}
+; CHECK-DAG: [[size]] = !{i32 4}
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%0 = type { i64 }
+
+@.str = private unnamed_addr addrspace(2) constant [4 x i8] c"%4s\00", align 1
+@.str.1 = private unnamed_addr addrspace(2) constant [4 x i8] c"foo\00", align 1
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent norecurse nounwind
+define dso_local spir_kernel void @test() #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !8 !kernel_arg_type !8 !kernel_arg_base_type !8 !kernel_arg_type_qual !8 !kernel_arg_name !8 !clspv.pod_args_impl !9 {
+entry:
+  %call = call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) @.str, ptr addrspace(2) @.str.1) #2
+  ret void
+}
+
+; Function Attrs: convergent nounwind
+declare !kernel_arg_name !10 spir_func i32 @printf(ptr addrspace(2), ...) #1
+
+attributes #0 = { convergent norecurse nounwind "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { convergent nounwind "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" }
+attributes #2 = { convergent nobuiltin nounwind "no-builtins" }
+
+!llvm.module.flags = !{!1, !2, !3}
+!opencl.ocl.version = !{!4}
+!opencl.spir.version = !{!4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4}
+!llvm.ident = !{!5, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6}
+!_Z28clspv.entry_point_attributes = !{!7}
+
+!0 = !{i32 10}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 7, !"direct-access-external-data", i32 0}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{i32 1, i32 2}
+!5 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 1e6fc9626c0f49ce952a67aef47e86253d13f74a)"}
+!6 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project ab674234c440ed27302f58eeccc612c83b32c43f)"}
+!7 = !{!"test", !" kernel"}
+!8 = !{}
+!9 = !{i32 3}
+!10 = !{!""}


### PR DESCRIPTION
literal string are store with a 32bit identifier, while the size of the arg when pointers are 64bit is 8 bytes. It does not match the real stored size of 4 bytes, which leads to error in the runtime when running the CTS.