### PR TITLE
fix IsImplicitCast for memcpy

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -907,7 +907,7 @@ bool IsImplicitCasts(Module &M, DenseMap<Value *, Type *> &type_cache,
       auto Src = call->getArgOperand(1);
       auto DstTy = clspv::InferType(Dst, M.getContext(), &type_cache);
       auto SrcTy = clspv::InferType(Src, M.getContext(), &type_cache);
-      if (DstTy != SrcTy) {
+      if (DstTy && SrcTy && DstTy != SrcTy) {
         if (SizeInBits(M.getDataLayout(), DstTy) >=
             SizeInBits(M.getDataLayout(), SrcTy)) {
           source = Src;

--- a/test/PointerCasts/issue-1171.cl
+++ b/test/PointerCasts/issue-1171.cl
@@ -1,0 +1,37 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct S {
+    int i;
+};
+
+kernel void Kernel1(global struct S *s1, global struct S *s2)
+{
+    s2->i = 0;
+    *s1 = *s2;
+}
+
+kernel void Kernel2(global struct S *s1, global struct S *s2)
+{
+    *s1 = *s2;
+    s2->i = 0;
+}
+
+kernel void Kernel3(global struct S *s1, global struct S *s2)
+{
+    *s1 = *s2;
+    s1->i = 0;
+}
+
+kernel void Kernel4(global struct S *s1, global struct S *s2)
+{
+    *s2 = *s1;
+    s1->i = 0;
+}
+
+kernel void Kernel5(global struct S *s1, global struct S *s2)
+{
+    *s2 = *s1;
+    s2->i = 0;
+}


### PR DESCRIPTION
If we can infer a type of one operand of memcpy, do nothing to avoid dereferencing nullptr.

fix #1171