### PR TITLE
rework alloca in simplifypointerbitcast

### DIFF
--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -372,6 +372,12 @@ void ComputeStore(IRBuilder<> &Builder, StoreInst *ST, Value *OrgGEPIdx,
 
   SmallVector<Value *, 8> STValues;
   Value *STVal = ST->getValueOperand();
+  if (auto cst = dyn_cast<Constant>(STVal)) {
+    if (cst->isZeroValue()) {
+      Builder.CreateStore(Constant::getNullValue(SrcTy), Src);
+      return;
+    }
+  }
   STValues.push_back(STVal);
 
   // If the output is a vec3, let's extract those 3 elements.

--- a/lib/SimplifyPointerBitcastPass.h
+++ b/lib/SimplifyPointerBitcastPass.h
@@ -26,6 +26,7 @@ struct SimplifyPointerBitcastPass
   void runOnInstFromCstExpr(llvm::Module &M) const;
   bool runOnTrivialBitcast(llvm::Module &M) const;
   bool runOnBitcastFromBitcast(llvm::Module &M) const;
+  bool runOnAllocaNotAliasing(llvm::Module &M) const;
   bool runOnGEPFromGEP(llvm::Module &M) const;
   bool runOnUnneededCasts(llvm::Module &M) const;
   bool runOnImplicitCasts(llvm::Module &M) const;

--- a/test/PointerCasts/issue-1180.ll
+++ b/test/PointerCasts/issue-1180.ll
@@ -1,0 +1,12 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[alloca:%[^ ]+]] = alloca [32 x i8], align 1
+; CHECK: getelementptr [8 x i8], ptr [[alloca]], i32 0, i32 7
+
+define dso_local spir_kernel void @kernel() {
+entry:
+  %0 = alloca [4 x i64], align 8
+  %1 = getelementptr [8 x i8], ptr %0, i32 0, i32 7
+  ret void
+}


### PR DESCRIPTION
rework alloca when its type is incompatible with its users.

Fix #1180