### PR TITLE
Remove strict aliasing in SmallerTypeNotAliasing

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1047,8 +1047,7 @@ bool IsArrayLike(StructType *Ty) {
 // found or it cannot descend any further. Writes out levels of indirection to
 // `Steps`.
 bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
-                               bool &PerfectMatch, const DataLayout &DL,
-                               bool strictAliasing) {
+                               bool &PerfectMatch, const DataLayout &DL) {
   int StepCount = 0;
 
   auto IsIntegerOrFloatTy = [](Type *Ty) {
@@ -1073,8 +1072,6 @@ bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
       ContainingTy = ArrayTy->getArrayElementType();
     } else if (auto *StructTy = dyn_cast<StructType>(ContainingTy)) {
       if (StructTy->isOpaque())
-        break;
-      if (!IsArrayLike(StructTy) && strictAliasing)
         break;
       ContainingTy = StructTy->getStructElementType(0);
     } else {

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -61,8 +61,7 @@ Value *CreateRem(IRBuilder<> &Builder, unsigned rem, Value *Val);
 bool IsArrayLike(StructType *Ty);
 
 bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
-                               bool &PerfectMatch, const DataLayout &DL,
-                               bool structAliasing = false);
+                               bool &PerfectMatch, const DataLayout &DL);
 
 void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
                           GetElementPtrInst *GEP, uint64_t &CstVal,

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -220,12 +220,12 @@ Type *SmallerTypeNotAliasing(const DataLayout &DL, Type *TyA, Type *TyB) {
 
   int Steps;
   bool PerfectMatch;
-  if (BitcastUtils::FindAliasingContainedType(TyA, TyB, Steps, PerfectMatch, DL,
-                                              true)) {
+  if (BitcastUtils::FindAliasingContainedType(TyA, TyB, Steps, PerfectMatch,
+                                              DL)) {
     return TyA;
   }
-  if (BitcastUtils::FindAliasingContainedType(TyB, TyA, Steps, PerfectMatch, DL,
-                                              true)) {
+  if (BitcastUtils::FindAliasingContainedType(TyB, TyA, Steps, PerfectMatch,
+                                              DL)) {
     return TyB;
   }
 

--- a/test/PointerCasts/issue-1032.cl
+++ b/test/PointerCasts/issue-1032.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK-COUNT-32: OpStore
+// CHECK-COUNT-16: OpStore
 
 struct Data
 {

--- a/test/PointerCasts/issue-1166.cl
+++ b/test/PointerCasts/issue-1166.cl
@@ -3,13 +3,10 @@
 // RUN: spirv-val %t.spv --target-env spv1.0
 // RUN: FileCheck %s < %t.spvasm
 
-// CHECK: [[uint:%[^ ]+]] = OpTypeInt 32 0
-// CHECK: [[uint2:%[^ ]+]] = OpTypeVector [[uint]] 2
 // CHECK: [[ulong:%[^ ]+]] = OpTypeInt 64 0
 // CHECK: [[ulong_8000000000:%[^ ]+]] = OpConstant [[ulong]] 8000000000
 
-// CHECK: Bitcast [[uint2]] [[ulong_8000000000]]
-// CHECK: Bitcast [[uint2]] [[ulong_8000000000]]
+// CHECK: OpStore {{.*}} [[ulong_8000000000]]
 
 struct S { long i1; int i2; int i3; };
 

--- a/test/PointerCasts/issue-1166.ll
+++ b/test/PointerCasts/issue-1166.ll
@@ -1,13 +1,11 @@
-; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast,replace-pointer-bitcast
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %s, i32 0
-; CHECK:  store i32 extractelement (<2 x i32> bitcast (<1 x i64> <i64 8000000000> to <2 x i32>), i64 0), ptr addrspace(1) [[gep]], align 4
-; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %s, i32 1
-; CHECK:  store i32 extractelement (<2 x i32> bitcast (<1 x i64> <i64 8000000000> to <2 x i32>), i64 1), ptr addrspace(1) [[gep]], align 4
-; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %s, i32 2
-; CHECK:  store i32 77, ptr addrspace(1) [[gep]], align 4
-; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %s, i32 3
+; CHECK:  [[gep:%[^ ]+]] = getelementptr %struct.S, ptr addrspace(1) %s, i32 0, i32 0
+; CHECK:  store i64 8000000000, ptr addrspace(1) [[gep]], align 8
+; CHECK:  [[gep:%[^ ]+]] = getelementptr inbounds %struct.S, ptr addrspace(1) %s, i32 0, i32 1
+; CHECK:  store i32 77, ptr addrspace(1) [[gep]], align 8
+; CHECK:  [[gep:%[^ ]+]] = getelementptr inbounds %struct.S, ptr addrspace(1) %s, i32 0, i32 2
 ; CHECK:  store i32 88, ptr addrspace(1) [[gep]], align 4
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/PointerCasts/issue-1184.cl
+++ b/test/PointerCasts/issue-1184.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct E { int i0, i1; };
+
+struct S
+{
+    long i; struct E e; // Fails
+    // struct E e; long i; // OK
+    // int i; struct E e; // OK
+};
+
+kernel void Kernel(global struct S* s)
+{
+    s->i = 1;
+    s->e.i0 = 1;
+    s->e.i1 = 1;
+}


### PR DESCRIPTION
strict aliasing is not needed in this function. On the contrary, it generates bug such as #1184.

No regression on CTS with swiftshader and nvidia

Fix #1184