### PR TITLE
Fix for struct needed to get downgraded to handle pointerbitcast

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1048,7 +1048,7 @@ bool IsArrayLike(StructType *Ty) {
 // `Steps`.
 bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
                                bool &PerfectMatch, const DataLayout &DL,
-                               bool strictAliasing) {
+                               bool StrictStruct) {
   int StepCount = 0;
 
   auto IsIntegerOrFloatTy = [](Type *Ty) {
@@ -1072,9 +1072,8 @@ bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
     } else if (auto *ArrayTy = dyn_cast<ArrayType>(ContainingTy)) {
       ContainingTy = ArrayTy->getArrayElementType();
     } else if (auto *StructTy = dyn_cast<StructType>(ContainingTy)) {
-      if (StructTy->isOpaque())
-        break;
-      if (!IsArrayLike(StructTy) && strictAliasing)
+      if (StructTy->isOpaque() ||
+          (StructTy->getStructNumElements() > 1 && StrictStruct))
         break;
       ContainingTy = StructTy->getStructElementType(0);
     } else {

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -62,7 +62,7 @@ bool IsArrayLike(StructType *Ty);
 
 bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
                                bool &PerfectMatch, const DataLayout &DL,
-                               bool structAliasing = false);
+                               bool StrictStruct = false);
 
 void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
                           GetElementPtrInst *GEP, uint64_t &CstVal,

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -150,7 +150,7 @@ Value *ExtractElementOrSubVector(Type *Ty, IRBuilder<> &Builder, Value *Val,
     // ValueTy: <4 x i32> - Ty: <2 x i16>
     // <4 x i32> -> <4 x i32>[Idx] -> i32
     assert(SrcEleSize == DstSize);
-    return Builder.CreateExtractElement(Val, Idx);
+    return Builder.CreateExtractElement(Val, Idx ? Idx : Builder.getInt32(0));
   } else if (NumElements == 2) {
     // ValueTy: <4 x i32> - Ty: <4 x i16>
     // <4 x i32> -> {<2 x i32>, <2 x i32>}[Idx] -> <2 x i32>
@@ -486,7 +486,8 @@ void CleanModule(WeakInstructions &ToBeDeleted) {
   }
 }
 
-void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
+bool DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
+  bool changed = false;
   while (auto gep = dyn_cast<GetElementPtrInst>(Src)) {
     IRBuilder<> B(gep);
     uint64_t CstVal;
@@ -503,6 +504,7 @@ void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
     gep->replaceAllUsesWith(new_gep);
     gep->eraseFromParent();
     Src = new_gep->getPointerOperand();
+    changed = true;
   }
   if (auto alloca = dyn_cast<AllocaInst>(Src)) {
     IRBuilder<> B(alloca);
@@ -514,6 +516,7 @@ void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
     auto new_alloca = B.CreateAlloca(Ty, alloca->getAddressSpace());
     alloca->replaceAllUsesWith(new_alloca);
     alloca->eraseFromParent();
+    changed = true;
   } else if (auto GV = dyn_cast<GlobalVariable>(Src)) {
     auto nb_elem = SizeInBits(DL, GV->getValueType()) / SizeInBits(DL, Ty);
     if (nb_elem > 1) {
@@ -529,7 +532,7 @@ void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
         !initializer->isNullValue() && !initializer->isZeroValue() &&
         !isa<UndefValue>(initializer)) {
       // unsupported do nothing...
-      return;
+      return changed;
     } else if (initializer && initializer->isOneValue()) {
       initializer = Constant::getAllOnesValue(Ty);
     } else if (initializer &&
@@ -549,6 +552,7 @@ void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
 
     GV->replaceAllUsesWith(new_GV);
     GV->eraseFromParent();
+    changed = true;
   } else if (auto Arg = dyn_cast<Argument>(Src)) {
     SmallVector<User *, 16> UserWorkList;
     auto TySize = SizeInBits(DL, Ty);
@@ -582,19 +586,15 @@ void DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
                                                   Idxs, "", gep);
         gep->replaceAllUsesWith(new_gep);
         gep->eraseFromParent();
+        changed = true;
       }
     }
   }
+  return changed;
 }
 
-} // namespace
-
-PreservedAnalyses
-clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
-  PreservedAnalyses PA;
-
+bool DowngradeModule(Module &M) {
   DenseMap<Value *, Type *> type_cache;
-  WeakInstructions ToBeDeleted;
   const DataLayout &DL = M.getDataLayout();
 
   // Downgrade object type when detecting implicit cast with inner source type
@@ -627,6 +627,10 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
           continue;
         }
 
+        if (auto gep = dyn_cast<GetElementPtrInst>(&I)) {
+          dest_ty = gep->getResultElementType();
+        }
+
         Type *EleTy = GetEleType(source_ty);
         while (source_ty != EleTy) {
           source_ty = EleTy;
@@ -635,12 +639,32 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
         size_t source_size = SizeInBits(DL, source_ty);
         size_t dest_size = SizeInBits(DL, dest_ty);
         if (source_size > dest_size) {
-          DowngradeSourceToTy(DL, source, dest_ty);
+          if (isa<IntToPtrInst>(source)) {
+            return DowngradeSourceToTy(DL, &I, dest_ty);
+          } else {
+            return DowngradeSourceToTy(DL, source, dest_ty);
+          }
         }
       }
     }
   }
-  type_cache.clear();
+  return false;
+}
+
+} // namespace
+
+PreservedAnalyses
+clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
+  PreservedAnalyses PA;
+
+  DenseMap<Value *, Type *> type_cache;
+  WeakInstructions ToBeDeleted;
+  const DataLayout &DL = M.getDataLayout();
+
+  bool changed;
+  do {
+    changed = DowngradeModule(M);
+  } while (changed);
 
   DenseSet<Instruction *> WorkList;
   for (auto &F : M) {

--- a/test/PointerCasts/issue-1032.cl
+++ b/test/PointerCasts/issue-1032.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK-COUNT-32: OpStore
+// CHECK-COUNT-16: OpStore
 
 struct Data
 {

--- a/test/PointerCasts/issue-1184.cl
+++ b/test/PointerCasts/issue-1184.cl
@@ -1,0 +1,19 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct E { int i0, i1; };
+
+struct S
+{
+    long i; struct E e; // Fails
+    // struct E e; long i; // OK
+    // int i; struct E e; // OK
+};
+
+kernel void Kernel(global struct S* s)
+{
+    s->i = 1;
+    s->e.i0 = 1;
+    s->e.i1 = 1;
+}

--- a/test/PointerCasts/issue-1185.cl
+++ b/test/PointerCasts/issue-1185.cl
@@ -1,0 +1,48 @@
+// RUN: clspv %s -o %t.spv -physical-storage-buffers -arch=spir64
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct V {
+    int x, y;
+};
+struct E {
+    struct V v;
+};
+struct S {
+    struct E e[2];
+};
+
+kernel void Kernel0(global struct S *s)
+{
+    s->e[0].v.x = 1;
+    s->e[0].v.y = 1;
+    s->e[1].v.x = 1;
+}
+
+kernel void Kernel1(global struct S *s)
+{
+    global struct E *e0 = (global struct E *)(((long)s->e) + sizeof(struct E) * 0);
+    e0->v.x = 1;
+    e0->v.y = 1;
+    global struct E *e1 = (global struct E *)(((long)s->e) + sizeof(struct E) * 1);
+    e1->v.x = 1;
+    e1->v.y = 1;
+}
+
+kernel void Kernel2(global struct S *s)
+{
+    s->e[0].v.x = 1;
+    s->e[1].v.x = 1;
+}
+
+kernel void Kernel3(global struct S *s)
+{
+    s->e[0].v.y = 1;
+    s->e[1].v.y = 1;
+}
+
+kernel void Kernel(global struct S *s)
+{
+    s->e[0].v.x = 1;
+    s->e[1].v.y = 1;
+}

--- a/test/UBO/copy_nested.cl
+++ b/test/UBO/copy_nested.cl
@@ -25,18 +25,16 @@ __kernel void foo(__global outer* data, __constant outer* c) {
 // CHECK-DAG: OpDecorate [[var:%[0-9a-zA-Z_]+]] NonWritable
 // CHECK-DAG: OpDecorate [[var]] DescriptorSet 0
 // CHECK-DAG: OpDecorate [[var]] Binding 1
-// CHECK: OpDecorate [[array:%[0-9a-zA-Z_]+]] ArrayStride 32
+// CHECK: OpDecorate [[array:%[0-9a-zA-Z_]+]] ArrayStride 16
 // CHECK-DAG: [[float:%[0-9a-zA-Z_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[float4:%[0-9a-zA-Z_]+]] = OpTypeVector [[float]] 4
-// CHECK-DAG: [[inner:%[0-9a-zA-Z_]+]] = OpTypeStruct [[float4]]
-// CHECK-DAG: [[outer:%[0-9a-zA-Z_]+]] = OpTypeStruct [[inner]]
 // CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
-// CHECK-DAG: [[int_2048:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2048
-// CHECK-DAG: [[array]] = OpTypeArray [[outer]] [[int_2048]]
+// CHECK-DAG: [[int_4096:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 4096
+// CHECK-DAG: [[array]] = OpTypeArray [[float4]] [[int_4096]]
 // CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[array]]
 // CHECK-DAG: [[ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[struct]]
 // CHECK-DAG: [[ptr_float4:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[float4]]
 // CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
 // CHECK: [[var]] = OpVariable [[ptr]] Uniform
-// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_float4]] [[var]] [[zero]] [[zero]] [[zero]]
+// CHECK: [[gep:%[0-9a-zA-Z_]+]] = OpAccessChain [[ptr_float4]] [[var]] [[zero]] [[zero]]
 // CHECK: OpLoad [[float4]] [[gep]]


### PR DESCRIPTION
When guessing the type from the users, do not consider aliasing when type match the first element of the struct.

Fix DowngradeSourceToTy to avoid modifying node on which we are iterating.

No regression on CTS with swiftshader and nvidia

Fix #1184
Fix #1185