### PR TITLE
fix to consider memcpy and memset with generic addrspace

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -187,7 +187,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {
   };
 
   for (auto &F : M) {
-    if (F.getName().startswith("llvm.memset")) {
+    if (F.getName().contains("llvm.memset")) {
       SmallVector<CallInst *, 8> CallsToReplace;
 
       for (auto U : F.users()) {
@@ -252,6 +252,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {
           Bitcast->eraseFromParent();
         }
       }
+      DeadFunctions.push_back(&F);
     }
   }
 
@@ -265,7 +266,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
   DenseMap<Value *, Type *> type_cache;
 
   for (auto &F : M) {
-    if (F.getName().startswith("llvm.memcpy")) {
+    if (F.getName().contains("llvm.memcpy")) {
       SmallVector<CallInst *, 8> CallsToReplaceWithSpirvCopyMemory;
 
       for (auto U : F.users()) {
@@ -313,6 +314,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemcpy(Module &M) {
         // Erase the call.
         CI->eraseFromParent();
       }
+      DeadFunctions.push_back(&F);
     }
   }
 

--- a/test/LLVMIntrinsics/issue-1173.cl
+++ b/test/LLVMIntrinsics/issue-1173.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv -cl-std=CLC++ -inline-entry-points -O3
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct S { int i1; };
+
+kernel void Kernel(global void* Memory)
+{
+    long a = (long) Memory;
+
+    //* (int*) a = 0; // OK, address space inferred
+     * (S*) a = {}; // Fails, address space not inferred. OK if externally optimized
+    // * (global S*) a = {}; // OK, address space explicit
+}

--- a/test/LLVMIntrinsics/issue-1173.ll
+++ b/test/LLVMIntrinsics/issue-1173.ll
@@ -1,0 +1,48 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics
+; RUN: FileCheck %s < %t.ll
+
+; CHECK-NOT: llvm.memcpy
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%struct.S = type { i32 }
+
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @_Z21llvm.memcpy.p4.p0.i32PU3AS1memcpy.p4.p0.i32(ptr addrspace(1) noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1) local_unnamed_addr #0
+
+; Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite)
+define dso_local spir_kernel void @Kernel(ptr addrspace(1) nocapture writeonly %Memory) local_unnamed_addr #1 !kernel_arg_addr_space !8 !kernel_arg_access_qual !9 !kernel_arg_type !10 !kernel_arg_base_type !10 !kernel_arg_type_qual !11 !kernel_arg_name !12 !clspv.pod_args_impl !13 {
+entry:
+  %ref.tmp = alloca %struct.S, align 8
+  %0 = getelementptr %struct.S, ptr %ref.tmp, i32 0, i32 0
+  store i32 0, ptr %0, align 8
+  call void @_Z21llvm.memcpy.p4.p0.i32PU3AS1memcpy.p4.p0.i32(ptr addrspace(1) %Memory, ptr nonnull %ref.tmp, i32 4, i1 false)
+  ret void
+}
+
+attributes #0 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite) "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!opencl.ocl.version = !{!3}
+!opencl.spir.version = !{!3, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4, !4}
+!llvm.ident = !{!5, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6}
+!_Z28clspv.entry_point_attributes = !{!7}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"direct-access-external-data", i32 0}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{i32 2, i32 0}
+!4 = !{i32 1, i32 2}
+!5 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 1e6fc9626c0f49ce952a67aef47e86253d13f74a)"}
+!6 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project ab674234c440ed27302f58eeccc612c83b32c43f)"}
+!7 = !{!"Kernel", !" kernel"}
+!8 = !{i32 1}
+!9 = !{!"none"}
+!10 = !{!"void*"}
+!11 = !{!""}
+!12 = !{!"Memory"}
+!13 = !{i32 2}


### PR DESCRIPTION
When LowerAddrSpaceCastPass rework the function to remove the generic addrspace part of it, it generates a name with a itanium mangling.

Take it into account in ReplaceLLVMInstrinsics so that those function are taken care of.

Also add them to the DeadFunctions to avoid error later in the verifier pass

Fix #1173