### PR TITLE
fix GetIdxsForTyFromOffset with private and private like addrspace

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1158,10 +1158,11 @@ GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
 
   // For private pointer, the first Idx needs to be '0'
   unsigned startIdx = 0;
-  if (AddrSpace == clspv::AddressSpace::Private ||
-      AddrSpace == clspv::AddressSpace::ModuleScopePrivate ||
-      AddrSpace == clspv::AddressSpace::PushConstant ||
-      AddrSpace == clspv::AddressSpace::Input) {
+  if ((AddrSpace == clspv::AddressSpace::Private ||
+       AddrSpace == clspv::AddressSpace::ModuleScopePrivate ||
+       AddrSpace == clspv::AddressSpace::PushConstant ||
+       AddrSpace == clspv::AddressSpace::Input) &&
+      SrcTy != DstTy) {
     Idxs.push_back(ConstantInt::get(Builder.getInt32Ty(), 0));
     startIdx = 1;
   }

--- a/test/PointerCasts/issue-1196.ll
+++ b/test/PointerCasts/issue-1196.ll
@@ -1,0 +1,14 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  [[alloca:%[^ ]+]] = alloca [196 x i8], align 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr [196 x i8], ptr [[alloca]], i32 0, i32 64
+; CHECK:  store i8 %val, ptr [[gep]], align 1
+
+define dso_local spir_kernel void @kernel(i8 %val) {
+entry:
+  %alloca = alloca { [8 x i64], [16 x i64], i32 }, align 16
+  %gep = getelementptr { [8 x i64], [16 x i64], i32 }, ptr %alloca, i32 0, i32 1, i32 0
+  store i8 %val, ptr %gep, align 1
+  ret void
+}


### PR DESCRIPTION
Private addrspace needs to have a zero as first indice. But when SrcTy == DstTy, we are in another scenario coming from pointer cast rework, where the first indice may not be zero.

Fix #1196