### PR TITLE
fix runOnImplicitCasts

### DIFF
--- a/test/PointerCasts/issue-1204.ll
+++ b/test/PointerCasts/issue-1204.ll
@@ -1,0 +1,11 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: getelementptr i8, ptr %md5, i32 4
+
+define dso_local spir_kernel void @kernel(ptr %md5) {
+entry:
+    %arraydecay518 = getelementptr [4 x i32], ptr %md5, i32 0, i32 0
+    %arrayidx519 = getelementptr i8, ptr %arraydecay518, i32 4
+    ret void
+}

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
@@ -7,19 +7,21 @@ target triple = "spir-unknown-unknown"
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
 ; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 2
-; CHECK: [[gep_src:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <4 x i8>
 ; CHECK: [[trunc0:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 0
 ; CHECK: [[trunc1:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 1
 ; CHECK: [[trunc2:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 2
 ; CHECK: [[trunc3:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 3
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: store i8 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 1
+; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 [[idx]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add1]]
 ; CHECK: store i8 [[trunc1]], ptr addrspace(1) [[gep]]
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 2
+; CHECK: [[add2:%[a-zA-Z0-9_.]+]] = add i32 [[add1]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add2]]
 ; CHECK: store i8 [[trunc2]], ptr addrspace(1) [[gep]]
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 3
+; CHECK: [[add3:%[a-zA-Z0-9_.]+]] = add i32 [[add2]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add3]]
 ; CHECK: store i8 [[trunc3]], ptr addrspace(1) [[gep]]
 
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
@@ -7,13 +7,13 @@ target triple = "spir-unknown-unknown"
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
 ; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 1
-; CHECK: [[gep_src:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <2 x i16>
 ; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 0
 ; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 0
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[idx]]
 ; CHECK: store i16 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 1
+; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[idx]], 1
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[add]]
 ; CHECK: store i16 [[trunc1]], ptr addrspace(1) [[gep]]
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {
 entry:


### PR DESCRIPTION
when src_gep indices are all zeros, just use src_gep pointer, and don't try to rework the indices which can lead to unsupported cases

Ref #1204