### PR TITLE
fix runOnImplicitCasts

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1151,6 +1151,40 @@ void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
   }
 }
 
+uint64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
+                               IRBuilder<> &Builder, Type *Ty, Type *TargetTy,
+                               uint64_t Offset, SmallVector<Value *, 2> *Idxs) {
+#ifndef NDEBUG
+  Type *SrcTy = Ty;
+#endif
+  while ((Ty->isVectorTy() || Ty->isArrayTy() || Ty->isStructTy()) &&
+         (TargetTy == nullptr ||
+          SizeInBits(DataLayout, Ty) > SizeInBits(DataLayout, TargetTy))) {
+    if (auto STy = dyn_cast<StructType>(Ty)) {
+      auto SLayout = DataLayout.getStructLayout(STy);
+      auto SId = SLayout->getElementContainingOffset(Offset / CHAR_BIT);
+      auto off = SLayout->getElementOffsetInBits(SId);
+      Ty = STy->getElementType(SId);
+      if (Idxs) {
+        Idxs->push_back(Builder.getInt32(SId));
+      }
+      Offset -= off;
+    } else {
+      auto NextTy = GetEleType(Ty);
+      assert(NextTy != Ty);
+      Ty = NextTy;
+      auto size = SizeInBits(DataLayout, Ty);
+      if (Idxs) {
+        Idxs->push_back(Builder.getInt32(Offset / size));
+      }
+      Offset %= size;
+    }
+    assert(Idxs == nullptr ||
+           GetElementPtrInst::getIndexedType(SrcTy, *Idxs) == Ty);
+  }
+  return Offset;
+}
+
 SmallVector<Value *, 2>
 GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
                        Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
@@ -1190,25 +1224,8 @@ GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
       Idxs.push_back(Builder.getInt32(CstVal / size));
       CstVal %= size;
     }
-    while ((Ty->isVectorTy() || Ty->isArrayTy() || Ty->isStructTy()) &&
-           SizeInBits(DataLayout, Ty) > SizeInBits(DataLayout, DstTy)) {
-      if (auto STy = dyn_cast<StructType>(Ty)) {
-        auto SLayout = DataLayout.getStructLayout(STy);
-        auto SId = SLayout->getElementContainingOffset(CstVal / CHAR_BIT);
-        auto offset = SLayout->getElementOffsetInBits(SId);
-        Ty = STy->getElementType(SId);
-        Idxs.push_back(Builder.getInt32(SId));
-        CstVal -= offset;
-      } else {
-        auto NextTy = GetEleType(Ty);
-        assert(NextTy != Ty);
-        Ty = NextTy;
-        auto size = SizeInBits(DataLayout, Ty);
-        Idxs.push_back(Builder.getInt32(CstVal / size));
-        CstVal %= size;
-      }
-      assert(GetElementPtrInst::getIndexedType(SrcTy, Idxs) == Ty);
-    }
+    CstVal =
+        GoThroughTypeAtOffset(DataLayout, Builder, Ty, DstTy, CstVal, &Idxs);
     if (CstVal != 0) {
       errs() << "Err: SrcTy = ";
       SrcTy->print(errs());

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -69,6 +69,10 @@ void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
                           GetElementPtrInst *GEP, uint64_t &CstVal,
                           Value *&DynVal, size_t &SmallerBitWidths);
 
+uint64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
+                               IRBuilder<> &Builder, Type *Ty, Type *TargetTy,
+                               uint64_t Offset, SmallVector<Value *, 2> *Idxs);
+
 SmallVector<Value *, 2>
 GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
                        Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,

--- a/test/PointerCasts/multiple_implcit_casts.ll
+++ b/test/PointerCasts/multiple_implcit_casts.ll
@@ -13,6 +13,12 @@
 ; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr %S2, ptr addrspace(1) %data, i32 %n, i32 1, i32 1, i32 1
 ; CHECK: store float 0.000000e+00, ptr addrspace(1) [[gep]]
 
+; CHECK: @test4
+; CHECK: [[shl:%[a-zA-Z0-9_.]+]] = shl i32 %n, 4
+; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[shl]], 3
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %data, i32 [[add]]
+; CHECK: store float 0.000000e+00, ptr addrspace(1) [[gep]]
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
@@ -40,6 +46,14 @@ define void @test3(ptr addrspace(1) %data, i32 %n) {
 entry:
   %gep1 = getelementptr inbounds %S2, ptr addrspace(1) %data, i32 %n
   %gep2 = getelementptr inbounds i8, ptr addrspace(1) %gep1, i32 9
+  store float 0.000000e+00, ptr addrspace(1) %gep2, align 4
+  ret void
+}
+
+define void @test4(ptr addrspace(1) %data, i32 %n) {
+entry:
+  %gep1 = getelementptr inbounds %S2, ptr addrspace(1) %data, i32 %n
+  %gep2 = getelementptr inbounds i8, ptr addrspace(1) %gep1, i32 3
   store float 0.000000e+00, ptr addrspace(1) %gep2, align 4
   ret void
 }

--- a/test/PointerCasts/opaque_trivial_casts.ll
+++ b/test/PointerCasts/opaque_trivial_casts.ll
@@ -80,7 +80,7 @@ entry:
 
 ; CHECK-LABEL: define void @test7(ptr addrspace(1) %in) {
 ; CHECK: entry:
-; CHECK:   getelementptr float, ptr addrspace(1) %in, i32 2
+; CHECK:   getelementptr i32, ptr addrspace(1) %in, i32 2
 ; CHECK-NEXT: ret void
 ; CHECK: }
 


### PR DESCRIPTION
When reworking a gep whose src is a gep and we recognise that the offset from the reworked gep will end up in the middle of the src type, rework the gep by merging it with the offset of the src one and by taking the src pointer.

Fix #1207