### PR TITLE
always use normalized sampler to read image3d with literal sampler

### DIFF
--- a/docs/OpenCLCOnVulkan.md
+++ b/docs/OpenCLCOnVulkan.md
@@ -823,6 +823,13 @@ describe:
 
 All supported.
 
+Reading 3D images with a unormalized sampler is not allowed in Vulkan. Thus
+OpenCL source code performing this operation is emulated by normalizing the
+coordinate before reading the image using a normalized sampler.
+
+The normalization of the coordinate can introduce an accuracy issue as the
+floating point division used is not correctly rounded.
+
 #### cl_khr_subgroups extension
 
 The OpenCL extension `cl_khr_subgroups` requires SPIR-V 1.3 or greater and

--- a/lib/BuiltinsEnum.h
+++ b/lib/BuiltinsEnum.h
@@ -29,6 +29,7 @@ enum BuiltinType : unsigned int {
   kSpirvCopyMemory,
   kClspvSamplerVarLiteral,
   kClspvCompositeConstruct,
+  kClspvGetImageSizes,
   kType_Clspv_End,
 
   kType_Async_Start,

--- a/lib/BuiltinsMap.inc
+++ b/lib/BuiltinsMap.inc
@@ -1117,6 +1117,7 @@ static std::unordered_map<const char *, Builtins::BuiltinType, cstr_hash,
         {"clspv.sampler_var_literal", Builtins::kClspvSamplerVarLiteral},
         {"clspv.composite_construct", Builtins::kClspvCompositeConstruct},
 
+        {"clspv.get_image_sizes", Builtins::kClspvGetImageSizes},
 };
 
 #endif // CLSPV_LIB_BUILTINSMAP_INC_

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(clspv_passes OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/ReplacePointerBitcastPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/RewriteInsertsPass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/RewritePackedStructs.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/SamplerUtils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ScalarizePass.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ShareModuleScopeVariables.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/SignedCompareFixupPass.cpp

--- a/lib/ReplaceOpenCLBuiltinPass.h
+++ b/lib/ReplaceOpenCLBuiltinPass.h
@@ -34,6 +34,7 @@ struct ReplaceOpenCLBuiltinPass
 
 private:
   bool runOnFunction(llvm::Function &F);
+  void removeUnusedSamplers(llvm::Module &M);
   bool replaceAbs(llvm::Function &F);
   bool replaceAbsDiff(llvm::Function &F, bool is_signed);
   bool replaceCopysign(llvm::Function &F);
@@ -86,7 +87,7 @@ private:
   bool replaceVstoreHalf16(llvm::Function &F);
   bool replaceHalfReadImage(llvm::Function &F);
   bool replaceHalfWriteImage(llvm::Function &F);
-  bool replaceSampledReadImageWithIntCoords(llvm::Function &F);
+  bool replaceSampledReadImage(llvm::Function &F);
   bool replaceAtomics(llvm::Function &F, spv::Op Op);
   bool replaceAtomics(llvm::Function &F, llvm::AtomicRMWInst::BinOp Op);
   bool replaceAtomicLoad(llvm::Function &F);

--- a/lib/SamplerUtils.cpp
+++ b/lib/SamplerUtils.cpp
@@ -1,0 +1,31 @@
+// Copyright 2023 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SamplerUtils.h"
+
+using namespace llvm;
+
+namespace clspv {
+
+Value *NormalizedCoordinate(Module &M, IRBuilder<> &B, Value *Coord, Value *Img,
+                            Type *ImgTy) {
+  auto getImageSizesFct = M.getOrInsertFunction(
+      "clspv.get_image_sizes",
+      FunctionType::get(Coord->getType(), {ImgTy}, false));
+  Value *ImgSizes = B.CreateCall(getImageSizesFct, {Img});
+
+  return B.CreateFDiv(Coord, ImgSizes);
+}
+
+} // namespace clspv

--- a/lib/SamplerUtils.h
+++ b/lib/SamplerUtils.h
@@ -1,0 +1,29 @@
+// Copyright 2023 The Clspv Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _CLSPV_SAMPLER_UTILS_H
+#define _CLSPV_SAMPLER_UTILS_H
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Value.h"
+
+namespace clspv {
+
+llvm::Value *NormalizedCoordinate(llvm::Module &M, llvm::IRBuilder<> &B,
+                                  llvm::Value *Coord, llvm::Value *Img,
+                                  llvm::Type *ImgTy);
+
+} // namespace clspv
+
+#endif

--- a/test/ImageBuiltins/read_image3d_with_literal_unorm_sampler.cl
+++ b/test/ImageBuiltins/read_image3d_with_literal_unorm_sampler.cl
@@ -1,0 +1,30 @@
+// RUN: clspv %s -o %t.spv --cl-native-math
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+// RUN: FileCheck %s < %t.spvasm
+
+// CHECK-DAG:  [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG:  [[float:%[^ ]+]] = OpTypeFloat 32
+// CHECK-DAG:  [[uint3:%[^ ]+]] = OpTypeVector [[uint]] 3
+// CHECK-DAG:  [[uint4:%[^ ]+]] = OpTypeVector [[uint]] 4
+// CHECK-DAG:  [[float4:%[^ ]+]] = OpTypeVector [[float]] 4
+// CHECK-DAG:  [[float_0:%[^ ]+]] = OpConstant [[float]] 0
+// CHECK-DAG:  [[uint_0:%[^ ]+]] = OpConstant [[uint]] 0
+// CHECK-DAG:  [[uint_1:%[^ ]+]] = OpConstant [[uint]] 1
+// CHECK-DAG:  [[uint_21:%[^ ]+]] = OpConstant [[uint]] 21
+// CHECK-DAG:  [[vec:%[^ ]+]] = OpConstantComposite [[uint4]] [[uint_1]] [[uint_1]] [[uint_1]] [[uint_1]]
+
+// CHECK:  [[sizes:%[^ ]+]] = OpImageQuerySizeLod [[uint3]] {{.*}} [[uint_0]]
+// CHECK:  [[shuffle:%[^ ]+]] = OpVectorShuffle [[uint4]] [[sizes]] [[vec]] 0 1 2 4
+// CHECK:  [[convert:%[^ ]+]] = OpConvertUToF [[float4]] [[shuffle]]
+// CHECK:  [[div:%[^ ]+]] = OpFDiv [[float4]] %44 [[convert]]
+// CHECK:  OpImageSampleExplicitLod [[float4]] {{.*}} [[div]] Lod [[float_0]]
+
+// CHECK:  OpExtInst %void {{.*}} LiteralSampler [[uint_0]] [[uint_0]] [[uint_21]]
+
+static const sampler_t my_sampler = CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST | CLK_NORMALIZED_COORDS_FALSE;
+
+void kernel foo(read_only image3d_t img, global float4 *out, int i)
+{
+    *out = read_imagef(img, my_sampler, (int4)(2, 3, 4, 5));
+}

--- a/test/ImageBuiltins/read_image3d_with_literal_unorm_sampler.ll
+++ b/test/ImageBuiltins/read_image3d_with_literal_unorm_sampler.ll
@@ -1,0 +1,63 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-opencl-builtin
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  [[sampler:%[^ ]+]] = call target("spirv.Sampler") @__translate_sampler_initializer(i32 21)
+; CHECK:  [[convert:%[^ ]+]] = sitofp <4 x i32> <i32 2, i32 3, i32 4, i32 5> to <4 x float>
+; CHECK:  [[sizes:%[^ ]+]] = call <4 x float> @clspv.get_image_sizes(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img)
+; CHECK:  [[div:%[^ ]+]] = fdiv <4 x float> [[convert]], [[sizes]]
+; CHECK:  call <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_f(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") [[sampler]], <4 x float> [[div]])
+
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_WorkgroupSize = addrspace(8) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent norecurse nounwind
+define spir_kernel void @foo(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img, ptr addrspace(1) align 16 %out, { i32 } %podargs) #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !9 !kernel_arg_type !10 !kernel_arg_base_type !11 !kernel_arg_type_qual !12 !kernel_arg_name !13 !clspv.pod_args_impl !14 !kernel_arg_map !15 {
+entry:
+  %i = extractvalue { i32 } %podargs, 0
+  %0 = call spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32 20) #3
+  %call.i = call spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %0, <4 x i32> <i32 2, i32 3, i32 4, i32 5>) #4
+  store <4 x float> %call.i, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+; Function Attrs: convergent nounwind willreturn memory(read)
+declare !kernel_arg_name !12 spir_func <4 x float> @_Z11read_imagef14ocl_image3d_ro11ocl_samplerDv4_i(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), target("spirv.Sampler"), <4 x i32>) #1
+
+; Function Attrs: speculatable memory(none)
+declare !kernel_arg_name !19 spir_func target("spirv.Sampler") @__translate_sampler_initializer(i32) #2
+
+attributes #0 = { convergent norecurse nounwind "less-precise-fpmad"="true" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
+attributes #1 = { convergent nounwind willreturn memory(read) "less-precise-fpmad"="true" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" }
+attributes #2 = { speculatable memory(none) }
+attributes #3 = { nounwind }
+attributes #4 = { convergent nobuiltin nounwind willreturn memory(read) "no-builtins" }
+
+!llvm.module.flags = !{!0, !1, !2}
+!opencl.ocl.version = !{!3}
+!opencl.spir.version = !{!3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3}
+!llvm.ident = !{!4, !5, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !5, !5, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6, !6}
+!_Z28clspv.entry_point_attributes = !{!7}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"direct-access-external-data", i32 0}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{i32 1, i32 2}
+!4 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 51e93736bb997a11ab4026e6a54bc89e0950df06)"}
+!5 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project 1e6fc9626c0f49ce952a67aef47e86253d13f74a)"}
+!6 = !{!"clang version 17.0.0 (https://github.com/llvm/llvm-project ab674234c440ed27302f58eeccc612c83b32c43f)"}
+!7 = !{!"foo", !" kernel"}
+!8 = !{i32 1, i32 1, i32 0}
+!9 = !{!"read_only", !"none", !"none"}
+!10 = !{!"image3d_t", !"float4*", !"int"}
+!11 = !{!"image3d_t", !"float __attribute__((ext_vector_type(4)))*", !"int"}
+!12 = !{!"", !"", !""}
+!13 = !{!"img", !"out", !"i"}
+!14 = !{i32 2}
+!15 = !{!16, !17, !18}
+!16 = !{!"img", i32 0, i32 0, i32 0, i32 0, !"ro_image"}
+!17 = !{!"out", i32 1, i32 1, i32 0, i32 0, !"buffer"}
+!18 = !{!"i", i32 2, i32 2, i32 0, i32 4, !"pod_pushconstant"}
+!19 = !{!""}


### PR DESCRIPTION
We cannot use unormalized sampled with 3D images.

This commit intend to fix that for literal sampler (static sampler defined in the kernel).

When detecting a case of reading a image3d with a literal sampler using unnormalized coordinate:
- create a equivalent sampler using normalized coordinate
- normalized the coordinate

Ref #1202