### PR TITLE
fix RedeclareGlobalPushConstants to avoid i64 index for struct

### DIFF
--- a/lib/PushConstant.cpp
+++ b/lib/PushConstant.cpp
@@ -312,7 +312,14 @@ void RedeclareGlobalPushConstants(Module &M, StructType *mangled_struct_ty,
 
         for (auto iter = gep_operator->idx_begin();
              iter != gep_operator->idx_end(); ++iter) {
-          indices.push_back(cast<Constant>(*iter));
+          auto cst = cast<Constant>(*iter);
+          if (cst->getType()->isIntegerTy(64) &&
+              GetElementPtrInst::getIndexedType(push_constant_ty, indices)
+                  ->isStructTy()) {
+            cst = ConstantInt::get(IntegerType::get(M.getContext(), 32),
+                                   cast<ConstantInt>(cst)->getZExtValue());
+          }
+          indices.push_back(cst);
         }
         auto new_gep = ConstantExpr::getGetElementPtr(
             push_constant_ty, new_GV, indices, gep_operator->isInBounds());

--- a/test/cluster_pod_args_spir64_cst_expr_gep.ll
+++ b/test/cluster_pod_args_spir64_cst_expr_gep.ll
@@ -1,0 +1,25 @@
+; RUN: clspv-opt %s -o %t.ll --passes=cluster-pod-kernel-args-pass
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[type:%[^ ]+]] = type { <3 x i32>, [[pc:%[^ ]+]] }
+; CHECK: [[pc]] = type { i32, i32 }
+
+; CHECK-COUNT-2: load i32, ptr addrspace(9) getelementptr inbounds ([[type]], ptr addrspace(9) @__push_constants, i32 0, i32 0, i64 2), align 4
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%0 = type { <3 x i32> }
+
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+@__spirv_LocalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
+
+; Function Attrs: convergent norecurse nounwind
+define dso_local spir_kernel void @main_function(i64 %0) !clspv.pod_args_impl !16 {
+entry:
+  %load = load i32, ptr addrspace(9) getelementptr inbounds (<3 x i32>, ptr addrspace(9) @__push_constants, i64 0, i64 2), align 4
+  ret void
+}
+
+!0 = !{i32 6}
+!16 = !{i32 3}


### PR DESCRIPTION
Structure can only be accessed through i32 index.
This bug was found running with spir64 and physical addressing enabled.