### PR TITLE
fix replacepointerbitcast for gep with result type smaller than src

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1157,6 +1157,21 @@ uint64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
 #ifndef NDEBUG
   Type *SrcTy = Ty;
 #endif
+  if (!(Ty->isVectorTy() || Ty->isArrayTy() || Ty->isStructTy())) {
+    auto size = SizeInBits(DataLayout, Ty);
+    if (Idxs) {
+      auto val = Offset / size;
+      if (Idxs->size() > 0) {
+        if (auto lastIdxCst = dyn_cast<ConstantInt>(Idxs->back())) {
+          val += lastIdxCst->getZExtValue();
+          Idxs->pop_back();
+        }
+      }
+      Idxs->push_back(Builder.getInt32(val));
+    }
+    Offset %= size;
+    return Offset;
+  }
   while ((Ty->isVectorTy() || Ty->isArrayTy() || Ty->isStructTy()) &&
          (TargetTy == nullptr ||
           SizeInBits(DataLayout, Ty) > SizeInBits(DataLayout, TargetTy))) {

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -215,7 +215,7 @@ void ReduceType(IRBuilder<> &Builder, bool IsGEPUser, Value *OrgGEPIdx,
       }
     }
   } else {
-    if (SrcTyBitWidth == DstTyBitWidth) {
+    if (SrcTyBitWidth == DstTyBitWidth && OrgGEPIdx) {
       OutAddrIdxs.push_back(OrgGEPIdx);
     } else {
       OutAddrIdxs.push_back(InAddrIdxs[InIdx++]);
@@ -743,6 +743,12 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
       }
 
       DstTy = GEP->getResultElementType();
+
+      if (DynVal == nullptr &&
+          GoThroughTypeAtOffset(DL, Builder, SrcTy, DstTy,
+                                CstVal * SmallerBitWidths, nullptr) != 0) {
+        SrcTy = DstTy;
+      }
       auto Idx = GetIdxsForTyFromOffset(
           DL, Builder, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths,
           (clspv::AddressSpace::Type)GEP->getPointerOperand()
@@ -776,9 +782,11 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
       IRBuilder<> Builder(cast<Instruction>(U));
 
       if (StoreInst *ST = dyn_cast<StoreInst>(U)) {
-        ComputeStore(Builder, ST, OrgGEPIdx, IsGEPUser, Src, SrcTy,
-                     ST->getValueOperand()->getType(), NewAddrIdxs,
-                     ToBeDeleted);
+        ComputeStore(Builder, ST,
+                     DstTy == ST->getValueOperand()->getType() ? OrgGEPIdx
+                                                               : nullptr,
+                     IsGEPUser, Src, SrcTy, ST->getValueOperand()->getType(),
+                     NewAddrIdxs, ToBeDeleted);
       } else if (LoadInst *LD = dyn_cast<LoadInst>(U)) {
         Value *DstVal = ComputeLoad(Builder, OrgGEPIdx, IsGEPUser, Src, SrcTy,
                                     LD->getType(), NewAddrIdxs, ToBeDeleted);

--- a/test/PointerCasts/issue-1222-2.ll
+++ b/test/PointerCasts/issue-1222-2.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt --passes=replace-pointer-bitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK:  [[load:%[^ ]+]] = load i32, ptr addrspace(1) %in, align 4
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %in, i32 8
+; CHECK:  store i32 [[load]], ptr addrspace(1) [[gep]], align 4
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  %load = load i32, ptr addrspace(1) %in, align 4
+  %gep = getelementptr [16 x i8], ptr addrspace(1) %in, i32 2
+  store i32 %load, ptr addrspace(1) %gep, align 4
+  ret void
+}
+

--- a/test/PointerCasts/issue-1222.ll
+++ b/test/PointerCasts/issue-1222.ll
@@ -1,0 +1,42 @@
+; RUN: clspv-opt --passes=replace-pointer-bitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %in, i32 0
+; CHECK:  [[load0:%[^ ]+]] = load i8, ptr addrspace(1) [[gep]], align 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %in, i32 1
+; CHECK:  [[load1:%[^ ]+]] = load i8, ptr addrspace(1) [[gep]], align 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %in, i32 2
+; CHECK:  [[load2:%[^ ]+]] = load i8, ptr addrspace(1) [[gep]], align 1
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %in, i32 3
+; CHECK:  [[load3:%[^ ]+]] = load i8, ptr addrspace(1) [[gep]], align 1
+; CHECK:  [[insert0:%[^ ]+]] = insertelement <4 x i8> poison, i8 [[load0]], i32 0
+; CHECK:  [[insert1:%[^ ]+]] = insertelement <4 x i8> [[insert0]], i8 [[load1]], i32 1
+; CHECK:  [[insert2:%[^ ]+]] = insertelement <4 x i8> [[insert1]], i8 [[load2]], i32 2
+; CHECK:  [[insert3:%[^ ]+]] = insertelement <4 x i8> [[insert2]], i8 [[load3]], i32 3
+; CHECK:  [[bitcast:%[^ ]+]] = bitcast <4 x i8> [[insert3]] to i32
+; CHECK:  [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %in, i32 3
+; CHECK:  [[bitcast2:%[^ ]+]] = bitcast i32 [[bitcast]] to <4 x i8>
+; CHECK:  [[extract0:%[^ ]+]] = extractelement <4 x i8> [[bitcast2]], i64 0
+; CHECK:  [[extract1:%[^ ]+]] = extractelement <4 x i8> [[bitcast2]], i64 1
+; CHECK:  [[extract2:%[^ ]+]] = extractelement <4 x i8> [[bitcast2]], i64 2
+; CHECK:  [[extract3:%[^ ]+]] = extractelement <4 x i8> [[bitcast2]], i64 3
+; CHECK:  [[gep0:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 0
+; CHECK:  store i8 [[extract0]], ptr addrspace(1) [[gep0]], align 1
+; CHECK:  [[gep1:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 1
+; CHECK:  store i8 [[extract1]], ptr addrspace(1) [[gep1]], align 1
+; CHECK:  [[gep2:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 2
+; CHECK:  store i8 [[extract2]], ptr addrspace(1) [[gep2]], align 1
+; CHECK:  [[gep3:%[^ ]+]] = getelementptr i8, ptr addrspace(1) [[gep]], i32 3
+; CHECK:  store i8 [[extract3]], ptr addrspace(1) [[gep3]], align 1
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  %load = load i32, ptr addrspace(1) %in, align 4
+  %gep = getelementptr [8 x i8], ptr addrspace(1) %in, i32 0, i32 3
+  store i32 %load, ptr addrspace(1) %gep, align 4
+  ret void
+}
+

--- a/test/PointerCasts/opaque_trivial_casts.ll
+++ b/test/PointerCasts/opaque_trivial_casts.ll
@@ -80,7 +80,7 @@ entry:
 
 ; CHECK-LABEL: define void @test7(ptr addrspace(1) %in) {
 ; CHECK: entry:
-; CHECK:   getelementptr i32, ptr addrspace(1) %in, i32 2
+; CHECK:   getelementptr float, ptr addrspace(1) %in, i32 2
 ; CHECK-NEXT: ret void
 ; CHECK: }
 


### PR DESCRIPTION
If we cannot figure out the indices from constant offset using the source type, it means that it is most probably smaller than the gep result type. In that case use the gep result type as the source type.

Also if the source type is not a vector, array of struct, still consider the scalar the go through it once.
We might need to merge it with some indice already existing.

Ref #1222