### PR TITLE
fix PointerBitcast considering type with null size

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -38,6 +38,20 @@
 
 namespace BitcastUtils {
 
+// Interface types are often something like: { [ 0 x Ty ] }.
+// SizeInBits returns zero for such types. Try to avoid it by go through the
+// type as long as SizeInBits returns zero to get the real type size for it.
+Type *reworkUnsizedType(const DataLayout &DL, Type *Ty) {
+  auto size = SizeInBits(DL, Ty);
+  auto Ele = GetEleType(Ty);
+  while (size == 0 && Ty != Ele) {
+    Ty = Ele;
+    Ele = GetEleType(Ty);
+    size = SizeInBits(DL, Ty);
+  }
+  return Ty;
+}
+
 void GroupScalarValuesIntoVector(IRBuilder<> &Builder,
                                  SmallVector<Value *, 8> &Values,
                                  unsigned NumElePerVec);
@@ -858,7 +872,8 @@ unsigned PointerOperandNum(Instruction *inst) {
 
 bool IsImplicitCasts(Module &M, DenseMap<Value *, Type *> &type_cache,
                      Instruction &I, Value *&source, Type *&source_ty,
-                     Type *&dest_ty, bool ReplacePhysicalPointerBitcasts) {
+                     Type *&dest_ty, bool ReplacePhysicalPointerBitcasts,
+                     bool reworkUnsizedTy) {
   // The following checks use InferType to distinguish when a pointer's
   // interpretation changes between instructions. This requires the input
   // to be an instruction whose result provides a clear type for a
@@ -963,6 +978,12 @@ bool IsImplicitCasts(Module &M, DenseMap<Value *, Type *> &type_cache,
         return false;
       }
     }
+  }
+  if (source_ty && reworkUnsizedTy) {
+    source_ty = reworkUnsizedType(M.getDataLayout(), source_ty);
+  }
+  if (dest_ty && reworkUnsizedTy) {
+    dest_ty = reworkUnsizedType(M.getDataLayout(), dest_ty);
   }
   return source_ty && dest_ty && source_ty != dest_ty;
 }
@@ -1206,6 +1227,10 @@ GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
   if (DstTy->isVoidTy()) {
     DstTy = Builder.getInt8Ty();
   }
+
+  SrcTy = reworkUnsizedType(DataLayout, SrcTy);
+  DstTy = reworkUnsizedType(DataLayout, DstTy);
+
   if (SizeInBits(DataLayout, DstTy) >= SizeInBits(DataLayout, SrcTy) &&
       DstTy != SrcTy) {
     DstTy = SrcTy;

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -25,6 +25,8 @@ using namespace llvm;
 
 namespace BitcastUtils {
 
+Type *reworkUnsizedType(const DataLayout &DL, Type *Ty);
+
 size_t SizeInBits(const DataLayout &DL, Type *Ty);
 size_t SizeInBits(IRBuilder<> &builder, Type *Ty);
 
@@ -44,7 +46,8 @@ bool RemoveCstExprFromFunction(Function *F);
 
 bool IsImplicitCasts(Module &M, DenseMap<Value *, Type *> &type_cache,
                      Instruction &I, Value *&source, Type *&source_ty,
-                     Type *&dest_ty, bool ReplacePhysicalPointerBitcasts);
+                     Type *&dest_ty, bool ReplacePhysicalPointerBitcasts,
+                     bool reworkUnsizedTy = true);
 
 unsigned PointerOperandNum(Instruction *inst);
 

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -720,6 +720,9 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
     }
     SrcTy = clspv::InferType(Src, M.getContext(), &type_cache);
 
+    SrcTy = BitcastUtils::reworkUnsizedType(DL, SrcTy);
+    DstTy = BitcastUtils::reworkUnsizedType(DL, DstTy);
+
     SmallVector<Value *, 4> NewAddrIdxs;
 
     // It consist of User* and bool whether user is gep or not.

--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -377,8 +377,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnUnneededCasts(Module &M) const {
         Value *source = nullptr;
         Type *source_ty = nullptr;
         Type *dest_ty = nullptr;
-        if (!IsImplicitCasts(M, type_cache, I, source, source_ty, dest_ty,
-                             true)) {
+        if (!IsImplicitCasts(M, type_cache, I, source, source_ty, dest_ty, true,
+                             false /* do not rework unsized types */)) {
           continue;
         }
 
@@ -440,8 +440,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
         Value *source = nullptr;
         Type *source_ty = nullptr;
         Type *dest_ty = nullptr;
-        if (!IsImplicitCasts(M, type_cache, I, source, source_ty, dest_ty,
-                             true)) {
+        if (!IsImplicitCasts(M, type_cache, I, source, source_ty, dest_ty, true,
+                             false /* do not rework unsized types */)) {
           continue;
         }
 

--- a/test/PointerCasts/issue-1222-3.ll
+++ b/test/PointerCasts/issue-1222-3.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt --passes=simplify-pointer-bitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; Nothing should have changed
+; CHECK: [[call:%[^ ]+]] = call ptr addrspace(2) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i8] } zeroinitializer)
+; CHECK: [[gep:%[^ ]+]] = getelementptr { [0 x i8] }, ptr addrspace(2) [[call]], i32 0
+; CHECK: load i32, ptr addrspace(2) [[gep]], align 4
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  %0 = call ptr addrspace(2) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i8] } zeroinitializer)
+  %1 = getelementptr { [0 x i8] }, ptr addrspace(2) %0, i32 0
+  %2 = load i32, ptr addrspace(2) %1, align 4
+  ret void
+}
+
+declare ptr addrspace(2) @_Z14clspv.resource.2(i32 %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, { [0 x i8] } %6)

--- a/test/PointerCasts/issue-1222-4.ll
+++ b/test/PointerCasts/issue-1222-4.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt --passes=replace-pointer-bitcast %s -o %t
+; RUN: FileCheck %s < %t
+
+; CHECK: [[call:%[^ ]+]] = call ptr addrspace(2) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i8] } zeroinitializer)
+; CHECK: [[gep:%[^ ]+]] = getelementptr { [0 x i8] }, ptr addrspace(2) [[call]], i32 0
+; CHECK: [[gep0:%[^ ]+]] = getelementptr i8, ptr addrspace(2) [[gep]], i32 0
+; CHECK: [[load0:%[^ ]+]] = load i8, ptr addrspace(2) [[gep0]], align 1
+; CHECK: [[gep1:%[^ ]+]] = getelementptr i8, ptr addrspace(2) [[gep]], i32 1
+; CHECK: [[load1:%[^ ]+]] = load i8, ptr addrspace(2) [[gep1]], align 1
+; CHECK: [[gep2:%[^ ]+]] = getelementptr i8, ptr addrspace(2) [[gep]], i32 2
+; CHECK: [[load2:%[^ ]+]] = load i8, ptr addrspace(2) [[gep2]], align 1
+; CHECK: [[gep3:%[^ ]+]] = getelementptr i8, ptr addrspace(2) [[gep]], i32 3
+; CHECK: [[load3:%[^ ]+]] = load i8, ptr addrspace(2) [[gep3]], align 1
+; CHECK: [[insert0:%[^ ]+]] = insertelement <4 x i8> poison, i8 [[load0]], i32 0
+; CHECK: [[insert1:%[^ ]+]] = insertelement <4 x i8> [[insert0]], i8 [[load1]], i32 1
+; CHECK: [[insert2:%[^ ]+]] = insertelement <4 x i8> [[insert1]], i8 [[load2]], i32 2
+; CHECK: [[insert3:%[^ ]+]] = insertelement <4 x i8> [[insert2]], i8 [[load3]], i32 3
+; CHECK: bitcast <4 x i8> [[insert3]] to i32
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %in, i32 %n) {
+entry:
+  %0 = call ptr addrspace(2) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x i8] } zeroinitializer)
+  %1 = getelementptr { [0 x i8] }, ptr addrspace(2) %0, i32 0
+  %2 = load i32, ptr addrspace(2) %1, align 4
+  ret void
+}
+
+declare ptr addrspace(2) @_Z14clspv.resource.2(i32 %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, { [0 x i8] } %6)


### PR DESCRIPTION
Types used to interface with SPIR-V have a null size (types like: `{[0 x Ty]}`).
Try to avoid it by going through the type as long as SizeInBits returns zero to get the real type size for it.

Do not do it for runOnUnneededCasts and runOnImplicitGEP because either it is already taken into account in ReplacePointerBitcastPass, or it can break the module to remove or insert gep.

Ref #1222