### PR TITLE
fix LowerPrivatePointerPHIPass by removing gep_map

### DIFF
--- a/lib/LowerPrivatePointerPHIPass.cpp
+++ b/lib/LowerPrivatePointerPHIPass.cpp
@@ -65,28 +65,20 @@ void replacePHIIncomingValue(PHINode *phi, PHINode *new_phi, Instruction *Src,
   phi->removeIncomingValue(BB, false);
 }
 
-} // namespace
-
-Value *clspv::LowerPrivatePointerPHIPass::makeNewGEP(
-    const DataLayout &DL, IRBuilder<> &B, Instruction *Src, Type *SrcTy,
-    Type *DstTy, uint64_t CstVal, Value *DynVal, size_t SmallerBitWidths) {
-  GEPMap key = {Src, DynVal, CstVal, SmallerBitWidths, SrcTy, DstTy};
-  auto find = gep_map.find(key);
-  if (find != gep_map.end()) {
-    return find->second;
-  }
-
+Value *makeNewGEP(const DataLayout &DL, IRBuilder<> &B, Instruction *Src,
+                  Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
+                  size_t SmallerBitWidths) {
   auto Idxs = BitcastUtils::GetIdxsForTyFromOffset(
       DL, B, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths,
       clspv::AddressSpace::Private);
-  return gep_map[key] = B.CreateGEP(SrcTy, Src, Idxs, "", true);
+  return B.CreateGEP(SrcTy, Src, Idxs, "", true);
 }
+} // namespace
 
 llvm::PreservedAnalyses
 clspv::LowerPrivatePointerPHIPass::run(Module &M,
                                        llvm::ModuleAnalysisManager &) {
   PreservedAnalyses PA;
-  gep_map.clear();
   for (auto &F : M) {
     runOnFunction(F);
   }

--- a/lib/LowerPrivatePointerPHIPass.h
+++ b/lib/LowerPrivatePointerPHIPass.h
@@ -35,35 +35,6 @@ private:
 
   using WeakInstructions = llvm::SmallVector<llvm::WeakTrackingVH, 32>;
   void cleanDeadInstructions(WeakInstructions &);
-
-  llvm::Value *makeNewGEP(const llvm::DataLayout &DL, llvm::IRBuilder<> &B,
-                          llvm::Instruction *Src, llvm::Type *SrcTy,
-                          llvm::Type *DstTy, uint64_t CstVal,
-                          llvm::Value *DynVal, size_t SmallerBitWidths);
-
-  struct GEPMap {
-    llvm::Value *Src;
-    llvm::Value *DynVal;
-    uint64_t CstVal;
-    size_t SmallerBitWidths;
-    llvm::Type *SrcTy;
-    llvm::Type *DstTy;
-
-    bool operator<(const clspv::LowerPrivatePointerPHIPass::GEPMap &o) const {
-      return Src < o.Src ||
-             (Src == o.Src &&
-              (DynVal < o.DynVal ||
-               (DynVal == o.DynVal &&
-                (CstVal < o.CstVal ||
-                 (CstVal == o.CstVal &&
-                  (SmallerBitWidths < o.SmallerBitWidths ||
-                   (SmallerBitWidths == o.SmallerBitWidths &&
-                    (SrcTy < o.SrcTy ||
-                     (SrcTy == o.SrcTy && (DstTy < o.DstTy))))))))));
-    };
-  };
-
-  std::map<GEPMap, llvm::Value *> gep_map;
 };
 } // namespace clspv
 

--- a/test/PrivatePointerPHI/icmp.ll
+++ b/test/PrivatePointerPHI/icmp.ll
@@ -9,6 +9,7 @@
 ; CHECK: [[gep:%[^ ]+]] = getelementptr inbounds [64 x i32], ptr [[alloca]], i32 0, i32 [[phi]]
 ; CHECK: load i32, ptr [[gep]], align 4
 ; CHECK: [[add_loop]] = add i32 1, [[phi]]
+; CHECK: [[gep:%[^ ]+]] = getelementptr inbounds [64 x i32], ptr [[alloca]], i32 0, i32 [[phi]]
 ; CHECK: [[icmp:%[^ ]+]] = icmp eq ptr [[gep]], [[alloca]]
 ; CHECK: br i1 [[icmp]], label %exit, label %loop
 

--- a/test/PrivatePointerPHI/ptrtoint.ll
+++ b/test/PrivatePointerPHI/ptrtoint.ll
@@ -6,6 +6,7 @@
 ; CHECK: [[gep:%[^ ]+]] = getelementptr inbounds [64 x i32], ptr %alloca, i32 0, i32 [[phi]]
 ; CHECK: load i32, ptr [[gep]], align 4
 ; CHECK: [[add]] = add i32 1, [[phi]]
+; CHECK: [[gep:%[^ ]+]] = getelementptr inbounds [64 x i32], ptr %alloca, i32 0, i32 [[phi]]
 ; CHECK: ptrtoint ptr [[gep]] to i32
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
When reusing geps, it is very complicated to make sure that the gep dominates the instruction that will be using it.

I tried to force the gep to be just after the `Src` instruction, but in that case, the gep might dominates some of its indices which is wrong as well.

Let's just get rid of this optimisation idea for the time being.

Ref #1222