### PR TITLE
fix phi on private pointer

### DIFF
--- a/lib/LowerPrivatePointerPHIPass.cpp
+++ b/lib/LowerPrivatePointerPHIPass.cpp
@@ -68,6 +68,9 @@ void replacePHIIncomingValue(PHINode *phi, PHINode *new_phi, Instruction *Src,
 Value *makeNewGEP(const DataLayout &DL, IRBuilder<> &B, Instruction *Src,
                   Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
                   size_t SmallerBitWidths) {
+  if (isa<AllocaInst>(Src) && !SrcTy->isArrayTy()) {
+    return Src;
+  }
   auto Idxs = BitcastUtils::GetIdxsForTyFromOffset(
       DL, B, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths,
       clspv::AddressSpace::Private);

--- a/test/PointerCasts/phi-from-gep.ll
+++ b/test/PointerCasts/phi-from-gep.ll
@@ -23,5 +23,50 @@ block:
 end:
 ; CHECK: phi ptr addrspace(1) [ [[gep]], %entry ], [ [[gepblock]], %block ]
   %phi = phi ptr addrspace(1) [ %0, %entry ], [ %1, %block ]
+  %gep = getelementptr i8, ptr addrspace(1) %phi, i32 7
+  ret void
+}
+
+define spir_kernel void @test2(ptr addrspace(1) %a, i32 %i) {
+entry:
+; CHECK: entry
+; CHECK-NEXT: [[shl0:%[^ ]+]] = shl i32 %i, 2
+; CHECK-NEXT: [[shl1:%[^ ]+]] = shl i32 [[shl0]], 1
+; CHECK-NEXT: [[add:%[^ ]+]] = add i32 [[shl1]], 4
+; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[add]]
+  %0 = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 2
+  br label %end
+
+block:
+; CHECK: block
+; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 %i, 1
+; CHECK-NEXT: [[gepblock:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[lshr]]
+  %1 = getelementptr i8, ptr addrspace(1) %a, i32 %i
+  br label %end
+
+end:
+; CHECK: phi ptr addrspace(1) [ [[gep]], %entry ], [ [[gepblock]], %block ]
+  %phi = phi ptr addrspace(1) [ %0, %entry ], [ %1, %block ]
+  %gep = getelementptr i16, ptr addrspace(1) %phi, i32 7
+  ret void
+}
+
+define spir_kernel void @test3(ptr addrspace(1) %a, i32 %i) {
+entry:
+; CHECK: entry
+; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 0
+  %0 = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i
+  br label %end
+
+block:
+; CHECK: block
+; CHECK-NEXT: [[gepblock:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 1
+  %1 = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 1
+  br label %end
+
+end:
+; CHECK: phi ptr addrspace(1) [ [[gep]], %entry ], [ [[gepblock]], %block ]
+  %phi = phi ptr addrspace(1) [ %0, %entry ], [ %1, %block ]
+  %gep = getelementptr i32, ptr addrspace(1) %phi, i32 7
   ret void
 }

--- a/test/PrivatePointerPHI/scalar-alloca.ll
+++ b/test/PrivatePointerPHI/scalar-alloca.ll
@@ -1,0 +1,26 @@
+; RUN: clspv-opt %s -o %t.ll --passes=lower-private-pointer-phi
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: entry:
+; CHECK-NEXT: [[alloca:%[^ ]+]] = alloca i32, align 4
+
+; CHECK: [[phi:%[^ ]+]] = phi i32 [ 0, %entry ], [ undef, %if ]
+; CHECK: load i32, ptr [[alloca]], align 4
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define void @test() {
+entry:
+  %alloca = alloca i32, align 4
+  br label %if
+
+if:
+  %phi = phi ptr [ undef, %if ], [ %alloca, %entry ]
+  %load = load i32, ptr %phi
+  %cmp = icmp eq i32 %load, 32
+  br i1 %cmp, label %exit, label %if
+
+exit:
+  ret void
+}

--- a/test/issue-1204.ll
+++ b/test/issue-1204.ll
@@ -2,11 +2,12 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; CHECK: [[entry:[^:]+]]:
-; CHECK:   [[shl:%[^ ]+]] = shl i32 %i, 1
-; CHECK:   [[gep1:%[^ ]+]] = getelementptr i16, ptr %s1, i32 [[shl]]
+; CHECK:   [[shl:%[^ ]+]] = shl i32 %i, 2
+; CHECK:   [[gep1:%[^ ]+]] = getelementptr i8, ptr %s1, i32 [[shl]]
 ; CHECK:   br i1 %test, label %[[b0:[^,]+]], label %[[b1:[^ ]+]]
 ; CHECK: [[b0]]:
-; CHECK:   [[gep2:%[^ ]+]] = getelementptr i16, ptr %s2, i32 %i
+; CHECK:   [[shl:%[^ ]+]] = shl i32 %i, 1
+; CHECK:   [[gep2:%[^ ]+]] = getelementptr i8, ptr %s2, i32 [[shl]]
 ; CHECK:   br i1 %test, label %[[b1]], label %[[b2:[^ ]+]]
 ; CHECK: [[b1]]:
 ; CHECK:   [[phi1:%[^ ]+]] = phi ptr [ [[gep1]], %entry ], [ [[gep2]], %b0 ]


### PR DESCRIPTION
- fix isimplicitcast for phi nodes:
  - compare infertype of phi with type of incoming values instead of incoming values against each other.
- insert needed gep between gep an phi aliasing
- consider scalar-alloca to avoid adding wrong gep

Fix #1224