### PR TITLE
Add fabs version not flushing to zero denormalized numbers

### DIFF
--- a/test/MathBuiltins/asin/float_asin.cl
+++ b/test/MathBuiltins/asin/float_asin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fabs/float2_fabs.cl
+++ b/test/MathBuiltins/fabs/float2_fabs.cl
@@ -3,12 +3,17 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 2
+// CHECK-DAG: %[[UINT_MAX_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2147483647
+// CHECK-DAG: %[[UINT2_MAX_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[AND_ID:[a-zA-Z0-9_]*]] = OpBitwiseAnd %[[UINT_VECTOR_TYPE_ID]] %[[BITCAST_ID]] %[[UINT2_MAX_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT_VECTOR_TYPE_ID]] %[[AND_ID]]
+// CHECK: OpStore {{.*}} %[[BITCAST_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)
 {

--- a/test/MathBuiltins/fabs/float3_fabs.cl
+++ b/test/MathBuiltins/fabs/float3_fabs.cl
@@ -3,12 +3,17 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 3
+// CHECK-DAG: %[[UINT_MAX_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2147483647
+// CHECK-DAG: %[[UINT3_MAX_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[AND_ID:[a-zA-Z0-9_]*]] = OpBitwiseAnd %[[UINT_VECTOR_TYPE_ID]] %[[BITCAST_ID]] %[[UINT3_MAX_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT_VECTOR_TYPE_ID]] %[[AND_ID]]
+// CHECK: OpStore {{.*}} %[[BITCAST_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/fabs/float3_fabs_novec3.cl
+++ b/test/MathBuiltins/fabs/float3_fabs_novec3.cl
@@ -3,12 +3,17 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT_MAX_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2147483647
+// CHECK-DAG: %[[UINT4_MAX_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[AND_ID:[a-zA-Z0-9_]*]] = OpBitwiseAnd %[[UINT_VECTOR_TYPE_ID]] %[[BITCAST_ID]] %[[UINT4_MAX_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT_VECTOR_TYPE_ID]] %[[AND_ID]]
+// CHECK: OpStore {{.*}} %[[BITCAST_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
 {

--- a/test/MathBuiltins/fabs/float4_fabs.cl
+++ b/test/MathBuiltins/fabs/float4_fabs.cl
@@ -3,12 +3,17 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
+// CHECK-DAG: %[[UINT_MAX_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2147483647
+// CHECK-DAG: %[[UINT4_MAX_ID:[a-zA-Z0-9_]*]] = OpConstantComposite %[[UINT_VECTOR_TYPE_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]] %[[UINT_MAX_ID]]
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT_VECTOR_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[AND_ID:[a-zA-Z0-9_]*]] = OpBitwiseAnd %[[UINT_VECTOR_TYPE_ID]] %[[BITCAST_ID]] %[[UINT4_MAX_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT_VECTOR_TYPE_ID]] %[[AND_ID]]
+// CHECK: OpStore {{.*}} %[[BITCAST_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
 {

--- a/test/MathBuiltins/fabs/float_fabs.cl
+++ b/test/MathBuiltins/fabs/float_fabs.cl
@@ -3,11 +3,14 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
+// CHECK-DAG: %[[UINT_MAX_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 2147483647
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
-// CHECK: OpStore {{.*}} %[[OP_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[UINT_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[AND_ID:[a-zA-Z0-9_]*]] = OpBitwiseAnd %[[UINT_TYPE_ID]] %[[BITCAST_ID]] %[[UINT_MAX_ID]]
+// CHECK: %[[BITCAST_ID:[a-zA-Z0-9_]*]] = OpBitcast %[[FLOAT_TYPE_ID]] %[[AND_ID]]
+// CHECK: OpStore {{.*}} %[[BITCAST_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
 {

--- a/test/MathBuiltins/recip/float2_half_recip.cl
+++ b/test/MathBuiltins/recip/float2_half_recip.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -inline-entry-points
+// RUN: clspv %target %s -o %t.spv -inline-entry-points --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/recip/float3_half_recip.cl
+++ b/test/MathBuiltins/recip/float3_half_recip.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -inline-entry-points
+// RUN: clspv %target %s -o %t.spv -inline-entry-points --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/recip/float3_half_recip_novec3.cl
+++ b/test/MathBuiltins/recip/float3_half_recip_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -inline-entry-points -vec3-to-vec4
+// RUN: clspv %target %s -o %t.spv -inline-entry-points -vec3-to-vec4 --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/recip/float4_half_recip.cl
+++ b/test/MathBuiltins/recip/float4_half_recip.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -inline-entry-points
+// RUN: clspv %target %s -o %t.spv -inline-entry-points --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/recip/float_half_recip.cl
+++ b/test/MathBuiltins/recip/float_half_recip.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -inline-entry-points
+// RUN: clspv %target %s -o %t.spv -inline-entry-points --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/round/float2_round.cl
+++ b/test/MathBuiltins/round/float2_round.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/round/float3_round.cl
+++ b/test/MathBuiltins/round/float3_round.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/round/float3_round_novec3.cl
+++ b/test/MathBuiltins/round/float3_round_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/round/float4_round.cl
+++ b/test/MathBuiltins/round/float4_round.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/round/float_round.cl
+++ b/test/MathBuiltins/round/float_round.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/NativeBuiltins/MathBuiltins/fabs/float2_fabs.cl
+++ b/test/NativeBuiltins/MathBuiltins/fabs/float2_fabs.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 2
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* a, global float2* b)
+{
+  *a = fabs(*b);
+}

--- a/test/NativeBuiltins/MathBuiltins/fabs/float3_fabs.cl
+++ b/test/NativeBuiltins/MathBuiltins/fabs/float3_fabs.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fabs(*b);
+}

--- a/test/NativeBuiltins/MathBuiltins/fabs/float3_fabs_novec3.cl
+++ b/test/NativeBuiltins/MathBuiltins/fabs/float3_fabs_novec3.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --use-native-builtins=fabs
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float3* a, global float3* b)
+{
+  *a = fabs(*b);
+}

--- a/test/NativeBuiltins/MathBuiltins/fabs/float4_fabs.cl
+++ b/test/NativeBuiltins/MathBuiltins/fabs/float4_fabs.cl
@@ -1,0 +1,16 @@
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_VECTOR_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)
+{
+  *a = fabs(*b);
+}

--- a/test/NativeBuiltins/MathBuiltins/fabs/float_fabs.cl
+++ b/test/NativeBuiltins/MathBuiltins/fabs/float_fabs.cl
@@ -6,11 +6,10 @@
 // CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
-// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FAbs
-// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Sqrt
-// CHECK: OpStore
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FAbs %[[LOADB_ID]]
+// CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
 {
-  *a = acos(*b);
+  *a = fabs(*b);
 }

--- a/test/div/float2_div.cl
+++ b/test/div/float2_div.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float3_div.cl
+++ b/test/div/float3_div.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float3_div_novec3.cl
+++ b/test/div/float3_div_novec3.cl
@@ -1,9 +1,9 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float4_div.cl
+++ b/test/div/float4_div.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float_div.cl
+++ b/test/div/float_div.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv


### PR DESCRIPTION
Both the OpenCL and the SPIR-V specification allow denormalized numbers to be flushed to zero.

But since llvm/llvm-project@5c0da5839de1bdc08f411a04305a9bdadf538ad5 patterns from libclc like in `cbrt` are converted to call to fabs:
```
float input;
int input_as_uint = as_uint(input);
int input_without_sign = input_as_uint & 0x7fffffff;
```
This is causing issue as the cbrt algorithm in libclc needs denormalized numbers not to be flushed to zero to be OpenCL compliant.

Unless clspv is called with fabs in the native builtins list, use a software version of fabs that guarantees denormalized numbers will not be flushed to zero.