### PR TITLE
fix runOnImplicitGEP for more than 1 index missing

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -460,11 +460,9 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
           auto *gep = dyn_cast<GetElementPtrInst>(&I);
           auto *call = dyn_cast_or_null<CallInst>(&I);
           bool userCall = call && !call->getCalledFunction()->isDeclaration();
-          if ((Steps > 0 && !gep) || (Steps == 1)) {
-            if (!userCall && (gep || PerfectMatch)) {
-              GEPAliasingList.push_back(
-                  {&I, Steps, PerfectMatch ? nullptr : gep});
-            }
+          if (!userCall && (gep || PerfectMatch)) {
+            GEPAliasingList.push_back(
+                {&I, Steps, PerfectMatch ? nullptr : gep});
           }
         } else if (isa<StoreInst>(&I) && !isa<GetElementPtrInst>(source)) {
           GEPBeforeStoreList.push_back({&I, dest_ty});

--- a/test/PointerCasts/issue-1225.ll
+++ b/test/PointerCasts/issue-1225.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast,replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[gep:%[^ ]+]] = getelementptr { %struct.s, %struct.s }, ptr %alloca, i32 0, i32 0, i32 0, i32 1
+; CHECK: load i64, ptr [[gep]], align 8
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%struct.s = type { [8 x i64], i32 }
+
+define spir_kernel void @foo() {
+entry:
+  %alloca = alloca { %struct.s, %struct.s }, align 8
+  %gep = getelementptr inbounds [8 x i64], ptr %alloca, i64 0, i64 1
+  %load = load i64, ptr %gep, align 8
+  ret void
+}


### PR DESCRIPTION
Since runOnGEPFromGEP has been supported more cases, the if statement removed by this commit is not needed. In fact, removing it fix code as shown in the test here added.

Fix #1225