### PR TITLE
disable long-vector by default now that llvm has been fixed

### DIFF
--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -219,9 +219,8 @@ llvm::cl::opt<bool> std430_ubo_layout(
 llvm::cl::opt<bool> int8_support("int8", llvm::cl::init(true),
                                  llvm::cl::desc("Allow 8-bit integers"));
 
-// TODO(#1231): long vector support is required due to sqrt.
 llvm::cl::opt<bool> long_vector_support(
-    "long-vector", llvm::cl::init(true),
+    "long-vector", llvm::cl::init(false),
     llvm::cl::desc("Allow vectors of 8 and 16 elements. Experimental"));
 
 llvm::cl::opt<bool> cl_arm_non_uniform_work_group_size(

--- a/test/LongVectorLowering/Frontend/lowering_disabled_function_body.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_function_body.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 

--- a/test/LongVectorLowering/Frontend/lowering_disabled_function_param_array.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_function_param_array.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 

--- a/test/LongVectorLowering/Frontend/lowering_disabled_function_param_pointer.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_function_param_pointer.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 

--- a/test/LongVectorLowering/Frontend/lowering_disabled_function_param_scalar.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_function_param_scalar.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 

--- a/test/LongVectorLowering/Frontend/lowering_disabled_function_param_struct.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_function_param_struct.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 

--- a/test/LongVectorLowering/Frontend/lowering_disabled_kernel_param_pointer.cl
+++ b/test/LongVectorLowering/Frontend/lowering_disabled_kernel_param_pointer.cl
@@ -1,6 +1,4 @@
 // RUN: clspv %target %s -verify
-// TODO(#1231)
-// XFAIL: *
 //
 // Test that long-vector types are rejected when the support is not enabled.
 


### PR DESCRIPTION
since https://github.com/llvm/llvm-project/pull/66651 has been merged we can revert part of https://github.com/google/clspv/pull/1232.

Fix #1231