### PR TITLE
Revert "decorate libclc functions with noimplicitFloat (#1256)"

### DIFF
--- a/lib/NativeMathPass.cpp
+++ b/lib/NativeMathPass.cpp
@@ -37,12 +37,6 @@ bool is_libclc_builtin(llvm::Function *F) {
   }
   return false;
 }
-bool builtin_needs_noimplicitfloat(const StringRef &builtin) {
-  // Using noimplicitfloat for those functions allow to have compliant OpenCL
-  // implementation of them even with native version of fabs.
-  DenseSet<StringRef> list = {"cbrt", "frexp", "powr"};
-  return list.contains(builtin);
-}
 } // namespace
 
 PreservedAnalyses clspv::NativeMathPass::run(Module &M,
@@ -69,11 +63,6 @@ PreservedAnalyses clspv::NativeMathPass::run(Module &M,
       // that we will not do it, let's remove the attribute so that they
       // can be inline if appropriate.
       F.removeFnAttr(Attribute::AttrKind::NoInline);
-
-      // Prevent unwanted transformation from InstCombine (Ref #1253).
-      if (builtin_needs_noimplicitfloat(F.getName())) {
-        F.addFnAttr(Attribute::AttrKind::NoImplicitFloat);
-      }
     }
   }
 


### PR DESCRIPTION
This reverts commit e3dc5f1f0ecabfe43c66b8a6bd029d1074a1b8f1.

This is not working because:
- the list is not correct as the builtins name are mangled
-  event with the correct name, builtin can be inlined leading to illegal code being generated