### PR TITLE
Add --producer-out-file to tests as needed

### DIFF
--- a/test/constant_data_seq_string.ll
+++ b/test/constant_data_seq_string.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.spv --passes=spirv-producer
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer --producer-out-file %t.spv
 
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/extract_constant.ll
+++ b/test/extract_constant.ll
@@ -1,5 +1,5 @@
-; RUN: clspv-opt %s -o %t.spv --passes=spirv-producer
-; RUN: FileCheck %s < %t.spv
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer --producer-out-file %t.spv
+; RUN: FileCheck %s < %t.ll
 
 ; CHECK: @array = global [8 x i8] zeroinitializer
 ; CHECK: [[ARRAY_PTR:[a-zA-Z0-9_]*]] = getelementptr inbounds [8 x i8], ptr @array, i32 0, i32 0


### PR DESCRIPTION
Otherwise, this fails tests in some environments that check the existence of the output file.