### PR TITLE
Update LLVM: avoid zeroinitializer for spirv.Image type

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "c65d8c71878361d441008a85f0c99305d9e3aff8"
+      "commit" : "6ec350b4834689af5192a970dc959017f732a8d8"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -637,7 +637,7 @@ bool clspv::AllocateDescriptorsPass::AllocateKernelArgDescriptors(Module &M) {
             Builder.getInt32(discriminants_list[discriminant_index].index);
         auto *coherent_arg = Builder.getInt32(
             discriminants_list[discriminant_index].discriminant.coherent);
-        auto *resource_type_arg = Constant::getNullValue(resource_type);
+        auto *resource_type_arg = clspv::GetDummyValue(resource_type);
         auto *call = Builder.CreateCall(
             var_fn, {set_arg, binding_arg, arg_kind_arg, arg_index_arg,
                      discriminant_index_arg, coherent_arg, resource_type_arg});

--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -21,6 +21,7 @@
 #include "clspv/Option.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -28,6 +29,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/IR/Type.h"
 
 using namespace clspv;
 using namespace llvm;
@@ -618,4 +620,13 @@ bool clspv::IsWriteOnlyImageType(llvm::Type *type) {
   }
 
   return false;
+}
+
+Constant *clspv::GetDummyValue(Type *valueTy) {
+  if (auto *targetExtTy = dyn_cast<TargetExtType>(valueTy)) {
+    if (!targetExtTy->hasProperty(TargetExtType::HasZeroInit)) {
+      return UndefValue::get(targetExtTy);
+    }
+  }
+  return Constant::getNullValue(valueTy);
 }

--- a/lib/Types.h
+++ b/lib/Types.h
@@ -16,6 +16,7 @@
 #define CLSPV_LIB_TYPES_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/IR/Constant.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
@@ -82,6 +83,10 @@ bool IsWriteOnlyImageType(llvm::Type *type);
 
 // Returns true if pointers in the module are 64-bit.
 bool PointersAre64Bit(llvm::Module &m);
+
+// Returns the null value for the type if the type supports it,
+// otherwise returns the undef value.
+llvm::Constant *GetDummyValue(llvm::Type *type);
 
 } // namespace clspv
 

--- a/lib/ZeroInitializeAllocasPass.cpp
+++ b/lib/ZeroInitializeAllocasPass.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "Types.h"
 #include "ZeroInitializeAllocasPass.h"
 
 using namespace llvm;
@@ -55,9 +56,9 @@ clspv::ZeroInitializeAllocasPass::run(Module &M, ModuleAnalysisManager &) {
   }
 
   for (AllocaInst *alloca : WorkList) {
-    auto *valueTy = alloca->getAllocatedType();
-    auto *store = new StoreInst(Constant::getNullValue(valueTy), alloca, false,
-                                Align(alloca->getAlign()));
+    auto *value = GetDummyValue(alloca->getAllocatedType());
+    auto *store =
+        new StoreInst(value, alloca, false, Align(alloca->getAlign()));
     store->insertAfter(alloca);
   }
 

--- a/test/AllocateDescriptors/spec_images_no_sharing.ll
+++ b/test/AllocateDescriptors/spec_images_no_sharing.ll
@@ -2,10 +2,10 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; CHECK: @foo
-; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", float, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] zeroinitializer)
+; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", float, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] undef)
 ; CHECK: ([[image]] [[res]],
 ; CHECK: @bar
-; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", i32, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.1(i32 0, i32 0, i32 7, i32 0, i32 1, i32 0, [[image]] zeroinitializer)
+; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", i32, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.1(i32 0, i32 0, i32 7, i32 0, i32 1, i32 0, [[image]] undef)
 ; CHECK: ([[image]] [[res]],
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/AllocateDescriptors/spec_images_sharing.ll
+++ b/test/AllocateDescriptors/spec_images_sharing.ll
@@ -2,10 +2,10 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; CHECK: @foo
-; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", float, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] zeroinitializer)
+; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image:target\(\"spirv.Image\", float, 0, 0, 0, 0, 2, 0, 1, 0\)]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] undef)
 ; CHECK: ([[image]] [[res]],
 ; CHECK: @bar
-; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] zeroinitializer)
+; CHECK: [[res:%[a-zA-Z0-9_.]+]] = call [[image]] @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, [[image]] undef)
 ; CHECK: ([[image]] [[res]],
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/AutoPodArgs/contains_read_image3d.ll
+++ b/test/AutoPodArgs/contains_read_image3d.ll
@@ -12,7 +12,7 @@ target triple = "spir-unknown-unknown"
 define dso_local spir_func <4 x float> @bar(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler, <4 x i32> %coord) #0 !kernel_arg_name !14 {
 entry:
   %img.addr = alloca target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), align 4
-  store target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) zeroinitializer, ptr %img.addr, align 4
+  store target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, ptr %img.addr, align 4
   %sampler.addr = alloca target("spirv.Sampler"), align 4
   store target("spirv.Sampler") zeroinitializer, ptr %sampler.addr, align 4
   %coord.addr = alloca <4 x i32>, align 16
@@ -34,7 +34,7 @@ declare !kernel_arg_name !17 spir_func <4 x float> @_Z11read_imagef14ocl_image3d
 define dso_local spir_kernel void @foo(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %img, target("spirv.Sampler") %sampler, ptr addrspace(1) align 16 %out, <4 x i32> %coord) #2 !kernel_arg_name !16 !kernel_arg_addr_space !17 !kernel_arg_access_qual !18 !kernel_arg_type !19 !kernel_arg_base_type !20 !kernel_arg_type_qual !21 {
 entry:
   %img.addr = alloca target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), align 4
-  store target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) zeroinitializer, ptr %img.addr, align 4
+  store target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, ptr %img.addr, align 4
   %sampler.addr = alloca target("spirv.Sampler"), align 4
   store target("spirv.Sampler") zeroinitializer, ptr %sampler.addr, align 4
   %out.addr = alloca ptr addrspace(1), align 4

--- a/test/ImageBuiltins/get_image_array_size_image1d_array_readonly.ll
+++ b/test/ImageBuiltins/get_image_array_size_image1d_array_readonly.ll
@@ -12,7 +12,7 @@ define spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 4 %out, 
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 1, 0, 0, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 1, 0, 0, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size39opencl.image1d_array_ro_t.float.sampled(target("spirv.Image", float, 0, 0, 1, 0, 1, 0, 0, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/get_image_array_size_image1d_array_readwrite.ll
+++ b/test/ImageBuiltins/get_image_array_size_image1d_array_readwrite.ll
@@ -12,7 +12,7 @@ define spir_kernel void @foo(ptr addrspace(1) %out, target("spirv.Image", float,
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size31opencl.image1d_array_rw_t.float(target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/get_image_array_size_image1d_array_writeonly.ll
+++ b/test/ImageBuiltins/get_image_array_size_image1d_array_writeonly.ll
@@ -14,7 +14,7 @@ define spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 4 %out, 
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size31opencl.image1d_array_wo_t.float(target("spirv.Image", float, 0, 0, 1, 0, 2, 0, 2, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/get_image_array_size_image2d_array_readonly.ll
+++ b/test/ImageBuiltins/get_image_array_size_image2d_array_readonly.ll
@@ -12,7 +12,7 @@ define spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 4 %out, 
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 1, 0, 0, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 1, 0, 0, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size39opencl.image2d_array_ro_t.float.sampled(target("spirv.Image", float, 1, 0, 1, 0, 1, 0, 0, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/get_image_array_size_image2d_array_readwrite.ll
+++ b/test/ImageBuiltins/get_image_array_size_image2d_array_readwrite.ll
@@ -12,7 +12,7 @@ define spir_kernel void @foo(ptr addrspace(1) %out, target("spirv.Image", float,
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 2, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 2, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size31opencl.image2d_array_rw_t.float(target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 2, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/get_image_array_size_image2d_array_writeonly.ll
+++ b/test/ImageBuiltins/get_image_array_size_image2d_array_writeonly.ll
@@ -14,7 +14,7 @@ define spir_kernel void @foo(ptr addrspace(1) nocapture writeonly align 4 %out, 
 entry:
   %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
   %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 1, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 1, 0) zeroinitializer)
+  %2 = call target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 1, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 1, 0) undef)
   %call = tail call spir_func i32 @_Z20get_image_array_size31opencl.image2d_array_wo_t.float(target("spirv.Image", float, 1, 0, 1, 0, 2, 0, 1, 0) %2)
   store i32 %call, ptr addrspace(1) %1, align 4
   ret void

--- a/test/ImageBuiltins/opaque_image_metadata.ll
+++ b/test/ImageBuiltins/opaque_image_metadata.ll
@@ -13,7 +13,7 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @sample_kernel(target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) %input, ptr addrspace(1) nocapture writeonly align 4 %outData) !kernel_arg_addr_space !7 !kernel_arg_access_qual !8 !kernel_arg_type !9 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !clspv.pod_args_impl !11 !push_constants_image_channel !12 {
 entry:
-  %0 = call target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) undef)
   %1 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x %struct.image_kernel_data] } zeroinitializer)
   %call = tail call spir_func i32 @_Z15get_image_width28ocl_image1d_ro.float.sampled(target("spirv.Image", float, 0, 0, 0, 0, 1, 0, 0, 0) %0) #2
   %2 = getelementptr { [0 x %struct.image_kernel_data] }, ptr addrspace(1) %1, i32 0, i32 0, i32 0, i32 0

--- a/test/ImageBuiltins/read_image3d_with_non_literal_sampler.ll
+++ b/test/ImageBuiltins/read_image3d_with_non_literal_sampler.ll
@@ -35,7 +35,7 @@ declare <4 x float> @_Z11read_imagef30ocl_image3d_ro_t.float.sampled11ocl_sample
 ; Function Attrs: norecurse nounwind
 define spir_kernel void @foo(target("spirv.Image", float, 2, 0, 0, 0, 1, 0, 0, 0) %img, target("spirv.Sampler") %sampler, ptr addrspace(1) nocapture writeonly align 16 %out) #0 !kernel_arg_addr_space !16 !kernel_arg_access_qual !17 !kernel_arg_type !18 !kernel_arg_base_type !19 !kernel_arg_type_qual !20 !kernel_arg_name !21 !clspv.pod_args_impl !22 !kernel_arg_map !23 {
 entry:
-  %0 = call target("spirv.Image", float, 2, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 2, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 2, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 2, 0, 0, 0, 1, 0, 0, 0) undef)
   %1 = call target("spirv.Sampler") @_Z14clspv.resource.1(i32 0, i32 1, i32 8, i32 1, i32 1, i32 0, target("spirv.Sampler") zeroinitializer)
   %2 = call ptr addrspace(1) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x <4 x float>] } zeroinitializer)
   %3 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0

--- a/test/KernelArgInfo/kernel-arg-info.ll
+++ b/test/KernelArgInfo/kernel-arg-info.ll
@@ -23,9 +23,9 @@ entry:
   %QUA.addr = alloca i32, align 4
   store i32 0, ptr %QUA.addr, align 4
   %im0.addr = alloca target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), align 8
-  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) zeroinitializer, ptr %im0.addr, align 8
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, ptr %im0.addr, align 8
   %im1.addr = alloca target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), align 8
-  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) zeroinitializer, ptr %im1.addr, align 8
+  store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, ptr %im1.addr, align 8
   %ptr.addr = alloca ptr addrspace(1), align 8
   store ptr addrspace(1) null, ptr %ptr.addr, align 8
   %tmp = alloca <4 x float>, align 16

--- a/test/SPIRVProducer/opaque_literal_sampler.ll
+++ b/test/SPIRVProducer/opaque_literal_sampler.ll
@@ -12,7 +12,7 @@ target triple = "spir-unknown-unknown"
 
 define spir_kernel void @test(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %t, ptr addrspace(1) nocapture writeonly align 16 %out, { <2 x float> } %podargs) !clspv.pod_args_impl !4 !kernel_arg_map !10 {
 entry:
-  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   %1 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <4 x float>] } zeroinitializer)
   %2 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %1, i32 0, i32 0, i32 0
   %3 = call ptr addrspace(9) @_Z14clspv.resource.2(i32 -1, i32 2, i32 5, i32 2, i32 2, i32 0, { { <2 x float> } } zeroinitializer)

--- a/test/SPIRVProducer/opaque_sample_image2d_float.ll
+++ b/test/SPIRVProducer/opaque_sample_image2d_float.ll
@@ -24,7 +24,7 @@ target triple = "spir-unknown-unknown"
 
 define dso_local spir_kernel void @test(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %t, target("spirv.Sampler") %s, ptr addrspace(1) nocapture writeonly align 16 %out) !clspv.pod_args_impl !10 {
 entry:
-  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   %1 = call target("spirv.Sampler") @_Z14clspv.resource.1(i32 0, i32 1, i32 8, i32 1, i32 1, i32 0, target("spirv.Sampler") zeroinitializer)
   %2 = call ptr addrspace(1) @_Z14clspv.resource.2(i32 0, i32 2, i32 0, i32 2, i32 2, i32 0, { [0 x <4 x float>] } zeroinitializer)
   %3 = getelementptr { [0 x <4 x float>] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0

--- a/test/Spv1p4/int_fetch.ll
+++ b/test/Spv1p4/int_fetch.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   %call = tail call spir_func <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampledDv2_i(target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void

--- a/test/Spv1p4/int_read.ll
+++ b/test/Spv1p4/int_read.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 0) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 0) undef)
   %call = tail call spir_func <4 x i32> @_Z11read_imagei23opencl.image2d_rw_t.intDv2_i(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 0) %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void

--- a/test/Spv1p4/int_sample.ll
+++ b/test/Spv1p4/int_sample.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   %3 = call target("spirv.Sampler") @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0, target("spirv.Sampler") zeroinitializer)
   %4 = tail call <4 x i32> @_Z11read_imagei31opencl.image2d_ro_t.int.sampled11ocl_samplerDv2_f(target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 0) %2, target("spirv.Sampler") %3, <2 x float> zeroinitializer)
   store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16

--- a/test/Spv1p4/int_write.ll
+++ b/test/Spv1p4/int_write.ll
@@ -14,7 +14,7 @@ declare spir_func void @_Z12write_imagei23opencl.image2d_wo_t.intDv2_iDv4_j(targ
 
 define spir_kernel void @foo(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) addrspace(1)* %i)!clspv.pod_args_impl !8 {
 entry:
-  %0 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) zeroinitializer)
+  %0 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) undef)
   tail call spir_func void @_Z12write_imagei23opencl.image2d_wo_t.intDv2_iDv4_j(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 0) %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
   ret void
 }

--- a/test/Spv1p4/interface_literal_sampler_in_helper.ll
+++ b/test/Spv1p4/interface_literal_sampler_in_helper.ll
@@ -25,7 +25,7 @@ entry:
 
 define spir_kernel void @foo(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %img) !clspv.pod_args_impl !0 {
 entry:
-  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   call void @bar(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %0)
   ret void
 }

--- a/test/Spv1p4/interface_sampler.ll
+++ b/test/Spv1p4/interface_sampler.ll
@@ -17,7 +17,7 @@ declare <4 x float> @_Z11read_imagef33opencl.image2d_ro_t.float.sampled11ocl_sam
 
 define spir_kernel void @test(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %img, <4 x float> addrspace(1)* nocapture %out) !clspv.pod_args_impl !4 {
 entry:
-  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   %1 = call { [0 x <4 x float>] } addrspace(1)* @_Z14clspv.resource.1(i32 1, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x <4 x float>] } zeroinitializer)
   %2 = getelementptr { [0 x <4 x float>] }, { [0 x <4 x float>] } addrspace(1)* %1, i32 0, i32 0, i32 0
   %3 = call target("spirv.Sampler") @_Z25clspv.sampler_var_literal(i32 0, i32 0, i32 16, target("spirv.Sampler") zeroinitializer)

--- a/test/Spv1p4/opaque_structs.ll
+++ b/test/Spv1p4/opaque_structs.ll
@@ -23,7 +23,7 @@ entry:
 
 define spir_kernel void @foo(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %img) !clspv.pod_args_impl !0 {
 entry:
-  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) zeroinitializer)
+  %0 = call target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) @_Z14clspv.resource.0(i32 1, i32 0, i32 6, i32 0, i32 0, i32 0, target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) undef)
   call void @bar(target("spirv.Image", float, 1, 0, 0, 0, 1, 0, 0, 0) %0)
   ret void
 }

--- a/test/Spv1p4/uint_fetch.ll
+++ b/test/Spv1p4/uint_fetch.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) undef)
   %call = tail call spir_func <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampledDv2_i(target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void

--- a/test/Spv1p4/uint_read.ll
+++ b/test/Spv1p4/uint_read.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 1) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 7, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 1) undef)
   %call = tail call spir_func <4 x i32> @_Z12read_imageui24opencl.image2d_rw_t.uintDv2_i(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 2, 1) %2, <2 x i32> zeroinitializer)
   store <4 x i32> %call, <4 x i32> addrspace(1)* %1, align 16
   ret void

--- a/test/Spv1p4/uint_sample.ll
+++ b/test/Spv1p4/uint_sample.ll
@@ -16,7 +16,7 @@ define spir_kernel void @foo(<4 x i32> addrspace(1)* nocapture %out, target("spi
 entry:
   %0 = call { [0 x <4 x i32>] } addrspace(1)* @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <4 x i32>] } zeroinitializer)
   %1 = getelementptr { [0 x <4 x i32>] }, { [0 x <4 x i32>] } addrspace(1)* %0, i32 0, i32 0, i32 0
-  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) zeroinitializer)
+  %2 = call target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) @_Z14clspv.resource.1(i32 0, i32 1, i32 6, i32 1, i32 1, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) undef)
   %3 = call target("spirv.Sampler") @_Z14clspv.resource.2(i32 0, i32 2, i32 8, i32 2, i32 2, i32 0, target("spirv.Sampler") zeroinitializer)
   %4 = tail call <4 x i32> @_Z12read_imageui32opencl.image2d_ro_t.uint.sampled11ocl_samplerDv2_f(target("spirv.Image", i32, 1, 0, 0, 0, 1, 0, 0, 1) %2, target("spirv.Sampler") %3, <2 x float> zeroinitializer)
   store <4 x i32> %4, <4 x i32> addrspace(1)* %1, align 16

--- a/test/Spv1p4/uint_write.ll
+++ b/test/Spv1p4/uint_write.ll
@@ -14,7 +14,7 @@ declare spir_func void @_Z13write_imageui24opencl.image2d_wo_t.uintDv2_iDv4_j(ta
 
 define spir_kernel void @foo(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) %i)!clspv.pod_args_impl !8 {
 entry:
-  %0 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) zeroinitializer)
+  %0 = call target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) @_Z14clspv.resource.0(i32 0, i32 0, i32 7, i32 0, i32 0, i32 0, target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) undef)
   tail call spir_func void @_Z13write_imageui24opencl.image2d_wo_t.uintDv2_iDv4_j(target("spirv.Image", i32, 1, 0, 0, 0, 2, 0, 1, 1) %0, <2 x i32> zeroinitializer, <4 x i32> zeroinitializer)
   ret void
 }


### PR DESCRIPTION
The spirv.Image target type no longer supports zeroinitializer value (See https://github.com/llvm/llvm-project/pull/73887)

Use undef instead.

Add a new clspv::GetDummyValue that returns the zeroinitializer value when it can, and otherwise returns the undef value.