### PR TITLE
Remove support for opaque pointers

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -280,7 +280,9 @@ enum class Vec3ToVec4SupportClass : int {
 
 Vec3ToVec4SupportClass Vec3ToVec4();
 
-// Returns true if opaque pointers are enabled
+// Returns true if opaque pointers are enabled.
+// Do not add new code that depends on this value. Assume it is true.
+// The false case is not supported.
 bool OpaquePointers();
 
 // Returns true if the debug information should be generated

--- a/lib/FrontendPlugin.cpp
+++ b/lib/FrontendPlugin.cpp
@@ -194,7 +194,7 @@ private:
     if (Ty->isPointerType()) {
       const Type *pointeeTy = Ty->getPointeeType().getTypePtr();
       if (pointeeTy && pointeeTy->isVoidType() &&
-          !(clspv::Option::OpaquePointers() && clspv::Option::Int8Support())) {
+          !clspv::Option::Int8Support()) {
         // We don't support void pointers.
         Instance.getDiagnostics().Report(
             SR.getBegin(), CustomDiagnosticsIDMap[CustomDiagnosticVoidPointer]);

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -390,10 +390,10 @@ static llvm::cl::opt<bool>
     force_no_vec3_to_vec4("no-vec3-to-vec4", llvm::cl::init(false),
                           llvm::cl::desc("Force NOT lowering vec3 to vec4"));
 
-static llvm::cl::opt<bool>
-    opaque_pointers("enable-opaque-pointers",
-                    llvm::cl::desc("Use opaque pointers"),
-                    llvm::cl::init(true));
+static llvm::cl::opt<bool> opaque_pointers(
+    "enable-opaque-pointers",
+    llvm::cl::desc("Use opaque pointers. DEPRECATED. This is always enabled"),
+    llvm::cl::init(true));
 
 static llvm::cl::opt<bool>
     debug_info("g", llvm::cl::init(false),

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1775,7 +1775,7 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty) {
 }
 
 SPIRVID SPIRVProducerPassImpl::getSPIRVType(Type *Ty, bool needs_layout) {
-  if (Ty->isOpaquePointerTy()) {
+  if (Ty->isPointerTy()) {
     llvm_unreachable("Unsupported opaque pointer");
   }
 

--- a/test/PointerCasts/opaque_implicit_gep.cl
+++ b/test/PointerCasts/opaque_implicit_gep.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map_arr_vec3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -module-constants-in-storage-buffer -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -module-constants-in-storage-buffer -vec3-to-vec4
 // RUN: clspv-reflection %t.spv -o %t.map
 // RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/any/any_char3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_char3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/any/any_int3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_int3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/any/any_long3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_long3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/any/any_short3_novec3.cl
+++ b/test/RelationalBuiltins/any/any_short3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_long3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_short3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_uchar3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/bitselect/bitselect_ulong3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/isequal_float3_novec3.cl
+++ b/test/RelationalBuiltins/isequal_float3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/isnan_float3_novec3.cl
+++ b/test/RelationalBuiltins/isnan_float3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_char3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_char3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_int3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_float3_uint3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_int3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_int3_uint3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_long3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_long3_ulong3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_short3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_short3_ushort3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_int3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_uint3_uint3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_long3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ulong3_ulong3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_short3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
+++ b/test/RelationalBuiltins/select/select_ushort3_ushort3_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/UndoInstCombine/undo_extract_cast.cl
+++ b/test/UndoInstCombine/undo_extract_cast.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/UndoInstCombine/undo_shuffle_cast.cl
+++ b/test/UndoInstCombine/undo_shuffle_cast.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float3_div_cst_novec3.cl
+++ b/test/div/float3_div_cst_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/div/float3_div_novec3.cl
+++ b/test/div/float3_div_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers --use-native-builtins=fabs
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --use-native-builtins=fabs
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/emit_ir.cl
+++ b/test/emit_ir.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s --output-format=ll -o %t.ll -enable-opaque-pointers=1
+// RUN: clspv %target %s --output-format=ll -o %t.ll
 // RUN: FileCheck %s < %t.ll
 
-// RUN: clspv %s --output-format=bc -o %t.bc -enable-opaque-pointers=1
+// RUN: clspv %s --output-format=bc -o %t.bc
 // RUN: llvm-dis %t.bc -o %t.bc.ll
 // RUN: FileCheck %s < %t.bc.ll
 

--- a/test/float3_add_novec3.cl
+++ b/test/float3_add_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/float3_mul_novec3.cl
+++ b/test/float3_mul_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/float3_sub_novec3.cl
+++ b/test/float3_sub_novec3.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 --enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/issue-679_opaque.cl
+++ b/test/issue-679_opaque.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t2.spv --enable-opaque-pointers
+// RUN: clspv %target %s -o %t2.spv
 // RUN: spirv-dis -o %t2.spvasm %t2.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t2.spv

--- a/test/void_ptr_functions.cl
+++ b/test/void_ptr_functions.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -int8 -enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/void_ptr_kernel.cl
+++ b/test/void_ptr_kernel.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -cl-kernel-arg-info -int8 -enable-opaque-pointers
+// RUN: clspv %target %s -o %t.spv -cl-kernel-arg-info -int8
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 // RUN: FileCheck %s < %t2.spvasm


### PR DESCRIPTION
Remove deprecated use of isOpaquePtrTy().

Update tests to remove --enable-opaque-pointers

Fixes: #1276