### PR TITLE
Fix clang warnings

### DIFF
--- a/lib/DirectResourceAccessPass.cpp
+++ b/lib/DirectResourceAccessPass.cpp
@@ -138,7 +138,7 @@ bool clspv::DirectResourceAccessPass::RewriteAccessesForArg(Function *fn,
   };
 
   // The common valid parameter info across all the callers seen so far.
-  ParamInfo common;
+  ParamInfo common = {};
   bool seen_one = false;
 
   // Tries to merge the given parameter info into |common|.  If it is the first

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2934,7 +2934,7 @@ void SPIRVProducerPassImpl::GenerateGlobalVar(GlobalVariable &GV) {
           module->getGlobalVariable(clspv::PushConstantsVariableName());
       auto STy = cast<StructType>(PushConstGV->getValueType());
       auto MD = PushConstGV->getMetadata(clspv::PushConstantsMetadataName());
-      bool Found = false;
+      bool Found [[maybe_unused]] = false;
       uint32_t Offset = 0;
 
       // Find the push constant offset for the module constants pointer


### PR DESCRIPTION
Zero-init to avoid "maybe uninitialized" warnings

Mark variable as [[maybe_unused]] when only used in an assert