### PR TITLE
ThreeElementVectorLowering: do not lower gep of gep of spirv gv

### DIFF
--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -614,8 +614,12 @@ Value *clspv::ThreeElementVectorLoweringPass::visitExtractValueInst(
 Value *clspv::ThreeElementVectorLoweringPass::visitGetElementPtrInst(
     GetElementPtrInst &I) {
   // do not lower GEP of spirv global variables as we do not lower them to vec4
-  if (isSpirvGlobalVariable(I.getPointerOperand()->getName())) {
-    return &I;
+  GetElementPtrInst *gep = &I;
+  while (gep) {
+    if (isSpirvGlobalVariable(gep->getPointerOperand()->getName())) {
+      return &I;
+    }
+    gep = dyn_cast<GetElementPtrInst>(gep->getPointerOperand());
   }
   Value *EquivalentPointer = visitOrSelf(I.getPointerOperand());
 

--- a/test/ThreeElementVectorLowering/gep_of_gep_of_push_constant.ll
+++ b/test/ThreeElementVectorLowering/gep_of_gep_of_push_constant.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t.ll --passes=three-element-vector-lowering --vec3-to-vec4
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  [[gep1:%[^ ]+]] = getelementptr inbounds %0, ptr addrspace(9) @__push_constants, i32 0, i32 1
+; CHECK:  [[gep2:%[^ ]+]] = getelementptr <3 x i32>, ptr addrspace(9) [[gep1]], i32 0, i32 1
+; CHECK:  load i32, ptr addrspace(9) [[gep2]], align 4
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32> }
+
+@__push_constants = addrspace(9) global %0 zeroinitializer, !push_constants !0
+
+define dso_local spir_kernel void @test() {
+entry:
+  %0 = getelementptr inbounds %0, ptr addrspace(9) @__push_constants, i32 0, i32 1
+  %1 = getelementptr <3 x i32>, ptr addrspace(9) %0, i32 0, i32 1
+  %2 = load i32, ptr addrspace(9) %1, align 4
+  ret void
+}
+
+!0 = !{i32 3, i32 4}


### PR DESCRIPTION
As we do not nower SPIR Gobal variable, do not lower any gep having a SPIR global variable as a parent recursively.

This will help avoid ending up on complicated pointer bitcast reworking in future PR.