### PR TITLE
fix SimplifyPointerBitcastPass::runOnGEPFromGEP

### DIFF
--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -79,8 +79,7 @@ uint64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
 SmallVector<Value *, 2>
 GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
                        Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
-                       size_t SmallerBitWidths,
-                       clspv::AddressSpace::Type AddrSpace);
+                       size_t SmallerBitWidths, Value *Src);
 } // namespace BitcastUtils
 
 #endif // _CLSPV_LIB_BITCAST_UTILS_PASS_H

--- a/lib/LowerPrivatePointerPHIPass.cpp
+++ b/lib/LowerPrivatePointerPHIPass.cpp
@@ -72,8 +72,7 @@ Value *makeNewGEP(const DataLayout &DL, IRBuilder<> &B, Instruction *Src,
     return Src;
   }
   auto Idxs = BitcastUtils::GetIdxsForTyFromOffset(
-      DL, B, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths,
-      clspv::AddressSpace::Private);
+      DL, B, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths, Src);
   return B.CreateGEP(SrcTy, Src, Idxs, "", true);
 }
 

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -488,11 +488,9 @@ bool DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
     Value *DynVal;
     size_t SmallerBitWidths;
     ExtractOffsetFromGEP(DL, B, gep, CstVal, DynVal, SmallerBitWidths);
-    auto Idxs = GetIdxsForTyFromOffset(
-        DL, B, Ty, Ty, CstVal, DynVal, SmallerBitWidths,
-        (clspv::AddressSpace::Type)gep->getPointerOperand()
-            ->getType()
-            ->getPointerAddressSpace());
+    auto Idxs =
+        GetIdxsForTyFromOffset(DL, B, Ty, Ty, CstVal, DynVal, SmallerBitWidths,
+                               gep->getPointerOperand());
     auto *new_gep =
         GetElementPtrInst::Create(Ty, gep->getPointerOperand(), Idxs, "", gep);
     gep->replaceAllUsesWith(new_gep);
@@ -571,11 +569,9 @@ bool DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
           RetTy = gep->getResultElementType();
         }
         ExtractOffsetFromGEP(DL, B, gep, CstVal, DynVal, SmallerBitWidths);
-        auto Idxs = GetIdxsForTyFromOffset(
-            DL, B, Ty, RetTy, CstVal, DynVal, SmallerBitWidths,
-            (clspv::AddressSpace::Type)gep->getPointerOperand()
-                ->getType()
-                ->getPointerAddressSpace());
+        auto Idxs =
+            GetIdxsForTyFromOffset(DL, B, Ty, RetTy, CstVal, DynVal,
+                                   SmallerBitWidths, gep->getPointerOperand());
         auto *new_gep = GetElementPtrInst::Create(Ty, gep->getPointerOperand(),
                                                   Idxs, "", gep);
         gep->replaceAllUsesWith(new_gep);
@@ -752,11 +748,9 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
                                 CstVal * SmallerBitWidths, nullptr) != 0) {
         SrcTy = DstTy;
       }
-      auto Idx = GetIdxsForTyFromOffset(
-          DL, Builder, SrcTy, DstTy, CstVal, DynVal, SmallerBitWidths,
-          (clspv::AddressSpace::Type)GEP->getPointerOperand()
-              ->getType()
-              ->getPointerAddressSpace());
+      auto Idx =
+          GetIdxsForTyFromOffset(DL, Builder, SrcTy, DstTy, CstVal, DynVal,
+                                 SmallerBitWidths, GEP->getPointerOperand());
       NewAddrIdxs.append(Idx);
 
       // If bitcast's user is gep, investigate gep's users too.

--- a/test/PointerCasts/issue-1243.ll
+++ b/test/PointerCasts/issue-1243.ll
@@ -2,9 +2,9 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; CHECK: [[gep:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i
-
-; TODO (#1243): Wrong simplification! we should have something with the div and mod of %i in the gep indices
-; CHECK: getelementptr <4 x i32>, ptr addrspace(1) %a, i32 0, i32 %i
+; CHECK: [[lshr:%[^ ]+]] = lshr i32 %i, 2
+; CHECK: [[and:%[^ ]+]] = and i32 %i, 3
+; CHECK: getelementptr <4 x i32>, ptr addrspace(1) %a, i32 [[lshr]], i32 [[and]]
 
 define spir_kernel void @test(ptr addrspace(1) %a, i32 %i) {
 entry:

--- a/test/PointerCasts/simplify_gep_from_gep.ll
+++ b/test/PointerCasts/simplify_gep_from_gep.ll
@@ -52,9 +52,11 @@ entry:
 ; CHECK-NEXT: entry
 ; CHECK-NEXT: [[shl:%[^ ]+]] = shl i32 %i, 2
 ; CHECK-NEXT: [[add:%[^ ]+]] = add i32 [[shl]], 4
-; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 [[add]], 2
-; CHECK-NEXT: [[and:%[^ ]+]] = and i32 [[add]], 3
-; CHECK-NEXT: getelementptr [2 x [4 x <4 x i32>]], ptr %a, i32 0, i32 [[lshr]], i32 [[and]], i32 %i
+; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 [[add]], 3
+; CHECK-NEXT: [[and:%[^ ]+]] = and i32 [[add]], 7
+; CHECK-NEXT: [[lshr2:%[^ ]+]] = lshr i32 [[and]], 2
+; CHECK-NEXT: [[and2:%[^ ]+]] = and i32 [[and]], 3
+; CHECK-NEXT: getelementptr [2 x [4 x <4 x i32>]], ptr %a, i32 [[lshr]], i32 [[lshr2]], i32 [[and2]], i32 %i
 
 define spir_kernel void @foo5(ptr %a, i32 %i) {
 entry:
@@ -90,9 +92,11 @@ entry:
 ; CHECK-NEXT: [[shl:%[^ ]+]] = shl i32 %i, 2
 ; CHECK-NEXT: [[add1:%[^ ]+]] = add i32 [[shl]], %i
 ; CHECK-NEXT: [[add2:%[^ ]+]] = add i32 [[add1]], 3
-; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 [[add2]], 2
-; CHECK-NEXT: [[and:%[^ ]+]] = and i32 [[add2]], 3
-; CHECK-NEXT: getelementptr [2 x [4 x <4 x i32>]], ptr %a, i32 0, i32 [[lshr]], i32 [[and]], i32 %i
+; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 [[add2]], 3
+; CHECK-NEXT: [[and:%[^ ]+]] = and i32 [[add2]], 7
+; CHECK-NEXT: [[lshr2:%[^ ]+]] = lshr i32 [[and]], 2
+; CHECK-NEXT: [[and2:%[^ ]+]] = and i32 [[and]], 3
+; CHECK-NEXT: getelementptr [2 x [4 x <4 x i32>]], ptr %a, i32 [[lshr]], i32 [[lshr2]], i32 [[and2]], i32 %i
 
 define spir_kernel void @foo8(ptr %a, i32 %i) {
 entry:

--- a/test/PointerCasts/srcGTdst/load_cast_float2_to_float.ll
+++ b/test/PointerCasts/srcGTdst/load_cast_float2_to_float.ll
@@ -4,12 +4,12 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0, i32 1
 ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0
-  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %b, i32 %i
+  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %b, i32 1
   %1 = load float, ptr addrspace(1) %arrayidx, align 4
   store float %1, ptr addrspace(1) %a, align 4
   ret void

--- a/test/PointerCasts/srcGTdst/load_cast_float2_to_int.ll
+++ b/test/PointerCasts/srcGTdst/load_cast_float2_to_int.ll
@@ -4,14 +4,14 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0, i32 1
 ; CHECK: [[gep2:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[gep]], i32 0
 ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep2]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float [[ld0]] to i32
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = getelementptr <2 x float>, ptr addrspace(1) %b, i32 0
-  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %0, i32 %i
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %0, i32 1
   %1 = load i32, ptr addrspace(1) %arrayidx, align 4
   store i32 %1, ptr addrspace(1) %a, align 4
   ret void

--- a/test/PointerCasts/srcGTdst/load_cast_float4_to_float.ll
+++ b/test/PointerCasts/srcGTdst/load_cast_float4_to_float.ll
@@ -4,12 +4,12 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0, i32 3
 ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0
-  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %0, i32 %i
+  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %0, i32 3
   %1 = load float, ptr addrspace(1) %arrayidx, align 8
   store float %1, ptr addrspace(1) %a, align 8
   ret void

--- a/test/PointerCasts/srcGTdst/load_cast_float4_to_int.ll
+++ b/test/PointerCasts/srcGTdst/load_cast_float4_to_int.ll
@@ -4,14 +4,14 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0, i32 3
 ; CHECK: [[gep2:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[gep]], i32 0
 ; CHECK: [[ld0:%[a-zA-Z0-9_.]+]] = load float, ptr addrspace(1) [[gep2]]
 ; CHECK: bitcast float [[ld0]] to i32
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = getelementptr <4 x float>, ptr addrspace(1) %b, i32 0
-  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %0, i32 %i
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %0, i32 3
   %1 = load i32, ptr addrspace(1) %arrayidx, align 8
   store i32 %1, ptr addrspace(1) %a, align 8
   ret void

--- a/test/PointerCasts/srcGTdst/store_cast_float2_to_char2_global_variable.ll
+++ b/test/PointerCasts/srcGTdst/store_cast_float2_to_char2_global_variable.ll
@@ -7,9 +7,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK:  [[gv:@[^ ]+]] = addrspace(1) global [4 x <2 x i8>] zeroinitializer
 ; CHECK:  [[load:%[^ ]+]] = load <2 x i8>, ptr addrspace(1) %b, align 2
 ; CHECK:  [[shl:%[^ ]+]] = shl i32 %i, 2
-; CHECK:  [[lshr:%[^ ]+]] = lshr i32 [[shl]], 2
-; CHECK:  [[and:%[^ ]+]] = and i32 [[shl]], 3
-; CHECK:  getelementptr [4 x <2 x i8>], ptr addrspace(1) [[gv]], i32 [[lshr]], i32 [[and]]
+; CHECK:  getelementptr [4 x <2 x i8>], ptr addrspace(1) [[gv]], i32 0, i32 [[shl]]
 ; CHECK:  store <2 x i8> [[load]], ptr addrspace(1) [[gv]], align 2
 
 @my_var = addrspace(1) global <2 x float> zeroinitializer

--- a/test/PointerCasts/srcGTdst/store_cast_float2_to_float.ll
+++ b/test/PointerCasts/srcGTdst/store_cast_float2_to_float.ll
@@ -4,13 +4,13 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0, i32 1
 ; CHECK: store float %0, ptr addrspace(1) [[gep]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = load float, ptr addrspace(1) %b, align 4
   %1 = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0
-  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %1, i32 %i
+  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %1, i32 1
   store float %0, ptr addrspace(1) %arrayidx, align 4
   ret void
 }

--- a/test/PointerCasts/srcGTdst/store_cast_float2_to_int.ll
+++ b/test/PointerCasts/srcGTdst/store_cast_float2_to_int.ll
@@ -5,14 +5,14 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; CHECK-DAG: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 %0 to float
-; CHECK-DAG: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0, i32 %i
+; CHECK-DAG: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0, i32 1
 ; CHECK-DAG: [[gep2:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[gep]], i32 0
 ; CHECK: store float [[cast]], ptr addrspace(1) [[gep2]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = load i32, ptr addrspace(1) %b, align 4
   %1 = getelementptr <2 x float>, ptr addrspace(1) %a, i32 0
-  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i32 %i
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i32 1
   store i32 %0, ptr addrspace(1) %arrayidx, align 4
   ret void
 }

--- a/test/PointerCasts/srcGTdst/store_cast_float4_to_float.ll
+++ b/test/PointerCasts/srcGTdst/store_cast_float4_to_float.ll
@@ -4,13 +4,13 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0, i32 %i
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0, i32 3
 ; CHECK: store float %0, ptr addrspace(1) [[gep]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = load float, ptr addrspace(1) %b, align 4
   %1 = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0
-  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %1, i32 %i
+  %arrayidx = getelementptr inbounds float, ptr addrspace(1) %1, i32 3
   store float %0, ptr addrspace(1) %arrayidx, align 4
   ret void
 }

--- a/test/PointerCasts/srcGTdst/store_cast_float4_to_int.ll
+++ b/test/PointerCasts/srcGTdst/store_cast_float4_to_int.ll
@@ -5,14 +5,14 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; CHECK-DAG: [[cast:%[a-zA-Z0-9_.]+]] = bitcast i32 %0 to float
-; CHECK-DAG: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0, i32 %i
+; CHECK-DAG: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0, i32 3
 ; CHECK-DAG: [[gep2:%[a-zA-Z0-9_.]+]] = getelementptr float, ptr addrspace(1) [[gep]], i32 0
 ; CHECK: store float [[cast]], ptr addrspace(1) [[gep2]]
-define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %i) {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) {
 entry:
   %0 = load i32, ptr addrspace(1) %b, align 4
   %1 = getelementptr <4 x float>, ptr addrspace(1) %a, i32 0
-  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i32 %i
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i32 3
   store i32 %0, ptr addrspace(1) %arrayidx, align 4
   ret void
 }


### PR DESCRIPTION
The most important part is the removal of the else condition is
runOnGEPFromGEP which was just assembling the 2 geps indices without
considering anything type-wise. Instead rework all those conditions to
have the else using ExtractOffsetFromGEP and GetIdxsForTyFromOffset
which contain a lot of logic to generate appropriate indices
considering the types in question.

Other changes are also needed to avoid regression in clspv tests and
in the OpenCL-CTS:

- Rework condition to avoid creating gep performing out-of-bound struct
  access.
- Rework condition in GetIdxsForTyFromOffset to know when to force first
  index to `0`.
- RunOnUnneededCasts is not needed anymore, and causes issues when not
  removed.
  
Depends on https://github.com/google/clspv/pull/1281