### PR TITLE
change infer type for phi nodes: consider incoming values

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -789,7 +789,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnPHIFromGEP(Module &M) const {
                                           PerfectMatch, DL) &&
                 PerfectMatch) {
               GEPAliasingList.push_back({phi, Steps, gep});
-            } else {
+            } else if (!FindAliasingContainedType(dest_ty, source_ty, Steps,
+                                                  PerfectMatch, DL)) {
 
               Worklist.emplace_back(std::make_pair(gep, dest_ty));
             }

--- a/test/PointerCasts/phi-from-gep.ll
+++ b/test/PointerCasts/phi-from-gep.ll
@@ -31,16 +31,15 @@ define spir_kernel void @test2(ptr addrspace(1) %a, i32 %i) {
 entry:
 ; CHECK: entry
 ; CHECK-NEXT: [[shl0:%[^ ]+]] = shl i32 %i, 2
-; CHECK-NEXT: [[shl1:%[^ ]+]] = shl i32 [[shl0]], 1
-; CHECK-NEXT: [[add:%[^ ]+]] = add i32 [[shl1]], 4
-; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[add]]
+; CHECK-NEXT: [[shl1:%[^ ]+]] = shl i32 [[shl0]], 2
+; CHECK-NEXT: [[add:%[^ ]+]] = add i32 [[shl1]], 8
+; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %a, i32 [[add]]
   %0 = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 2
   br label %end
 
 block:
 ; CHECK: block
-; CHECK-NEXT: [[lshr:%[^ ]+]] = lshr i32 %i, 1
-; CHECK-NEXT: [[gepblock:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %a, i32 [[lshr]]
+; CHECK-NEXT: [[gepblock:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %a, i32 %i
   %1 = getelementptr i8, ptr addrspace(1) %a, i32 %i
   br label %end
 
@@ -54,7 +53,7 @@ end:
 define spir_kernel void @test3(ptr addrspace(1) %a, i32 %i) {
 entry:
 ; CHECK: entry
-; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i, i32 0
+; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i
   %0 = getelementptr <4 x i32>, ptr addrspace(1) %a, i32 %i
   br label %end
 


### PR DESCRIPTION
Refactor the part of InferType dealing with users type in a function.

For PHI Nodes, consider the type coming from the users, but also the
type from the incoming values.

The goal here is to end up with a reported type which is the bigger
one that all users and incoming values can easily bitcast to/from.

Previous implementation is leading to unsupported cases in pointer
bitcast passes for issue #1208 #1209 #1220 #1221 #1223

Depends on https://github.com/google/clspv/pull/1282