### PR TITLE
Fixed " undeclared identifier" for the atomic_store* functions with c…

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -229,6 +229,12 @@ clang::TargetInfo *PrepareTargetInfo(CompilerInstance &instance) {
     if (clspv::Option::ImageSupport()) {
       EnabledFeatureMacros.insert(clspv::FeatureMacro::__opencl_c_images);
     }
+    // The futures should be enabled for __OPENCL_C_VERSION__ == 300
+    // while the __SPIR__ and __SPIRV__ defines are undefined.
+    EnabledFeatureMacros.insert(
+        clspv::FeatureMacro::__opencl_c_atomic_scope_device);
+    EnabledFeatureMacros.insert(
+        clspv::FeatureMacro::__opencl_c_atomic_order_seq_cst);
 
     // TODO remove when feature macros are added to OpenCLExtensions.def
     // https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Basic/OpenCLExtensions.def#L119

--- a/test/Features/cl3-no-features.cl
+++ b/test/Features/cl3-no-features.cl
@@ -20,14 +20,6 @@
 #error __opencl_c_subgroups should not be defined
 #endif
 
-#ifdef __opencl_c_atomic_order_seq_cst
-#error __opencl_c_atomic_order_seq_cst should not be defined
-#endif
-
-#ifdef __opencl_c_atomic_scope_device
-#error __opencl_c_atomic_scope_device should not be defined
-#endif
-
 #ifdef __opencl_c_atomic_scope_all_devices
 #error __opencl_c_atomic_scope_all_devices should not be defined
 #endif

--- a/test/Features/cl3-some-features.cl
+++ b/test/Features/cl3-some-features.cl
@@ -24,8 +24,8 @@
 #error __opencl_c_atomic_order_seq_cst should be defined
 #endif
 
-#ifdef __opencl_c_atomic_scope_device
-#error __opencl_c_atomic_scope_device should not be defined
+#ifndef __opencl_c_atomic_scope_device
+#error __opencl_c_atomic_scope_device should be defined
 #endif
 
 #ifdef __opencl_c_atomic_scope_all_devices


### PR DESCRIPTION
…l-std=3.0 argument.

The OCL-CTS has failed the atomic_fence test in the test_c11_atomics testsuite .

The diference between std2.0 and std3.0  in the file opencl-c-base.h
```
// Define feature macros for OpenCL C 2.0
#if (__OPENCL_CPP_VERSION__ == 100 || __OPENCL_C_VERSION__ == 200)
#define __opencl_c_pipes 1
#define __opencl_c_generic_address_space 1
#define __opencl_c_work_group_collective_functions 1
#define __opencl_c_atomic_order_acq_rel 1
#define __opencl_c_atomic_order_seq_cst 1
#define __opencl_c_atomic_scope_device 1
#define __opencl_c_atomic_scope_all_devices 1
#define __opencl_c_device_enqueue 1
#define __opencl_c_read_write_images 1
#define __opencl_c_program_scope_global_variables 1
#define __opencl_c_images 1
#endif

// Define header-only feature macros for OpenCL C 3.0.
#if (__OPENCL_CPP_VERSION__ == 202100 || __OPENCL_C_VERSION__ == 300)
// For the SPIR and SPIR-V target all features are supported.
#if defined(__SPIR__) || defined(__SPIRV__)
#define __opencl_c_work_group_collective_functions 1
#define __opencl_c_atomic_order_seq_cst 1
#define __opencl_c_atomic_scope_device 1
#define __opencl_c_atomic_scope_all_devices 1
#define __opencl_c_read_write_images 1
#endif // defined(__SPIR__)
```