### PR TITLE
Explicitly annotate intentional fallthroughs

### DIFF
--- a/lib/InlineFuncWithPointerBitCastArgPass.cpp
+++ b/lib/InlineFuncWithPointerBitCastArgPass.cpp
@@ -70,7 +70,7 @@ bool clspv::InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
                 case Instruction::Call:
                   // We found a call instruction which needs to be inlined!
                   WorkList.insert(cast<CallInst>(Inst));
-                  // Fall-through
+                  [[fallthrough]];
                 case Instruction::PHI:
                   // If we previously checked this phi...
                   if (0 < CheckedPhis.count(Inst)) {
@@ -79,7 +79,7 @@ bool clspv::InlineFuncWithPointerBitCastArgPass::InlineFunctions(Module &M) {
                   }
 
                   CheckedPhis.insert(Inst);
-                  // Fall-through
+                  [[fallthrough]];
                 case Instruction::GetElementPtr:
                 case Instruction::BitCast:
                   // These pointer users could have a call user, and so we

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1350,6 +1350,7 @@ void SPIRVProducerPassImpl::FindTypesForResourceVars() {
       for (auto *elem_ty : cast<StructType>(type)->elements()) {
         work_list.push_back(elem_ty);
       }
+      break;
     default:
       // This type and its contained types don't get layout.
       break;


### PR DESCRIPTION
Use the C++17 attribute.
This avoids warnings, triggered in Clang 16 at least.