### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "d5a3de4aeef4f4f1c52692533ddb9fdf45aef9d3"
+      "commit" : "0f1847cb2c5462a09d65a9b5ac24904ac3c15a0f"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/ClusterPodKernelArgumentsPass.cpp
+++ b/lib/ClusterPodKernelArgumentsPass.cpp
@@ -238,6 +238,7 @@ clspv::ClusterPodKernelArgumentsPass::run(Module &M, ModuleAnalysisManager &) {
 
     // Create the new function and set key properties.
     auto NewFunc = Function::Create(NewFuncTy, F->getLinkage());
+    NewFunc->setIsNewDbgInfoFormat(true);
     // The new function adopts the real name so that linkage to the outside
     // world remains the same.
     NewFunc->setName(F->getName());

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -1049,9 +1049,19 @@ bool LinkBuiltinLibrary(llvm::Module *module) {
       Err.print("internal_additional_library:", llvm::errs());
       return false;
     }
+    for (auto &F : *add_library) {
+      if (!F.isDeclaration()) {
+        F.setIsNewDbgInfoFormat(true);
+      }
+    }
     L.linkInModule(std::move(add_library), 0);
   }
 
+  for (auto &F : *library) {
+    if (!F.isDeclaration()) {
+      F.setIsNewDbgInfoFormat(true);
+    }
+  }
   L.linkInModule(std::move(library), 0);
 
   return true;

--- a/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.cpp
@@ -79,6 +79,7 @@ Function *getFunctionIfNeeded(Module &M, StringRef Name,
     if (D) {
       // function must be inserted for use by dependent
       F = cast<Function>(M.getOrInsertFunction(Name, FType).getCallee());
+      F->setIsNewDbgInfoFormat(true);
       F->setCallingConv(CallingConv::SPIR_FUNC);
       return F;
     }

--- a/lib/HideConstantLoadsPass.cpp
+++ b/lib/HideConstantLoadsPass.cpp
@@ -82,6 +82,7 @@ PreservedAnalyses clspv::HideConstantLoadsPass::run(Module &M,
       FunctionType *fnTy = FunctionType::get(loadedTy, {loadedTy}, false);
       auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
       fn = cast<Function>(fn_constant.getCallee());
+      fn->setIsNewDbgInfoFormat(true);
       fn->setOnlyReadsMemory();
     }
 

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -306,6 +306,7 @@ Function *getBIFScalarVersion(Function &Builtin) {
 
   if (ScalarFn == nullptr) {
     ScalarFn = Function::Create(FunctionTy, Builtin.getLinkage(), ScalarName);
+    ScalarFn->setIsNewDbgInfoFormat(true);
     ScalarFn->setCallingConv(Builtin.getCallingConv());
     ScalarFn->copyAttributesFrom(&Builtin);
 
@@ -503,6 +504,7 @@ Function *createFunctionWithMappedTypes(Function &F,
   assert(!F.isVarArg() && "varargs not supported");
 
   auto *Wrapper = Function::Create(EquivalentFunctionTy, F.getLinkage());
+  Wrapper->setIsNewDbgInfoFormat(true);
   Wrapper->takeName(&F);
   Wrapper->setCallingConv(F.getCallingConv());
   Wrapper->copyAttributesFrom(&F);
@@ -584,6 +586,7 @@ Value *convertOpAnyOrAllOperation(CallInst &VectorCall,
         FunctionType::get(VectorCall.getFunctionType()->getReturnType(),
                           ParamTys, false),
         OpAnyOrAllInitialFunction->getLinkage(), OpAnyOrAllFunctionName);
+    OpAnyOrAllFunction->setIsNewDbgInfoFormat(true);
 
     OpAnyOrAllFunction->setCallingConv(
         OpAnyOrAllInitialFunction->getCallingConv());

--- a/lib/LowerAddrSpaceCastPass.cpp
+++ b/lib/LowerAddrSpaceCastPass.cpp
@@ -264,6 +264,7 @@ llvm::Value *clspv::LowerAddrSpaceCastPass::visitCallInst(llvm::CallInst &I) {
       return eqF;
 
     eqF = Function::Create(FunctionTy, F->getLinkage(), Name);
+    eqF->setIsNewDbgInfoFormat(true);
     FunctionMap[F] = eqF;
     M->getFunctionList().push_front(eqF);
 

--- a/lib/MultiVersionUBOFunctionsPass.cpp
+++ b/lib/MultiVersionUBOFunctionsPass.cpp
@@ -240,6 +240,7 @@ Function *clspv::MultiVersionUBOFunctionsPass::AddExtraArguments(
   auto pair =
       module->getOrInsertFunction(fn->getName(), new_type, fn->getAttributes());
   Function *new_function = cast<Function>(pair.getCallee());
+  new_function->setIsNewDbgInfoFormat(true);
   new_function->setCallingConv(fn->getCallingConv());
   new_function->copyMetadata(fn, 0);
 

--- a/lib/PhysicalPointerArgsPass.cpp
+++ b/lib/PhysicalPointerArgsPass.cpp
@@ -72,6 +72,7 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
         FunctionType::get(F.getReturnType(), NewParamTypes, false);
 
     auto NewFunc = Function::Create(NewFuncTy, F.getLinkage());
+    NewFunc->setIsNewDbgInfoFormat(true);
     // The new function adopts the real name so that linkage to the outside
     // world remains the same.
     NewFunc->setName(F.getName());

--- a/lib/PrintfPass.cpp
+++ b/lib/PrintfPass.cpp
@@ -86,6 +86,7 @@ void clspv::PrintfPass::DefinePrintfInstance(Module &M, CallInst *CI,
   auto FuncCallee = M.getOrInsertFunction(FuncName, FuncTy);
   auto *Func = dyn_cast<Function>(FuncCallee.getCallee());
   assert(Func);
+  Func->setIsNewDbgInfoFormat(true);
 
   auto *NewCI = CallInst::Create(Func, NewArgs, "", CI);
   CI->replaceAllUsesWith(NewCI);

--- a/lib/RemoveUnusedArguments.cpp
+++ b/lib/RemoveUnusedArguments.cpp
@@ -94,6 +94,7 @@ void clspv::RemoveUnusedArguments::removeUnusedParameters(
     auto inserted =
         M.getOrInsertFunction(f->getName(), new_type, fn_attrs).getCallee();
     Function *new_function = cast<Function>(inserted);
+    new_function->setIsNewDbgInfoFormat(true);
     new_function->setCallingConv(f->getCallingConv());
     new_function->copyMetadata(f, 0);
 

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -93,6 +93,8 @@ bool clspv::ReplaceLLVMIntrinsicsPass::runOnFunction(Function &F) {
     return replaceAddSubSat(F, true, false);
   case Intrinsic::sadd_sat:
     return replaceAddSubSat(F, true, true);
+  case Intrinsic::is_fpclass:
+    return replaceIsFpClass(F);
   // SPIR-V OpAssumeTrueKHR requires ExpectAssumeKHR capability in SPV_KHR_expect_assume extension.
   // Vulkan doesn't support that, so remove assume declaration.
   case Intrinsic::assume:
@@ -128,6 +130,22 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceCallsWithValue(
   DeadFunctions.push_back(&F);
 
   return !ToRemove.empty();
+}
+
+bool clspv::ReplaceLLVMIntrinsicsPass : replaceIsFpClass(Function &F) {
+  return replaceCallsWithValue(F, [](CallInst *call) {
+    auto mask = cast<ConstantInt>(call->getArgOperand(1))->getZExtValue();
+    Value *result = nullptr;
+    IRBuilder<> builder(call);
+    // TODO(#1307): handle other codes
+    if (mask & 0x40) {
+      return builder.CreateFCmpOEQ(
+          call->getArgOperand(0),
+          Constant::getNullValue(call->getArgOperand(0)->getType()));
+    }
+    assert(false);
+    return result;
+  });
 }
 
 bool clspv::ReplaceLLVMIntrinsicsPass::replaceBswap(Function &F) {

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -132,7 +132,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceCallsWithValue(
   return !ToRemove.empty();
 }
 
-bool clspv::ReplaceLLVMIntrinsicsPass : replaceIsFpClass(Function &F) {
+bool clspv::ReplaceLLVMIntrinsicsPass::replaceIsFpClass(Function &F) {
   return replaceCallsWithValue(F, [](CallInst *call) {
     auto mask = cast<ConstantInt>(call->getArgOperand(1))->getZExtValue();
     Value *result = nullptr;

--- a/lib/ReplaceLLVMIntrinsicsPass.h
+++ b/lib/ReplaceLLVMIntrinsicsPass.h
@@ -35,6 +35,7 @@ struct ReplaceLLVMIntrinsicsPass
   bool replaceCountZeroes(llvm::Function &F, bool leading);
   bool replaceCopysign(llvm::Function &F);
   bool replaceAddSubSat(llvm::Function &F, bool is_signed, bool is_add);
+  bool replaceIsFpClass(llvm::Function &F);
 
   bool replaceCallsWithValue(
       llvm::Function &F,

--- a/lib/RewriteInsertsPass.cpp
+++ b/lib/RewriteInsertsPass.cpp
@@ -214,6 +214,7 @@ clspv::RewriteInsertsPass::GetConstructFunction(Module &M,
     FunctionType *fnTy = FunctionType::get(constructed_type, elements, false);
     auto fn_constant = M.getOrInsertFunction(fn_name, fnTy);
     fn = cast<Function>(fn_constant.getCallee());
+    fn->setIsNewDbgInfoFormat(true);
     fn->setOnlyReadsMemory();
   }
   return fn;

--- a/lib/SpecializeImageTypes.cpp
+++ b/lib/SpecializeImageTypes.cpp
@@ -368,6 +368,7 @@ void SpecializeImageTypesPass::RewriteFunction(Function *f) {
   auto callee =
       module->getOrInsertFunction(f->getName(), func_type, f->getAttributes());
   auto new_func = cast<Function>(callee.getCallee());
+  new_func->setIsNewDbgInfoFormat(true);
   new_func->setCallingConv(f->getCallingConv());
   new_func->copyMetadata(f, 0);
 

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -158,6 +158,7 @@ Function *createFunctionWithMappedTypes(Function &F,
   assert(!F.isVarArg() && "varargs not supported");
 
   auto *Wrapper = Function::Create(EquivalentFunctionTy, F.getLinkage());
+  Wrapper->setIsNewDbgInfoFormat(F.IsNewDbgInfoFormat);
   Wrapper->takeName(&F);
   Wrapper->setCallingConv(F.getCallingConv());
   Wrapper->copyAttributesFrom(&F);
@@ -1102,6 +1103,7 @@ Value *clspv::ThreeElementVectorLoweringPass::convertSIMDBuiltinCall(
   Function *Fct =
       Function::Create(FunctionType::get(EquivalentReturnTy, ParamTys, false),
                        InitialFunction->getLinkage(), FunctionName);
+  Fct->setIsNewDbgInfoFormat(true);
 
   Fct->setCallingConv(InitialFunction->getCallingConv());
   Fct->copyAttributesFrom(InitialFunction);

--- a/lib/UBOTypeTransformPass.cpp
+++ b/lib/UBOTypeTransformPass.cpp
@@ -278,6 +278,7 @@ bool clspv::UBOTypeTransformPass::RemapFunctions(
     auto inserted = M.getOrInsertFunction(func->getName(), replacement_type,
                                           func->getAttributes());
     Function *replacement = cast<Function>(inserted.getCallee());
+    replacement->setIsNewDbgInfoFormat(true);
     function_replacements_[func] = replacement;
     replacement->setCallingConv(func->getCallingConv());
     replacement->copyMetadata(func, 0);

--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -65,6 +65,7 @@ PreservedAnalyses clspv::UndoByvalPass::run(Module &M,
 
       // Create new function.
       Function *NewFunc = Function::Create(NewFuncTy, F->getLinkage());
+      NewFunc->setIsNewDbgInfoFormat(true);
       NewFunc->takeName(F);
 
       // Insert the function just after the original to preserve the ordering of

--- a/lib/UndoSRetPass.cpp
+++ b/lib/UndoSRetPass.cpp
@@ -74,6 +74,7 @@ PreservedAnalyses clspv::UndoSRetPass::run(Module &M, ModuleAnalysisManager &) {
 
         // Create new function.
         Function *NewFunc = Function::Create(NewFuncTy, F->getLinkage());
+        NewFunc->setIsNewDbgInfoFormat(true);
         NewFunc->takeName(F);
 
         // Insert the function just after the original to preserve the ordering

--- a/lib/WrapKernelPass.cpp
+++ b/lib/WrapKernelPass.cpp
@@ -20,6 +20,7 @@ void clspv::WrapKernelPass::runOnFunction(Module &M, llvm::Function *F) {
   auto *NewFuncTy = FunctionType::get(F->getReturnType(), NewParamTypes, false);
 
   auto NewFunc = Function::Create(NewFuncTy, F->getLinkage());
+  NewFunc->setIsNewDbgInfoFormat(true);
   NewFunc->setName(F->getName().str());
   F->setName(F->getName().str() + ".inner");
   NewFunc->setCallingConv(F->getCallingConv());

--- a/test/debug-information-control-flow.cl
+++ b/test/debug-information-control-flow.cl
@@ -13,7 +13,6 @@ void kernel foo(global uint *dst, global uint *srcA, global uint *srcB) {
 
 // CHECK:       OpLine [[filename:%[^ ]+]] 7 0
 // CHECK-NEXT:  OpLoad
-// CHECK-NEXT:  OpLine [[filename]] 0 0
 // CHECK-NEXT:  OpNoLine
 // CHECK-NEXT:  OpAccessChain
 // CHECK-NEXT:  OpLine [[filename]] 8 0

--- a/test/debug-information.cl
+++ b/test/debug-information.cl
@@ -10,7 +10,6 @@ void kernel foo(global uint *dst, global uint *src) {
 
 // CHECK:       OpLine [[filename:%[^ ]+]] 7 0
 // CHECK-NEXT:  OpLoad
-// CHECK-NEXT:  OpLine [[filename]] 0 0
 // CHECK-NEXT:  OpNoLine
 // CHECK-NEXT:  OpAccessChain
 // CHECK-NEXT:  OpLine [[filename]] 8 0


### PR DESCRIPTION
* Handle switch to new debug info format
  * linked libraries are converted
  * newly created functions (with bodies) are converted
  * updated test expectations
* Bare minimum handling of llvm.is_fpclass (see #1307) to unblock known cts failures

This passed internal testing as an import.