### PR TITLE
Copy metadata for new call functions when undoing pass by val

### DIFF
--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -144,6 +144,8 @@ PreservedAnalyses clspv::UndoByvalPass::run(Module &M,
 
         CallInst *NewCall = CallInst::Create(NewFunc, Args, "", Call);
         NewCall->setCallingConv(NewFunc->getCallingConv());
+        auto Instr = dyn_cast<Instruction>(User);
+        NewCall->copyMetadata(*Instr);
 
         Call->replaceAllUsesWith(NewCall);
         Call->eraseFromParent();

--- a/lib/UndoByvalPass.cpp
+++ b/lib/UndoByvalPass.cpp
@@ -144,8 +144,7 @@ PreservedAnalyses clspv::UndoByvalPass::run(Module &M,
 
         CallInst *NewCall = CallInst::Create(NewFunc, Args, "", Call);
         NewCall->setCallingConv(NewFunc->getCallingConv());
-        auto Instr = dyn_cast<Instruction>(User);
-        NewCall->copyMetadata(*Instr);
+        NewCall->copyMetadata(*Call);
 
         Call->replaceAllUsesWith(NewCall);
         Call->eraseFromParent();

--- a/test/issue-1228.cl
+++ b/test/issue-1228.cl
@@ -4,8 +4,7 @@ typedef struct Baz {
     float x;
 } Baz;
 
-static int foo(Baz baz) {
-	return 1;
+static void foo(Baz baz) {
 }
 
 __kernel void test(__global Baz *baz) {

--- a/test/issue-1228.cl
+++ b/test/issue-1228.cl
@@ -1,0 +1,13 @@
+// RUN: clspv -inline-entry-points -g -O0 %s -o %t.spv 
+
+typedef struct Baz {
+    float x;
+} Baz;
+
+static int foo(Baz baz) {
+	return 1;
+}
+
+__kernel void test(__global Baz *baz) {
+    foo(baz[0]);
+}


### PR DESCRIPTION
This change fixes #1228 by correctly copying over the metadata to any new calls generated as a result of undoing pass by val.