### PR TITLE
clean unsused instruction to avoid fake pointer bitcast

### DIFF
--- a/test/PointerCasts/issue-1318.ll
+++ b/test/PointerCasts/issue-1318.ll
@@ -1,0 +1,17 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast,replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[ptr:%[^ ]+]] = inttoptr i64 %a to ptr addrspace(1)
+; CHECK: [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) [[ptr]], i32 1
+; CHECK: load i32, ptr addrspace(1) [[gep]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define spir_kernel void @foo(i64 %a) {
+entry:
+  %0 = inttoptr i64 %a to ptr addrspace(1)
+  %1 = getelementptr i8, ptr addrspace(1) %0, i64 4
+  %2 = load i32, ptr addrspace(1) %1, align 4
+  ret void
+}

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_char_to_float.ll
@@ -6,22 +6,21 @@ target triple = "spir-unknown-unknown"
 
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
-; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 2
+; CHECK: [[shl:%[^ ]+]] = shl i32 {{.*}}, 2
+; CHECK: [[add:%[^ ]+]] = add i32 [[shl]], 1
+; CHECK: [[gep_src:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <4 x i8>
 ; CHECK: [[trunc0:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 0
 ; CHECK: [[trunc1:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 1
 ; CHECK: [[trunc2:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 2
 ; CHECK: [[trunc3:%[^ ]+]] = extractelement <4 x i8> [[cast]], i64 3
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[idx]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 0
 ; CHECK: store i8 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[add1:%[a-zA-Z0-9_.]+]] = add i32 [[idx]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add1]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 1
 ; CHECK: store i8 [[trunc1]], ptr addrspace(1) [[gep]]
-; CHECK: [[add2:%[a-zA-Z0-9_.]+]] = add i32 [[add1]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add2]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 2
 ; CHECK: store i8 [[trunc2]], ptr addrspace(1) [[gep]]
-; CHECK: [[add3:%[a-zA-Z0-9_.]+]] = add i32 [[add2]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) %soa, i32 [[add3]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i8, ptr addrspace(1) [[gep_src]], i32 3
 ; CHECK: store i8 [[trunc3]], ptr addrspace(1) [[gep]]
 
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {
@@ -29,7 +28,7 @@ entry:
   %0 = load i32, ptr addrspace(5) getelementptr (<3 x i32>, ptr addrspace(5) @__spirv_GlobalInvocationId, i32 0, i32 0)
   %mul = mul i32 4, %0
   %1 = sdiv i32 %mul, 4
-  %cast = getelementptr i8, ptr addrspace(1) %soa, i32 0
+  %cast = getelementptr i8, ptr addrspace(1) %soa, i32 1
   %2 = getelementptr float, ptr addrspace(1) %cast, i32 %1
   %conv = uitofp i32 %0 to float
   store float %conv, ptr addrspace(1) %2, align 4

--- a/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
+++ b/test/PointerCasts/srcLTdst/srcelemLTdstelem/store_cast_short_to_float.ll
@@ -7,20 +7,21 @@ target triple = "spir-unknown-unknown"
 @__spirv_GlobalInvocationId = addrspace(5) global <3 x i32> zeroinitializer
 
 ; CHECK: [[idx:%[^ ]+]] = shl i32 {{.*}}, 1
+; CHECK: [[add:%[^ ]+]] = add i32 [[idx]], 1
+; CHECK: [[gep_src:%[^ ]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[add]]
 ; CHECK: [[cast:%[a-zA-Z0-9_.]+]] = bitcast float %conv to <2 x i16>
 ; CHECK: [[trunc0:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 0
 ; CHECK: [[trunc1:%[a-zA-Z0-9_.]+]] = extractelement <2 x i16> [[cast]], i64 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[idx]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 0
 ; CHECK: store i16 [[trunc0]], ptr addrspace(1) [[gep]]
-; CHECK: [[add:%[a-zA-Z0-9_.]+]] = add i32 [[idx]], 1
-; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) %soa, i32 [[add]]
+; CHECK: [[gep:%[a-zA-Z0-9_.]+]] = getelementptr i16, ptr addrspace(1) [[gep_src]], i32 1
 ; CHECK: store i16 [[trunc1]], ptr addrspace(1) [[gep]]
 define spir_kernel void @writeToSoaBuffer(ptr addrspace(1) %soa) {
 entry:
   %0 = load i32, ptr addrspace(5) getelementptr (<3 x i32>, ptr addrspace(5) @__spirv_GlobalInvocationId, i32 0, i32 0)
   %mul = mul i32 4, %0
   %1 = sdiv i32 %mul, 4
-  %cast = getelementptr i16, ptr addrspace(1) %soa, i32 0
+  %cast = getelementptr i16, ptr addrspace(1) %soa, i32 1
   %2 = getelementptr float, ptr addrspace(1) %cast, i32 %1
   %conv = uitofp i32 %0 to float
   store float %conv, ptr addrspace(1) %2, align 4


### PR DESCRIPTION
fix #1318