### PR TITLE
Update SPIRV-Headers and SPIRV-Tools

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,7 +14,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "branch" : "main",
       "subdir" : "third_party/SPIRV-Headers",
-      "commit" : "4183b260f4cccae52a89efdfcdd43c4897989f42"
+      "commit" : "4f7b471f1a66b6d06462cd4ba57628cc0cd087d7"
     },
     {
       "name" : "SPIRV-Tools",
@@ -22,7 +22,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "branch" : "main",
       "subdir" : "third_party/SPIRV-Tools",
-      "commit" : "a996591b1c67e789e88e99ae3881272f5fc47374"
+      "commit" : "02470f606fe1571de808cb773d8c521ab201aaff"
     }
   ]
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -687,6 +687,7 @@ private:
   Type *SamplerPointerTy;
   Type *SamplerDataTy;
   DenseMap<unsigned, SPIRVID> SamplerLiteralToIDMap;
+  DenseSet<uint32_t> DecoratedNonUniform;
 
   // If a function F has a pointer-to-__constant parameter, then this variable
   // will map F's type to (G, index of the parameter), where in a first phase
@@ -4638,8 +4639,11 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         setNonUniformPointers();
 
         SPIRVOperandVec Ops;
-        Ops << getSPIRVValue(op) << spv::DecorationNonUniform;
-        addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+        auto id = getSPIRVValue(op);
+        if (DecoratedNonUniform.insert(id.get()).second) {
+          Ops << id << spv::DecorationNonUniform;
+          addSPIRVInst<kAnnotations>(spv::OpDecorate, Ops);
+        }
       }
     }
   }


### PR DESCRIPTION
* Prevent the SPIRVProducer from adding duplicate NonUniform decorations

https://github.com/KhronosGroup/SPIRV-Tools/pull/5641 added new validation.