### PR TITLE
Add option for CLC++2021

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -168,7 +168,8 @@ enum class SourceLanguage {
   OpenCL_C_12,
   OpenCL_C_20,
   OpenCL_C_30,
-  OpenCL_CPP
+  OpenCL_CPP,
+  OpenCL_CPP_2021
 };
 
 SourceLanguage Language();
@@ -178,6 +179,7 @@ std::set<FeatureMacro> EnabledFeatureMacros();
 // Returns true when the source language makes use of the generic address space.
 inline bool LanguageUsesGenericAddressSpace() {
   return (Language() == SourceLanguage::OpenCL_CPP) ||
+         (Language() == SourceLanguage::OpenCL_CPP_2021) ||
          (Language() == SourceLanguage::OpenCL_C_20) ||
          (Language() == SourceLanguage::OpenCL_C_30 &&
           EnabledFeatureMacros().count(

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -288,6 +288,9 @@ int SetCompilerInstanceOptions(
   case clspv::Option::SourceLanguage::OpenCL_CPP:
     standard = clang::LangStandard::lang_openclcpp10;
     break;
+  case clspv::Option::SourceLanguage::OpenCL_CPP_2021:
+    standard = clang::LangStandard::lang_openclcpp2021;
+    break;
   default:
     llvm_unreachable("Unknown source language");
   }
@@ -314,6 +317,16 @@ int SetCompilerInstanceOptions(
   instance.getDiagnosticOpts().Warnings.push_back("no-builtin-macro-redefined");
   // TODO(#995): Re-enable this warning.
   instance.getDiagnosticOpts().Warnings.push_back("no-unsafe-buffer-usage");
+
+  if (clspv::Option::Language() == clspv::Option::SourceLanguage::OpenCL_CPP ||
+      clspv::Option::Language() ==
+          clspv::Option::SourceLanguage::OpenCL_CPP_2021) {
+    instance.getDiagnosticOpts().Warnings.push_back("no-missing-prototypes");
+  }
+  if (clspv::Option::Language() ==
+      clspv::Option::SourceLanguage::OpenCL_CPP_2021) {
+    instance.getDiagnosticOpts().Warnings.push_back("no-c++98-compat");
+  }
 
   instance.getLangOpts().SinglePrecisionConstants =
       cl_single_precision_constants;
@@ -835,7 +848,9 @@ int ParseOptions(const int argc, const char *const argv[]) {
         clspv::Option::Language() ==
             clspv::Option::SourceLanguage::OpenCL_C_20 ||
         clspv::Option::Language() ==
-            clspv::Option::SourceLanguage::OpenCL_CPP) {
+            clspv::Option::SourceLanguage::OpenCL_CPP ||
+        clspv::Option::Language() ==
+            clspv::Option::SourceLanguage::OpenCL_CPP_2021) {
       llvm::errs() << "POD arguments as push constants are not compatible with "
                       "module scope push constants\n";
       return -1;

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -241,7 +241,9 @@ llvm::cl::opt<clspv::Option::SourceLanguage> cl_std(
                      clEnumValN(clspv::Option::SourceLanguage::OpenCL_C_30,
                                 "CL3.0", "OpenCL C 3.0"),
                      clEnumValN(clspv::Option::SourceLanguage::OpenCL_CPP,
-                                "CLC++", "C++ for OpenCL")));
+                                "CLC++", "C++ for OpenCL"),
+                     clEnumValN(clspv::Option::SourceLanguage::OpenCL_CPP_2021,
+                                "CLC++2021", "C++ for OpenCL")));
 
 llvm::cl::opt<clspv::Option::SPIRVVersion> spv_version(
     "spv-version", llvm::cl::desc("Specify the SPIR-V binary version"),
@@ -479,6 +481,7 @@ bool GlobalOffset() { return global_offset; }
 bool GlobalOffsetPushConstant() { return global_offset_push_constant; }
 bool NonUniformNDRangeSupported() {
   return ((Language() == SourceLanguage::OpenCL_CPP) ||
+          (Language() == SourceLanguage::OpenCL_CPP_2021) ||
           (Language() == SourceLanguage::OpenCL_C_20) ||
           (Language() == SourceLanguage::OpenCL_C_30) ||
           ArmNonUniformWorkGroupSize()) &&

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3372,6 +3372,10 @@ void SPIRVProducerPassImpl::GenerateModuleInfo() {
     LangID = spv::SourceLanguageOpenCL_CPP;
     LangVer = 100;
     break;
+  case clspv::Option::SourceLanguage::OpenCL_CPP_2021:
+    LangID = spv::SourceLanguageOpenCL_CPP;
+    LangVer = 202100;
+    break;
   default:
     break;
   }

--- a/test/CPlusPlus/cpp-2021.cl
+++ b/test/CPlusPlus/cpp-2021.cl
@@ -1,0 +1,11 @@
+// RUN: clspv %target -cl-std=CLC++2021 -inline-entry-points %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpSource OpenCL_CPP 202100
+// CHECK: OpStore %{{[0-9]+}} %uint_202100
+
+kernel void test(global int *x) {
+    x[0] = __OPENCL_CPP_VERSION__;
+}


### PR DESCRIPTION
* Allows `-cl-std=CLC++2021`
* Removes `missing-prototypes` warnings for C++ (any version)
* Removes `c++98-compat` warnings for CLC++2021
* Test