### PR TITLE
Support PHI in LowerAddrSpaceCastPass

### DIFF
--- a/lib/LowerAddrSpaceCastPass.h
+++ b/lib/LowerAddrSpaceCastPass.h
@@ -45,6 +45,7 @@ private:
   llvm::Value *visitCallInst(llvm::CallInst &I);
   llvm::Value *visitIntToPtrInst(llvm::IntToPtrInst &I);
   llvm::Value *visitPtrToIntInst(llvm::PtrToIntInst &I);
+  llvm::Value *visitPHINode(llvm::PHINode &I);
   llvm::Value *visitInstruction(llvm::Instruction &I);
 
   void runOnFunction(llvm::Function &F);

--- a/test/AddressSpaceCast/issue-1341.ll
+++ b/test/AddressSpaceCast/issue-1341.ll
@@ -1,7 +1,8 @@
 ; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
 ; RUN: FileCheck %s < %t.ll
 
-; CHECK: %0 = phi ptr [ %{{.*}}, %entry ], [ %{{.*}}, %arrayinit.body ]
+; CHECK: arrayinit.body:
+; CHECK-NEXT: {{.*}} = phi ptr [ %{{.*}}, %entry ], [ %{{.*}}, %arrayinit.body ]
 ; CHECK-NOT: %arrayinit.cur = phi ptr addrspace(4) [ %arrayinit.begin, %entry ], [ %arrayinit.next, %arrayinit.body ]
 
 define dso_local spir_kernel void @fun() {

--- a/test/AddressSpaceCast/issue-1341.ll
+++ b/test/AddressSpaceCast/issue-1341.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: %0 = phi ptr [ %{{.*}}, %entry ], [ %{{.*}}, %arrayinit.body ]
+; CHECK-NOT: %arrayinit.cur = phi ptr addrspace(4) [ %arrayinit.begin, %entry ], [ %arrayinit.next, %arrayinit.body ]
+
+define dso_local spir_kernel void @fun() {
+entry:
+  %mem = alloca [4 x float]
+  %data = addrspacecast ptr %mem to ptr addrspace(4)
+  %arrayinit.begin = getelementptr inbounds [4 x float], ptr addrspace(4) %data, i32 0, i32 0
+  %arrayinit.end = getelementptr inbounds float, ptr addrspace(4) %arrayinit.begin, i32 4
+  br label %arrayinit.body
+
+arrayinit.body:
+  %arrayinit.cur = phi ptr addrspace(4) [ %arrayinit.begin, %entry ], [ %arrayinit.next, %arrayinit.body ]
+  %arrayinit.next = getelementptr inbounds float, ptr addrspace(4) %arrayinit.cur, i32 1
+  %arrayinit.done = icmp eq ptr addrspace(4) %arrayinit.next, %arrayinit.end
+  br i1 %arrayinit.done, label %arrayinit.end2, label %arrayinit.body
+
+arrayinit.end2:
+  ret void
+}


### PR DESCRIPTION
* Adds support for phi instructions in LowerAddrSpaceCast
* Adds code to remove dead phi instructions (overcomes the circular dependency)
* Adds test

Note that I have made the assumption that the first incoming value to the phi node will not depend on the phi node itself... I guess this could be improved in the future.

Closes #1341 

