### PR TITLE
Improve handling of PHI in LowerAddrSpaceCast

### DIFF
--- a/lib/LowerAddrSpaceCastPass.cpp
+++ b/lib/LowerAddrSpaceCastPass.cpp
@@ -419,7 +419,12 @@ Value *clspv::LowerAddrSpaceCastPass::visitPHINode(llvm::PHINode &I) {
     CommonTy = B.getPtrTy(clspv::AddressSpace::Generic);
     for (unsigned j = 0; j < N; ++j) {
       if (Replacements[j]->getType() != CommonTy) {
-        Replacements[j] = B.CreateAddrSpaceCast(Replacements[j], CommonTy);
+        // Insert the addrspacecast in the original BB, after the original
+        // operand.
+        IRBuilder<> IBB(I.getIncomingBlock(j));
+        IBB.SetInsertPoint(
+            cast<Instruction>(I.getIncomingValue(j))->getNextNode());
+        Replacements[j] = IBB.CreateAddrSpaceCast(Replacements[j], CommonTy);
       }
     }
   }

--- a/test/AddressSpaceCast/issue-1364.ll
+++ b/test/AddressSpaceCast/issue-1364.ll
@@ -1,0 +1,24 @@
+; RUN: clspv-opt %s -o %t.ll --passes=lower-addrspacecast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: arrayinit.body:
+; CHECK-NEXT: {{.*}} = phi ptr [ %{{.*}}, %arrayinit.body ], [ %{{.*}}, %entry ]
+; CHECK-NOT: %arrayinit.cur = phi ptr addrspace(4) [ %arrayinit.next, %arrayinit.body ], [ %arrayinit.begin, %entry ]
+
+define dso_local spir_kernel void @fun() {
+entry:
+  %mem = alloca [4 x float]
+  %data = addrspacecast ptr %mem to ptr addrspace(4)
+  %arrayinit.begin = getelementptr inbounds [4 x float], ptr addrspace(4) %data, i32 0, i32 0
+  %arrayinit.end = getelementptr inbounds float, ptr addrspace(4) %arrayinit.begin, i32 4
+  br label %arrayinit.body
+
+arrayinit.body:
+  %arrayinit.cur = phi ptr addrspace(4) [ %arrayinit.next, %arrayinit.body ], [ %arrayinit.begin, %entry ]
+  %arrayinit.next = getelementptr inbounds float, ptr addrspace(4) %arrayinit.cur, i32 1
+  %arrayinit.done = icmp eq ptr addrspace(4) %arrayinit.next, %arrayinit.end
+  br i1 %arrayinit.done, label %arrayinit.end2, label %arrayinit.body
+
+arrayinit.end2:
+  ret void
+}


### PR DESCRIPTION
Adds logic to check for phi dependent operands
Figures out the phi type from non-dependent types
Test with dependent incoming value first

It also keeps the phi node valid if the incoming values have different address spaces by re-inserting some addrspacecasts. It will crash at the spirv producer but an additional pass could try and fix it up before then.

Closes #1364 