### PR TITLE
fix detection to run ThreeElementVectorLoweringPass

### DIFF
--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -289,7 +289,7 @@ bool clspv::ThreeElementVectorLoweringPass::vec3ShouldBeLowered(Function &F) {
 
 bool clspv::ThreeElementVectorLoweringPass::haveInvalidVec3GEP(Value *Value) {
   auto gep = dyn_cast<GetElementPtrInst>(Value);
-  if (!gep) {
+  if (!gep || gep->getNumIndices() <= 1) {
     return false;
   }
 

--- a/lib/ThreeElementVectorLoweringPass.h
+++ b/lib/ThreeElementVectorLoweringPass.h
@@ -104,8 +104,9 @@ private:
 private:
   // High-level implementation details of runOnModule.
 
-  /// Look for bitcast of vec3 inside the function
-  bool vec3BitcastInFunction(llvm::Function &F);
+  /// Look for vec3 patterns inside the function that requires lowering vec3 to
+  /// vec4.
+  bool vec3ShouldBeLowered(llvm::Function &F);
 
   /// Returns whether the vec3 should be transformed into vec4
   bool vec3ShouldBeLowered(llvm::Module &M);
@@ -113,6 +114,10 @@ private:
   /// Returns whether a value have an implicit cast or not, works only with
   /// opaque pointers
   bool haveImplicitCast(llvm::Value *Value);
+
+  // Returns true if the type before last indice is a vec3 and last indice is
+  // not constant or bigger or equal to 3.
+  bool haveInvalidVec3GEP(llvm::Value *Value);
 
   /// Lower all global variables in the module.
   bool runOnGlobals(llvm::Module &M);

--- a/test/ThreeElementVectorLowering/invalid_vec3_gep.ll
+++ b/test/ThreeElementVectorLowering/invalid_vec3_gep.ll
@@ -1,0 +1,13 @@
+; RUN: clspv-opt %s -o %t.ll --passes=three-element-vector-lowering
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  getelementptr inbounds <4 x i32>, ptr %a, i32 2, i32 3
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @test1(ptr %a) {
+entry:
+  %gep = getelementptr inbounds <3 x i32>, ptr %a, i32 2, i32 3
+  ret void
+}

--- a/test/ThreeElementVectorLowering/invalid_vec3_gep2.ll
+++ b/test/ThreeElementVectorLowering/invalid_vec3_gep2.ll
@@ -1,0 +1,13 @@
+; RUN: clspv-opt %s -o %t.ll --passes=three-element-vector-lowering
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  getelementptr inbounds <4 x i32>, ptr %a, i32 2, i32 %i
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @test1(ptr %a, i32 %i) {
+entry:
+  %gep = getelementptr inbounds <3 x i32>, ptr %a, i32 2, i32 %i
+  ret void
+}

--- a/test/ThreeElementVectorLowering/valid_vec3_gep.ll
+++ b/test/ThreeElementVectorLowering/valid_vec3_gep.ll
@@ -1,0 +1,13 @@
+; RUN: clspv-opt %s -o %t.ll --passes=three-element-vector-lowering
+; RUN: FileCheck %s < %t.ll
+
+; CHECK:  getelementptr inbounds <3 x i32>, ptr %a, i32 2, i32 2
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+define dso_local spir_kernel void @test1(ptr %a) {
+entry:
+  %gep = getelementptr inbounds <3 x i32>, ptr %a, i32 2, i32 2
+  ret void
+}


### PR DESCRIPTION
If a gep ends up trying to access the 4th element of a vec3, we need to lower vec3 to vec4.

This is fixing a regression on CTS test_half
Ref https://github.com/kpet/clvk/pull/698