### PR TITLE
add cl_khr_subgroup_extended_types define

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -347,6 +347,13 @@ int SetCompilerInstanceOptions(
     instance.getPreprocessorOpts().addMacroDef("__FAST_RELAXED_MATH__");
   }
 
+  if (clspv::Option::SpvVersion() >= clspv::Option::SPIRVVersion::SPIRV_1_3) {
+    // TODO remove when extension is added to OpenCLExtensions.def
+    // https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Basic/OpenCLExtensions.def
+    instance.getPreprocessorOpts().addMacroDef(
+        "cl_khr_subgroup_extended_types");
+  }
+
   for (auto define : Defines) {
     instance.getPreprocessorOpts().addMacroDef(define);
   }

--- a/test/vector_subgroup_broadcast.cl
+++ b/test/vector_subgroup_broadcast.cl
@@ -1,0 +1,13 @@
+// RUN: clspv %s -o %t.spv --spv-version=1.3
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.3
+
+// CHECK: [[float:%[^ ]+]] = OpTypeFloat 32
+// CHECK: [[float4:%[^ ]+]] = OpTypeVector [[float]] 4
+// CHECK: [[load:%[^ ]+]] = OpLoad [[float4]]
+// CHECK: OpGroupNonUniformBroadcast [[float4]] {{.*}} [[load]]
+
+kernel void foo(global float4 *buffer) {
+    sub_group_broadcast(*buffer, 0u);
+}


### PR DESCRIPTION
This define is missing from clang OpenCLExtensions.def. 
Adding it manually if SPIRVVersion is 1.3 or later to be sure that GroupNonUniformBallot capability is supported.