### PR TITLE
Fix trunc to bool handling

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4768,8 +4768,12 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         // But OpUConvert only takes integer types in input, not boolean type.
         // Instead use OpINotEqual.
         SPIRVOperandVec Ops;
-        Ops << Ty << I.getOperand(0)
-            << getSPIRVValue(ConstantInt::get(OpTy, 0));
+        Ops << OpTy << I.getOperand(0)
+            << getSPIRVValue(ConstantInt::get(OpTy, 1));
+        auto oAnd1 = addSPIRVInst(spv::OpBitwiseAnd, Ops);
+
+        Ops.clear();
+        Ops << Ty << oAnd1 << getSPIRVValue(ConstantInt::get(OpTy, 0));
         RID = addSPIRVInst(spv::OpINotEqual, Ops);
       } else {
         // Ops[0] = Result Type ID

--- a/test/trunc_to_bool.ll
+++ b/test/trunc_to_bool.ll
@@ -17,4 +17,7 @@ entry:
 ; CHECK-DAG: [[bool:%[^ ]+]] = OpTypeBool
 ; CHECK-DAG: [[v2bool:%[^ ]+]] = OpTypeVector [[bool]] 2
 ; CHECK-DAG: [[null:%[^ ]+]] = OpConstantNull [[v2uint]]
-; CHECK: OpINotEqual [[v2bool]] [[null]] [[null]]
+; CHECK-DAG: [[u1:%[^ ]+]] = OpConstant [[uint]] 1
+; CHECK-DAG: [[v1:%[^ ]+]] = OpConstantComposite [[v2uint]] [[u1]] [[u1]]
+; CHECK-DAG: [[and:%[^ ]+]] = OpBitwiseAnd [[v2uint]] [[null]] [[v1]]
+; CHECK: OpINotEqual [[v2bool]] [[and]] [[null]]


### PR DESCRIPTION
LLVM defines '%trunc = trunc i32 %2 to i1' as discarding the high bits of %2 prior to conversion, but the SPIRV-Producer pass was implementing it as '%2 != 0'. And away the high bits before doing the conversion.

Fixes #1379.