### PR TITLE
add nocontraction decoration to conversions to floating point

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -531,11 +531,13 @@ struct SPIRVProducerPassImpl {
   bool CalledWithCoherentResource(Argument &Arg);
 
   bool NeedDecorationNoContraction(spv::Op op) {
-    static const SmallVector<spv::Op> list_full = {spv::OpFMul,    spv::OpFDiv,
-                                                   spv::OpFNegate, spv::OpFAdd,
-                                                   spv::OpFSub,    spv::OpFRem};
+    static const SmallVector<spv::Op> list_full = {
+        spv::OpFMul,     spv::OpFDiv,        spv::OpFNegate,
+        spv::OpFAdd,     spv::OpFSub,        spv::OpFRem,
+        spv::OpFConvert, spv::OpConvertUToF, spv::OpConvertSToF};
     static const SmallVector<spv::Op> list_mad_enable = {
-        spv::OpFDiv, spv::OpFNegate, spv::OpFSub, spv::OpFRem};
+        spv::OpFDiv,     spv::OpFNegate,     spv::OpFSub,       spv::OpFRem,
+        spv::OpFConvert, spv::OpConvertUToF, spv::OpConvertSToF};
     auto check_list = [&op](const SmallVector<spv::Op> &list) {
       for (auto opf : list) {
         if (op == opf)


### PR DESCRIPTION
It will allow to avoid optimization of certain driver breaking the implementation of the libclc.