### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "402eca265f7162e26b8b74d18297fd76c9f100de"
+      "commit" : "67a55e01e3f13d6ea5be917765a4171cd68cb5ac"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -532,7 +532,6 @@ std::string Builtins::GetMangledTypeName(Type *Ty) {
   case Type::PPC_FP128TyID:
   case Type::LabelTyID:
   case Type::MetadataTyID:
-  case Type::X86_MMXTyID:
   case Type::TokenTyID:
   default:
     assert(0);

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -336,8 +336,10 @@ int SetCompilerInstanceOptions(
       clspv::Option::ClMadEnable() || clspv::Option::UnsafeMath();
   // cl_no_signed_zeros ignored for now!
   instance.getLangOpts().UnsafeFPMath = clspv::Option::UnsafeMath();
-  instance.getLangOpts().FiniteMathOnly = clspv::Option::FiniteMath();
   instance.getLangOpts().FastRelaxedMath = clspv::Option::FastRelaxedMath();
+
+  instance.getLangOpts().NoHonorInfs = clspv::Option::FiniteMath();
+  instance.getLangOpts().NoHonorNaNs = clspv::Option::FiniteMath();
 
   // Preprocessor options
   if (!clspv::Option::ImageSupport()) {


### PR DESCRIPTION
remove X64_MMXTyId as it has been removed from llvm
FiniteMathOnly has been removed. Instead use explicit NoHonorInfs and NoHonorNans options.