### PR TITLE
fix runOnUpgradeableConstantCasts

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -929,6 +929,13 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
         GetElementPtrInst::Create(dest_ty, ptr, NewGEPIdxs, "", GEPInfo.gep);
 
     unsigned PointerOperandNum = BitcastUtils::PointerOperandNum(I);
+    if (auto phi = dyn_cast<PHINode>(I)) {
+      for (uint32_t iOp = 0; iOp < phi->getNumOperands(); iOp++) {
+        if (I->getOperand(iOp) == GEPInfo.gep) {
+          PointerOperandNum = iOp;
+        }
+      }
+    }
 
     LLVM_DEBUG(dbgs() << "\n##runOnUpgradeableConstantCasts:\nreplace operand "
                       << PointerOperandNum << " of: ";

--- a/test/PointerCasts/upgradeable_from_phi.ll
+++ b/test/PointerCasts/upgradeable_from_phi.ll
@@ -1,0 +1,23 @@
+; RUN: clspv-opt --passes=simplify-pointer-bitcast %s -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-DAG: phi ptr addrspace(1) [ [[gepA:%[^ ]+]], %blockA ], [ [[gepB:%[^ ]+]], %blockB ]
+; CHECK-DAG: [[gepA]] = getelementptr <4 x i8>, ptr addrspace(1) %a, i32 2
+; CHECK-DAG: [[gepB]] = getelementptr <4 x i8>, ptr addrspace(1) %a, i32 32
+
+define spir_kernel void @foo(ptr addrspace(1) %a, i1 %cmp) {
+entry:
+  br i1 %cmp, label %blockA, label %blockB
+blockA:
+  %gepA = getelementptr <4 x i8>, ptr addrspace(1) %a, i32 2
+  br label %end
+blockB:
+  %gepB = getelementptr i8, ptr addrspace(1) %a, i32 128
+  br label %end
+end:
+  %phi = phi ptr addrspace(1) [ %gepA, %blockA ], [ %gepB, %blockB ]
+  ret void
+}

--- a/test/PointerCasts/upgradeable_from_phi.ll
+++ b/test/PointerCasts/upgradeable_from_phi.ll
@@ -4,11 +4,11 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK-DAG: phi ptr addrspace(1) [ [[gepA:%[^ ]+]], %blockA ], [ [[gepB:%[^ ]+]], %blockB ]
+; CHECK-DAG: phi ptr addrspace(1) [ [[gepA:%[^ ]+]], %blockA ], [ [[gepB:%[^ ]+]], %blockC ], [ [[gepB]], %blockD ]
 ; CHECK-DAG: [[gepA]] = getelementptr <4 x i8>, ptr addrspace(1) %a, i32 2
 ; CHECK-DAG: [[gepB]] = getelementptr <4 x i8>, ptr addrspace(1) %a, i32 32
 
-define spir_kernel void @foo(ptr addrspace(1) %a, i1 %cmp) {
+define spir_kernel void @foo(ptr addrspace(1) %a, i1 %cmp, i1 %cmp2) {
 entry:
   br i1 %cmp, label %blockA, label %blockB
 blockA:
@@ -16,8 +16,12 @@ blockA:
   br label %end
 blockB:
   %gepB = getelementptr i8, ptr addrspace(1) %a, i32 128
+  br i1 %cmp2, label %blockC, label %blockD
+blockC:
+  br label %end
+blockD:
   br label %end
 end:
-  %phi = phi ptr addrspace(1) [ %gepA, %blockA ], [ %gepB, %blockB ]
+  %phi = phi ptr addrspace(1) [ %gepA, %blockA ], [ %gepB, %blockC ], [ %gepB, %blockD ]
   ret void
 }


### PR DESCRIPTION
Get the right operand number when looking at phi nodes.