### PR TITLE
keep source-level debug location information for each instruction

### DIFF
--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -31,6 +31,9 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
                            Type *RetType, ArrayRef<Value *> Args,
                            const MemoryEffects &MemEffects) {
 
+  // Get the source location for the instruction
+  const DILocation *DbgLoc = Insert->getDebugLoc();
+  
   // Prepare mangled name
   std::string MangledName = clspv::SPIRVOpIntrinsicFunction();
   MangledName += ".";
@@ -65,7 +68,14 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
     ArgValues.push_back(Arg);
   }
 
-  return CallInst::Create(func, ArgValues, "", Insert);
+  Instruction *NewInst = CallInst::Create(func, ArgValues, "", Insert);
+
+  // Set the location for the new one
+  if (DbgLoc) {
+    NewInst->setDebugLoc(DbgLoc);
+  }
+
+  return NewInst;
 }
 
 } // namespace clspv

--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -70,7 +70,7 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
 
   Instruction *NewInst = CallInst::Create(func, ArgValues, "", Insert);
 
-  // Set the location for the new one
+  // Set the source location for the new one
   if (DbgLoc) {
     NewInst->setDebugLoc(DbgLoc);
   }


### PR DESCRIPTION
Fixed #1400 that `OpLine` information can be generated also for atomic instructions.