### PR TITLE
keep source-level location also for atomic instructions

### DIFF
--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -30,7 +30,7 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
                            ArrayRef<Attribute::AttrKind> Attributes,
                            Type *RetType, ArrayRef<Value *> Args,
                            const MemoryEffects &MemEffects) {
-  
+
   // Prepare mangled name
   std::string MangledName = clspv::SPIRVOpIntrinsicFunction();
   MangledName += ".";

--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -31,6 +31,9 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
                            Type *RetType, ArrayRef<Value *> Args,
                            const MemoryEffects &MemEffects) {
 
+  // Get the source location for the instruction
+  const DILocation *DbgLoc = Insert->getDebugLoc();
+  
   // Prepare mangled name
   std::string MangledName = clspv::SPIRVOpIntrinsicFunction();
   MangledName += ".";
@@ -65,7 +68,14 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
     ArgValues.push_back(Arg);
   }
 
-  return CallInst::Create(func, ArgValues, "", Insert);
+  Instruction *NewInst = CallInst::Create(func, ArgValues, "", Insert);
+
+  // Set the source location for the new instruction
+  if (DbgLoc) {
+    NewInst->setDebugLoc(DbgLoc);
+  }
+
+  return NewInst;
 }
 
 } // namespace clspv

--- a/lib/SPIRVOp.cpp
+++ b/lib/SPIRVOp.cpp
@@ -30,9 +30,6 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
                            ArrayRef<Attribute::AttrKind> Attributes,
                            Type *RetType, ArrayRef<Value *> Args,
                            const MemoryEffects &MemEffects) {
-
-  // Get the source location for the instruction
-  const DILocation *DbgLoc = Insert->getDebugLoc();
   
   // Prepare mangled name
   std::string MangledName = clspv::SPIRVOpIntrinsicFunction();
@@ -71,9 +68,7 @@ Instruction *InsertSPIRVOp(Instruction *Insert, spv::Op Opcode,
   Instruction *NewInst = CallInst::Create(func, ArgValues, "", Insert);
 
   // Set the source location for the new instruction
-  if (DbgLoc) {
-    NewInst->setDebugLoc(DbgLoc);
-  }
+  NewInst->setDebugLoc(Insert->getDebugLoc());
 
   return NewInst;
 }


### PR DESCRIPTION
Fixed the bug #1400 that missing `OpLine` information for atomic instructions