### PR TITLE
rename Intrinsic::getDeclaration to Intrinsic::getOrInsertDeclaration

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "125aa10b3d645bd26523a1bc321bb2e6b1cf04e1"
+      "commit" : "30deb76d46053c243561c6fa072c5a30407241cb"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -95,8 +95,9 @@ bool clspv::ReplaceLLVMIntrinsicsPass::runOnFunction(Function &F) {
     return replaceAddSubSat(F, true, true);
   case Intrinsic::is_fpclass:
     return replaceIsFpClass(F);
-  // SPIR-V OpAssumeTrueKHR requires ExpectAssumeKHR capability in SPV_KHR_expect_assume extension.
-  // Vulkan doesn't support that, so remove assume declaration.
+  // SPIR-V OpAssumeTrueKHR requires ExpectAssumeKHR capability in
+  // SPV_KHR_expect_assume extension. Vulkan doesn't support that, so remove
+  // assume declaration.
   case Intrinsic::assume:
   // SPIR-V OpLifetimeStart and OpLifetimeEnd require Kernel capability.
   // Vulkan doesn't support that, so remove all lifteime bounds declarations.
@@ -465,7 +466,7 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceCountZeroes(Function &F,
     IRBuilder<> builder(Call);
     auto ty = Call->getType()->getWithNewBitWidth(32);
     auto c32 = ConstantInt::get(ty, 32);
-    auto func_32bit = Intrinsic::getDeclaration(
+    auto func_32bit = Intrinsic::getOrInsertDeclaration(
         F.getParent(), leading ? Intrinsic::ctlz : Intrinsic::cttz, ty);
     if (bitwidth < 32) {
       // Extend the input to 32-bits and perform a clz/ctz.

--- a/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
+++ b/test/ProgramScopeConstants/in_storage_buffer_descriptor_map.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -module-constants-in-storage-buffer -int8=0
+// RUN: clspv %target %s -o %t.spv -module-constants-in-storage-buffer
 // RUN: clspv-reflection %t.spv -o %t.map
 // RUN: FileCheck -check-prefix=MAP %s < %t.map
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -54,11 +54,10 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 // CHECK-DAG: [[c_var_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[array]]
 // CHECK-DAG: [[c_var_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[int]]
 // CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
-// CHECK-DAG: [[undef:%[0-9a-zA-Z_]+]] = OpUndef [[int]]
-// CHECK-DAG: [[zero_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[zero]] [[undef]]
+// CHECK-DAG: [[zero_zero:%[0-9a-zA-Z_]+]] = OpConstantNull [[data_type]]
 // CHECK-DAG: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
-// CHECK-DAG: [[one_undef:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[one]] [[undef]]
-// CHECK-DAG: [[array_const:%[0-9a-zA-Z_]+]] = OpConstantComposite [[array]] [[zero_undef]] [[one_undef]]
+// CHECK-DAG: [[one_zero:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[one]] [[zero]]
+// CHECK-DAG: [[array_const:%[0-9a-zA-Z_]+]] = OpConstantComposite [[array]] [[zero_zero]] [[one_zero]]
 // CHECK-DAG: [[c_var:%[0-9a-zA-Z_]+]] = OpVariable [[c_var_ptr]] Private [[array_const]]
 // CHECK-DAG: [[data]] = OpVariable [[data_ptr]] StorageBuffer
 //     CHECK: [[c_arg]] = OpVariable [[c_arg_ptr]] Uniform


### PR DESCRIPTION
Update LLVM
    
    - Rename Intrinsic::getDeclaration to Intrinsic::getOrInsertDeclaration
    - Update one test to avoid disabling int8

Bug: https://crbug.com/373696543