### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "4cdfa2a2c80d59db10d1a17e4ff0ec9902952759"
+      "commit" : "1fd8d3fea53e6e4573cdce55bd38ef0a7813a442"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -406,6 +406,7 @@ int SetCompilerInstanceOptions(
 
   // Set up diagnostics
   instance.createDiagnostics(
+      *llvm::vfs::getRealFileSystem(),
       new clang::TextDiagnosticPrinter(*diagnosticsStream,
                                        &instance.getDiagnosticOpts()),
       true);

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2557,7 +2557,7 @@ void SPIRVProducerPassImpl::GenerateResourceVars() {
     case clspv::ArgKind::StorageImage:
     case clspv::ArgKind::StorageTexelBuffer:
     case clspv::ArgKind::UniformTexelBuffer:
-      type = info->data_type->getPointerTo(AddressSpace::UniformConstant);
+      type = PointerType::get(info->data_type, AddressSpace::UniformConstant);
       break;
     default:
       break;
@@ -3604,7 +3604,7 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVBuiltin(spv::BuiltIn BID,
     addCapability(Cap);
 
     auto *data_ty = IntegerType::get(module->getContext(), 32);
-    auto *ptr_ty = data_ty->getPointerTo(AddressSpace::Input);
+    auto *ptr_ty = PointerType::get(data_ty, AddressSpace::Input);
     auto ptr_id = getSPIRVPointerType(ptr_ty, data_ty);
     RID = addSPIRVGlobalVariable(ptr_id, spv::StorageClassInput);
 

--- a/test/Printf/printf_args.cl
+++ b/test/Printf/printf_args.cl
@@ -54,7 +54,7 @@ kernel void test(char c, short s, int i, float f, long l) {
 // CHECK: OpStore %{{[0-9a-zA-Z_]+}} %[[f_i32_0]]
 // CHECK: OpStore %{{[0-9a-zA-Z_]+}} %[[f_i32_1]]
 // CHECK: %[[arg_l_bitcast:[0-9a-zA-Z_]+]] = OpBitcast %[[v2uint]] %[[arg_l]]
-// CHECK: %[[l_i32_0:[0-9a-zA-Z_]+]] = OpUConvert %[[uint]] %[[arg_l]]
+// CHECK: %[[l_i32_0:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uint]] %[[arg_l_bitcast]] 0
 // CHECK: %[[l_i32_1:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uint]] %[[arg_l_bitcast]] 1
 // CHECK: OpStore %{{[0-9a-zA-Z_]+}} %[[l_i32_0]]
 // CHECK: OpStore %{{[0-9a-zA-Z_]+}} %[[l_i32_1]]


### PR DESCRIPTION
- fix new api for createDiagnostics
- remove deprecated getPointerTo
- fix tests/Printf/printf_args.cl