### PR TITLE
remove useless code in PrintfPass.cpp

### DIFF
--- a/lib/PrintfPass.cpp
+++ b/lib/PrintfPass.cpp
@@ -339,14 +339,6 @@ PreservedAnalyses clspv::PrintfPass::run(Module &M, ModuleAnalysisManager &) {
         F->addMetadata(clspv::PrintfKernelMetadataName(),
                        *MDNode::get(M.getContext(), {}));
       }
-    } else {
-      for (auto &F : M) {
-        if (!F.getMetadata(clspv::PrintfKernelMetadataName())) {
-          F.addMetadata(clspv::PrintfKernelMetadataName(),
-                        *MDNode::get(M.getContext(), {}));
-        }
-        break;
-      }
     }
   }
 


### PR DESCRIPTION
This code does not make much sense. clspv read PrintKernelMetadataName only for SPIR_KERNEL, so setting it for other function is useless.

Remove it also removes a warning because of the break inside the loop (-Wno-unreachable-code-loop-increment)