### PR TITLE
Use cmake 3.31.2 on linux, win; Python 3.12 on windows

### DIFF
--- a/kokoro/scripts/linux/build-amber.sh
+++ b/kokoro/scripts/linux/build-amber.sh
@@ -22,7 +22,7 @@ set -e
 set -x
 
 # Common tools.
-using cmake-3.26.3
+using cmake-3.31.2
 using gcc-10
 using ninja-1.10.0
 using python-3.12

--- a/kokoro/scripts/linux/build-clvk.sh
+++ b/kokoro/scripts/linux/build-clvk.sh
@@ -22,7 +22,7 @@ set -e
 set -x
 
 # Common tools.
-using cmake-3.26.3
+using cmake-3.31.2
 using gcc-10
 using ninja-1.10.0
 using python-3.12

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -22,7 +22,7 @@ set -e
 set -x
 
 # Common tools.
-using cmake-3.26.3
+using cmake-3.31.2
 using gcc-13
 using ninja-1.10.0
 using python-3.12

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -19,12 +19,11 @@ set SRC=%cd%\github\clspv
 set BUILD_TYPE=%1
 set VS_VERSION=%2
 
-:: Define the Python version and download URL
-set "pythonVersion=3.8.10"
-:: Download Python installer
-wget "https://www.python.org/ftp/python/%pythonVersion%/python-%pythonVersion%-amd64.exe" -O "%TEMP%\python-installer.exe"
-:: Install Python silently
-"%TEMP%\python-installer.exe" /quiet InstallAllUsers=1 PrependPath=1
+:: Use updated CMake
+set PATH=c:\cmake-3.31.2\bin;%PATH%
+
+:: Use updated Python
+set PATH=c:\Python312;%PATH%
 
 cd %SRC%
 python utils/fetch_sources.py


### PR DESCRIPTION
The Windows build VM now has Python 3.12, so use it from its path.