### PR TITLE
do not lower mad to fma when using only native fma

### DIFF
--- a/lib/ReplaceOpenCLBuiltinPass.cpp
+++ b/lib/ReplaceOpenCLBuiltinPass.cpp
@@ -2118,9 +2118,7 @@ bool ReplaceOpenCLBuiltinPass::replaceMul(Function &F, bool is_float,
                                           bool is_mad) {
   // floating-point fma can be handle later in the flow if they are allowed
   if (is_float && is_mad &&
-      (clspv::Option::UseNativeBuiltins().count(
-           clspv::Builtins::BuiltinType::kFma) > 0 ||
-       clspv::Option::ClMadEnable() || clspv::Option::UnsafeMath())) {
+      (clspv::Option::ClMadEnable() || clspv::Option::UnsafeMath())) {
     return false;
   }
   return replaceCallsWithValue(F, [&](CallInst *CI) -> llvm::Value * {

--- a/test/mad-float-optimization.cl
+++ b/test/mad-float-optimization.cl
@@ -8,12 +8,12 @@
 // RUN: FileCheck %s < %t.mad.spvasm
 // RUN: spirv-val --target-env spv1.0 %t.mad.spv
 
+// CHECK: OpExtInst {{.*}} Fma
+
 // RUN: clspv %target %s -o %t.native.spv --use-native-builtins=fma
 // RUN: spirv-dis -o %t.native.spvasm %t.native.spv
-// RUN: FileCheck %s < %t.native.spvasm
+// RUN: FileCheck %s --check-prefix=NOOPT < %t.native.spvasm
 // RUN: spirv-val --target-env spv1.0 %t.native.spv
-
-// CHECK: OpExtInst {{.*}} Fma
 
 // RUN: clspv %target %s -o %t.spv
 // RUN: spirv-dis -o %t.spvasm %t.spv


### PR DESCRIPTION
make -cl-mad-enable or -cl-unsafe-math-optimisation required to lower mad to fma.

This avoid CTS failure on erf for Nvidia devices