### PR TITLE
Fix/remove dead const globals for PhysicalStorageBuffers support

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -246,7 +246,7 @@ clang::TargetInfo *PrepareTargetInfo(CompilerInstance &instance) {
           enabled) {
         instance.getPreprocessorOpts().addMacroDef(str);
       }
-      if (feat == clspv::FeatureMacro::__opencl_c_int64 && !enabled) {
+      if (feat == clspv::FeatureMacro::__opencl_c_int64 && !enabled){
         instance.getPreprocessorOpts().addMacroUndef(str);
       }
     }
@@ -704,7 +704,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     pm.addPass(clspv::SimplifyPointerBitcastPass());
     pm.addPass(clspv::ReplacePointerBitcastPass());
     pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::DCEPass()));
-
+  
     pm.addPass(clspv::UndoTranslateSamplerFoldPass());
 
     if (clspv::Option::ModuleConstantsInStorageBuffer()) {
@@ -1198,6 +1198,7 @@ int CompilePrograms(const std::vector<std::string> &programs,
         ProgramToModule(context, "source", program, output_log, &error));
     if (error != 0)
       return error;
+
   }
   assert(modules.size() > 0 && modules.back() != nullptr);
 

--- a/lib/PhysicalPointerArgsPass.cpp
+++ b/lib/PhysicalPointerArgsPass.cpp
@@ -22,6 +22,7 @@
 #include "clspv/Option.h"
 
 #include "Constants.h"
+#include "NormalizeGlobalVariable.h"
 #include "Types.h"
 
 using namespace llvm;
@@ -169,6 +170,7 @@ PreservedAnalyses clspv::PhysicalPointerArgsPass::run(Module &M,
       F->eraseFromParent();
     }
   }
+  clspv::NormalizeGlobalVariables(M);
 
   return PA;
 }

--- a/test/PhysicalStorageBuffers/physical_dead_const_global.cl
+++ b/test/PhysicalStorageBuffers/physical_dead_const_global.cl
@@ -1,0 +1,22 @@
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -module-constants-in-storage-buffer
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__constant float myconst[4] = {
+    1.0000000000f, 0.0000000149f, -2.5000002384f, -0.0000000894f,
+};
+
+__kernel void test(__global float* a) {
+    a[get_global_id(0)] = myconst[2];
+}
+
+// CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
+// CHECK: [[ClspvReflection:%[a-zA-Z0-9_]+]] = OpExtInstImport "NonSemantic.ClspvReflection.5"
+// CHECK: OpMemoryModel PhysicalStorageBuffer64
+// CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32
+// CHECK-DAG: [[uint_0:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 0
+// CHECK-DAG: [[uint_8:%[a-zA-Z0-9_]+]] = OpConstant [[uint]] 8
+
+// CHECK: [[KernelReflection:%[a-zA-Z0-9_]+]] = OpExtInst %void [[ClspvReflection]] Kernel
+// CHECK-PC: OpExtInst %void [[ClspvReflection]] ArgumentPointerPushConstant [[KernelReflection]] [[uint_0]] [[uint_0]] [[uint_8]]

--- a/test/PhysicalStorageBuffers/physical_dead_const_global.cl
+++ b/test/PhysicalStorageBuffers/physical_dead_const_global.cl
@@ -8,7 +8,7 @@ __constant float myconst[4] = {
 };
 
 __kernel void test(__global float* a) {
-    a[get_global_id(0)] = myconst[2];
+    a[0] = myconst[2];
 }
 
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"


### PR DESCRIPTION
Move PhysicalPointerArgsPass before:
- AutoPodArgsPass
- DeclarePushConstantsPass
- DefineOpenCLWorkItemBuiltinsPass

Also call NormalizeGlobalVariables at end of
PhysicalPointerArgsPass to remove dead const globals.

Otherwise, subsequent PCs will see 8 byte offset
for a dead/removed module constant storage buffer.