### PR TITLE
kokoro: simplify check-format jobs

### DIFF
--- a/kokoro/check-format/continuous.cfg
+++ b/kokoro/check-format/continuous.cfg
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # Continuous integration build configuration.
-build_file: "clspv/kokoro/check-format/build_continuous.sh"
+build_file: "clspv/kokoro/check-format/build.sh"
 
 

--- a/kokoro/check-format/presubmit.cfg
+++ b/kokoro/check-format/presubmit.cfg
@@ -1,11 +1,10 @@
-#!/bin/bash
-# Copyright 2019 The Clspv Authors. All rights reserved.
+# Copyright (c) 2019 The Clspv Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fail on any error.
-set -e
-# Display commands being run.
-set -x
+# Presubmit build configuration.
+build_file: "clspv/kokoro/check-format/build.sh"
 
-DIR=$(dirname $0)
-$DIR/build.sh FULL

--- a/kokoro/check-format/presubmit_check_format.cfg
+++ b/kokoro/check-format/presubmit_check_format.cfg
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#### Deprecated.  Delete this file after the Google-internal job
+#### configuration file has been renamed to 'presubmit.cfg'
+
 # Presubmit build configuration.
 build_file: "clspv/kokoro/check-format/build.sh"
 


### PR DESCRIPTION
- rename presubmit job config file. The fact it is for check-format is already in the directory name. Keep the old file until the Google-internal config file has been renamed.

- presubmit and continuous use the same build script