### PR TITLE
kokoro: check-format uses a streamlined formatter image

### DIFF
--- a/kokoro/check-format/build-docker.sh
+++ b/kokoro/check-format/build-docker.sh
@@ -13,30 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script should be run from the project root directory.
+
 # Fail on any error.
 set -e
 
-. /bin/using.sh # Declare the bash 'using' function
-
-# Display commands being run.
-set -x
-
-BUILD_ROOT=$PWD
-SRC=$PWD/github/clspv
+# Verify this script is run from the root directory.
+[ -d .git ]
+[ -f docs/OpenCLCOnVulkan.md ]
 
 # This is required to run any git command in the docker since owner will
 # have changed between the clone environment, and the docker container.
 # Marking the root of the repo as safe for ownership changes.
-git config --global --add safe.directory $SRC
+git config --global --add safe.directory $(pwd)
 
-using python-3.12
-using clang-13.0.1
-which clang-format
-
-cd $SRC
-python3 utils/fetch_sources.py
-cp third_party/llvm/clang/tools/clang-format/clang-format-diff.py utils/clang-format-diff.py
+# The docker image should have set these
+[ -f "$CLANG_FORMAT" ]
+[ -f "$CLANG_FORMAT_DIFF" ]
 
 echo $(date): Check formatting...
-./utils/check_code_format.sh
+# $1 should be FULL for continuous build, so formatting is checked against the
+# parent of HEAD.
+# Otherwise, compare formatting against 'main'
+./utils/check_code_format.sh $1
 echo $(date): check completed.

--- a/kokoro/check-format/build_continuous.sh
+++ b/kokoro/check-format/build_continuous.sh
@@ -25,4 +25,4 @@ docker run --rm -i \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
   --workdir "${ROOT_DIR}" \
   "us-east4-docker.pkg.dev/shaderc-build/radial-docker/ubuntu-24.04-amd64/formatter" \
-  "${SCRIPT_DIR}/build-docker.sh"
+  "${SCRIPT_DIR}/build-docker.sh" FULL

--- a/kokoro/check-format/continuous.cfg
+++ b/kokoro/check-format/continuous.cfg
@@ -13,6 +13,4 @@
 # limitations under the License.
 
 # Continuous integration build configuration.
-build_file: "clspv/kokoro/check-format/build.sh"
-
-
+build_file: "clspv/kokoro/check-format/build_continuous.sh"

--- a/utils/check_code_format.sh
+++ b/utils/check_code_format.sh
@@ -12,11 +12,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Script to determine if source code in Pull Request is properly formatted.
+
+
+# This script determine if the source code in a Pull Request is properly formatted.
 # Exits with non 0 exit code if formatting is needed.
-#
-# This script assumes to be invoked at the project root directory.
+# Assumptions:
+#    - git and python3 are on the path
+#    - Runs from the project root diretory.
+#    - 'clang-format' is on the path, or env var CLANG_FORMAT points to it.
+#    - 'clang-format-diff.py' is in the utils directory, or env var
+#       points to it.CLANG_FORMAT_DIFF
+
+CLANG_FORMAT=${CLANG_FORMAT_DIFF:-clang-format}
+if [ ! -f "$CLANG_FORMAT" ]; then
+  echo missing clang-format: set CLANG_FORMAT or put clang-format in the PATH
+  exit 1
+fi
+
+# Find clang-format-diff.py from an environment variable, or use a default
+CLANG_FORMAT_DIFF=${CLANG_FORMAT_DIFF:-./utils/clang-format-diff.py}
+if [ ! -f "$CLANG_FORMAT_DIFF" ]; then
+  echo missing clang-format-diffy.py: set CLANG_FORMAT_DIFF or put it in ./utils/clang-format-diff.py
+  exit 1
+fi
 
 if [ "$1" = "FULL" ]; then
   FILES_TO_CHECK=$(git diff --name-only HEAD~ | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
@@ -30,9 +48,9 @@ if [ -z "${FILES_TO_CHECK}" ]; then
 fi
 
 if [ "$1" = "FULL" ]; then
-  FORMAT_DIFF=$(git diff -U0 HEAD~ -- ${FILES_TO_CHECK} | python3 ./utils/clang-format-diff.py -p1 -style=file)
+  FORMAT_DIFF=$(git diff -U0 HEAD~ -- ${FILES_TO_CHECK} | python3 "$CLANG_FORMAT_DIFF" -p1 -style=file -binary="$CLANG_FORMAT" )
 else
-  FORMAT_DIFF=$(git diff -U0 main -- ${FILES_TO_CHECK} | python3 ./utils/clang-format-diff.py -p1 -style=file)
+  FORMAT_DIFF=$(git diff -U0 main -- ${FILES_TO_CHECK} | python3 "$CLANG_FORMAT_DIFF" -p1 -style=file -binary="$CLANG_FORMAT" )
 fi
 
 if [ -z "${FORMAT_DIFF}" ]; then


### PR DESCRIPTION
Avoid downloading all of LLVM and Clang source during check-format.

Instead, take clang-format-diff.py from the image.

Update ./utils/check_code_format.sh so it can use env vars:
 - CLANG_FORMAT to find clang-format
 - CLANG_FORMAT_DIFF to find clang-format-diff.py

Both of these are set in the Docker image.

BUG=397439901