### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "f8300f1c2a767e2ffaa6440249439b66bb5dec3b"
+      "commit" : "6053ca004a58ed6a1bd10c5c470857cb6a2c0db7"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -102,6 +102,8 @@ Function *getIntrinsicScalarVersion(Function &Intrinsic) {
   case Intrinsic::fmuladd:
   case Intrinsic::fshl:
   case Intrinsic::log:
+  case Intrinsic::smax:
+  case Intrinsic::umax:
   case Intrinsic::pow:
   case Intrinsic::sin:
   case Intrinsic::sadd_sat:

--- a/test/LongVectorLowering/smax.ll
+++ b/test/LongVectorLowering/smax.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+declare <8 x i32> @llvm.smax.v8i32(<8 x i32>, <8 x i32>)
+
+define spir_func <8 x i32> @test(<8 x i32> %a, <8 x i32> %b) {
+entry:
+  %x = call <8 x i32> @llvm.smax.v8i32(<8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %x
+}
+
+; CHECK-NOT: declare <8 x i32> @llvm.smax.v8i32
+
+; CHECK-LABEL: @test
+; CHECK-COUNT-8: @llvm.smax.i32
+
+; CHECK-NOT: declare <8 x i32> @llvm.fmuladd.v8i32

--- a/test/LongVectorLowering/umax.ll
+++ b/test/LongVectorLowering/umax.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt --passes=long-vector-lowering %s -o %t
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+declare <8 x i32> @llvm.umax.v8i32(<8 x i32>, <8 x i32>)
+
+define spir_func <8 x i32> @test(<8 x i32> %a, <8 x i32> %b) {
+entry:
+  %x = call <8 x i32> @llvm.umax.v8i32(<8 x i32> %a, <8 x i32> %b)
+  ret <8 x i32> %x
+}
+
+; CHECK-NOT: declare <8 x i32> @llvm.umax.v8i32
+
+; CHECK-LABEL: @test
+; CHECK-COUNT-8: @llvm.umax.i32
+
+; CHECK-NOT: declare <8 x i32> @llvm.fmuladd.v8i32


### PR DESCRIPTION
add missing support for smax and umax in LongVectorLoweringPass