### PR TITLE
Fix explicit type layout generation

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,7 +14,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Headers",
       "branch" : "main",
       "subdir" : "third_party/SPIRV-Headers",
-      "commit" : "4f7b471f1a66b6d06462cd4ba57628cc0cd087d7"
+      "commit" : "54a521dd130ae1b2f38fef79b09515702d135bdd"
     },
     {
       "name" : "SPIRV-Tools",
@@ -22,7 +22,7 @@
       "subrepo" : "KhronosGroup/SPIRV-Tools",
       "branch" : "main",
       "subdir" : "third_party/SPIRV-Tools",
-      "commit" : "02470f606fe1571de808cb773d8c521ab201aaff"
+      "commit" : "bac6ca7568287e7b045129f34cc69ae0cdb7d4e0"
     }
   ]
 }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -1589,7 +1589,8 @@ SPIRVID SPIRVProducerPassImpl::addSPIRVGlobalVariable(const SPIRVID &TypeID,
   return VID;
 }
 
-SPIRVID SPIRVProducerPassImpl::ChangeLayout(SPIRVID object, Type *type, bool removeLayout) {
+SPIRVID SPIRVProducerPassImpl::ChangeLayout(SPIRVID object, Type *type,
+                                            bool removeLayout) {
   auto dst_id = getSPIRVType(type, !removeLayout);
 
   SPIRVID copy = object;
@@ -1604,9 +1605,11 @@ SPIRVID SPIRVProducerPassImpl::ChangeLayout(SPIRVID object, Type *type, bool rem
     if (struct_ty || array_ty) {
       SPIRVOperandVec constructOps;
       constructOps << dst_id;
-      uint32_t num_eles = struct_ty ? struct_ty->getNumElements() : array_ty->getNumElements();
+      uint32_t num_eles =
+          struct_ty ? struct_ty->getNumElements() : array_ty->getNumElements();
       for (uint32_t i = 0; i < num_eles; i++) {
-        auto sub_type = struct_ty ? struct_ty->getElementType(i) : array_ty->getElementType();
+        auto sub_type = struct_ty ? struct_ty->getElementType(i)
+                                  : array_ty->getElementType();
 
         // Extract from src
         SPIRVOperandVec Ops;
@@ -5906,7 +5909,8 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
     auto value_ty = value->getType();
     auto needs_layout = PointerRequiresLayout(ptr_ty->getPointerAddressSpace());
     if (needs_layout && (value_ty->isArrayTy() || value_ty->isStructTy())) {
-      RID = ChangeLayout(getSPIRVValue(value), value_ty, /* removeLayout = */ false);
+      RID = ChangeLayout(getSPIRVValue(value), value_ty,
+                         /* removeLayout = */ false);
     }
 
     // Ops[0] = Pointer ID

--- a/test/CommonBuiltins/step/float2_step.cl
+++ b/test/CommonBuiltins/step/float2_step.cl
@@ -9,7 +9,5 @@ kernel void foo(global float2 *A, float2 edge, float2 x) {
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Step [[_28]] [[_30]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Step
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/CommonBuiltins/step/float3_step.cl
+++ b/test/CommonBuiltins/step/float3_step.cl
@@ -9,7 +9,5 @@ kernel void foo(global float3 *A, float3 edge, float3 x) {
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Step [[_28]] [[_30]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Step
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/CommonBuiltins/step/float4_step.cl
+++ b/test/CommonBuiltins/step/float4_step.cl
@@ -9,7 +9,5 @@ kernel void foo(global float4 *A, float4 edge, float4 x) {
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Step [[_28]] [[_30]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Step
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/CommonBuiltins/step/float_step.cl
+++ b/test/CommonBuiltins/step/float_step.cl
@@ -8,7 +8,5 @@ kernel void foo(global float *A, float edge, float x) {
 }
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Step [[_27]] [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Step
 // CHECK: OpStore {{.*}} [[_30]]

--- a/test/HalfStorage/clspv_vloada_half2_global.cl
+++ b/test/HalfStorage/clspv_vloada_half2_global.cl
@@ -20,10 +20,9 @@ kernel void foo(global float2* A, global uint* B, uint n) {
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK: [[_32:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B:%[0-9a-zA-Z_]+]] [[_uint_0]] [[_uint_0]]
-// CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
-// CHECK-64: [[_offset_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]] [[_34]]
+// CHECK-64: [[_offset_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]]
 // CHECK-64: [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]] [[_uint_0]] [[_offset_long]]
-// CHECK-32: [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]] [[_uint_0]] [[_34]]
+// CHECK-32: [[_35:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]] [[_uint_0]]
 // CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_35]]
 // CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_36]]
 // CHECK: [[_31:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A:%[0-9a-zA-Z_]+]] [[_uint_0]] [[_uint_0]]

--- a/test/HalfStorage/clspv_vloada_half2_local.cl
+++ b/test/HalfStorage/clspv_vloada_half2_local.cl
@@ -20,10 +20,9 @@ kernel void foo(global float2* A, local uint* B, uint n) {
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
 // CHECK: [[_5:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B:%[0-9a-zA-Z_]+]] [[_uint_0]]
-// CHECK: [[_35:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
-// CHECK-64: [[_offset_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]] [[_35]]
+// CHECK-64: [[_offset_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]]
 // CHECK-64: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]] [[_offset_long]]
-// CHECK-32: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]] [[_35]]
+// CHECK-32: [[_36:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[B]]
 // CHECK: [[_37:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]] [[_36]]
 // CHECK: [[_38:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_37]]
 // CHECK: [[_33:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A:%[0-9a-zA-Z_]+]] [[_uint_0]] [[_uint_0]]

--- a/test/HalfStorage/clspv_vloada_half2_private.cl
+++ b/test/HalfStorage/clspv_vloada_half2_private.cl
@@ -13,14 +13,13 @@ kernel void foo(global float2* A, uint v, uint w, uint n) {
 // CHECK-DAG: [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK: [[_36:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
 // CHECK: OpStore
 // CHECK: OpStore
 // CHECK: [[_44:%[0-9a-zA-Z_]+]] = OpLoad [[_uint]]
 // CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_44]]
 // CHECK: [[_34:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A:%[0-9a-zA-Z_]+]] [[_uint_0]] [[_uint_0]]
 // CHECK: OpStore [[_34]] [[_45]]
-// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_36]]
+// CHECK: [[_46:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16
 // CHECK: [[_47:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A]] [[_uint_0]] [[_uint_1]]
 // CHECK: OpStore [[_47]] [[_46]]
 // CHECK: OpReturn

--- a/test/HalfStorage/clspv_vloada_half4_private.cl
+++ b/test/HalfStorage/clspv_vloada_half4_private.cl
@@ -22,13 +22,11 @@ kernel void foo(global float4* A, uint2 v, uint2 w, uint n) {
 // CHECK-DAG: [[_v2float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK-DAG: [[_uint_1:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 1
-// CHECK: [[_41:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2uint]]
-// CHECK: [[_45:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
 // CHECK: OpStore
 // CHECK: OpStore
-// CHECK-64: [[_convert_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]] [[_45]]
+// CHECK-64: [[_convert_long:%[0-9a-zA-Z_]+]] = OpUConvert [[_ulong]]
 // CHECK-64: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} {{.*}} [[_convert_long]]
-// CHECK-32: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} {{.*}} [[_45]]
+// CHECK-32: [[_48:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} {{.*}}
 // CHECK: [[_49:%[0-9a-zA-Z_]+]] = OpLoad [[_v2uint]] [[_48]]
 // CHECK: [[_50:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_49]] 0
 // CHECK: [[_51:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_49]] 1
@@ -37,10 +35,8 @@ kernel void foo(global float4* A, uint2 v, uint2 w, uint n) {
 // CHECK: [[_54:%[0-9a-zA-Z_]+]] = OpVectorShuffle [[_v4float]] [[_52]] [[_53]] 0 1 2 3
 // CHECK: [[_39:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A:%[0-9a-zA-Z_]+]] [[_uint_0]] [[_uint_0]]
 // CHECK: OpStore [[_39]] [[_54]]
-// CHECK: [[_55:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_41]] 0
-// CHECK: [[_56:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]] [[_41]] 1
-// CHECK: [[_57:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_55]]
-// CHECK: [[_58:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16 [[_56]]
+// CHECK: [[_57:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16
+// CHECK: [[_58:%[0-9a-zA-Z_]+]] = OpExtInst [[_v2float]] {{.*}} UnpackHalf2x16
 // CHECK: [[_59:%[0-9a-zA-Z_]+]] = OpVectorShuffle [[_v4float]] [[_57]] [[_58]] 0 1 2 3
 // CHECK: [[_60:%[0-9a-zA-Z_]+]] = OpAccessChain {{.*}} [[A]] [[_uint_0]] [[_uint_1]]
 // CHECK: OpStore [[_60]] [[_59]]

--- a/test/HalfStorage/vload_half.cl
+++ b/test/HalfStorage/vload_half.cl
@@ -24,9 +24,8 @@ __kernel void test(__global half *a, int b, __global float *dst) {
 // CHECK-DAG: [[global_half_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[half_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_half_ptr]] StorageBuffer
-// CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
-// CHECK-32: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint0]] [[b]]
-// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
+// CHECK-32: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint0]]
+// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]]
 // CHECK-64: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint0]] [[b_long]]
 // CHECK: [[valh:%[^ ]+]] = OpLoad [[ushort]] [[addr]]
 // CHECK: [[vali32:%[^ ]+]] = OpUConvert [[uint]] [[valh]]

--- a/test/HalfStorage/vload_half16.cl
+++ b/test/HalfStorage/vload_half16.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir
+// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir64
+// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 __kernel void test(__global half *a, int b, __global float16 *dst) {
     *dst = vload_half16(b, a);
@@ -40,6 +40,7 @@ __kernel void test(__global half *a, int b, __global float16 *dst) {
 // CHECK-DAG: [[global_uint4_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint4_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_uint4_ptr]] StorageBuffer
+// CHECK: OpCopyLogical
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
 // CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]

--- a/test/HalfStorage/vload_half2.cl
+++ b/test/HalfStorage/vload_half2.cl
@@ -24,11 +24,10 @@ __kernel void test(__global half *a, int b, __global float2 *dst) {
 // CHECK-DAG: [[global_uint_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_uint_ptr]] StorageBuffer
-// CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
-// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
+// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]]
 // CHECK-64: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[b_long]]
-// CHECK-32: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[b]]
+// CHECK-32: [[addr:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]]
 // CHECK: [[ld:%[^ ]+]] = OpLoad [[uint]] [[addr]]
 
 // CHECK: [[val:%[^ ]+]] = OpExtInst [[float2]] {{.*}} UnpackHalf2x16 [[ld]]

--- a/test/HalfStorage/vload_half3.cl
+++ b/test/HalfStorage/vload_half3.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -arch=spir
+// RUN: clspv %target %s -o %t.spv -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -arch=spir64
+// RUN: clspv %target %s -o %t.spv -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 __kernel void test(__global half *a, int b, __global float3 *dst) {
     *dst = vload_half3(b, a);
@@ -32,6 +32,7 @@ __kernel void test(__global half *a, int b, __global float3 *dst) {
 // CHECK-DAG: [[global_half_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[half_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_half_ptr]] StorageBuffer
+// CHECK: OpCopyLogical
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
 // CHECK-64: [[b_ulong:%[^ ]+]] = OpSConvert [[ulong]] [[b]]

--- a/test/HalfStorage/vload_half4.cl
+++ b/test/HalfStorage/vload_half4.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -arch=spir
+// RUN: clspv %target %s -o %t.spv -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -arch=spir64
+// RUN: clspv %target %s -o %t.spv -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 __kernel void test(__global half *a, int b, __global float4 *dst) {
     *dst = vload_half4(b, a);
@@ -28,6 +28,7 @@ __kernel void test(__global half *a, int b, __global float4 *dst) {
 // CHECK-DAG: [[global_uint2_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint2_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_uint2_ptr]] StorageBuffer
+// CHECK: OpCopyLogical
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
 // CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]

--- a/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
+++ b/test/HalfStorage/vload_half4_pointer_cast_from_float4.cl
@@ -11,11 +11,8 @@
 // CHECK-DAG: %[[CONSTANT_0_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 0
 // CHECK-DAG: %[[CONSTANT_1_ID:[a-zA-Z0-9_]*]] = OpConstant %[[UINT_TYPE_ID]] 1
 
-// CHECK: %[[LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[UINT2_TYPE_ID]]
-// CHECK: %[[EX0:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] %[[LOAD_ID]] 0
-// CHECK: %[[EX1:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]] %[[LOAD_ID]] 1
-// CHECK: %[[LO_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT2_TYPE_ID]] {{.*}} UnpackHalf2x16 %[[EX0]]
-// CHECK: %[[HI_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT2_TYPE_ID]] {{.*}} UnpackHalf2x16 %[[EX1]]
+// CHECK: %[[LO_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT2_TYPE_ID]] {{.*}} UnpackHalf2x16
+// CHECK: %[[HI_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT2_TYPE_ID]] {{.*}} UnpackHalf2x16
 // CHECK: %[[RECOMBINE_ID:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[FLOAT4_TYPE_ID]] %[[LO_ID]] %[[HI_ID]] 0 1 2 3
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b)

--- a/test/HalfStorage/vload_half8.cl
+++ b/test/HalfStorage/vload_half8.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir
+// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir64
+// RUN: clspv %target %s -o %t.spv -long-vector -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 __kernel void test(__global half *a, int b, __global float8 *dst) {
     *dst = vload_half8(b, a);
@@ -31,6 +31,7 @@ __kernel void test(__global half *a, int b, __global float8 *dst) {
 // CHECK-DAG: [[global_uint4_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint4_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_uint4_ptr]] StorageBuffer
+// CHECK: OpCopyLogical
 // CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
 // CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]

--- a/test/HalfStorage/vloada_half2_global.cl
+++ b/test/HalfStorage/vloada_half2_global.cl
@@ -42,12 +42,11 @@ kernel void foo(global float2* A, global uint* B, uint n) {
 // CHECK-DAG: [[A1:%[^ ]+]] = OpAccessChain [[_ptr_StorageBuffer_v2float]] [[A]] [[uint_0]] [[uint_1]]
 // CHECK-DAG: [[n0:%[^ ]+]] = OpAccessChain [[_ptr_PushConstant__struct_19]] [[n]] [[uint_0]]
 // CHECK-DAG: [[n0s:%[^ ]+]] = OpLoad [[_struct_19]] [[n0]]
-// CHECK-DAG: [[nVal:%[^ ]+]] = OpCompositeExtract [[uint]] [[n0s]] 0
 
-// CHECK-64-DAG: [[nValL:%[^ ]+]] = OpUConvert [[ulong]] [[nVal]]
+// CHECK-64-DAG: [[nValL:%[^ ]+]] = OpUConvert [[ulong]]
 
-// CHECK-32-DAG: [[BnPtr:%[^ ]+]] = OpAccessChain [[_ptr_StorageBuffer_uint]] [[B]] [[uint_0]] [[nVal]]
-// CHECK-64-DAG: [[BnPtr:%[^ ]+]] = OpAccessChain [[_ptr_StorageBuffer_uint]] [[B]] [[uint_0]] [[nValL]]
+// CHECK-32-DAG: [[BnPtr:%[^ ]+]] = OpAccessChain [[_ptr_StorageBuffer_uint]] [[B]] [[uint_0]]
+// CHECK-64-DAG: [[BnPtr:%[^ ]+]] = OpAccessChain [[_ptr_StorageBuffer_uint]] [[B]] [[uint_0]]
 // CHECK-DAG: [[Bn:%[^ ]+]] = OpLoad [[uint]] [[BnPtr]]
 // CHECK-DAG: [[Bn2f:%[^ ]+]] = OpExtInst [[v2float]] {{.*}} UnpackHalf2x16 [[Bn]]
 // CHECK-DAG: OpStore [[A0]] [[Bn2f]]

--- a/test/HalfStorage/vloada_half3.cl
+++ b/test/HalfStorage/vloada_half3.cl
@@ -28,11 +28,10 @@ __kernel void test(__global half *a, int b, __global float3 *dst) {
 // CHECK-DAG: [[global_uint2_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint2_ptr]]
 
 // CHECK: [[a:%[^ ]+]] = OpVariable [[global_uint2_ptr]] StorageBuffer
-// CHECK: [[b:%[^ ]+]] = OpCompositeExtract [[uint]] {{.*}} 0
 
-// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]] [[b]]
+// CHECK-64: [[b_long:%[^ ]+]] = OpSConvert [[ulong]]
 // CHECK-64: [[addr0:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[b_long]]
-// CHECK-32: [[addr0:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]] [[b]]
+// CHECK-32: [[addr0:%[^ ]+]] = OpAccessChain {{.*}} [[a]] [[uint_0]]
 // CHECK: [[val0:%[^ ]+]] = OpLoad [[uint2]] [[addr0]]
 
 // CHECK: [[val01i32:%[^ ]+]] = OpCompositeExtract [[uint]] [[val0]] 0

--- a/test/ImageBuiltins/read_imagef_int.cl
+++ b/test/ImageBuiltins/read_imagef_int.cl
@@ -14,7 +14,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image1d
 // CHECK-DAG:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_int]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_int]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4float]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4float]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imagef_int2.cl
+++ b/test/ImageBuiltins/read_imagef_int2.cl
@@ -15,6 +15,5 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image2d
 // CHECK-DAG:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_int]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2int]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4float]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4float]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  OpStore {{.*}} [[_33]]

--- a/test/ImageBuiltins/read_imagef_int4.cl
+++ b/test/ImageBuiltins/read_imagef_int4.cl
@@ -11,8 +11,7 @@
 // CHECK-DAG: %[[INT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[INT_TYPE_ID]] 4
 // CHECK-DAG: %[[INT0:[a-zA-Z0-9_]*]] = OpConstant %[[INT_TYPE_ID]] 0
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[READ_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT4_TYPE_ID]]
-// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpImageFetch %[[FLOAT4_TYPE_ID]] %[[I_LOAD_ID]] %[[C_LOAD_ID]] Lod %[[INT0]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpImageFetch %[[FLOAT4_TYPE_ID]] %[[I_LOAD_ID]] %{{.*}} Lod %[[INT0]]
 // CHECK: OpStore {{.*}} %[[OP_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image3d_t i, int4 c, global float4* a)

--- a/test/ImageBuiltins/read_imagef_sampler_float.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float.cl
@@ -16,8 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK-DAG: [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLoad [[_2]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpSampledImage [[_18]] [[_28]] [[_27]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_32]] [[_30]] Lod [[_float_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_32]] {{.*}} Lod [[_float_0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imagef_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagef_sampler_float2.cl
@@ -41,7 +41,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CLUSTER: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_2]]
 // CLUSTER: [[_29:%[a-zA-Z0-9_]+]] = OpLoad [[_4]]
 // CLUSTER: [[_32:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_12]]
-// CLUSTER: [[_33:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]] [[_32]] 0
 // CLUSTER: [[_34:%[a-zA-Z0-9_]+]] = OpSampledImage [[_19]] [[_29]] [[_28]]
-// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_34]] [[_33]] Lod [[_float_0]]
+// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4float]] [[_34]] {{.*}} Lod [[_float_0]]
 // CLUSTER: OpStore {{.*}} [[_35]]

--- a/test/ImageBuiltins/read_imagei_int.cl
+++ b/test/ImageBuiltins/read_imagei_int.cl
@@ -15,8 +15,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image1d
 // CHECK-DAG:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_int]] 1D 0 0 0 1 Unknown
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]
 

--- a/test/ImageBuiltins/read_imagei_int2.cl
+++ b/test/ImageBuiltins/read_imagei_int2.cl
@@ -16,8 +16,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image2d
 // CHECK-DAG:  [[_v2int:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2int]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]
 

--- a/test/ImageBuiltins/read_imagei_int4.cl
+++ b/test/ImageBuiltins/read_imagei_int4.cl
@@ -15,8 +15,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image3d
 // CHECK-DAG:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_int]] 3D 0 0 0 1 Unknown
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v4uint]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4int]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]
 

--- a/test/ImageBuiltins/read_imagei_sampler_float.cl
+++ b/test/ImageBuiltins/read_imagei_sampler_float.cl
@@ -19,9 +19,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK-DAG: [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLoad [[_2]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpSampledImage [[_18]] [[_28]] [[_27]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] [[_30]] Lod [[_float_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] {{.*}} Lod [[_float_0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]
 

--- a/test/ImageBuiltins/read_imagei_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imagei_sampler_float2.cl
@@ -48,9 +48,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CLUSTER: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_2]]
 // CLUSTER: [[_29:%[a-zA-Z0-9_]+]] = OpLoad [[_4]]
 // CLUSTER: [[_32:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_12]]
-// CLUSTER: [[_33:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]] [[_32]] 0
 // CLUSTER: [[_34:%[a-zA-Z0-9_]+]] = OpSampledImage [[_19]] [[_29]] [[_28]]
-// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_34]] [[_33]] Lod [[_float_0]]
+// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_34]] {{.*}} Lod [[_float_0]]
 // CLUSTER: [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_35]]
 // CLUSTER: OpStore {{.*}} [[cast]]
 

--- a/test/ImageBuiltins/read_imageui_int.cl
+++ b/test/ImageBuiltins/read_imageui_int.cl
@@ -13,7 +13,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image1d
 // CHECK-DAG:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_uint]] 1D 0 0 0 1 Unknown
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_uint]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imageui_int2.cl
+++ b/test/ImageBuiltins/read_imageui_int2.cl
@@ -14,7 +14,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image2d
 // CHECK-DAG:  [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2uint]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imageui_int4.cl
+++ b/test/ImageBuiltins/read_imageui_int4.cl
@@ -13,7 +13,6 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image3d
 // CHECK-DAG:  [[_4:%[0-9a-zA-Z_]+]] = OpTypeImage [[_uint]] 3D 0 0 0 1 Unknown
 // CHECK-DAG:  [[_int0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v4uint]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] [[_30]] Lod [[_int0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageFetch [[_v4uint]] [[_28]] {{.*}} Lod [[_int0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imageui_sampler_float.cl
+++ b/test/ImageBuiltins/read_imageui_sampler_float.cl
@@ -17,8 +17,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK-DAG: [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLoad [[_2]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_4]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_float]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpSampledImage [[_18]] [[_28]] [[_27]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4uint]] [[_32]] [[_30]] Lod [[_float_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4uint]] [[_32]] {{.*}} Lod [[_float_0]]
 // CHECK:  OpStore {{.*}} [[_33]]
 

--- a/test/ImageBuiltins/read_imageui_sampler_float2.cl
+++ b/test/ImageBuiltins/read_imageui_sampler_float2.cl
@@ -43,8 +43,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CLUSTER: [[_28:%[a-zA-Z0-9_]+]] = OpLoad [[_2]]
 // CLUSTER: [[_29:%[a-zA-Z0-9_]+]] = OpLoad [[_4]]
 // CLUSTER: [[_32:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_12]]
-// CLUSTER: [[_33:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]] [[_32]] 0
 // CLUSTER: [[_34:%[a-zA-Z0-9_]+]] = OpSampledImage [[_19]] [[_29]] [[_28]]
-// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4uint]] [[_34]] [[_33]] Lod [[_float_0]]
+// CLUSTER: [[_35:%[a-zA-Z0-9_]+]] = OpImageSampleExplicitLod [[_v4uint]] [[_34]] {{.*}} Lod [[_float_0]]
 // CLUSTER: OpStore {{.*}} [[_35]]
 

--- a/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image2d_passed_to_other_function.cl
@@ -21,8 +21,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(sampler_t s, read
 // CHECK-DAG:  [[_19:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
 // CHECK-DAG:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
 // CHECK:  = OpFunction
-// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_26:%[0-9a-zA-Z_]+]] [[_40]]
+// CHECK:  [[_42:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_26:%[0-9a-zA-Z_]+]]
 // CHECK:  OpStore {{.*}} [[_42]]
 // CHECK:  [[_26]] = OpFunction [[_v4float]]
 // CHECK:  [[_29:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2float]]

--- a/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/read_only_image3d_passed_to_other_function.cl
@@ -22,8 +22,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(read_only image3d
 // CHECK-DAG:  [[_17:%[0-9a-zA-Z_]+]] = OpTypeSampledImage [[_4]]
 // CHECK-DAG:  [[_float_0:%[0-9a-zA-Z_]+]] = OpConstant [[_float]] 0
 // CHECK:  = OpFunction
-// CHECK:  [[_38:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_24:%[0-9a-zA-Z_]+]] [[_38]]
+// CHECK:  [[_40:%[0-9a-zA-Z_]+]] = OpFunctionCall [[_v4float]] [[_24:%[0-9a-zA-Z_]+]]
 // CHECK:  OpStore {{.*}} [[_40]]
 // CHECK:  [[_24]] = OpFunction [[_v4float]]
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]

--- a/test/ImageBuiltins/two_int_images.cl
+++ b/test/ImageBuiltins/two_int_images.cl
@@ -32,16 +32,14 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) bar(read_only image3d
 // CHECK:  [[foo]] = OpFunction
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLoad [[_2]]
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_2D]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2float]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpSampledImage [[sampled2D]] [[_28]] [[_27]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] [[_30]] Lod [[_float_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] {{.*}} Lod [[_float_0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]
 // CHECK:  [[bar]] = OpFunction
 // CHECK:  [[_28:%[0-9a-zA-Z_]+]] = OpLoad [[_3D]]
-// CHECK:  [[_30:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK:  [[_27:%[0-9a-zA-Z_]+]] = OpLoad [[_2]]
 // CHECK:  [[_32:%[0-9a-zA-Z_]+]] = OpSampledImage [[sampled3D]] [[_28]] [[_27]]
-// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] [[_30]] Lod [[_float_0]]
+// CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpImageSampleExplicitLod [[_v4int]] [[_32]] {{.*}} Lod [[_float_0]]
 // CHECK:  [[cast:%[0-9a-zA-Z_]+]] = OpBitcast [[_v4uint]] [[_33]]
 // CHECK:  OpStore {{.*}} [[cast]]

--- a/test/ImageBuiltins/write_imagef_int.cl
+++ b/test/ImageBuiltins/write_imagef_int.cl
@@ -8,9 +8,7 @@
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image1d_t i, int c, float4 a)
 {

--- a/test/ImageBuiltins/write_imagef_sampler_int2.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int2.cl
@@ -9,9 +9,7 @@
 // CHECK-DAG: %[[UINT2_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 2
 // CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT2_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2d_t i, int2 c, float4 a)
 {

--- a/test/ImageBuiltins/write_imagef_sampler_int4.cl
+++ b/test/ImageBuiltins/write_imagef_sampler_int4.cl
@@ -11,9 +11,7 @@
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[FLOAT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image3d_t i, int4 c, float4 a)
 {

--- a/test/ImageBuiltins/write_imagei_int.cl
+++ b/test/ImageBuiltins/write_imagei_int.cl
@@ -9,10 +9,8 @@
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[INT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[INT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]] %[[A_LOAD_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[cast]]
+// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]] %{{.*}} %[[cast]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image1d_t i, int c, int4 a)
 {

--- a/test/ImageBuiltins/write_imagei_sampler_int2.cl
+++ b/test/ImageBuiltins/write_imagei_sampler_int2.cl
@@ -10,10 +10,8 @@
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[INT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[INT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT2_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]] %[[A_LOAD_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[cast]]
+// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]] %{{.*}} %[[cast]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2d_t i, int2 c, int4 a)
 {

--- a/test/ImageBuiltins/write_imagei_sampler_int4.cl
+++ b/test/ImageBuiltins/write_imagei_sampler_int4.cl
@@ -9,10 +9,8 @@
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK-DAG: %[[INT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[INT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]] %[[A_LOAD_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[cast]]
+// CHECK: %[[cast:[a-zA-Z0-9_]*]] = OpBitcast %[[INT4_TYPE_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]] %{{.*}} %[[cast]]
 
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
 

--- a/test/ImageBuiltins/write_imageui_int.cl
+++ b/test/ImageBuiltins/write_imageui_int.cl
@@ -7,9 +7,7 @@
 // CHECK-DAG: %[[WRITE_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[UINT_TYPE_ID]] 1D 0 0 0 2 Unknown
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image1d_t i, int c, uint4 a)
 {

--- a/test/ImageBuiltins/write_imageui_sampler_int2.cl
+++ b/test/ImageBuiltins/write_imageui_sampler_int2.cl
@@ -8,9 +8,7 @@
 // CHECK-DAG: %[[UINT2_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 2
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT2_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2d_t i, int2 c, uint4 a)
 {

--- a/test/ImageBuiltins/write_imageui_sampler_int4.cl
+++ b/test/ImageBuiltins/write_imageui_sampler_int4.cl
@@ -7,9 +7,7 @@
 // CHECK-DAG: %[[WRITE_ONLY_IMAGE_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeImage %[[UINT_TYPE_ID]] 3D 0 0 0 2 Unknown
 // CHECK-DAG: %[[UINT4_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[UINT_TYPE_ID]] 4
 // CHECK: %[[I_LOAD_ID:[a-zA-Z0-9_]*]] = OpLoad %[[WRITE_ONLY_IMAGE_TYPE_ID]]
-// CHECK: %[[C_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: %[[A_LOAD_ID:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[UINT4_TYPE_ID]]
-// CHECK: OpImageWrite %[[I_LOAD_ID]] %[[C_LOAD_ID]] %[[A_LOAD_ID]]
+// CHECK: OpImageWrite %[[I_LOAD_ID]]
 
 #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
 

--- a/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image2d_passed_to_other_function.cl
@@ -19,9 +19,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image2
 // CHECK-DAG:  [[_v2uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 2
 // CHECK-DAG:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
 // CHECK:  = OpFunction
-// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v2uint]]
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]]
-// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall {{.*}} [[_21:%[0-9a-zA-Z_]+]] [[_31]] [[_33]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall {{.*}} [[_21:%[0-9a-zA-Z_]+]] {{.*}} [[_33]]
 // CHECK:  [[_21]] = OpFunction
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v2uint]]
 // CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]

--- a/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
+++ b/test/ImageBuiltins/write_only_image3d_passed_to_other_function.cl
@@ -21,9 +21,8 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(write_only image3
 // CHECK-DAG:  [[_v4uint:%[0-9a-zA-Z_]+]] = OpTypeVector [[_uint]] 4
 // CHECK-DAG:  [[_v4float:%[0-9a-zA-Z_]+]] = OpTypeVector [[_float]] 4
 // CHECK:  = OpFunction
-// CHECK:  [[_31:%[0-9a-zA-Z_]+]] = OpCompositeExtract [[_v4uint]]
 // CHECK:  [[_33:%[0-9a-zA-Z_]+]] = OpLoad [[_v4float]]
-// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall {{.*}} [[_21:%[0-9a-zA-Z_]+]] [[_31]] [[_33]]
+// CHECK:  [[_34:%[0-9a-zA-Z_]+]] = OpFunctionCall {{.*}} [[_21:%[0-9a-zA-Z_]+]] {{.*}} [[_33]]
 // CHECK:  [[_21]] = OpFunction
 // CHECK:  [[_23:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4uint]]
 // CHECK:  [[_24:%[0-9a-zA-Z_]+]] = OpFunctionParameter [[_v4float]]

--- a/test/Int8/simple_kernel.cl
+++ b/test/Int8/simple_kernel.cl
@@ -30,9 +30,8 @@ kernel void foo(global char* in, global char* out, int idx) {
 // CHECK: [[add:%[a-zA-Z0-9_]+]] = OpIAdd [[char]] [[b]] [[a]]
 // CHECK: OpReturnValue [[add]]
 // CHECK: OpFunction
-// CHECK: [[idx:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]]
-// CHECK-64: [[idx_long:%[a-zA-Z0-9_]+]] = OpSConvert [[long]] [[idx]]
-// CHECK-32-DAG: [[idx1:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[idx]] [[one]]
+// CHECK-64: [[idx_long:%[a-zA-Z0-9_]+]] = OpSConvert [[long]] [[idx:%[a-zA-Z0-9_]+]]
+// CHECK-32-DAG: [[idx1:%[a-zA-Z0-9_]+]] = OpIAdd [[int]] [[idx:%[a-zA-Z0-9_]+]] [[one]]
 // CHECK-64-DAG: [[gepx:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] {{.*}} [[zero]] [[idx_long]]
 // CHECK-32-DAG: [[gepx:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] {{.*}} [[zero]] [[idx]]
 // CHECK-64-DAG: [[idx1_long:%[a-zA-Z0-9_]+]] = OpIAdd [[long]] [[idx_long]] [[one_long]]

--- a/test/IntegerBuiltins/rotate/rotate_uchar_0.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar_0.cl
@@ -1,11 +1,12 @@
-// RUN: clspv %target  %s -o %t.spv -int8
+// RUN: clspv %target  %s -o %t.spv -int8 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK:     %[[a_struct:[0-9a-zA-Z_]+]] = OpLoad {{.*}} {{.*}}
-// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[a_struct]] 0
+// CHECK:     %[[copy:[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} %[[a_struct]]
+// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[copy]] 0
 // CHECK:     OpStore {{.*}} %[[a]]
 
 kernel void test_rotate(global uchar* out, uchar a)

--- a/test/IntegerBuiltins/rotate/rotate_uchar_64.cl
+++ b/test/IntegerBuiltins/rotate/rotate_uchar_64.cl
@@ -1,11 +1,12 @@
-// RUN: clspv %target  %s -o %t.spv -int8
+// RUN: clspv %target  %s -o %t.spv -int8 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[uchar:[0-9a-zA-Z_]+]] = OpTypeInt 8 0
 // CHECK:     %[[a_struct:[0-9a-zA-Z_]+]] = OpLoad {{.*}} {{.*}}
-// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[a_struct]] 0
+// CHECK:     %[[copy:[0-9a-zA-Z_]+]] = OpCopyLogical {{.*}} %[[a_struct]]
+// CHECK:     %[[a:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]] %[[copy]] 0
 // CHECK:     OpStore {{.*}} %[[a]]
 
 kernel void test_rotate(global uchar* out, uchar a)

--- a/test/LLVMIntrinsics/smax.ll
+++ b/test/LLVMIntrinsics/smax.ll
@@ -19,9 +19,7 @@ entry:
   ret void
 }
 declare i8 @llvm.smax.i8(i8, i8)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] SMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] SMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -32,9 +30,7 @@ entry:
   ret void
 }
 declare i16 @llvm.smax.i16(i16, i16)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] SMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] SMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -45,9 +41,7 @@ entry:
   ret void
 }
 declare i32 @llvm.smax.i32(i32, i32)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] SMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] SMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -58,7 +52,5 @@ entry:
   ret void
 }
 declare i64 @llvm.smax.i64(i64, i64)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] SMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] SMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]

--- a/test/LLVMIntrinsics/smin.ll
+++ b/test/LLVMIntrinsics/smin.ll
@@ -19,9 +19,7 @@ entry:
   ret void
 }
 declare i8 @llvm.smin.i8(i8, i8)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] SMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] SMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -32,9 +30,7 @@ entry:
   ret void
 }
 declare i16 @llvm.smin.i16(i16, i16)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] SMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] SMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -45,9 +41,7 @@ entry:
   ret void
 }
 declare i32 @llvm.smin.i32(i32, i32)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] SMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] SMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -58,7 +52,5 @@ entry:
   ret void
 }
 declare i64 @llvm.smin.i64(i64, i64)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] SMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] SMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]

--- a/test/LLVMIntrinsics/umax.ll
+++ b/test/LLVMIntrinsics/umax.ll
@@ -19,9 +19,7 @@ entry:
   ret void
 }
 declare i8 @llvm.umax.i8(i8, i8)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -32,9 +30,7 @@ entry:
   ret void
 }
 declare i16 @llvm.umax.i16(i16, i16)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -45,9 +41,7 @@ entry:
   ret void
 }
 declare i32 @llvm.umax.i32(i32, i32)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -58,7 +52,5 @@ entry:
   ret void
 }
 declare i64 @llvm.umax.i64(i64, i64)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMax %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMax
 ; CHECK: OpStore {{.*}} %[[OP_ID]]

--- a/test/LLVMIntrinsics/umin.ll
+++ b/test/LLVMIntrinsics/umin.ll
@@ -19,9 +19,7 @@ entry:
   ret void
 }
 declare i8 @llvm.umin.i8(i8, i8)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT8_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT8_TYPE_ID]] %[[EXT_INST]] UMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -32,9 +30,7 @@ entry:
   ret void
 }
 declare i16 @llvm.umin.i16(i16, i16)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT16_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT16_TYPE_ID]] %[[EXT_INST]] UMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -45,9 +41,7 @@ entry:
   ret void
 }
 declare i32 @llvm.umin.i32(i32, i32)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT32_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT32_TYPE_ID]] %[[EXT_INST]] UMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]
 
 
@@ -58,7 +52,5 @@ entry:
   ret void
 }
 declare i64 @llvm.umin.i64(i64, i64)
-; CHECK: %[[A:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 0
-; CHECK: %[[B:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[INT64_TYPE_ID]] {{.*}} 1
-; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMin %[[A]] %[[B]]
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[INT64_TYPE_ID]] %[[EXT_INST]] UMin
 ; CHECK: OpStore {{.*}} %[[OP_ID]]

--- a/test/MathBuiltins/acos/float2_acospi.cl
+++ b/test/MathBuiltins/acos/float2_acospi.cl
@@ -9,9 +9,8 @@ void kernel foo(global float2* A, float2 x)
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
-// CHECK: [[LOAD_ID:%[a-zA-Z0-9_]+]] = OpCompositeExtract
 // CHECK-NOT: OpExtInst {{%[a-zA-Z0-9_]+}} {{%[a-zA-Z0-9_]+}} Acos
-// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v2float]] {{%[a-zA-Z0-9_]+}} [[LOAD_ID]]
+// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v2float]] {{%[a-zA-Z0-9_]+}}
 // CHECK: OpStore {{.*}} [[OP_ID]]
 // CHECK: OpFunction
 // CHECK: OpLabel

--- a/test/MathBuiltins/acos/float4_acospi.cl
+++ b/test/MathBuiltins/acos/float4_acospi.cl
@@ -9,9 +9,8 @@ void kernel foo(global float4* A, float4 x)
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
-// CHECK: [[LOAD_ID:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK-NOT: OpExtInst {{%[a-zA-Z0-9_]+}} {{%[a-zA-Z0-9_]+}} Acos
-// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v4float]] {{%[a-zA-Z0-9_]+}} [[LOAD_ID]]
+// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v4float]] {{%[a-zA-Z0-9_]+}}
 // CHECK: OpStore {{.*}} [[OP_ID]]
 // CHECK: OpFunction
 // CHECK: OpLabel

--- a/test/MathBuiltins/asin/float2_asinpi.cl
+++ b/test/MathBuiltins/asin/float2_asinpi.cl
@@ -9,9 +9,8 @@ void kernel foo(global float2* A, float2 x)
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
-// CHECK: [[LOAD_ID:%[a-zA-Z0-9_]+]] = OpCompositeExtract
 // CHECK-NOT: OpExtInst {{%[a-zA-Z0-9_]+}} {{%[a-zA-Z0-9_]+}} Acos
-// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v2float]] {{%[a-zA-Z0-9_]+}} [[LOAD_ID]]
+// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v2float]] {{%[a-zA-Z0-9_]+}}
 // CHECK: OpStore {{.*}} [[OP_ID]]
 // CHECK: OpFunction
 // CHECK: OpLabel

--- a/test/MathBuiltins/asin/float4_asinpi.cl
+++ b/test/MathBuiltins/asin/float4_asinpi.cl
@@ -9,9 +9,8 @@ void kernel foo(global float4* A, float4 x)
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
-// CHECK: [[LOAD_ID:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
 // CHECK-NOT: OpExtInst {{%[a-zA-Z0-9_]+}} {{%[a-zA-Z0-9_]+}} Acos
-// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v4float]] {{%[a-zA-Z0-9_]+}} [[LOAD_ID]]
+// CHECK: [[OP_ID:%[a-zA-Z0-9_]*]] = OpFunctionCall [[_v4float]] {{%[a-zA-Z0-9_]+}}
 // CHECK: OpStore {{.*}} [[OP_ID]]
 // CHECK: OpFunction
 // CHECK: OpLabel

--- a/test/MathBuiltins/atan/float2_atan2pi.cl
+++ b/test/MathBuiltins/atan/float2_atan2pi.cl
@@ -12,8 +12,6 @@ void kernel foo(global float2* A, float2 y, float2 x)
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Atan2 [[_30]] [[_32]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Atan2
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v2float]] [[_17]] [[_33]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/atan/float2_atanpi.cl
+++ b/test/MathBuiltins/atan/float2_atanpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float2* A, float2 x)
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Atan [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Atan
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v2float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/atan/float3_atan2pi.cl
+++ b/test/MathBuiltins/atan/float3_atan2pi.cl
@@ -12,8 +12,6 @@ void kernel foo(global float3* A, float3 y, float3 x)
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan2 [[_30]] [[_32]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan2
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_33]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/atan/float3_atanpi.cl
+++ b/test/MathBuiltins/atan/float3_atanpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float3* A, float3 x)
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Atan
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/atan/float4_atan2pi.cl
+++ b/test/MathBuiltins/atan/float4_atan2pi.cl
@@ -12,8 +12,6 @@ void kernel foo(global float4* A, float4 y, float4 x)
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan2 [[_30]] [[_32]]
+// CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan2
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_33]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/atan/float4_atanpi.cl
+++ b/test/MathBuiltins/atan/float4_atanpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float4* A, float4 x)
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Atan
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/MathBuiltins/atan/float_atan2pi.cl
+++ b/test/MathBuiltins/atan/float_atan2pi.cl
@@ -10,8 +10,6 @@ void kernel foo(global float* A, float x, float y)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Atan2 [[_28]] [[_30]]
+// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Atan2
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_float_0_31831]] [[_31]]
 // CHECK: OpStore {{.*}} [[_32]]

--- a/test/MathBuiltins/atan/float_atanpi.cl
+++ b/test/MathBuiltins/atan/float_atanpi.cl
@@ -10,7 +10,6 @@ void kernel foo(global float* A, float x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Atan [[_27]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Atan
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_float_0_31831]] [[_28]]
 // CHECK: OpStore {{.*}} [[_29]]

--- a/test/MathBuiltins/fmod/float2_fmod.cl
+++ b/test/MathBuiltins/fmod/float2_fmod.cl
@@ -8,7 +8,5 @@ kernel void foo(global float2 *A, float2 x, float2 y) {
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v2float]] [[_27]] [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v2float]]
 // CHECK: OpStore {{.*}} [[_30]]

--- a/test/MathBuiltins/fmod/float3_fmod.cl
+++ b/test/MathBuiltins/fmod/float3_fmod.cl
@@ -8,7 +8,5 @@ kernel void foo(global float3 *A, float3 x, float3 y) {
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v3float]] [[_27]] [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v3float]]
 // CHECK: OpStore {{.*}} [[_30]]

--- a/test/MathBuiltins/fmod/float4_fmod.cl
+++ b/test/MathBuiltins/fmod/float4_fmod.cl
@@ -8,7 +8,5 @@ kernel void foo(global float4 *A, float4 x, float4 y) {
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v4float]] [[_27]] [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpFRem [[_v4float]]
 // CHECK: OpStore {{.*}} [[_30]]

--- a/test/MathBuiltins/fmod/float_fmod.cl
+++ b/test/MathBuiltins/fmod/float_fmod.cl
@@ -7,7 +7,5 @@ kernel void foo(global float *A, float x, float y) {
   *A = fmod(x,y);
 }
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
-// CHECK: [[_26:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFRem [[_float]] [[_26]] [[_28]]
+// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFRem [[_float]]
 // CHECK: OpStore {{.*}} [[_29]]

--- a/test/MathBuiltins/fract/float2_fract_private.cl
+++ b/test/MathBuiltins/fract/float2_fract_private.cl
@@ -14,8 +14,7 @@ void kernel foo(global float2* A, global float2* B, float2 x)
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] {{1|0.99999}}
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_1]] [[_float_1]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Floor [[_31]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Floor [[_31:%[a-zA-Z0-9_]+]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Fract [[_31]]
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/fract/float3_fract_private.cl
+++ b/test/MathBuiltins/fract/float3_fract_private.cl
@@ -16,8 +16,7 @@ void kernel foo(global float3* A, global float3* B, float3 x)
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_1]] [[_float_1]] [[_float_1]]
 // CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpAccessChain
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpAccessChain
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Floor [[_31]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Floor [[_31:%[a-zA-Z0-9_]+]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Fract [[_31]]
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore [[_28]] [[_34]]

--- a/test/MathBuiltins/fract/float4_fract_private.cl
+++ b/test/MathBuiltins/fract/float4_fract_private.cl
@@ -14,8 +14,7 @@ void kernel foo(global float4* A, global float4* B, float4 x)
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] {{1|0.99999}}
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_1]] [[_float_1]] [[_float_1]] [[_float_1]]
-// CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_31]]
+// CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Floor [[_31:%[a-zA-Z0-9_]+]]
 // CHECK: [[_33:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Fract [[_31]]
 // CHECK: [[_34:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] NMin [[_33]] [[_17]]
 // CHECK: OpStore {{.*}} [[_34]]

--- a/test/MathBuiltins/fract/float_fract_private.cl
+++ b/test/MathBuiltins/fract/float_fract_private.cl
@@ -12,8 +12,7 @@ void kernel foo(global float* A, global float* B, float x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_float_1:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] {{1|0.99999}}
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Floor [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Floor [[_29:%[a-zA-Z0-9_]+]]
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Fract [[_29]]
 // CHECK: [[_32:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] NMin [[_31]] [[_float_1]]
 // CHECK: OpStore {{.*}} [[_32]]

--- a/test/NativeBuiltins/MathBuiltins/acos/float2_acospi.cl
+++ b/test/NativeBuiltins/MathBuiltins/acos/float2_acospi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float2* A, float2 x)
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Acos [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Acos
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v2float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/acos/float3_acospi.cl
+++ b/test/NativeBuiltins/MathBuiltins/acos/float3_acospi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float3* A, float3 x)
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Acos [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Acos
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/acos/float4_acospi.cl
+++ b/test/NativeBuiltins/MathBuiltins/acos/float4_acospi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float4* A, float4 x)
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Acos [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Acos
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/acos/float_acospi.cl
+++ b/test/NativeBuiltins/MathBuiltins/acos/float_acospi.cl
@@ -10,7 +10,6 @@ void kernel foo(global float* A, float x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Acos [[_27]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Acos
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_float_0_31831]] [[_28]]
 // CHECK: OpStore {{.*}} [[_29]]

--- a/test/NativeBuiltins/MathBuiltins/asin/float2_asinpi.cl
+++ b/test/NativeBuiltins/MathBuiltins/asin/float2_asinpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float2* A, float2 x)
 // CHECK-DAG: [[_v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 2
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v2float]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v2float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Asin [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v2float]] [[_1]] Asin
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v2float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/asin/float3_asinpi.cl
+++ b/test/NativeBuiltins/MathBuiltins/asin/float3_asinpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float3* A, float3 x)
 // CHECK-DAG: [[_v3float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 3
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v3float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v3float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Asin [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v3float]] [[_1]] Asin
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v3float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/asin/float4_asinpi.cl
+++ b/test/NativeBuiltins/MathBuiltins/asin/float4_asinpi.cl
@@ -12,7 +12,6 @@ void kernel foo(global float4* A, float4 x)
 // CHECK-DAG: [[_v4float:%[a-zA-Z0-9_]+]] = OpTypeVector [[_float]] 4
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
 // CHECK-DAG: [[_17:%[a-zA-Z0-9_]+]] = OpConstantComposite [[_v4float]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]] [[_float_0_31831]]
-// CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_v4float]]
-// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Asin [[_29]]
+// CHECK: [[_30:%[a-zA-Z0-9_]+]] = OpExtInst [[_v4float]] [[_1]] Asin
 // CHECK: [[_31:%[a-zA-Z0-9_]+]] = OpFMul [[_v4float]] [[_17]] [[_30]]
 // CHECK: OpStore {{.*}} [[_31]]

--- a/test/NativeBuiltins/MathBuiltins/asin/float_asinpi.cl
+++ b/test/NativeBuiltins/MathBuiltins/asin/float_asinpi.cl
@@ -10,7 +10,6 @@ void kernel foo(global float* A, float x)
 // CHECK: [[_1:%[a-zA-Z0-9_]+]] = OpExtInstImport "GLSL.std.450"
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[_float_0_31831:%[a-zA-Z0-9_]+]] = OpConstant [[_float]] 0.3183
-// CHECK: [[_27:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]]
-// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Asin [[_27]]
+// CHECK: [[_28:%[a-zA-Z0-9_]+]] = OpExtInst [[_float]] [[_1]] Asin
 // CHECK: [[_29:%[a-zA-Z0-9_]+]] = OpFMul [[_float]] [[_float_0_31831]] [[_28]]
 // CHECK: OpStore {{.*}} [[_29]]

--- a/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
+++ b/test/PhysicalStorageBuffers/physical_constant_pointer_args.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-pushconstant
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-pushconstant -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-PC
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-ubo
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-ubo -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-UBO
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void copy(constant short *a, global int *b, int x, int y) {
     size_t gid = get_global_id(0);
@@ -29,8 +29,9 @@ kernel void copy(constant short *a, global int *b, int x, int y) {
 // CHECK-DAG: [[ptr_physical_uint]] = OpTypePointer PhysicalStorageBuffer [[uint]]
 
 // CHECK: [[pod_struct:%[a-zA-Z0-9_]+]] = OpLoad [[pod_struct_ty]]
-// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 0
-// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[pod_struct]]
+// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 0
+// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 1
 // CHECK: [[ptr_a:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_ushort]] [[ptr_int_a]]
 // CHECK: [[ptr_b:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_uint]] [[ptr_int_b]]
 // CHECK: [[ptr_a_access_chain:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_ushort]] [[ptr_a]]

--- a/test/PhysicalStorageBuffers/physical_global_pointer_args.cl
+++ b/test/PhysicalStorageBuffers/physical_global_pointer_args.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-pushconstant
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-pushconstant -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-PC
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-ubo
+// RUN: clspv %s -o %t.spv -arch=spir64 -physical-storage-buffers -pod-ubo -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-UBO
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void copy(global short *a, global int *b, int x, int y) {
     size_t gid = get_global_id(0);
@@ -29,8 +29,9 @@ kernel void copy(global short *a, global int *b, int x, int y) {
 // CHECK-DAG: [[ptr_physical_uint]] = OpTypePointer PhysicalStorageBuffer [[uint]]
 
 // CHECK: [[pod_struct:%[a-zA-Z0-9_]+]] = OpLoad [[pod_struct_ty]]
-// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 0
-// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[pod_struct]]
+// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 0
+// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 1
 // CHECK: [[ptr_a:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_ushort]] [[ptr_int_a]]
 // CHECK: [[ptr_b:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_uint]] [[ptr_int_b]]
 // CHECK: [[ptr_a_access_chain:%[a-zA-Z0-9_]+]] = OpPtrAccessChain [[ptr_physical_ushort]] [[ptr_a]]

--- a/test/PhysicalStorageBuffers/physical_global_ptrtoint.cl
+++ b/test/PhysicalStorageBuffers/physical_global_ptrtoint.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv -arch=spir64 -physical-storage-buffers
+// RUN: clspv %target %s -o %t.spv -arch=spir64 -physical-storage-buffers -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void test(global ulong *a, global int *b)
 {
@@ -20,8 +20,9 @@ kernel void test(global ulong *a, global int *b)
 // CHECK-DAG: [[pod_struct_ty:%[a-zA-Z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
 
 // CHECK: [[pod_struct:%[a-zA-Z0-9_]+]] = OpLoad [[pod_struct_ty]]
-// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 0
-// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[pod_struct]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[pod_struct]]
+// CHECK: [[ptr_int_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 0
+// CHECK: [[ptr_int_b:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[ulong]] [[copy]] 1
 // CHECK: [[ptr_a:%[a-zA-Z0-9_]+]] = OpConvertUToPtr [[ptr_physical_ulong]] [[ptr_int_a]]
 // CHECK: [[gid_x_ptr:%[a-zA-Z0-9_]+]] = OpAccessChain %{{[a-zA-Z0-9_]+}} [[global_id]] [[uint_0]]
 // CHECK: [[gid_x_load:%[a-zA-Z0-9_]+]] = OpLoad [[uint]] [[gid_x_ptr]]

--- a/test/PointerAccessChains/pointer_index_in_called_function.cl
+++ b/test/PointerAccessChains/pointer_index_in_called_function.cl
@@ -1,18 +1,18 @@
-// RUN: clspv %target %s -o %t.spv -no-inline-single -arch=spir
+// RUN: clspv %target %s -o %t.spv -no-inline-single -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -no-inline-single -arch=spir64
+// RUN: clspv %target %s -o %t.spv -no-inline-single -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 
-// RUN: clspv %target %s -o %t.spv -no-dra -no-inline-single -arch=spir
+// RUN: clspv %target %s -o %t.spv -no-dra -no-inline-single -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm -check-prefix=NODRA
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 typedef struct {
   float x[12];

--- a/test/Printf/printf_args.cl
+++ b/test/Printf/printf_args.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %s -o %t.spv -enable-printf
+// RUN: clspv %s -o %t.spv -enable-printf -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void test(char c, short s, int i, float f, long l) {
     printf("Argument: %f", f);
@@ -24,6 +24,7 @@ kernel void test(char c, short s, int i, float f, long l) {
 // CHECK-DAG: %[[eight:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 8{{$}}
 // CHECK-DAG: %[[string0:[0-9a-zA-Z_]+]] = OpString "Argument: %f"
 // CHECK-DAG: %[[string1:[0-9a-zA-Z_]+]] = OpString "Arguments: %c %hd %d %f %ld"
+// CHECK: OpCopyLogical
 // CHECK-DAG: %[[arg_c:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[uchar]]
 // CHECK-DAG: %[[arg_s:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[ushort]]
 // CHECK-DAG: %[[arg_f:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[float]]

--- a/test/Printf/printf_vector.cl
+++ b/test/Printf/printf_vector.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %s -o %t.spv -enable-printf -long-vector
+// RUN: clspv %s -o %t.spv -enable-printf -long-vector -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void test(char2 c, short2 s, int2 i, float8 f, long4 l) {
     printf("Vectors: %v2hhd %v2hd %v2d %v8hlf %v4ld", c, s, i, f, l);
@@ -28,6 +28,7 @@ kernel void test(char2 c, short2 s, int2 i, float8 f, long4 l) {
 // CHECK-DAG: %[[const_32:[0-9a-zA-Z_]+]] = OpConstant %[[uint]] 32{{$}}
 // CHECK-DAG: %[[string0:[0-9a-zA-Z_]+]] = OpString "Vectors: %v2hhd %v2hd %v2d %v8hlf %v4ld"
 
+// CHECK: OpCopyLogical
 // CHECK-DAG: %[[arg_c:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[v2uchar]]
 // CHECK-DAG: %[[arg_s:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[v2ushort]]
 // CHECK-DAG: %[[arg_i:[0-9a-zA-Z_]+]] = OpCompositeExtract %[[v2uint]]

--- a/test/PushConstant/two_ints.cl
+++ b/test/PushConstant/two_ints.cl
@@ -1,9 +1,9 @@
-// RUN: clspv %target %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args
+// RUN: clspv %target %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: clspv-reflection %t.spv -o %t.map
+// RUN: clspv-reflection %t.spv -o %t.map --target-env vulkan1.2
 // RUN: FileCheck --check-prefix=MAP %s < %t.map
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK: OpDecorate {{.*}} Block
 // CHECK: OpMemberDecorate [[cluster:%[a-zA-Z0-9_]+]] 0 Offset 0
@@ -18,8 +18,9 @@
 // CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[ptr]] PushConstant
 // CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
-// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
-// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[ld]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 1
 // CHECK: OpIAdd [[int]] [[x]] [[y]]
 
 //      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer

--- a/test/PushConstant/two_kernels_share_pc.cl
+++ b/test/PushConstant/two_kernels_share_pc.cl
@@ -1,9 +1,9 @@
-// RUN: clspv %target %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args
+// RUN: clspv %target %s -o %t.spv -pod-pushconstant -cluster-pod-kernel-args -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: clspv-reflection %t.spv -o %t.map
+// RUN: clspv-reflection %t.spv -o %t.map --target-env vulkan1.2
 // RUN: FileCheck --check-prefix=MAP %s < %t.map
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK: OpDecorate {{.*}} Block
 // CHECK: OpMemberDecorate [[cluster:%[a-zA-Z0-9_]+]] 0 Offset 0
@@ -18,13 +18,15 @@
 // CHECK-DAG: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[ptr]] PushConstant
 // CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
-// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
-// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[ld]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 1
 // CHECK: OpIAdd [[int]] [[x]] [[y]]
 // CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] [[int0]]
 // CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
-// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
-// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[ld]]
+// CHECK: [[x:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 0
+// CHECK: [[y:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 1
 // CHECK: OpIAdd [[int]] [[x]] [[y]]
 
 //      MAP: kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer

--- a/test/RelationalBuiltins/isordered/double_spirv.cl
+++ b/test/RelationalBuiltins/isordered/double_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void foo(global int* out, double x, double y) {
   int i = 0;

--- a/test/RelationalBuiltins/isordered/float_spirv.cl
+++ b/test/RelationalBuiltins/isordered/float_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void foo(global int* out, float x, float y) {
   int i = 0;

--- a/test/RelationalBuiltins/isordered/half_spirv.cl
+++ b/test/RelationalBuiltins/isordered/half_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/RelationalBuiltins/isunordered/double_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/double_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void foo(global int* out, double x, double y) {
   int i = 0;

--- a/test/RelationalBuiltins/isunordered/float_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/float_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 kernel void foo(global int* out, float x, float y) {
   int i = 0;

--- a/test/RelationalBuiltins/isunordered/half_spirv.cl
+++ b/test/RelationalBuiltins/isunordered/half_spirv.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv -spv-version=1.4
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: FileCheck %s < %t.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/test/SPIRVProducer/opaque_local_arg.ll
+++ b/test/SPIRVProducer/opaque_local_arg.ll
@@ -3,14 +3,16 @@
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val %t.spv
 
+; CHECK: OpMemberDecorate [[struct:%[a-zA-Z0-9_]+]] 1 Offset 16
 ; CHECK: OpDecorate [[size:%[a-zA-Z0-9_]+]] SpecId 3
 ; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
 ; CHECK-DAG: [[int4:%[a-zA-Z0-9_]+]] = OpTypeVector [[int]] 4
 ; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 ; CHECK-DAG: [[float4:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 4
-; CHECK-DAG: [[struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int4]] [[float4]]
+; CHECK-DAG: [[struct]] = OpTypeStruct [[int4]] [[float4]]
+; CHECK-DAG: [[alt_struct:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int4]] [[float4]]
 ; CHECK-DAG: [[size]] = OpSpecConstant [[int]]
-; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[struct]] [[size]]
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray [[alt_struct]] [[size]]
 ; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Workgroup [[array]]
 ; CHECK: OpVariable [[ptr]] Workgroup
 

--- a/test/UBO/clustered_pod_type_mutate.ll
+++ b/test/UBO/clustered_pod_type_mutate.ll
@@ -1,8 +1,8 @@
-; RUN: clspv-opt -constant-args-ubo %s -o %t.ll -producer-out-file %t.spv --passes=ubo-type-transform,spirv-producer
+; RUN: clspv-opt -constant-args-ubo %s -o %t.ll -producer-out-file %t.spv --passes=ubo-type-transform,spirv-producer --spv-version=1.4
 ; RUN: spirv-dis %t.spv -o %t.spvasm
-; RUN: spirv-val --target-env vulkan1.0 %t.spv
+; RUN: spirv-val --target-env vulkan1.2 %t.spv
 ; RUN: FileCheck %s < %t.spvasm
-; RUN: clspv-reflection %t.spv -o %t.map
+; RUN: clspv-reflection %t.spv -o %t.map --target-env vulkan1.2
 ; RUN: FileCheck --check-prefix=MAP %s < %t.map
 
 ; MAP:      kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
@@ -21,11 +21,13 @@
 ; CHECK: [[char:%[a-zA-Z0-9_]+]] = OpTypeInt 8 0
 ; CHECK: [[S]] = OpTypeStruct [[int]] [[char]]
 ; CHECK: [[cluster]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]] [[S]]
+; CHECK: [[alt_S:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int]] [[char]]
 ; CHECK: [[pod_var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
 ; CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[pod_var]]
 ; CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
-; CHECK: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
-; CHECK: [[s:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[S]] [[ld]] 4
+; CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[ld]]
+; CHECK: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 0
+; CHECK: [[s:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[alt_S]] [[copy]] 4
 ; CHECK: [[s_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[s]] 0
 ; CHECK: OpIAdd [[int]] [[s_a]] [[a]]
 

--- a/test/UBO/clustered_pod_ubo.ll
+++ b/test/UBO/clustered_pod_ubo.ll
@@ -1,8 +1,8 @@
-; RUN: clspv-opt -constant-args-ubo %s -o %t.ll -producer-out-file %t.spv --passes=ubo-type-transform,spirv-producer
+; RUN: clspv-opt -constant-args-ubo %s -o %t.ll -producer-out-file %t.spv --passes=ubo-type-transform,spirv-producer --spv-version=1.4
 ; RUN: spirv-dis %t.spv -o %t.spvasm
-; RUN: spirv-val --target-env vulkan1.0 %t.spv
+; RUN: spirv-val --target-env vulkan1.2 %t.spv
 ; RUN: FileCheck %s < %t.spvasm
-; RUN: clspv-reflection %t.spv -o %t.map
+; RUN: clspv-reflection %t.spv -o %t.map --target-env vulkan1.2
 ; RUN: FileCheck --check-prefix=MAP %s < %t.map
 
 ; MAP:      kernel,foo,arg,out,argOrdinal,0,descriptorSet,0,binding,0,offset,0,argKind,buffer
@@ -23,11 +23,13 @@
 ; CHECK-NOT: OpTypeInt 8 0
 ; CHECK: [[S]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
 ; CHECK: [[cluster]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]] [[S]]
+; CHECK: [[alt_S:%[a-zA-Z0-9_]+]] = OpTypeStruct [[int]] [[int]] [[int]] [[int]]
 ; CHECK: [[pod_var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Uniform
 ; CHECK: [[gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[pod_var]]
 ; CHECK: [[ld:%[a-zA-Z0-9_]+]] = OpLoad [[cluster]] [[gep]]
-; CHECK: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[ld]] 0
-; CHECK: [[s:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[S]] [[ld]] 4
+; CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[ld]]
+; CHECK: [[a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[copy]] 0
+; CHECK: [[s:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[alt_S]] [[copy]] 4
 ; CHECK: [[s_a:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[int]] [[s]] 0
 ; CHECK: OpIAdd [[int]] [[s_a]] [[a]]
 

--- a/test/UBO/transform_global.cl
+++ b/test/UBO/transform_global.cl
@@ -1,16 +1,16 @@
-// RUN: clspv %target -constant-args-ubo -inline-entry-points %s -o %t.spv -int8=0 -pod-ubo -arch=spir
+// RUN: clspv %target -constant-args-ubo -inline-entry-points %s -o %t.spv -int8=0 -pod-ubo -arch=spir -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: clspv-reflection %t.spv -o %t2.map
+// RUN: clspv-reflection %t.spv -o %t2.map --target-env vulkan1.2
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target -constant-args-ubo -inline-entry-points %s -o %t.spv -int8=0 -pod-ubo -arch=spir64
+// RUN: clspv %target -constant-args-ubo -inline-entry-points %s -o %t.spv -int8=0 -pod-ubo -arch=spir64 -spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: clspv-reflection %t.spv -o %t2.map
+// RUN: clspv-reflection %t.spv -o %t2.map --target-env vulkan1.2
 // RUN: FileCheck -check-prefix=MAP %s < %t2.map
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 typedef struct {
   int x __attribute__((aligned(16)));
@@ -40,6 +40,7 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 // CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK-64-DAG: [[long:%[0-9a-zA-Z_]+]] = OpTypeInt 64 0
 // CHECK-DAG: [[data_type]] = OpTypeStruct [[int]] [[int]]
+// CHECK-DAG: [[alt_data_type:%[a-zA-Z0-9_.]+]] = OpTypeStruct [[int]] [[int]]
 // CHECK-DAG: [[runtime]] = OpTypeRuntimeArray [[data_type]]
 // CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 // CHECK-DAG: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
@@ -50,13 +51,13 @@ __kernel void foo(__global data_type *data, __constant data_type *c_arg,
 // CHECK-DAG: [[data_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[int]]
 // CHECK-DAG: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
 // CHECK-DAG: [[two:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 2
-// CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[two]]
+// CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[alt_data_type]] [[two]]
 // CHECK-DAG: [[c_var_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[array]]
 // CHECK-DAG: [[c_var_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Private [[int]]
 // CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0
-// CHECK-DAG: [[zero_zero:%[0-9a-zA-Z_]+]] = OpConstantNull [[data_type]]
+// CHECK-DAG: [[zero_zero:%[0-9a-zA-Z_]+]] = OpConstantNull [[alt_data_type]]
 // CHECK-DAG: [[one:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 1
-// CHECK-DAG: [[one_zero:%[0-9a-zA-Z_]+]] = OpConstantComposite [[data_type]] [[one]] [[zero]]
+// CHECK-DAG: [[one_zero:%[0-9a-zA-Z_]+]] = OpConstantComposite [[alt_data_type]] [[one]] [[zero]]
 // CHECK-DAG: [[array_const:%[0-9a-zA-Z_]+]] = OpConstantComposite [[array]] [[zero_zero]] [[one_zero]]
 // CHECK-DAG: [[c_var:%[0-9a-zA-Z_]+]] = OpVariable [[c_var_ptr]] Private [[array_const]]
 // CHECK-DAG: [[data]] = OpVariable [[data_ptr]] StorageBuffer

--- a/test/UBO/transform_local.ll
+++ b/test/UBO/transform_local.ll
@@ -20,6 +20,7 @@
 ; CHECK-NOT: OpExtension
 ; CHECK-DAG: [[int:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 ; CHECK-DAG: [[data_type]] = OpTypeStruct [[int]] [[int]]
+; CHECK-DAG: [[alt_data_type:%[a-zA-Z0-9_.]+]] = OpTypeStruct [[int]] [[int]]
 ; CHECK-DAG: [[runtime]] = OpTypeRuntimeArray [[data_type]]
 ; CHECK-DAG: [[struct:%[0-9a-zA-Z_]+]] = OpTypeStruct [[runtime]]
 ; CHECK-DAG: [[data_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer StorageBuffer [[struct]]
@@ -31,7 +32,7 @@
 ; CHECK-DAG: [[size2:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
 ; CHECK-DAG: [[size3:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
 ; CHECK-DAG: [[size:%[0-9a-zA-Z_]+]] = OpSpecConstant [[int]] 1
-; CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[data_type]] [[size]]
+; CHECK-DAG: [[array:%[0-9a-zA-Z_]+]] = OpTypeArray [[alt_data_type]] [[size]]
 ; CHECK-DAG: [[l_arg_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Workgroup [[array]]
 ; CHECK-DAG: [[c_arg_ele_ptr:%[0-9a-zA-Z_]+]] = OpTypePointer Uniform [[int]]
 ; CHECK-DAG: [[zero:%[0-9a-zA-Z_]+]] = OpConstant [[int]] 0

--- a/test/as_float.cl
+++ b/test/as_float.cl
@@ -1,10 +1,10 @@
 // Test for https://github.com/google/clspv/issues/166
 // Function declarations were missing from builtin header.
 
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 
 kernel void foo(global float *A, uint a) {

--- a/test/char4_insert.cl
+++ b/test/char4_insert.cl
@@ -4,10 +4,10 @@ kernel void foo(global uchar4* A, int n) {
  *A = (uchar4)(1,2,(uchar)n,4);
 }
 
-// RUN: clspv %target %s -o %t.spv -int8=0
+// RUN: clspv %target %s -o %t.spv -int8=0 --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK:  [[_uint:%[0-9a-zA-Z_]+]] = OpTypeInt 32 0
 // CHECK:  [[_uint_0:%[0-9a-zA-Z_]+]] = OpConstant [[_uint]] 0

--- a/test/char4_insert_from_float.cl
+++ b/test/char4_insert_from_float.cl
@@ -4,10 +4,10 @@ kernel void foo(global char4* A, float f) {
  *A = (char4)(1,2,(char)f,4);
 }
 
-// RUN: clspv %target %s -o %t.spv -int8=0
+// RUN: clspv %target %s -o %t.spv -int8=0 --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // This is ok because results ought to be unspecified if the conversion overflows.
 

--- a/test/cluster_pod_args_globals_scalars.cl
+++ b/test/cluster_pod_args_globals_scalars.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -cluster-pod-kernel-args -arch=spir
+// RUN: clspv %target %s -o %t.spv -cluster-pod-kernel-args -arch=spir --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -cluster-pod-kernel-args -arch=spir64
+// RUN: clspv %target %s -o %t.spv -cluster-pod-kernel-args -arch=spir64 --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, float f, global float* B, uint n)
 {
@@ -27,8 +27,9 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* A, 
 // CHECK: [[_16:%[a-zA-Z0-9_]+]] = OpVariable [[__ptr_PushConstant__struct_8]] PushConstant
 // CHECK: [[_19:%[a-zA-Z0-9_]+]] = OpAccessChain [[__ptr_PushConstant__struct_7]] [[_16]] [[_uint_0]]
 // CHECK: [[_20:%[a-zA-Z0-9_]+]] = OpLoad [[__struct_7]] [[_19]]
-// CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[_20]] 0
-// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[_20]] 1
+// CHECK: [[copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[_20]]
+// CHECK: [[_21:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_float]] [[copy]] 0
+// CHECK: [[_22:%[a-zA-Z0-9_]+]] = OpCompositeExtract [[_uint]] [[copy]] 1
 // CHECK-64: [[_22_long:%[a-zA-Z0-9_]+]] = OpUConvert [[_ulong]] [[_22]]
 // CHECK-64: [[_23:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[_uint_0]] [[_22_long]]
 // CHECK-32: [[_23:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} {{.*}} [[_uint_0]] [[_22]]

--- a/test/cluster_pod_args_reuse_pod_type.cl
+++ b/test/cluster_pod_args_reuse_pod_type.cl
@@ -11,10 +11,10 @@ kernel void bar(global float* B, float f, float g) {
   *B = f - g;
 }
 
+// CHECK: OpMemberDecorate [[__struct_6:%[a-zA-Z0-9_]+]] 1 Offset 4
 // CHECK-DAG: [[_float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
 // CHECK-DAG: [[__runtimearr_float:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[_float]]
 // CHECK-DAG: [[__struct_4:%[a-zA-Z0-9_]+]] = OpTypeStruct [[__runtimearr_float]]
-// CHECK-DAG: [[__struct_6:%[a-zA-Z0-9_]+]] = OpTypeStruct [[_float]] [[_float]]
+// CHECK-DAG: [[__struct_6]] = OpTypeStruct [[_float]] [[_float]]
 // CHECK-DAG: [[__struct_7:%[a-zA-Z0-9_]+]] = OpTypeStruct [[__struct_6]]
-// The { float float } struct type only occurs once
-// CHECK-NOT:  OpTypeStruct [[_float]] [[_float]]
+// CHECK-DAG:  OpTypeStruct [[_float]] [[_float]]

--- a/test/opselect_float2.cl
+++ b/test/opselect_float2.cl
@@ -25,8 +25,7 @@ void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float2* A,
 // CHECK-DAG: %[[float_1:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 1
 // CHECK-DAG: %[[float_2:[a-zA-Z0-9_]*]] = OpConstant %[[float]] 2
 // CHECK-DAG: %[[v2_1_2:[a-zA-Z0-9_]*]] = OpConstantComposite %[[float2]] %[[float_1]] %[[float_2]]
-// CHECK: %[[n:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[uint]]
-// CHECK: %[[eq:[a-zA-Z0-9_]*]] = OpIEqual %[[BOOL_TYPE_ID]] %[[n]] %[[uint_0]]
+// CHECK: %[[eq:[a-zA-Z0-9_]*]] = OpIEqual %[[BOOL_TYPE_ID]] {{%[a-zA-Z0-9_.]+}} %[[uint_0]]
 // CHECK: %[[eq_vec0:[a-zA-Z0-9_]*]] = OpCompositeInsert %[[bool2]] %[[eq]] %[[undef]] 0
 // CHECK: %[[eq_splat:[a-zA-Z0-9_]*]] = OpVectorShuffle %[[bool2]] %[[eq_vec0]] %[[undef]] 0 0
 // CHECK: %[[sel:[a-zA-Z0-9_]*]] = OpSelect %[[float2]] %[[eq_splat]] %[[v2_3_4]] %[[v2_1_2]]

--- a/test/ptr_function_as_return.cl
+++ b/test/ptr_function_as_return.cl
@@ -1,12 +1,12 @@
-// RUN: clspv %target %s -o %t.spv -arch=spir
+// RUN: clspv %target %s -o %t.spv -arch=spir --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -arch=spir64
+// RUN: clspv %target %s -o %t.spv -arch=spir64 --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 int* inner(int* arr) {
   return &arr[0];

--- a/test/uchar4_insert_from_float.cl
+++ b/test/uchar4_insert_from_float.cl
@@ -4,10 +4,10 @@ kernel void foo(global uchar4* A, float f) {
  *A = (uchar4)(1,2,(uchar)f,4);
 }
 
-// RUN: clspv %target %s -o %t.spv -int8=0
+// RUN: clspv %target %s -o %t.spv -int8=0 --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 
 

--- a/test/uint_arg_static_load_store.cl
+++ b/test/uint_arg_static_load_store.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global uint* a, uint b)

--- a/test/vector_insert_element.cl
+++ b/test/vector_insert_element.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[UINT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeInt 32 0
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32

--- a/test/vector_shuffle.cl
+++ b/test/vector_shuffle.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4

--- a/test/vector_shuffle_float3.cl
+++ b/test/vector_shuffle_float3.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 3

--- a/test/vector_shuffle_hi_lo.cl
+++ b/test/vector_shuffle_hi_lo.cl
@@ -1,7 +1,7 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target %s -o %t.spv --spv-version=1.4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
-// RUN: spirv-val --target-env vulkan1.0 %t.spv
+// RUN: spirv-val --target-env vulkan1.2 %t.spv
 
 // CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
 // CHECK-DAG: %[[FLOAT_4_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4


### PR DESCRIPTION
* Update SPIRV-Headers and SPIRV-Tools
* Change the producer to always discriminate between laid out and non-laid out storage classes instead of being version based
* Introduce function to handle layout conversions
  * OpCopyLogical for 1.4 or later
  * recursive extract and construct for earlier versions

Test modifications take a couple forms:
* simplification (dropping composite extracts)
* increasing spir-v version and using OpCopyLogical

Tested internally against expected CTS passes.