### PR TITLE
Fix SimplifyPointerBitcastPass hang on const GEP GVs

### DIFF
--- a/lib/BitcastUtils.cpp
+++ b/lib/BitcastUtils.cpp
@@ -1392,4 +1392,10 @@ GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
   return Idxs;
 }
 
+bool IsGVConstantGEP(GetElementPtrInst *GEP) {
+  assert(GEP != nullptr);
+  return isa<GlobalVariable>(GEP->getPointerOperand()) &&
+         GEP->hasAllConstantIndices();
+}
+
 } // namespace BitcastUtils

--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -84,6 +84,8 @@ SmallVector<Value *, 2>
 GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
                        Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
                        size_t SmallerBitWidths, Value *Src);
+
+bool IsGVConstantGEP(GetElementPtrInst *GEP);
 } // namespace BitcastUtils
 
 #endif // _CLSPV_LIB_BITCAST_UTILS_PASS_H

--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -432,8 +432,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
         } else if (auto gep = dyn_cast<GetElementPtrInst>(&I)) {
           if (IsClspvResourceOrLocal(gep->getPointerOperand())) {
             GEPCastList.push_back(dyn_cast<GetElementPtrInst>(&I));
-          } else if (isa<GlobalVariable>(gep->getPointerOperand()) &&
-                     gep->hasAllConstantIndices()) {
+          } else if (IsGVConstantGEP(gep)) {
             GEPGVList.push_back(dyn_cast<GetElementPtrInst>(&I));
           }
         }
@@ -787,8 +786,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
               IsClspvResourceOrLocal(gep->getPointerOperand())) {
             continue;
           }
-          if (isa<GlobalVariable>(gep->getPointerOperand()) &&
-              gep->hasAllConstantIndices())
+          if (IsGVConstantGEP(gep))
             continue;
 
           uint64_t cstVal;
@@ -988,8 +986,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUnneededIndices(Module &M) const {
         if (auto gep = dyn_cast<GetElementPtrInst>(source)) {
           if (gep->getNumIndices() <= 1)
             continue;
-          if (isa<GlobalVariable>(gep->getPointerOperand()) &&
-              gep->hasAllConstantIndices())
+          if (IsGVConstantGEP(gep))
             continue;
           if (SizeInBits(DL, source_ty) < SizeInBits(DL, dest_ty)) {
             if (auto cst = dyn_cast<ConstantInt>(

--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -572,13 +572,6 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
     LLVM_DEBUG(dbgs() << "\n##runOnImplicitGEP (from GV):\nreplacing: ";
                gep->dump());
     LLVM_DEBUG(dbgs() << "by: "; new_gep->dump(););
-
-    // Tag all-constant-indice-global-GEPs to stay in normalized form to
-    // prevent conversion-thrashing with latter sub-passes
-    // TODO: this could be better handled without the use of metadata tagging
-    MDNode *MD = MDNode::get(new_gep->getContext(), {});
-    new_gep->setMetadata("clspv.const_gep_gv", MD);
-
     gep->replaceAllUsesWith(new_gep);
     gep->eraseFromParent();
     changed = true;
@@ -794,7 +787,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
               IsClspvResourceOrLocal(gep->getPointerOperand())) {
             continue;
           }
-          if (gep->getMetadata("clspv.const_gep_gv"))
+          if (isa<GlobalVariable>(gep->getPointerOperand()) &&
+              gep->hasAllConstantIndices())
             continue;
 
           uint64_t cstVal;
@@ -994,7 +988,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnUnneededIndices(Module &M) const {
         if (auto gep = dyn_cast<GetElementPtrInst>(source)) {
           if (gep->getNumIndices() <= 1)
             continue;
-          if (gep->getMetadata("clspv.const_gep_gv"))
+          if (isa<GlobalVariable>(gep->getPointerOperand()) &&
+              gep->hasAllConstantIndices())
             continue;
           if (SizeInBits(DL, source_ty) < SizeInBits(DL, dest_ty)) {
             if (auto cst = dyn_cast<ConstantInt>(

--- a/test/PointerCasts/issue-1473.cl
+++ b/test/PointerCasts/issue-1473.cl
@@ -1,0 +1,25 @@
+// RUN: clspv --long-vector %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+__kernel void test(__global int8 *output)
+{ 
+    int i = 0;
+    __local int x[8];
+    __local int8* xPtr;
+
+    for (i = 0; i < 8; ++i)
+    {
+        x[i] = 8 - i;
+    }
+    
+    xPtr = (__local int8 *)x;
+    output[0].s0 = xPtr[0].s0;
+    output[0].s1 = xPtr[0].s1;
+    output[0].s2 = xPtr[0].s2;
+    output[0].s3 = xPtr[0].s3;
+    output[0].s4 = xPtr[0].s4;
+    output[0].s5 = xPtr[0].s5;
+    output[0].s6 = xPtr[0].s6;
+    output[0].s7 = xPtr[0].s7;
+}

--- a/test/PointerCasts/issue-1473.cl
+++ b/test/PointerCasts/issue-1473.cl
@@ -2,6 +2,8 @@
 // RUN: spirv-dis %t.spv -o %t.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
+// This test used to involve an infinite loop
+
 __kernel void test(__global int8 *output)
 { 
     int i = 0;

--- a/test/PointerCasts/issue-1473.ll
+++ b/test/PointerCasts/issue-1473.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast,replace-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; This test used to involve an infinite loop
+
+; CHECK:  [[gep:%[^ ]+]] = getelementptr [8 x i32], ptr addrspace(3) @test.x, i32 0
+; CHECK-COUNT-8: getelementptr i32, ptr addrspace(3) [[gep]], i32
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir-unknown-unknown"
+
+@test.x = internal addrspace(3) global [8 x i32] undef, align 4
+
+define dso_local spir_kernel void @test(ptr addrspace(1) align 32 %output) {
+entry:
+  %arrayidx1 = getelementptr inbounds <8 x i32>, ptr addrspace(3) @test.x, i32 0
+  %0 = load <8 x i32>, ptr addrspace(3) %arrayidx1, align 32
+  ret void
+}


### PR DESCRIPTION
This change marks all-constant-indice-global-GEPs via metadata tag as an indicator to avoid further transforms on subsequent sub-passes.

This fixes issue where SimplifyPointerBitcastPass endlessly loops on converting and reconverting these particular GEPs.

fixes: #1473