### PR TITLE
kokoro format-check: use merge-base to find files to scan

### DIFF
--- a/utils/check_code_format.sh
+++ b/utils/check_code_format.sh
@@ -39,7 +39,7 @@ fi
 if [ "$1" = "FULL" ]; then
   FILES_TO_CHECK=$(git diff --name-only HEAD~ | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
 else
-  FILES_TO_CHECK=$(git diff --name-only main | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+  FILES_TO_CHECK=$(git diff --name-only $(git merge-base main HEAD) | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
 fi
 
 if [ -z "${FILES_TO_CHECK}" ]; then


### PR DESCRIPTION
When doing the clang format check, the current branch is compared with main to see which files changed, and if there are any formating issues in those files. This can cause false positives if the current branch is too far behind main. If another PR fixed the formating in main, then that will be flagged as an error because it looks like the current PR will undo that change.

The fix is to use the merge-base for main and HEAD to find the first common ancestor of the two to determine which files are changed in the current branch.

Bug: crbug.com/414577655