### PR TITLE
Fix Dynamic Indexing in Multi-Dimensional Arrays

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -710,10 +710,10 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
         return false;
       }
     } else {
-      // if gep contains dynamic indices, only consider i8 gep with and look for
-      // mul and shl composing the single indice.
-      if (gep->getSourceElementType() != Type::getInt8Ty(M.getContext()) &&
-          gep->getNumIndices() == 1) {
+      // if gep contains dynamic indices, only consider i8 gep width and look
+      // for mul and shl composing the single indice.
+      if (gep->getSourceElementType() != Type::getInt8Ty(M.getContext()) ||
+          gep->getNumIndices() != 1) {
         return false;
       }
       cstVal = 0;


### PR DESCRIPTION
As described in [issue 1487](https://github.com/google/clspv/issues/1487).
There was an issue in ```SimplifyPointerBitcast```, specifically ```runOnUpgradeableConstantCasts```, where dynamic indices would be lost for GEP operations on multi-dimensional arrays. This change resolves the issue by marking the GEP indices to not be upgradable when the number of indices != 1.