### PR TITLE
Fix trial of building failure on systems where function `rsqrt` is declared as cmath builtin

### DIFF
--- a/lib/FixupBuiltinsPass.cpp
+++ b/lib/FixupBuiltinsPass.cpp
@@ -28,7 +28,7 @@ using namespace clspv;
 using namespace llvm;
 
 namespace clspv_local {
-double rsqrt(double input) { return 1.0 / sqrt(input); }
+static double rsqrt(double input) { return 1.0 / sqrt(input); }
 } // namespace
 
 PreservedAnalyses FixupBuiltinsPass::run(Module &M, ModuleAnalysisManager &) {

--- a/lib/FixupBuiltinsPass.cpp
+++ b/lib/FixupBuiltinsPass.cpp
@@ -27,7 +27,7 @@
 using namespace clspv;
 using namespace llvm;
 
-namespace {
+namespace clspv_local {
 double rsqrt(double input) { return 1.0 / sqrt(input); }
 } // namespace
 
@@ -45,7 +45,7 @@ bool FixupBuiltinsPass::runOnFunction(Function &F) {
   case Builtins::kSqrt:
     return fixupSqrt(F, sqrt);
   case Builtins::kRsqrt:
-    return fixupSqrt(F, rsqrt);
+    return fixupSqrt(F, clspv_local::rsqrt);
   case Builtins::kReadImagef:
   case Builtins::kReadImagei:
   case Builtins::kReadImageui:


### PR DESCRIPTION
On some machine, compilation tends to fail due to the pre-declared rsqrt on cmath.  
Namespace will be named `clspv_local` to avoid the declaration crash.  
Plus, Method will be static to avoid global declaration to avoid.

The change will look something like this.

```cc
/** Naming annonymous */
namespace clspv_local {
static double rsqrt(double input) { return 1.0 / sqrt(input); }
} // namespace

bool FixupBuiltinsPass::runOnFunction(Function &F) {
  auto &FI = Builtins::Lookup(&F);
  switch (FI.getType()) {
  case Builtins::kSqrt:
    return fixupSqrt(F, sqrt);
  case Builtins::kRsqrt:
    return fixupSqrt(F, clspv_local::rsqrt); /** Using rsqrt with namespace since rsqrt is not part of the regular cmath as I know. */
  case Builtins::kReadImagef:
  case Builtins::kReadImagei:
  case Builtins::kReadImageui:
    if (clspv::Option::HackImage1dBufferBGRA() &&
        !FI.getParameter(1).isSampler()) {
      return fixupReadImage(F);
    } else {
      return false;
    }
  default:
    return false;
  }
}
```