### PR TITLE
kokoro: increase timeout for windows builds to 300 min

### DIFF
--- a/kokoro/windows-msvc-2019-release/common.cfg
+++ b/kokoro/windows-msvc-2019-release/common.cfg
@@ -1,0 +1,16 @@
+# Copyright 2025 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Windows builds suddenly got much longer.  crbug.com/437080645
+timeout_mins: 300

--- a/kokoro/windows-vs2022-amd64-debug/common.cfg
+++ b/kokoro/windows-vs2022-amd64-debug/common.cfg
@@ -1,0 +1,16 @@
+# Copyright 2025 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Windows builds suddenly got much longer.  crbug.com/437080645
+timeout_mins: 300

--- a/kokoro/windows-vs2022-amd64-release/common.cfg
+++ b/kokoro/windows-vs2022-amd64-release/common.cfg
@@ -1,0 +1,16 @@
+# Copyright 2025 The Clspv Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Windows builds suddenly got much longer.  crbug.com/437080645
+timeout_mins: 300


### PR DESCRIPTION
Revert this if we can drastically reduce build times again.

Bug: crbug.com/437080645