### PR TITLE
kokoro: windows: use Ninja instead of Visual Studio

### DIFF
--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -28,14 +28,6 @@ set PATH=c:\Python312;%PATH%
 cd %SRC%
 python utils/fetch_sources.py --ci
 
-:: #########################################
-:: set up msvc build env
-:: #########################################
-if %VS_VERSION% == 2022 (
-  set GENERATOR="Visual Studio 17 2022"
-  echo "Using VS 2022..."
-)
-
 cd %SRC%
 mkdir build
 cd build
@@ -50,7 +42,7 @@ if "%KOKORO_GITHUB_COMMIT%." == "." (
   set BUILD_SHA=%KOKORO_GITHUB_COMMIT%
 )
 
-cmake -G%GENERATOR% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% .. -Thost=x64
+cmake -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe ..
 
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 


### PR DESCRIPTION
Visual Studio is not capable of building libclc as a runtime. Let's switch to Ninja.

Ref #1519