### PR TITLE
Improve gep from gep bitcast handling

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -304,7 +304,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnGEPFromGEP(Module &M) const {
       for (uint32_t i = 0; i < OtherGEP->getNumOperands() - 1; i++) {
         Value *op = OtherGEP->getOperand(i + 1);
         TyIdxs.push_back(op);
-        Type *idxTy = GetElementPtrInst::getIndexedType(OtherGEP->getSourceElementType(), TyIdxs);
+        Type *idxTy = GetElementPtrInst::getIndexedType(
+            OtherGEP->getSourceElementType(), TyIdxs);
         Types.push_back(idxTy);
         if (i > 0 && isa<StructType>(Types[i - 1])) {
           startIndex = i + 1;
@@ -324,7 +325,8 @@ bool clspv::SimplifyPointerBitcastPass::runOnGEPFromGEP(Module &M) const {
         if (CstSrcLastIdxOp && CstSrcLastIdxOp->isZero()) {
           Idxs.push_back(GEP->getOperand(1));
         } else {
-          Idxs.push_back(Builder.CreateAdd(GEPIdxOp, *(OtherGEP->op_end() - 1)));
+          Idxs.push_back(
+              Builder.CreateAdd(GEPIdxOp, *(OtherGEP->op_end() - 1)));
         }
       } else {
         uint64_t cstVal;

--- a/test/PointerCasts/gep_from_gep_struct.ll
+++ b/test/PointerCasts/gep_from_gep_struct.ll
@@ -1,0 +1,78 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[i:%[a-zA-Z0-9_.]+]] = phi i32
+; CHECK: getelementptr %struct.work_item_data, ptr addrspace(1) %outData, i32 %{{.*}}, i32 1, i32 [[i]]
+
+source_filename = "work_item.cl"
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir-unknown-unknown"
+
+%0 = type { <3 x i32>, <3 x i32>, <3 x i32>, <3 x i32>, <3 x i32> }
+%struct.work_item_data = type { i32, [3 x i32], [3 x i32], [3 x i32], [3 x i32], [3 x i32], [3 x i32], [3 x i32], [3 x i32] }
+
+@__push_constants = local_unnamed_addr addrspace(9) global %0 zeroinitializer, !push_constants !0
+@__spirv_GlobalInvocationId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
+@__spirv_LocalInvocationId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkgroupId = local_unnamed_addr addrspace(5) global <3 x i32> zeroinitializer
+@__spirv_WorkDim = local_unnamed_addr addrspace(8) global i32 0
+
+; Function Attrs: nofree norecurse nounwind memory(read, argmem: readwrite)
+define dso_local spir_kernel void @sample_kernel(ptr addrspace(1) writeonly align 4 captures(none) %outData) local_unnamed_addr #0 !kernel_arg_addr_space !9 !kernel_arg_access_qual !10 !kernel_arg_type !11 !kernel_arg_base_type !11 !kernel_arg_type_qual !12 !kernel_arg_name !13 !clspv.pod_args_impl !14 {
+entry:
+  %0 = load i32, ptr addrspace(5) @__spirv_GlobalInvocationId, align 16
+  %1 = load i32, ptr addrspace(9) getelementptr inbounds nuw (i8, ptr addrspace(9) @__push_constants, i32 32), align 16
+  %2 = add i32 %1, %0
+  %3 = load i32, ptr addrspace(8) @__spirv_WorkDim, align 4
+  %4 = getelementptr %struct.work_item_data, ptr addrspace(1) %outData, i32 %2
+  store i32 %3, ptr addrspace(1) %4, align 4
+  %cmp.i6.not = icmp eq i32 %3, 0
+  br i1 %cmp.i6.not, label %__clang_ocl_kern_imp_sample_kernel.exit, label %for.body.i.lr.ph
+
+for.body.i.lr.ph:                                 ; preds = %entry
+  %.split = getelementptr inbounds %struct.work_item_data, ptr addrspace(1) %outData, i32 %2, i32 1
+  br label %for.body.i
+
+for.body.i:                                       ; preds = %for.body.i.lr.ph, %for.body.i
+  %i.i.07 = phi i32 [ 0, %for.body.i.lr.ph ], [ %inc.i, %for.body.i ]
+  %5 = icmp ult i32 %i.i.07, 3
+  %6 = select i1 %5, i32 %i.i.07, i32 0
+  %7 = getelementptr inbounds %0, ptr addrspace(9) @__push_constants, i32 0, i32 1, i32 %6
+  %8 = load i32, ptr addrspace(9) %7, align 4
+  %9 = select i1 %5, i32 %8, i32 1
+  %10 = getelementptr inbounds i32, ptr addrspace(1) %.split, i32 %i.i.07
+  store i32 %9, ptr addrspace(1) %10, align 4
+  %inc.i = add nuw i32 %i.i.07, 1
+  %37 = load i32, ptr addrspace(8) @__spirv_WorkDim, align 4
+  %cmp.i = icmp ult i32 %inc.i, %37
+  br i1 %cmp.i, label %for.body.i, label %__clang_ocl_kern_imp_sample_kernel.exit
+
+__clang_ocl_kern_imp_sample_kernel.exit:          ; preds = %for.body.i, %entry
+  ret void
+}
+
+attributes #0 = { nofree norecurse nounwind memory(read, argmem: readwrite) "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="false" }
+
+!llvm.module.flags = !{!1, !2, !3}
+!opencl.ocl.version = !{!4}
+!opencl.spir.version = !{!4}
+!llvm.ident = !{!5, !6}
+!_Z28clspv.entry_point_attributes = !{!7, !8}
+
+!0 = !{i32 1, i32 3, i32 4, i32 5, i32 6}
+!1 = !{i32 1, !"wchar_size", i32 4}
+!2 = !{i32 7, !"direct-access-external-data", i32 0}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{i32 3, i32 0}
+!5 = !{!"clang version 22.0.0git (https://github.com/llvm/llvm-project af86add989a6156ccff99dd5e0ebd9ab30538d0f)"}
+!6 = !{!"clang version 22.0.0git (https://github.com/llvm/llvm-project 4b5f22bd38507675e0e8e490b97af32858b50d81)"}
+!7 = !{!"sample_kernel", !"__kernel"}
+!8 = !{!"__clang_ocl_kern_imp_sample_kernel", !"__kernel"}
+!9 = !{i32 1}
+!10 = !{!"none"}
+!11 = !{!"work_item_data*"}
+!12 = !{!""}
+!13 = !{!"outData"}
+!14 = !{i32 3}
+

--- a/test/WorkItemBuiltins/get_global_id.ll
+++ b/test/WorkItemBuiltins/get_global_id.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z13get_global_idj(i32 3)
 ; CHECK: call spir_func i32 @_Z13get_global_idj(i32 %b)

--- a/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.ll
+++ b/test/WorkItemBuiltins/get_global_offset-spec-constant-non-constant-dim.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll -global-offset --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll -global-offset --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z17get_global_offsetj
 

--- a/test/WorkItemBuiltins/get_global_size.ll
+++ b/test/WorkItemBuiltins/get_global_size.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z15get_global_sizej(i32 3)
 ; CHECK: call spir_func i32 @_Z15get_global_sizej(i32 %b)

--- a/test/WorkItemBuiltins/get_group_id.ll
+++ b/test/WorkItemBuiltins/get_group_id.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z12get_group_idj(i32 3)
 ; CHECK: call spir_func i32 @_Z12get_group_idj(i32 %b)

--- a/test/WorkItemBuiltins/get_local_id.ll
+++ b/test/WorkItemBuiltins/get_local_id.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z12get_local_idj(i32 3)
 ; CHECK: call spir_func i32 @_Z12get_local_idj(i32 %b)

--- a/test/WorkItemBuiltins/get_num_groups.ll
+++ b/test/WorkItemBuiltins/get_num_groups.ll
@@ -1,7 +1,5 @@
-; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse,instcombine
+; RUN: clspv-opt %s -o %t.ll --passes=define-opencl-workitem-builtins,early-cse
 ; RUN: FileCheck %s < %t.ll
-; b/445660270 https://github.com/google/clspv/issues/1524
-;XFAIL: *
 
 ; CHECK: call spir_func i32 @_Z14get_num_groupsj(i32 3)
 ; CHECK: call spir_func i32 @_Z14get_num_groupsj(i32 %b)

--- a/test/packed_struct_novec3.cl
+++ b/test/packed_struct_novec3.cl
@@ -1,11 +1,9 @@
-// b/445660270 https://github.com/google/clspv/issues/1524
-// XFAIL: *
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 -arch=spir
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 -arch=spir
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-32
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
 
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4 -arch=spir64
+// RUN: clspv %s -o %t.spv -vec3-to-vec4 -arch=spir64
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm --check-prefixes=CHECK,CHECK-64
 // RUN: spirv-val --target-env vulkan1.0 %t.spv
@@ -67,10 +65,12 @@ __kernel void test(__global int *a) {
 // CHECK-DAG: [[uint2:%[^ ]+]] = OpConstant [[uint]] 2
 // CHECK-32-DAG: [[uint3:%[^ ]+]] = OpConstant [[uint]] 3
 // CHECK-32-DAG: [[uint4:%[^ ]+]] = OpConstant [[uint]] 4
+// CHECK-32-DAG: [[uint5:%[^ ]+]] = OpConstant [[uint]] 5
 // CHECK-64-DAG: [[ulong1:%[^ ]+]] = OpConstant [[ulong]] 1
 // CHECK-64-DAG: [[ulong2:%[^ ]+]] = OpConstant [[ulong]] 2
 // CHECK-64-DAG: [[ulong3:%[^ ]+]] = OpConstant [[ulong]] 3
 // CHECK-64-DAG: [[ulong4:%[^ ]+]] = OpConstant [[ulong]] 4
+// CHECK-64-DAG: [[ulong5:%[^ ]+]] = OpConstant [[ulong]] 5
 // CHECK: [[s1:%[^ ]+]] = OpVariable [[S1arrayptr]] Workgroup
 // CHECK: [[s2:%[^ ]+]] = OpVariable [[S2arrayptr]] Workgroup
 // CHECK: [[gidptr:%[^ ]+]] = OpVariable [[uintv3input]] Input
@@ -80,22 +80,24 @@ __kernel void test(__global int *a) {
 // CHECK-64: [[gid_long:%[^ ]+]] = OpSConvert [[ulong]] [[gid]]
 // CHECK-64: [[_0:%[^ ]+]] = OpAccessChain [[uintv3workgroup]] [[s1]] [[gid_long]] [[uint0]]
 // CHECK-64: [[_1:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s1]] [[gid_long]] [[uint1]]
-// CHECK-64: [[gid_times_8:%[^ ]+]] = OpShiftLeftLogical [[ulong]] [[gid_long]] [[ulong3]]
-// CHECK-64: [[id:%[^ ]+]] = OpBitwiseOr [[ulong]] [[gid_times_8]] [[ulong1]]
-// CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
-// CHECK-64: [[id:%[^ ]+]] = OpBitwiseOr [[ulong]] [[gid_times_8]] [[ulong2]]
-// CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
+// CHECK-64: [[shl_5_long:%[^ ]+]] = OpShiftLeftLogical [[ulong]] [[gid_long]] [[ulong5]]
+// CHECK-64: [[gid_times_8:%[^ ]+]] = OpShiftRightLogical [[ulong]] [[shl_5_long]] [[ulong2]]
 // CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[gid_times_8]]
-// CHECK-64: [[id:%[^ ]+]] = OpBitwiseOr [[ulong]] [[gid_times_8]] [[ulong4]]
+// CHECK-64: [[id:%[^ ]+]] = OpIAdd [[ulong]] [[gid_times_8]] [[ulong1]]
+// CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
+// CHECK-64: [[id:%[^ ]+]] = OpIAdd [[ulong]] [[gid_times_8]] [[ulong2]]
+// CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
+// CHECK-64: [[id:%[^ ]+]] = OpIAdd [[ulong]] [[gid_times_8]] [[ulong4]]
 // CHECK-64: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
 
 // CHECK-32: [[_0:%[^ ]+]] = OpAccessChain [[uintv3workgroup]] [[s1]] [[gid]] [[uint0]]
 // CHECK-32: [[_1:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s1]] [[gid]] [[uint1]]
-// CHECK-32: [[gid_times_8:%[^ ]+]] = OpShiftLeftLogical [[uint]] [[gid]] [[uint3]]
-// CHECK-32: [[id:%[^ ]+]] = OpBitwiseOr [[uint]] [[gid_times_8]] [[uint1]]
-// CHECK-32: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
-// CHECK-32: [[id:%[^ ]+]] = OpBitwiseOr [[uint]] [[gid_times_8]] [[uint2]]
+// CHECK-32: [[shl_5:%[^ ]+]] = OpShiftLeftLogical [[uint]] [[gid]] [[uint5]]
+// CHECK-32: [[gid_times_8:%[^ ]+]] = OpShiftRightLogical [[uint]] [[shl_5]] [[uint2]]
+// CHECK-32: [[_2:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[gid_times_8]]
+// CHECK-32: [[id:%[^ ]+]] = OpIAdd [[uint]] [[gid_times_8]] [[uint1]]
 // CHECK-32: [[_3:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
-// CHECK-32: [[_4:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[gid_times_8]]
-// CHECK-32: [[id:%[^ ]+]] = OpBitwiseOr [[uint]] [[gid_times_8]] [[uint4]]
+// CHECK-32: [[id:%[^ ]+]] = OpIAdd [[uint]] [[gid_times_8]] [[uint2]]
+// CHECK-32: [[_4:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]
+// CHECK-32: [[id:%[^ ]+]] = OpIAdd [[uint]] [[gid_times_8]] [[uint4]]
 // CHECK-32: [[_5:%[^ ]+]] = OpAccessChain [[uintworkgroup]] [[s2]] [[id]]


### PR DESCRIPTION
Refs #1524

* Split the default case in runOnGEPFromGEP to handle struct based geps differently

This fixes the work item builtin CTS failures.