### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "fd9a1dcc01766c71932898e9643ce28bf2801bad",
+      "commit" : "891f002026df122b36813b9e1819769c94327503",
       "patches" : [
           {"patch": "patches/0002-fix-clang_cmake_builddir.patch"}
       ]

--- a/lib/LowerAddrSpaceCastPass.cpp
+++ b/lib/LowerAddrSpaceCastPass.cpp
@@ -171,7 +171,8 @@ llvm::Value *clspv::LowerAddrSpaceCastPass::visitAddrSpaceCastInst(
   // Returns a pointer that points to a region in the address space if
   // "to_addrspace" can cast ptr to the address space. Otherwise it returns
   // NULL.
-  if (ptr->getType() != I.getSrcTy() && ptr->getType() != I.getDestTy()) {
+  if (isa<ConstantPointerNull>(ptr) ||
+      (ptr->getType() != I.getSrcTy() && ptr->getType() != I.getDestTy())) {
     ptr = ConstantPointerNull::get(cast<PointerType>(I.getType()));
   }
   if (ptr->getType() == I.getDestTy()) {

--- a/test/LogicalPtrToInt/compare_local_ptr.cl
+++ b/test/LogicalPtrToInt/compare_local_ptr.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %s -o %t.spv
+// RUN: clspv %s -o %t.spv --cl-std=CL3.0 --inline-entry-points -enable-feature-macros=__opencl_c_generic_address_space
 // RUN: spirv-val %t.spv --target-env spv1.0
 // RUN: spirv-dis %t.spv -o %t.spvasm
 


### PR DESCRIPTION
LogicalPtrToInt/compare_local_ptr.cl needs LowerAddrSpaceCastPass to run to handle the addrspacecast now generated by llvm.

LowerAddrSpaceCastPass also needs to handle cast of NULL better.