### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "f5dab90875c4435890a19410fcb4bcd8a96357b2"
+      "commit" : "53f84636eb86e6c64c1ec405f70b3dd2b27f4ddc"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -1105,7 +1105,7 @@ bool LinkBuiltinLibrary(llvm::Module *module) {
     L.linkInModule(std::move(add_library), 0);
   }
 
-  L.linkInModule(std::move(library), 0);
+  L.linkInModule(std::move(library), Linker::LinkOnlyNeeded);
 
   return true;
 }

--- a/test/BuiltinsWithGenericPointer/fract_print.cl
+++ b/test/BuiltinsWithGenericPointer/fract_print.cl
@@ -5,9 +5,9 @@
 // CHECK: declare spir_func float @_Z5fractfPU3AS4f(float, ptr addrspace(4))
 
 // CHECK: @clspv.builtins.used = appending global [3 x ptr] [ptr @_Z5fractfPf, ptr @_Z5fractfPU3AS1f, ptr @_Z5fractfPU3AS3f], section "llvm.metadata"
-// CHECK-DAG: define linkonce_odr dso_local spir_func float @_Z5fractfPf(
-// CHECK-DAG: define linkonce_odr dso_local spir_func float @_Z5fractfPU3AS3f(
-// CHECK-DAG: define linkonce_odr dso_local spir_func float @_Z5fractfPU3AS1f(
+// CHECK-DAG: define dso_local spir_func float @_Z5fractfPf(
+// CHECK-DAG: define dso_local spir_func float @_Z5fractfPU3AS3f(
+// CHECK-DAG: define dso_local spir_func float @_Z5fractfPU3AS1f(
 
 __kernel void foo(__global float *out1, __global float *out2, __global float *in) {
     size_t i = get_global_id(0);


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/f07988ff3ec8b8b838f5c6ce9e1ec519e16432a9 which removed a tool that used to set the linkage to linkonce_odr on the clc builtins. Thus we now need to make sure to link only what we needed to avoid bring the whole libclc (leading to a huge increase in build time, and various other bugs).