### PR TITLE
Add support for negative offset in getelementptr

### DIFF
--- a/lib/BitcastUtils.h
+++ b/lib/BitcastUtils.h
@@ -71,18 +71,18 @@ bool FindAliasingContainedType(Type *ContainingTy, Type *TargetTy, int &Steps,
                                bool StrictStruct = false);
 
 void ExtractOffsetFromGEP(const DataLayout &DataLayout, IRBuilder<> &Builder,
-                          GetElementPtrInst *GEP, uint64_t &CstVal,
+                          GetElementPtrInst *GEP, int64_t &CstVal,
                           Value *&DynVal, size_t &SmallerBitWidths);
 
-uint64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
-                               IRBuilder<> &Builder, Type *Ty, Type *TargetTy,
-                               uint64_t Offset, SmallVector<Value *, 2> *Idxs);
+int64_t GoThroughTypeAtOffset(const DataLayout &DataLayout,
+                              IRBuilder<> &Builder, Type *Ty, Type *TargetTy,
+                              int64_t Offset, SmallVector<Value *, 2> *Idxs);
 
 bool IsClspvResourceOrLocal(Value *val);
 
 SmallVector<Value *, 2>
 GetIdxsForTyFromOffset(const DataLayout &DataLayout, IRBuilder<> &Builder,
-                       Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
+                       Type *SrcTy, Type *DstTy, int64_t CstVal, Value *DynVal,
                        size_t SmallerBitWidths, Value *Src);
 
 bool IsGVConstantGEP(GetElementPtrInst *GEP);

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -161,7 +161,7 @@ clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
     auto *PtrOp = Instr->getOperand(0);
     Value *MemBase = nullptr;
-    uint64_t CstOffset = 0;
+    int64_t CstOffset = 0;
     Value *DynOffset = nullptr;
 
     if (processValue(M.getDataLayout(), PtrOp, CstOffset, DynOffset, MemBase)) {
@@ -184,14 +184,14 @@ clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
 bool clspv::LogicalPointerToIntPass::processValue(const DataLayout &DL,
                                                   Value *Val,
-                                                  uint64_t &CstOffset,
+                                                  int64_t &CstOffset,
                                                   llvm::Value *&DynOffset,
                                                   Value *&MemBase) {
   if (auto *GEP = dyn_cast<GetElementPtrInst>(Val)) {
     // Convert GEP indices to byte offset
     IRBuilder<> B(GEP);
     size_t SmallerBitWidths;
-    uint64_t CstVal = 0;
+    int64_t CstVal = 0;
     Value *DynVal = nullptr;
     BitcastUtils::ExtractOffsetFromGEP(DL, B, GEP, CstVal, DynVal,
                                        SmallerBitWidths);

--- a/lib/LogicalPointerToIntPass.h
+++ b/lib/LogicalPointerToIntPass.h
@@ -27,7 +27,7 @@ struct LogicalPointerToIntPass : llvm::PassInfoMixin<LogicalPointerToIntPass> {
 private:
   bool isMemBase(llvm::Value *Val);
   bool processValue(const llvm::DataLayout &DL, llvm::Value *Value,
-                    uint64_t &CstOffset, llvm::Value *&DynOffset,
+                    int64_t &CstOffset, llvm::Value *&DynOffset,
                     llvm::Value *&MemBase);
   uint64_t getMemBaseAddr(llvm::Value *MemBase);
   bool InlineFunctions(llvm::Module &M);

--- a/lib/LowerPrivatePointerPHIPass.cpp
+++ b/lib/LowerPrivatePointerPHIPass.cpp
@@ -46,7 +46,7 @@ void partitionInstructions(ArrayRef<WeakTrackingVH> Instructions,
 }
 
 void replacePHIIncomingValue(PHINode *phi, PHINode *new_phi, Instruction *Src,
-                             uint64_t CstVal, Value *DynVal) {
+                             int64_t CstVal, Value *DynVal) {
   IRBuilder<> B(Src);
   if (DynVal == nullptr) {
     DynVal = ConstantInt::get(new_phi->getType(), CstVal);
@@ -66,7 +66,7 @@ void replacePHIIncomingValue(PHINode *phi, PHINode *new_phi, Instruction *Src,
 }
 
 Value *makeNewGEP(const DataLayout &DL, IRBuilder<> &B, Instruction *Src,
-                  Type *SrcTy, Type *DstTy, uint64_t CstVal, Value *DynVal,
+                  Type *SrcTy, Type *DstTy, int64_t CstVal, Value *DynVal,
                   size_t SmallerBitWidths) {
   if (isa<AllocaInst>(Src) && !SrcTy->isArrayTy()) {
     return Src;
@@ -150,7 +150,7 @@ void clspv::LowerPrivatePointerPHIPass::runOnFunction(Function &F) {
       alloca = new_alloca;
     }
 
-    SmallVector<std::tuple<Value *, Instruction *, uint64_t, Value *>> nodes;
+    SmallVector<std::tuple<Value *, Instruction *, int64_t, Value *>> nodes;
     for (auto use : alloca->users()) {
       nodes.push_back(std::make_tuple(use, alloca, 0, nullptr));
     }
@@ -160,7 +160,7 @@ void clspv::LowerPrivatePointerPHIPass::runOnFunction(Function &F) {
     while (!nodes.empty()) {
       Value *node;
       Instruction *Src;
-      uint64_t CstVal;
+      int64_t CstVal;
       Value *DynVal;
       std::tie(node, Src, CstVal, DynVal) = nodes.pop_back_val();
       if (seen.count(node) != 0) {
@@ -173,7 +173,7 @@ void clspv::LowerPrivatePointerPHIPass::runOnFunction(Function &F) {
       }
       if (auto gep = dyn_cast<GetElementPtrInst>(node)) {
         IRBuilder<> B(gep);
-        uint64_t gep_CstVal;
+        int64_t gep_CstVal;
         Value *gep_DynVal;
         size_t gep_SmallerBitWidths;
         BitcastUtils::ExtractOffsetFromGEP(DL, B, gep, gep_CstVal, gep_DynVal,

--- a/lib/ReplacePointerBitcastPass.cpp
+++ b/lib/ReplacePointerBitcastPass.cpp
@@ -484,7 +484,7 @@ bool DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
   bool changed = false;
   while (auto gep = dyn_cast<GetElementPtrInst>(Src)) {
     IRBuilder<> B(gep);
-    uint64_t CstVal;
+    int64_t CstVal;
     Value *DynVal;
     size_t SmallerBitWidths;
     ExtractOffsetFromGEP(DL, B, gep, CstVal, DynVal, SmallerBitWidths);
@@ -561,7 +561,7 @@ bool DowngradeSourceToTy(const DataLayout &DL, Value *Src, Type *Ty) {
           UserWorkList.push_back(U);
         }
         IRBuilder<> B(gep);
-        uint64_t CstVal;
+        int64_t CstVal;
         Value *DynVal;
         size_t SmallerBitWidths;
         Type *RetTy = Ty;
@@ -728,7 +728,7 @@ clspv::ReplacePointerBitcastPass::run(Module &M, ModuleAnalysisManager &) {
     if (auto GEP = dyn_cast<GetElementPtrInst>(Inst)) {
       IRBuilder<> Builder(GEP);
 
-      uint64_t CstVal;
+      int64_t CstVal;
       Value *DynVal;
       size_t SmallerBitWidths;
       ExtractOffsetFromGEP(DL, Builder, GEP, CstVal, DynVal, SmallerBitWidths);

--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -334,7 +334,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnGEPFromGEP(Module &M) const {
               Builder.CreateAdd(GEPIdxOp, *(OtherGEP->op_end() - 1)));
         }
       } else {
-        uint64_t cstVal;
+        int64_t cstVal;
         Value *dynVal;
         size_t smallerBitWidths;
         ExtractOffsetFromGEP(M.getDataLayout(), Builder, OtherGEP, cstVal,
@@ -540,7 +540,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
         dyn_cast<GetElementPtrInst>(LoadInst->getPointerOperand());
     auto Ptr = initial_gep->getPointerOperand();
 
-    uint64_t cstVal;
+    int64_t cstVal;
     Value *dynVal;
     size_t smallerBitWidths;
     ExtractOffsetFromGEP(M.getDataLayout(), Builder, initial_gep, cstVal,
@@ -577,7 +577,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
     auto ptr = gep->getPointerOperand();
     auto ty = InferType(ptr, M.getContext(), &type_cache);
     IRBuilder<> Builder{gep};
-    uint64_t cstVal;
+    int64_t cstVal;
     Value *dynVal;
     size_t smallerBitWidths;
     ExtractOffsetFromGEP(DL, Builder, gep, cstVal, dynVal, smallerBitWidths);
@@ -597,7 +597,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitGEP(Module &M) const {
     auto ptr = gep->getPointerOperand();
     auto ty = InferType(ptr, M.getContext(), &type_cache);
     IRBuilder<> Builder{gep};
-    uint64_t cstVal;
+    int64_t cstVal;
     Value *dynVal;
     size_t smallerBitWidths;
     ExtractOffsetFromGEP(DL, Builder, gep, cstVal, dynVal, smallerBitWidths);
@@ -668,7 +668,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitCasts(Module &M) const {
     } else {
       src_ty = src_gep->getResultElementType();
       src = src_gep;
-      uint64_t CstVal;
+      int64_t CstVal;
       Value *DynVal;
       size_t SmallerBitWidths;
       ExtractOffsetFromGEP(DL, Builder, inst_gep, CstVal, DynVal,
@@ -679,7 +679,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnImplicitCasts(Module &M) const {
                                 CstVal * SmallerBitWidths, nullptr) != 0) {
         src = src_gep->getPointerOperand();
         src_ty = inst_gep->getSourceElementType();
-        uint64_t srcCstVal;
+        int64_t srcCstVal;
         Value *srcDynVal;
         size_t srcSmallerBitWidths;
         ExtractOffsetFromGEP(DL, Builder, src_gep, srcCstVal, srcDynVal,
@@ -728,14 +728,14 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
 
   struct UpgradeInfo {
     Instruction *inst;
-    uint64_t cst;
+    int64_t cst;
     Value *val;
     size_t smallerBitWidth;
     Type *dest_ty;
     GetElementPtrInst *gep;
   };
   auto gepIndicesCanBeUpgradedTo = [&DL, &M](Type *ty, GetElementPtrInst *gep,
-                                             uint64_t &cstVal, Value *&dynVal,
+                                             int64_t &cstVal, Value *&dynVal,
                                              size_t &smallerBitWidths) {
     if (gep->hasAllConstantIndices()) {
       // should not be used as all indices are constant
@@ -826,7 +826,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
           if (IsGVConstantGEP(gep))
             continue;
 
-          uint64_t cstVal;
+          int64_t cstVal;
           Value *dynVal;
           size_t smallerBitWidths;
 
@@ -904,7 +904,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
                 continue;
               }
               auto gep = dyn_cast<GetElementPtrInst>(value);
-              uint64_t cstVal;
+              int64_t cstVal;
               Value *dynVal;
               size_t smallerBitWidths;
               if (gep == nullptr ||
@@ -929,7 +929,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
 
   for (auto GEPInfo : GEPsDefiningPHIsWorklist) {
     auto gep = dyn_cast<GetElementPtrInst>(GEPInfo.inst);
-    uint64_t cst = GEPInfo.cst;
+    int64_t cst = GEPInfo.cst;
     Value *val = GEPInfo.val;
     size_t smallerBitWidths = GEPInfo.smallerBitWidth;
     Type *dest_ty = GEPInfo.dest_ty;
@@ -958,7 +958,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
   DenseSet<Instruction *> ToBeRemoved;
   for (auto GEPInfo : Worklist) {
     Instruction *I = GEPInfo.inst;
-    uint64_t cst = GEPInfo.cst;
+    int64_t cst = GEPInfo.cst;
     Value *val = GEPInfo.val;
     size_t smallerBitWidths = GEPInfo.smallerBitWidth;
     Type *dest_ty = GEPInfo.dest_ty;
@@ -1125,7 +1125,7 @@ bool clspv::SimplifyPointerBitcastPass::runOnPHIFromGEP(Module &M) const {
     Type *Ty = pair.second;
 
     IRBuilder<> Builder{gep};
-    uint64_t CstVal;
+    int64_t CstVal;
     Value *DynVal;
     size_t SmallerBitWidths;
     ExtractOffsetFromGEP(DL, Builder, gep, CstVal, DynVal, SmallerBitWidths);

--- a/test/PointerCasts/negative_gep.ll
+++ b/test/PointerCasts/negative_gep.ll
@@ -1,0 +1,16 @@
+; RUN: clspv-opt %s -o %t --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: [[gep:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %a, i32 -1
+; CHECK: store i32 {{.*}}, ptr addrspace(1) [[gep]], align 32
+
+define spir_kernel void @foo(ptr addrspace(1) %a, i32 %i) {
+entry:
+  %0 = load i32, ptr addrspace(1) %a, align 32
+  %1 = getelementptr i8, ptr addrspace(1) %a, i32 -4
+  store i32 %0, ptr addrspace(1) %1, align 32
+  ret void
+}


### PR DESCRIPTION
Negative offset in a constant form were not handle by the helper functions reworking pointer accesses with getelementptr.

It is valid for getelementptr to have negative argument, thus we need to support it.