### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "bb092120f1f031824def23311d8ceb0f39941f3b"
+      "commit" : "7189c4bb83d90c383741a9480fceca9c7bf74b27"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -754,6 +754,22 @@ Value *clspv::LongVectorLoweringPass::visitConstant(Constant &Cst) {
     return ConstantArray::get(cast<ArrayType>(EquivalentTy), Scalars);
   }
 
+  if (auto *CFP = dyn_cast<ConstantFP>(&Cst)) {
+    assert(isa<ArrayType>(EquivalentTy));
+    // This occurs for splats of float constants. They have vector type.
+    auto *vecTy = cast<VectorType>(Cst.getType());
+    auto num_elems = vecTy->getElementCount().getFixedValue();
+    Type *scalarTy = vecTy->getElementType();
+    const auto floatVal = CFP->getValueAPF();
+
+    SmallVector<Constant *, 16> Scalars;
+    for (decltype(num_elems) i = 0; i < num_elems; ++i) {
+      Scalars.push_back(ConstantFP::get(scalarTy, floatVal));
+    }
+
+    return ConstantArray::get(cast<ArrayType>(EquivalentTy), Scalars);
+  }
+
   // TODO(#874): this pass needs updated to handle constantexpr more robustly.
   if (auto *CE = dyn_cast<ConstantExpr>(&Cst)) {
     switch (CE->getOpcode()) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -2471,21 +2471,34 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVConstant(Constant *C, Type *TyHint) {
   } else if (const ConstantFP *CFP = dyn_cast<ConstantFP>(Cst)) {
     uint64_t FPVal = CFP->getValueAPF().bitcastToAPInt().getZExtValue();
     Type *CFPTy = CFP->getType();
-    if (CFPTy->isFloatTy()) {
-      LiteralNum.push_back(FPVal & 0xFFFFFFFF);
-    } else if (CFPTy->isDoubleTy()) {
-      LiteralNum.push_back(FPVal & 0xFFFFFFFF);
-      LiteralNum.push_back(FPVal >> 32);
-    } else if (CFPTy->isHalfTy()) {
-      LiteralNum.push_back(FPVal & 0xFFFF);
+
+    if (auto *vecTy = dyn_cast<llvm::VectorType>(CFPTy)) {
+      // A splat over floats is represented as a ConstantFP.
+      Opcode = spv::OpConstantComposite;
+
+      Constant *scalar =
+          ConstantFP::get(vecTy->getElementType(), CFP->getValueAPF());
+      SPIRVID spirv_scalar = getSPIRVConstant(scalar);
+      auto num_elem = vecTy->getElementCount().getFixedValue();
+      while (num_elem-- > 0) {
+        Ops << spirv_scalar;
+      }
     } else {
-      CFPTy->print(errs());
-      llvm_unreachable("Implement this ConstantFP Type");
+      if (CFPTy->isFloatTy()) {
+        LiteralNum.push_back(FPVal & 0xFFFFFFFF);
+      } else if (CFPTy->isDoubleTy()) {
+        LiteralNum.push_back(FPVal & 0xFFFFFFFF);
+        LiteralNum.push_back(FPVal >> 32);
+      } else if (CFPTy->isHalfTy()) {
+        LiteralNum.push_back(FPVal & 0xFFFF);
+      } else {
+        CFPTy->print(errs());
+        llvm_unreachable("Implement this ConstantFP Type");
+      }
+
+      Opcode = spv::OpConstant;
+      Ops << LiteralNum;
     }
-
-    Opcode = spv::OpConstant;
-
-    Ops << LiteralNum;
   } else if (isa<ConstantDataSequential>(Cst) &&
              cast<ConstantDataSequential>(Cst)->isString()) {
 

--- a/lib/ThreeElementVectorLoweringPass.cpp
+++ b/lib/ThreeElementVectorLoweringPass.cpp
@@ -405,6 +405,11 @@ Value *clspv::ThreeElementVectorLoweringPass::visitConstant(Constant &Cst) {
     return ConstantVector::get(Elements);
   }
 
+  if (auto *CFP = dyn_cast<ConstantFP>(&Cst)) {
+    // Return a splat of the original value, but widened as needed.
+    return ConstantFP::get(EquivalentTy, CFP->getValueAPF());
+  }
+
   if (auto *Array = dyn_cast<ConstantArray>(&Cst)) {
     SmallVector<Constant *, 16> Elements;
     for (unsigned i = 0; i < Array->getNumOperands(); ++i) {


### PR DESCRIPTION
- SPIRVProducer: support ConstantFP that is a splat of a scalar float
- Handle splat fp constant vector in three-element-vector lowering
- Handle splat fp constant vector in long vector lowering