### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "7189c4bb83d90c383741a9480fceca9c7bf74b27"
+      "commit" : "665984f5b3271b54d4e97797fa7f8ad598b2106a"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -123,7 +123,7 @@ Function *getIntrinsicScalarVersion(Function &Intrinsic) {
   case Intrinsic::ssub_sat:
   case Intrinsic::usub_sat: {
     SmallVector<Type *, 16> ParamTys;
-    bool Success = Intrinsic::getIntrinsicSignature(&Intrinsic, ParamTys);
+    bool Success = Intrinsic::isSignatureValid(&Intrinsic, ParamTys);
     assert(Success);
     (void)Success;
 


### PR DESCRIPTION
- Adapt to rename of llvm::Intrinsic::getIntrinsicSignature to isSignatureValid.