### PR TITLE
ReplaceLLVMIntrinsics: Support non-zero and dynamic llvm.memset

### DIFF
--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -392,96 +392,222 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceFshl(Function &F) {
   });
 }
 
+static Value *buildPattern(Type *Ty, Value *Pattern, IRBuilder<> &Builder) {
+  if (Pattern->getType() != Builder.getInt8Ty()) {
+    Pattern = Builder.CreateIntCast(Pattern, Builder.getInt8Ty(), false);
+  }
+  auto build = [&](Type *T, Value *P, auto &self) {
+    if (T->isIntegerTy()) {
+      unsigned bitwidth = T->getIntegerBitWidth();
+      if (bitwidth == 8)
+        return P;
+
+      Value *V = Builder.CreateZExt(P, T);
+      Value *Res = V;
+      for (unsigned i = 1; i < bitwidth / 8; ++i) {
+        Res = Builder.CreateOr(Res, Builder.CreateShl(V, i * 8));
+      }
+      return Res;
+    } else if (T->isFloatingPointTy()) {
+      unsigned bitwidth = T->getPrimitiveSizeInBits();
+      Type *IntTy = Type::getIntNTy(T->getContext(), bitwidth);
+      return Builder.CreateBitCast(self(IntTy, P, self), T);
+    } else if (auto *VecTy = dyn_cast<FixedVectorType>(T)) {
+      Value *Scalar = self(VecTy->getElementType(), P, self);
+      Value *Vec = UndefValue::get(VecTy);
+      for (unsigned i = 0; i < VecTy->getNumElements(); ++i) {
+        Vec = Builder.CreateInsertElement(Vec, Scalar, i);
+      }
+      return Vec;
+    } else if (auto *ArrTy = dyn_cast<ArrayType>(T)) {
+      Value *Elem = self(ArrTy->getElementType(), P, self);
+      Value *Arr = UndefValue::get(ArrTy);
+      for (unsigned i = 0; i < ArrTy->getNumElements(); ++i) {
+        Arr = Builder.CreateInsertValue(Arr, Elem, {i});
+      }
+      return Arr;
+    } else if (auto *StructTy = dyn_cast<StructType>(T)) {
+      Value *Str = UndefValue::get(StructTy);
+      for (unsigned i = 0; i < StructTy->getNumElements(); ++i) {
+        Value *Elem = self(StructTy->getElementType(i), P, self);
+        Str = Builder.CreateInsertValue(Str, Elem, {i});
+      }
+      return Str;
+    }
+    llvm_unreachable("Unsupported type for memset pattern");
+  };
+  return build(Ty, Pattern, build);
+}
+
+static Type *unpackTy(uint64_t Size, Type *Ty, unsigned &NumUnpackings,
+                      const DataLayout &Layout) {
+  auto ElemSize = Layout.getTypeSizeInBits(Ty) / 8;
+  while (Size < ElemSize) {
+    auto EleTy = BitcastUtils::GetEleType(Ty);
+    assert(EleTy != Ty);
+    Ty = EleTy;
+    NumUnpackings++;
+    ElemSize = Layout.getTypeSizeInBits(Ty) / 8;
+  }
+  return Ty;
+}
+
+static void replaceMemsetStatic(CallInst *CI, Module &M,
+                                const DataLayout &Layout,
+                                DenseMap<Value *, Type *> &type_cache) {
+  auto ConstantNumBytes = cast<ConstantInt>(CI->getArgOperand(2));
+  auto Initializer = CI->getArgOperand(1);
+  auto NewArg = CI->getArgOperand(0);
+  auto Bitcast = dyn_cast<BitCastInst>(NewArg);
+  if (Bitcast != nullptr) {
+    NewArg = Bitcast->getOperand(0);
+  }
+
+  auto I32Ty = Type::getInt32Ty(M.getContext());
+  auto NumBytes = ConstantNumBytes->getZExtValue();
+  auto PointeeTy = clspv::InferType(NewArg, M.getContext(), &type_cache);
+  if (PointeeTy == nullptr) {
+    PointeeTy = UpdateTy(M.getContext(), NumBytes);
+    NewArg = GetElementPtrInst::Create(
+        PointeeTy, NewArg, {ConstantInt::get(I32Ty, 0)}, "", CI->getIterator());
+  }
+
+  Type *NewArgTy = PointeeTy;
+  unsigned Unpacking = 0;
+  PointeeTy = unpackTy(NumBytes, PointeeTy, Unpacking, Layout);
+
+  IRBuilder<> Builder(CI);
+
+  // Construct the broadcasted payload dynamically based on the final packed
+  // type
+  Value *PatternValue = buildPattern(PointeeTy, Initializer, Builder);
+
+  auto Zero = ConstantInt::get(I32Ty, 0);
+  SmallVector<Value *, 3> Indices;
+  for (unsigned i = 0; i < Unpacking; i++) {
+    Indices.push_back(Zero);
+  }
+  Indices.push_back(Zero);
+
+  const auto num_stores = NumBytes / Layout.getTypeAllocSize(PointeeTy);
+  bool IsVolatile = cast<ConstantInt>(CI->getArgOperand(3))->isOneValue();
+
+  for (uint32_t i = 0; i < num_stores; i++) {
+    Indices.back() = ConstantInt::get(I32Ty, i);
+    auto Ptr = GetElementPtrInst::Create(NewArgTy, NewArg, Indices, "",
+                                         CI->getIterator());
+    auto *St = new StoreInst(PatternValue, Ptr, CI->getIterator());
+    St->setVolatile(IsVolatile);
+  }
+
+  CI->eraseFromParent();
+  if (Bitcast != nullptr) {
+    Bitcast->eraseFromParent();
+  }
+}
+
+static void replaceMemsetDynamic(CallInst *CI, Module &M, Value *Dst,
+                                 Value *Val, Value *Len, bool IsVolatile) {
+  IRBuilder<> Builder(CI);
+  auto *I8Ty = Builder.getInt8Ty();
+  Type *SizeTy = Len->getType();
+
+  // Build Pattern Payload (Broadcast Val to PointeeTy)
+  Value *ValCast = Builder.CreateIntCast(Val, I8Ty, false);
+
+  // Bulk Loop
+  BasicBlock *PreheaderBB = CI->getParent();
+  Function *Func = PreheaderBB->getParent();
+  BasicBlock *PostBB = PreheaderBB->splitBasicBlock(CI, "");
+  BasicBlock *HeaderBB = BasicBlock::Create(M.getContext(), "", Func);
+  BasicBlock *LoopBB = BasicBlock::Create(M.getContext(), "", Func);
+
+  PreheaderBB->getTerminator()->eraseFromParent();
+  Builder.SetInsertPoint(PreheaderBB);
+  Builder.CreateBr(HeaderBB);
+
+  Builder.SetInsertPoint(HeaderBB);
+  PHINode *Idx = Builder.CreatePHI(SizeTy, 2);
+  Idx->addIncoming(ConstantInt::get(SizeTy, 0), PreheaderBB);
+  Builder.CreateCondBr(Builder.CreateICmpULT(Idx, Len), LoopBB, PostBB);
+
+  Builder.SetInsertPoint(LoopBB);
+  Value *GEP = Builder.CreateGEP(I8Ty, Dst, Idx);
+  Builder.CreateStore(ValCast, GEP)->setVolatile(IsVolatile);
+  Value *NextIdx = Builder.CreateAdd(Idx, ConstantInt::get(SizeTy, 1));
+  Idx->addIncoming(NextIdx, LoopBB);
+  Builder.CreateBr(HeaderBB);
+
+  Builder.SetInsertPoint(PostBB);
+  CI->eraseFromParent();
+}
+
 bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {
   bool Changed = false;
   auto Layout = M.getDataLayout();
-
   DenseMap<Value *, Type *> type_cache;
-
-  auto unpack = [&Layout](CallInst &CI, uint64_t Size, Type **Ty,
-                          unsigned *NumUnpackings) {
-    auto ElemSize = Layout.getTypeSizeInBits(*Ty) / 8;
-    while (Size < ElemSize) {
-      auto EleTy = BitcastUtils::GetEleType(*Ty);
-      assert(EleTy != *Ty);
-      *Ty = EleTy;
-      (*NumUnpackings)++;
-      ElemSize = Layout.getTypeSizeInBits(*Ty) / 8;
-    }
-  };
 
   for (auto &F : M) {
     if (F.getName().contains("llvm.memset")) {
-      SmallVector<CallInst *, 8> CallsToReplace;
-
+      SmallVector<CallInst *, 8> StaticToReplace;
+      struct dynamicMemsetInfo {
+        CallInst *CI;
+        Value *Dst;
+        Value *Val;
+        Value *Len;
+        bool IsVolatile;
+      };
+      SmallVector<dynamicMemsetInfo, 8> DynamicToReplace;
       for (auto U : F.users()) {
-        if (auto CI = dyn_cast<CallInst>(U)) {
-          auto Initializer = dyn_cast<ConstantInt>(CI->getArgOperand(1));
+        auto *CI = cast<CallInst>(U);
+        auto ConstantNumBytes = dyn_cast<ConstantInt>(CI->getArgOperand(2));
+        auto Dst = CI->getArgOperand(0);
+        auto Val = CI->getArgOperand(1);
+        bool IsVolatile =
+            cast<ConstantInt>(CI->getArgOperand(3))->getZExtValue();
 
-          // We only handle cases where the initializer is a constant int that
-          // is 0.
-          if (!Initializer || (0 != Initializer->getZExtValue())) {
-            Initializer->print(errs());
-            llvm_unreachable("Unhandled llvm.memset.* instruction that had a "
-                             "non-0 initializer!");
+        Type *PointeeTy = clspv::InferType(Dst, M.getContext(), &type_cache);
+        if (!PointeeTy)
+          PointeeTy =
+              UpdateTy(M.getContext(),
+                       ConstantNumBytes ? ConstantNumBytes->getZExtValue() : 1);
+
+        // Can we safely unroll? (Only if exactly divisible)
+        bool CanUnroll = false;
+        if (ConstantNumBytes) {
+          unsigned int unused;
+          PointeeTy = unpackTy(ConstantNumBytes->getZExtValue(), PointeeTy,
+                               unused, Layout);
+          CanUnroll = ConstantNumBytes->getZExtValue() %
+                          Layout.getTypeAllocSize(PointeeTy) ==
+                      0;
+        }
+
+        if (CanUnroll) {
+          StaticToReplace.push_back(CI);
+        } else {
+          if (!clspv::Option::Int8Support()) {
+            llvm_unreachable(
+                "Dynamic/Unaligned memset requires Int8 capability!");
           }
-
-          CallsToReplace.push_back(CI);
+          DynamicToReplace.push_back({CI, Dst, Val,
+                                      ConstantNumBytes
+                                          ? (Value *)ConstantNumBytes
+                                          : CI->getArgOperand(2),
+                                      IsVolatile});
         }
+        Changed = true;
       }
-
-      for (auto CI : CallsToReplace) {
-        auto NewArg = CI->getArgOperand(0);
-        auto Bitcast = dyn_cast<BitCastInst>(NewArg);
-        if (Bitcast != nullptr) {
-          NewArg = Bitcast->getOperand(0);
-        }
-
-        auto I32Ty = Type::getInt32Ty(M.getContext());
-        auto NumBytes = cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
-        auto PointeeTy = clspv::InferType(NewArg, M.getContext(), &type_cache);
-        if (PointeeTy == nullptr) {
-          PointeeTy = UpdateTy(M.getContext(), NumBytes);
-          NewArg = GetElementPtrInst::Create(PointeeTy, NewArg,
-                                             {ConstantInt::get(I32Ty, 0)}, "",
-                                             CI->getIterator());
-        }
-        Type *NewArgTy = PointeeTy;
-        unsigned Unpacking = 0;
-        unpack(*CI, NumBytes, &PointeeTy, &Unpacking);
-
-        auto NullValue = Constant::getNullValue(PointeeTy);
-        auto Zero = ConstantInt::get(I32Ty, 0);
-
-        SmallVector<Value *, 3> Indices;
-        for (unsigned i = 0; i < Unpacking; i++) {
-          Indices.push_back(Zero);
-        }
-        // Add a placeholder for the final index.
-        Indices.push_back(Zero);
-
-        const auto num_stores = NumBytes / Layout.getTypeAllocSize(PointeeTy);
-        assert((NumBytes == num_stores * Layout.getTypeAllocSize(PointeeTy)) &&
-               "Null memset can't be divided evenly across multiple stores.");
-        assert((num_stores & 0xFFFFFFFF) == num_stores);
-
-        for (uint32_t i = 0; i < num_stores; i++) {
-          Indices.back() = ConstantInt::get(I32Ty, i);
-          auto Ptr = GetElementPtrInst::Create(NewArgTy, NewArg, Indices, "",
-                                               CI->getIterator());
-          new StoreInst(NullValue, Ptr, CI->getIterator());
-        }
-
-        CI->eraseFromParent();
-
-        if (Bitcast != nullptr) {
-          Bitcast->eraseFromParent();
-        }
+      for (auto CI : StaticToReplace) {
+        replaceMemsetStatic(CI, M, Layout, type_cache);
+      }
+      for (auto info : DynamicToReplace) {
+        replaceMemsetDynamic(info.CI, M, info.Dst, info.Val, info.Len,
+                             info.IsVolatile);
       }
       DeadFunctions.push_back(&F);
     }
   }
-
   return Changed;
 }
 

--- a/test/LLVMIntrinsics/issue-1604.ll
+++ b/test/LLVMIntrinsics/issue-1604.ll
@@ -1,0 +1,73 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: spirv-val %t.spv --target-env vulkan1.0
+
+; RUN: clspv-opt %s --passes=replace-llvm-intrinsics -o %t.ll
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: [[cmp:%[^ ]+]] = icmp sgt
+; CHECK-NEXT: br i1 [[cmp]], label %[[preheaderBB:[^ ]+]], label %[[exitBB:[^ ]+]]
+
+; CHECK: [[preheaderBB]]:
+; CHECK-NEXT: [[len:%[^ ]+]] = shl nuw i32
+; CHECK-NEXT: br label %[[headerBB:[^ ]+]]
+
+; CHECK: [[postBB:[^ ]+]]:
+; CHECK-NEXT: br label %[[exitBB]]
+
+; CHECK: [[exitBB]]:
+; CHECK-NEXT: ret void
+
+; CHECK: [[headerBB]]:
+; CHECK-NEXT: [[phi:%[^ ]+]] = phi i32 [ 0, %[[preheaderBB]] ], [ [[next:%[^ ]+]], %[[loopBB:[^ ]+]] ]
+; CHECK-NEXT: [[cmp:%[^ ]+]] = icmp ult i32 [[phi]], [[len]]
+; CHECK-NEXT: br i1 [[cmp]], label %[[loopBB]], label %[[postBB]]
+
+; CHECK: [[loopBB]]:
+; CHECK-NEXT: [[gep:%[^ ]+]] = getelementptr i8, ptr addrspace(1) %0, i32 [[phi]]
+; CHECK-NEXT: store i8 -1, ptr addrspace(1) [[gep]]
+; CHECK-NEXT: [[next]] = add i32 [[phi]], 1
+; CHECK-NEXT: br label %[[headerBB]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan"
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write)
+define dso_local spir_kernel void @foo(ptr addrspace(1) noundef writeonly align 4 captures(none) %0, i32 noundef %1) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+  %3 = icmp sgt i32 %1, 0
+  br i1 %3, label %4, label %6
+
+4:                                                ; preds = %2
+  %5 = shl nuw i32 %1, 2
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) align 4 %0, i8 -1, i32 %5, i1 false), !tbaa !8
+  br label %6
+
+6:                                                ; preds = %4, %2
+  ret void
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p1.i32(ptr addrspace(1) writeonly captures(none), i8, i32, i1 immarg) #2
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" }
+attributes #1 = { alwaysinline mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+
+!llvm.module.flags = !{!0, !1}
+!opencl.ocl.version = !{!2}
+!opencl.spir.version = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, i32 2}
+!3 = !{!"Ubuntu clang version 21.1.2 (2ubuntu6)"}
+!4 = !{i32 1, i32 0}
+!5 = !{!"none", !"none"}
+!6 = !{!"int*", !"int"}
+!7 = !{!"", !""}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"int", !10, i64 0}
+!10 = !{!"omnipotent char", !11, i64 0}
+!11 = !{!"Simple C/C++ TBAA"}
+

--- a/test/LLVMIntrinsics/memset_opaque_non_zero.ll
+++ b/test/LLVMIntrinsics/memset_opaque_non_zero.ll
@@ -1,0 +1,94 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+%struct.TestStruct = type { i32, i64 }
+
+declare void @llvm.memset.p1.i32(ptr addrspace(1), i8, i32, i1)
+
+; ------------------------------------------------------------------------------
+; 1. Integer (T->isIntegerTy())
+; ------------------------------------------------------------------------------
+define dso_local spir_kernel void @test_integer(ptr addrspace(1) %dst) {
+entry:
+  ; Hint to clspv::InferType that %dst is an i32 pointer
+  %0 = getelementptr i32, ptr addrspace(1) %dst, i32 0
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 42, i32 4, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test_integer
+; CHECK: getelementptr i32, ptr addrspace(1) %dst, i32 0
+; CHECK: [[gep_int:%[^ ]+]] = getelementptr i32, ptr addrspace(1) %dst, i32 0
+; CHECK: store i32 707406378, ptr addrspace(1) [[gep_int]]
+
+
+; ------------------------------------------------------------------------------
+; 2. Floating Point (T->isFloatingPointTy())
+; ------------------------------------------------------------------------------
+define dso_local spir_kernel void @test_float(ptr addrspace(1) %dst) {
+entry:
+  ; Hint to clspv::InferType that %dst is a float pointer
+  %0 = getelementptr float, ptr addrspace(1) %dst, i32 0
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 42, i32 4, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test_float
+; CHECK: getelementptr float, ptr addrspace(1) %dst, i32 0
+; CHECK: [[gep_flt:%[^ ]+]] = getelementptr float, ptr addrspace(1) %dst, i32 0
+; CHECK: store float f0x2A2A2A2A, ptr addrspace(1) [[gep_flt]]
+
+
+; ------------------------------------------------------------------------------
+; 3. Fixed Vector (dyn_cast<FixedVectorType>(T))
+; ------------------------------------------------------------------------------
+define dso_local spir_kernel void @test_vector(ptr addrspace(1) %dst) {
+entry:
+  ; Hint to clspv::InferType that %dst is a <4 x i32> pointer
+  %0 = getelementptr <4 x i32>, ptr addrspace(1) %dst, i32 0
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 42, i32 16, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test_vector
+; CHECK: getelementptr <4 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK: [[gep_vec:%[^ ]+]] = getelementptr <4 x i32>, ptr addrspace(1) %dst, i32 0
+; CHECK: store <4 x i32> splat (i32 707406378), ptr addrspace(1) [[gep_vec]]
+
+
+; ------------------------------------------------------------------------------
+; 4. Array (dyn_cast<ArrayType>(T))
+; ------------------------------------------------------------------------------
+define dso_local spir_kernel void @test_array(ptr addrspace(1) %dst) {
+entry:
+  ; Hint to clspv::InferType that %dst is a [2 x i32] pointer
+  %0 = getelementptr [2 x i32], ptr addrspace(1) %dst, i32 0
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 42, i32 8, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test_array
+; CHECK: getelementptr [2 x i32], ptr addrspace(1) %dst, i32 0
+; CHECK: [[gep_arr:%[^ ]+]] = getelementptr [2 x i32], ptr addrspace(1) %dst, i32 0
+; CHECK: store [2 x i32] [i32 707406378, i32 707406378], ptr addrspace(1) [[gep_arr]]
+
+
+; ------------------------------------------------------------------------------
+; 5. Struct (dyn_cast<StructType>(T))
+; ------------------------------------------------------------------------------
+define dso_local spir_kernel void @test_struct(ptr addrspace(1) %dst) {
+entry:
+  ; Hint to clspv::InferType that %dst is a %struct.TestStruct pointer
+  %0 = getelementptr %struct.TestStruct, ptr addrspace(1) %dst, i32 0
+  ; Size is 16 bytes due to standard 64-bit padding between i32 and i64
+  tail call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 42, i32 16, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test_struct
+; CHECK: getelementptr %struct.TestStruct, ptr addrspace(1) %dst, i32 0
+; CHECK: [[gep_str:%[^ ]+]] = getelementptr %struct.TestStruct, ptr addrspace(1) %dst, i32 0
+; CHECK: store %struct.TestStruct { i32 707406378, i64 3038287259199220266 }, ptr addrspace(1) [[gep_str]]


### PR DESCRIPTION
Previously, the ReplaceLLVMIntrinsicsPass only supported `llvm.memset` instructions that had a constant zero initializer and a constant length that perfectly divided into the pointee type. Any deviation resulted in an `llvm_unreachable` compiler crash.

This patch refactors `replaceMemset` to support the full range of memset semantics:
* Non-zero initialization: Added a recursive `buildPattern` utility that correctly broadcasts an `i8` initialization payload across integers, floats, fixed vectors, arrays, and struct fields.
* Dynamic and unaligned lengths: When a memset cannot be statically unrolled (due to variable length or non-divisible size), it now generates a safe byte-by-byte loop (`replaceMemsetDynamic`).
* Architecture-agnostic loops: The dynamic loop's induction variable dynamically matches the integer type of the length operand, preventing `ICmp` type mismatch crashes on 64-bit targets.
* Volatile correctness: Preserves the `isvolatile` flag from the memset intrinsic onto the generated `StoreInst` instructions.

Added `issue-1604.ll` to verify the dynamic loop CFG generation, and `memset_opaque_non_zero.ll` to ensure `buildPattern` correctly lowers non-zero patterns across all supported LLVM IR types.

Fixes #1604