### PR TITLE
Add tests for IR input math intrinsics

### DIFF
--- a/lib/Builtins.cpp
+++ b/lib/Builtins.cpp
@@ -743,17 +743,47 @@ Builtins::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
   if (func_info.getName().find("llvm.floor.") == 0) {
     return glsl::ExtInst::ExtInstFloor;
   }
+  if (func_info.getName().find("llvm.asin.") == 0) {
+    return glsl::ExtInst::ExtInstAsin;
+  }
   if (func_info.getName().find("llvm.sin.") == 0) {
     return glsl::ExtInst::ExtInstSin;
+  }
+  if (func_info.getName().find("llvm.sinh.") == 0) {
+    return glsl::ExtInst::ExtInstSinh;
+  }
+  if (func_info.getName().find("llvm.acos.") == 0) {
+    return glsl::ExtInst::ExtInstAcos;
   }
   if (func_info.getName().find("llvm.cos.") == 0) {
     return glsl::ExtInst::ExtInstCos;
   }
+  if (func_info.getName().find("llvm.cosh.") == 0) {
+    return glsl::ExtInst::ExtInstCosh;
+  }
+  if (func_info.getName().find("llvm.atan.") == 0) {
+    return glsl::ExtInst::ExtInstAtan;
+  }
+  if (func_info.getName().find("llvm.atan2.") == 0) {
+    return glsl::ExtInst::ExtInstAtan2;
+  }
+  if (func_info.getName().find("llvm.tan.") == 0) {
+    return glsl::ExtInst::ExtInstTan;
+  }
+  if (func_info.getName().find("llvm.tanh.") == 0) {
+    return glsl::ExtInst::ExtInstTanh;
+  }
   if (func_info.getName().find("llvm.exp.") == 0) {
     return glsl::ExtInst::ExtInstExp;
   }
+  if (func_info.getName().find("llvm.exp2.") == 0) {
+    return glsl::ExtInst::ExtInstExp2;
+  }
   if (func_info.getName().find("llvm.log.") == 0) {
     return glsl::ExtInst::ExtInstLog;
+  }
+  if (func_info.getName().find("llvm.log2.") == 0) {
+    return glsl::ExtInst::ExtInstLog2;
   }
   if (func_info.getName().find("llvm.pow.") == 0) {
     return glsl::ExtInst::ExtInstPow;
@@ -793,6 +823,9 @@ Builtins::getExtInstEnum(const Builtins::FunctionInfo &func_info) {
   }
   if (func_info.getName().find("llvm.maximumnum.v") == 0) {
     return glsl::ExtInst::ExtInstFMax;
+  }
+  if (func_info.getName().find("llvm.ldexp") == 0) {
+    return glsl::ExtInst::ExtInstLdexp;
   }
 
   return kGlslExtInstBad;

--- a/test/MathBuiltins/acos/float_native_acos.ll
+++ b/test/MathBuiltins/acos/float_native_acos.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @acos(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.acos.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.acos.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Acos

--- a/test/MathBuiltins/asin/float_native_asin.ll
+++ b/test/MathBuiltins/asin/float_native_asin.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @asin_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.asin.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.asin.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Asin

--- a/test/MathBuiltins/atan/float_native_atan.ll
+++ b/test/MathBuiltins/atan/float_native_atan.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @atan_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.atan.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.atan.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Atan

--- a/test/MathBuiltins/atan2/float_native_atan2.ll
+++ b/test/MathBuiltins/atan2/float_native_atan2.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @atan_float(ptr addrspace(1) noalias %out, float %x, float %y) {
+entry:
+  %call = call spir_func float @llvm.atan2.f32(float %x, float %y)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.atan2.f32(float, float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Atan2

--- a/test/MathBuiltins/ceil/float_ceil.ll
+++ b/test/MathBuiltins/ceil/float_ceil.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @ceil_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.ceil.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.ceil.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Ceil

--- a/test/MathBuiltins/cos/float_native_cos.ll
+++ b/test/MathBuiltins/cos/float_native_cos.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @cos_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.cos.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.cos.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Cos

--- a/test/MathBuiltins/cosh/float_native_cosh.ll
+++ b/test/MathBuiltins/cosh/float_native_cosh.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @cosh_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.cosh.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.cosh.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Cosh

--- a/test/MathBuiltins/exp/float_native_exp.ll
+++ b/test/MathBuiltins/exp/float_native_exp.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @exp_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.exp.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.exp.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Exp

--- a/test/MathBuiltins/exp2/float_native_exp2.ll
+++ b/test/MathBuiltins/exp2/float_native_exp2.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @exp2_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.exp2.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.exp2.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Exp2

--- a/test/MathBuiltins/floor/float_floor.ll
+++ b/test/MathBuiltins/floor/float_floor.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @floor_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.floor.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.floor.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Floor

--- a/test/MathBuiltins/fma/float_fma.ll
+++ b/test/MathBuiltins/fma/float_fma.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @fma_float(ptr addrspace(1) noalias %out, float %x, float %y, float %z) {
+entry:
+  %call = call spir_func float @llvm.fma.f32(float %x, float %y, float %z)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.fma.f32(float, float, float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Fma

--- a/test/MathBuiltins/ldexp/float_ldexp.ll
+++ b/test/MathBuiltins/ldexp/float_ldexp.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @ldexp_float(ptr addrspace(1) noalias %out, float %x, i32 %y) {
+entry:
+  %call = call spir_func float @llvm.ldexp.f32.i32(float %x, i32 %y)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.ldexp.f32.i32(float, i32)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Ldexp

--- a/test/MathBuiltins/log/float_native_log.ll
+++ b/test/MathBuiltins/log/float_native_log.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @log_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.log.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.log.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Log

--- a/test/MathBuiltins/log2/float_native_log2.ll
+++ b/test/MathBuiltins/log2/float_native_log2.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @log2_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.log2.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.log2.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Log2

--- a/test/MathBuiltins/pow/float_pow.ll
+++ b/test/MathBuiltins/pow/float_pow.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @pow_float(ptr addrspace(1) noalias %out, float %x, float %y) {
+entry:
+  %call = call spir_func float @llvm.pow.f32(float %x, float %y)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.pow.f32(float, float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Pow

--- a/test/MathBuiltins/rint/float_rint.ll
+++ b/test/MathBuiltins/rint/float_rint.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @rint_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.rint.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.rint.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] RoundEven

--- a/test/MathBuiltins/sin/float_native_sin.ll
+++ b/test/MathBuiltins/sin/float_native_sin.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @sin_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.sin.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.sin.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Sin

--- a/test/MathBuiltins/sinh/float_native_sinh.ll
+++ b/test/MathBuiltins/sinh/float_native_sinh.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @sinh_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.sinh.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.sinh.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Sinh

--- a/test/MathBuiltins/sqrt/float_native_sqrt.ll
+++ b/test/MathBuiltins/sqrt/float_native_sqrt.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @sqrt_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.sqrt.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.sqrt.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Sqrt

--- a/test/MathBuiltins/tan/float_native_tan.ll
+++ b/test/MathBuiltins/tan/float_native_tan.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @tan_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.tan.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.tan.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Tan

--- a/test/MathBuiltins/tanh/float_native_tanh.ll
+++ b/test/MathBuiltins/tanh/float_native_tanh.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @tanh_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.tanh.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.tanh.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Tanh

--- a/test/MathBuiltins/trunc/float_trunc.ll
+++ b/test/MathBuiltins/trunc/float_trunc.ll
@@ -1,0 +1,20 @@
+; RUN: clspv -x=ir %s -o %t.spv
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+; RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define spir_kernel void @trunc_float(ptr addrspace(1) noalias %out, float %x) {
+entry:
+  %call = call spir_func float @llvm.trunc.f32(float %x)
+  store float %call, ptr addrspace(1) %out, align 32
+  ret void
+}
+
+declare spir_func float @llvm.trunc.f32(float)
+
+; CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+; CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+; CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] Trunc


### PR DESCRIPTION
There are currently no IR input tests for stressing LLVM math intrinsics are consumed without an error, and then mapped to GLSL extended instructions in SPIR-V output. These llvm intrinsics

This patch adds those tests as well as includes some missing mappings.

Related to https://github.com/google/clspv/issues/1607