### PR TITLE
Fix crash when casting NULL literal across address spaces

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5537,15 +5537,17 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         // Ops[1] = Source Value ID
         SPIRVOperandVec Ops;
 
-        if (I.getOpcode() == Instruction::IntToPtr) {
-          auto *inferred_ty =
-              clspv::InferType(&I, module->getContext(), &InferredTypeCache);
-          assert(inferred_ty);
-          Ops << getSPIRVPointerType(I.getType(), inferred_ty);
+        Type *Ty;
+        if (I.getOpcode() == Instruction::IntToPtr ||
+            I.getOpcode() == Instruction::AddrSpaceCast) {
+          Ty = clspv::InferType(&I, module->getContext(), &InferredTypeCache);
+          assert(Ty);
+          Ops << getSPIRVPointerType(I.getType(), Ty);
         } else {
-          Ops << I.getType();
+          Ty = I.getType();
+          Ops << Ty;
         }
-        Ops << I.getOperand(0);
+        Ops << getSPIRVValue(I.getOperand(0), Ty);
 
         auto Op = GetSPIRVCastOpcode(I);
         RID = addSPIRVInst(Op, Ops);

--- a/test/issue-1610.cl
+++ b/test/issue-1610.cl
@@ -1,0 +1,17 @@
+// RUN: clspv %s -o %t.spv -cl-std=CL3.0 --enable-feature-macros=__opencl_c_generic_address_space -inline-entry-points
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+// RUN: FileCheck %s < %t.spvasm
+
+// CHECK-DAG: [[uint:%[^ ]+]] = OpTypeInt 32 0
+// CHECK-DAG: [[uint_ptr:%[^ ]+]] = OpTypePointer StorageBuffer [[uint]]
+// CHECK-DAG: [[null_ptr:%[^ ]+]] = OpConstantNull [[uint_ptr]]
+// CHECK-DAG: [[out:%[^ ]+]] = OpVariable {{.*}} StorageBuffer
+// CHECK: [[gep:%[^ ]+]] = OpAccessChain [[uint_ptr]] [[out]]
+// CHECK: [[load:%[^ ]+]] = OpLoad [[uint]] [[null_ptr]]
+// CHECK: OpStore [[gep]] [[load]]
+
+__kernel void mykernel(__global int* out) {
+ __global int* foo = NULL;
+ *out = *foo;
+}


### PR DESCRIPTION
Address an "Unsupported opaque pointer" crash occurring during the SPIRVProducerPass when encountering an `AddrSpaceCast` where the source operand is a literal `NULL`.

Extended `clspv::InferType` logic to cover `Instruction::AddrSpaceCast` alongside `IntToPtr`, ensuring the underlying point-to type is accurately resolved and passed to `getSPIRVValue` to properly generate `OpConstantNull`.

Fixes #1610