### PR TITLE
Add LLVM memmove intrinsic support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ TAGS
 cscope.*
 .DS_Store
 third_party/
+.venv

--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -327,6 +327,10 @@ enum class SpvKhrFma : uint32_t {
 // Returns true if OpFmaKHR is supported for the type size.
 bool SupportsFmaKHR(uint32_t scalarSizeInBits);
 
+// Return maximum compile time known size to llvm memmove intrinsic, such
+// that it can be implemented with an alloca
+uint32_t MemmoveAllocaLimit();
+
 } // namespace Option
 } // namespace clspv
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -468,7 +468,7 @@ static llvm::cl::opt<uint32_t> memmove_alloca_limit(
     "memmove-alloca-limit",
     llvm::cl::desc(
         "Max size of the alloca used to implement memmove intrinsic"),
-    llvm::cl::init(128));
+    llvm::cl::init(16));
 
 } // namespace
 

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -464,6 +464,12 @@ static llvm::cl::list<clspv::Option::SpvKhrFma> spv_khr_fma(
     llvm::cl::values(clEnumValN(clspv::Option::SpvKhrFma::fp64, "64",
                                 "Enable SPV_KHR_fma for fp64")));
 
+static llvm::cl::opt<uint32_t> memmove_alloca_limit(
+    "memmove-alloca-limit",
+    llvm::cl::desc(
+        "Max size of the alloca used to implement memmove intrinsic"),
+    llvm::cl::init(128));
+
 } // namespace
 
 namespace clspv {
@@ -643,6 +649,8 @@ bool SupportsFmaKHR(uint32_t scalarSizeInBits) {
   auto end = spv_khr_fma.end();
   return std::find(begin, end, fma) != end;
 }
+
+uint32_t MemmoveAllocaLimit() { return memmove_alloca_limit; }
 
 } // namespace Option
 } // namespace clspv

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -553,37 +553,109 @@ static bool replaceMemmoveDynamic(Module &M, MemMoveInst *MMI) {
     return false;
   }
 
-  if (clspv::Option::PhysicalStorageBuffers()) {
-    // expandMemMoveAsLoop creates a 'icmp ptr' instruction that is converted
-    // into an int comparison to avoid lowering the icmp to OpPtrDiff which
-    // isn't supported for PhysicalStorageBuffer
-    ICmpInst *ICmpToProcess = nullptr;
-
-    for (auto &I : *BB) {
-      if (auto ICmp = dyn_cast<ICmpInst>(&I)) {
-        if (ICmp->getOperand(0) == MMI->getSource() &&
-            ICmp->getOperand(1) == MMI->getDest()) {
-          ICmpToProcess = ICmp;
-          break;
-        }
+  // expandMemMoveAsLoop creates a 'icmp ptr' instruction that we try to
+  // transform to avoid lowering to OpPtrDiff which isn't supported for
+  // PhysicalStorageBuffer or Function storage classes.
+  ICmpInst *ICmpToProcess = nullptr;
+  for (auto &I : *BB) {
+    if (auto ICmp = dyn_cast<ICmpInst>(&I)) {
+      if (ICmp->getOperand(0) == MMI->getSource() &&
+          ICmp->getOperand(1) == MMI->getDest()) {
+        ICmpToProcess = ICmp;
+        break;
       }
     }
+  }
 
-    if (ICmpToProcess) {
+  bool TransformedICMP = false;
+  if (ICmpToProcess) {
+    // Try to constant fold the icmp if the operands point to the same alloca
+    // in the private address space at compile time known offsets
+    Value *LHS = ICmpToProcess->getOperand(0);
+    Value *RHS = ICmpToProcess->getOperand(1);
+    auto Pred = ICmpToProcess->getPredicate();
+
+    // APInts to accumulate base offsets (relative to the alloca pointer in
+    // bits/bytes)
+    APInt LHSOffset(64, 0);
+    APInt RHSOffset(64, 0);
+
+    // Strip away GEPs/Bitcasts and extract the root pointer base allocation
+    auto DL = M.getDataLayout();
+    Value *LHSBase = LHS->stripAndAccumulateConstantOffsets(
+        DL, LHSOffset, /*AllowNonInbounds=*/true);
+    Value *RHSBase = RHS->stripAndAccumulateConstantOffsets(
+        DL, RHSOffset, /*AllowNonInbounds=*/true);
+
+    // Check if both pointers safely root back to the exact same alloca
+    // instruction
+    if (LHSBase && RHSBase && isa<AllocaInst>(LHSBase) && LHSBase == RHSBase) {
+      bool Result = false;
+
+      // Evaluate the ICmp predicate natively at compile time
+      switch (Pred) {
+      case ICmpInst::ICMP_EQ:
+        Result = (LHSOffset == RHSOffset);
+        break;
+      case ICmpInst::ICMP_NE:
+        Result = (LHSOffset != RHSOffset);
+        break;
+      case ICmpInst::ICMP_SLT:
+        Result = LHSOffset.slt(RHSOffset);
+        break;
+      case ICmpInst::ICMP_SLE:
+        Result = LHSOffset.sle(RHSOffset);
+        break;
+      case ICmpInst::ICMP_SGT:
+        Result = LHSOffset.sgt(RHSOffset);
+        break;
+      case ICmpInst::ICMP_SGE:
+        Result = LHSOffset.sge(RHSOffset);
+        break;
+      case ICmpInst::ICMP_ULT:
+        Result = LHSOffset.ult(RHSOffset);
+        break;
+      case ICmpInst::ICMP_ULE:
+        Result = LHSOffset.ule(RHSOffset);
+        break;
+      case ICmpInst::ICMP_UGT:
+        Result = LHSOffset.ugt(RHSOffset);
+        break;
+      case ICmpInst::ICMP_UGE:
+        Result = LHSOffset.uge(RHSOffset);
+        break;
+      default:
+        llvm_unreachable("Unhandled ICMP predicate in memmove lowering");
+        break;
+      }
+
+      // Replace all dynamic uses of the comparison with our constant factor
+      Value *FoldedConstant =
+          ConstantInt::get(Type::getInt1Ty(M.getContext()), Result);
+      ICmpToProcess->replaceAllUsesWith(FoldedConstant);
+      ICmpToProcess->eraseFromParent();
+      TransformedICMP = true;
+    } else if (clspv::Option::PhysicalStorageBuffers()) {
+      // If we are using physical storage buffers then we can use
+      // OpConvertPtrToU and compare the integer representation
       IntegerType *SizeT = clspv::PointersAre64Bit(M)
                                ? IntegerType::get(M.getContext(), 64)
                                : IntegerType::get(M.getContext(), 32);
       IRBuilder<> B(ICmpToProcess);
-      auto LHS = B.CreatePtrToInt(ICmpToProcess->getOperand(0), SizeT);
-      auto RHS = B.CreatePtrToInt(ICmpToProcess->getOperand(1), SizeT);
-      ICmpToProcess->replaceAllUsesWith(
-          B.CreateICmp(ICmpToProcess->getPredicate(), LHS, RHS));
+      auto LHSToInt = B.CreatePtrToInt(ICmpToProcess->getOperand(0), SizeT);
+      auto RHSToInt = B.CreatePtrToInt(ICmpToProcess->getOperand(1), SizeT);
+      ICmpToProcess->replaceAllUsesWith(B.CreateICmp(Pred, LHSToInt, RHSToInt));
       ICmpToProcess->eraseFromParent();
+      TransformedICMP = true;
     }
-  } else if (clspv::Option::SpvVersion() <
-             clspv::Option::SPIRVVersion::SPIRV_1_4) {
-    llvm_unreachable(
-        "Using OpPtrDiff to implement memmove requires SPIR-V version 1.4 or later");
+  }
+
+  // If we couldn't modify the generated icmp instruction rely on OpPtrDiff in
+  // SPIR-V which is only available after version 1.4
+  if (!TransformedICMP &&
+      (clspv::Option::SpvVersion() < clspv::Option::SPIRVVersion::SPIRV_1_4)) {
+    llvm_unreachable("Using OpPtrDiff to implement memmove requires SPIR-V "
+                     "version 1.4 or later");
   }
 
   MMI->eraseFromParent();

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "llvm/ADT/APFloat.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -21,6 +22,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
 
 #include "BitcastUtils.h"
 #include "clspv/Option.h"
@@ -62,6 +64,7 @@ clspv::ReplaceLLVMIntrinsicsPass::run(Module &M, ModuleAnalysisManager &) {
 
   // Remove lifetime annotations first.  They could be using memset
   // and memcpy calls.
+  replaceMemmove(M);
   replaceMemset(M);
   replaceMemcpy(M);
 
@@ -540,6 +543,70 @@ static void replaceMemsetDynamic(CallInst *CI, Module &M, Value *Dst,
 
   Builder.SetInsertPoint(PostBB);
   CI->eraseFromParent();
+}
+
+static void replaceMemmoveStatic(Module &M, MemMoveInst *MMI) {
+  auto *Length = cast<ConstantInt>(MMI->getLength());
+  auto NumBytes = Length->getZExtValue();
+  auto *AllocaTy =
+      ArrayType::get(IntegerType::getInt8Ty(M.getContext()), NumBytes);
+
+  IRBuilder<> Builder(MMI);
+  Builder.SetInsertPointPastAllocas(MMI->getFunction());
+  auto Alloca = Builder.CreateAlloca(AllocaTy);
+  MaybeAlign SrcAlign = MMI->getSourceAlign();
+  if (SrcAlign.has_value())
+    Alloca->setAlignment(SrcAlign.value());
+
+  Builder.SetInsertPoint(MMI);
+  Builder.CreateMemCpy(Alloca, SrcAlign, MMI->getRawSource(), SrcAlign, Length,
+                       MMI->isVolatile());
+
+  auto *SecondCpy =
+      Builder.CreateMemCpy(MMI->getRawDest(), MMI->getDestAlign(), Alloca,
+                           SrcAlign, Length, MMI->isVolatile());
+
+  MMI->replaceAllUsesWith(SecondCpy);
+  MMI->eraseFromParent();
+}
+
+bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemmove(Module &M) {
+  bool Changed = false;
+  for (auto &F : M) {
+    if (F.getName().contains("llvm.memmove")) {
+      SmallVector<MemMoveInst *, 8> CallsToReplace;
+
+      for (auto U : F.users()) {
+        if (auto MMI = dyn_cast<MemMoveInst>(U)) {
+          CallsToReplace.push_back(MMI);
+        }
+      }
+
+      for (auto MMI : CallsToReplace) {
+        if (!isa<ConstantInt>(MMI->getLength())) {
+          // Use LLVM utility to expand memmove intrinsic as a loop of byte
+          // sized copies, requiring the Int8 capability. This expansion also
+          // requires SPIRV 1.4 and later due to use of pointer comparison
+          // semantics in implementation to decide whether to copy front to
+          // back, or back to front.
+          expandMemMoveAsLoop(MMI, TargetTransformInfo(M.getDataLayout()));
+          MMI->eraseFromParent();
+        } else {
+          // Creates an intermediate alloca byte array of a known size, then
+          // memcpy the src operand ptr into the alloca, followed by a memcpy of
+          // the alloca to the dst operand ptr. Requires Int8 capability.
+          replaceMemmoveStatic(M, MMI);
+        }
+        Changed = true;
+      }
+
+      if (F.user_empty()) {
+        DeadFunctions.push_back(&F);
+      }
+    }
+  }
+
+  return Changed;
 }
 
 bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemset(Module &M) {

--- a/lib/ReplaceLLVMIntrinsicsPass.cpp
+++ b/lib/ReplaceLLVMIntrinsicsPass.cpp
@@ -545,9 +545,64 @@ static void replaceMemsetDynamic(CallInst *CI, Module &M, Value *Dst,
   CI->eraseFromParent();
 }
 
-static void replaceMemmoveStatic(Module &M, MemMoveInst *MMI) {
+static bool replaceMemmoveDynamic(Module &M, MemMoveInst *MMI) {
+  // Use LLVM utility to expand memmove intrinsic as a loop of byte
+  // copies.
+  auto BB = MMI->getParent(); // Record original basic block
+  if (!expandMemMoveAsLoop(MMI, TargetTransformInfo(M.getDataLayout()))) {
+    return false;
+  }
+
+  if (clspv::Option::PhysicalStorageBuffers()) {
+    // expandMemMoveAsLoop creates a 'icmp ptr' instruction that is converted
+    // into an int comparison to avoid lowering the icmp to OpPtrDiff which
+    // isn't supported for PhysicalStorageBuffer
+    ICmpInst *ICmpToProcess = nullptr;
+
+    for (auto &I : *BB) {
+      if (auto ICmp = dyn_cast<ICmpInst>(&I)) {
+        if (ICmp->getOperand(0) == MMI->getSource() &&
+            ICmp->getOperand(1) == MMI->getDest()) {
+          ICmpToProcess = ICmp;
+          break;
+        }
+      }
+    }
+
+    if (ICmpToProcess) {
+      IntegerType *SizeT = clspv::PointersAre64Bit(M)
+                               ? IntegerType::get(M.getContext(), 64)
+                               : IntegerType::get(M.getContext(), 32);
+      IRBuilder<> B(ICmpToProcess);
+      auto LHS = B.CreatePtrToInt(ICmpToProcess->getOperand(0), SizeT);
+      auto RHS = B.CreatePtrToInt(ICmpToProcess->getOperand(1), SizeT);
+      ICmpToProcess->replaceAllUsesWith(
+          B.CreateICmp(ICmpToProcess->getPredicate(), LHS, RHS));
+      ICmpToProcess->eraseFromParent();
+    }
+  } else if (clspv::Option::SpvVersion() <
+             clspv::Option::SPIRVVersion::SPIRV_1_4) {
+    llvm_unreachable(
+        "Using OpPtrDiff to implement memmove requires SPIR-V version 1.4 or later");
+  }
+
+  MMI->eraseFromParent();
+  return true;
+}
+
+static bool replaceMemmoveStatic(Module &M, MemMoveInst *MMI) {
+  // Creates an intermediate alloca byte array of a known size, then
+  // memcpy the src operand ptr into the alloca, followed by a memcpy of
+  // the alloca to the dst operand ptr.
   auto *Length = cast<ConstantInt>(MMI->getLength());
   auto NumBytes = Length->getZExtValue();
+
+  if (NumBytes > clspv::Option::MemmoveAllocaLimit()) {
+    // If limit on maximum size of alloca exceeded, then fall back to
+    // dynamic implementation
+    return replaceMemmoveDynamic(M, MMI);
+  }
+
   auto *AllocaTy =
       ArrayType::get(IntegerType::getInt8Ty(M.getContext()), NumBytes);
 
@@ -568,6 +623,7 @@ static void replaceMemmoveStatic(Module &M, MemMoveInst *MMI) {
 
   MMI->replaceAllUsesWith(SecondCpy);
   MMI->eraseFromParent();
+  return true;
 }
 
 bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemmove(Module &M) {
@@ -582,22 +638,17 @@ bool clspv::ReplaceLLVMIntrinsicsPass::replaceMemmove(Module &M) {
         }
       }
 
+      if (!CallsToReplace.empty() && !clspv::Option::Int8Support()) {
+        llvm_unreachable("Lowering memmove intrinsic requires Int8 Capability");
+      }
+
       for (auto MMI : CallsToReplace) {
-        if (!isa<ConstantInt>(MMI->getLength())) {
-          // Use LLVM utility to expand memmove intrinsic as a loop of byte
-          // sized copies, requiring the Int8 capability. This expansion also
-          // requires SPIRV 1.4 and later due to use of pointer comparison
-          // semantics in implementation to decide whether to copy front to
-          // back, or back to front.
-          expandMemMoveAsLoop(MMI, TargetTransformInfo(M.getDataLayout()));
-          MMI->eraseFromParent();
-        } else {
-          // Creates an intermediate alloca byte array of a known size, then
-          // memcpy the src operand ptr into the alloca, followed by a memcpy of
-          // the alloca to the dst operand ptr. Requires Int8 capability.
-          replaceMemmoveStatic(M, MMI);
+        bool DidTransform = isa<ConstantInt>(MMI->getLength())
+                                ? replaceMemmoveStatic(M, MMI)
+                                : replaceMemmoveDynamic(M, MMI);
+        if (DidTransform) {
+          Changed = true;
         }
-        Changed = true;
       }
 
       if (F.user_empty()) {

--- a/lib/ReplaceLLVMIntrinsicsPass.h
+++ b/lib/ReplaceLLVMIntrinsicsPass.h
@@ -26,6 +26,7 @@ struct ReplaceLLVMIntrinsicsPass
   // TODO: update module-based funtions to work like function-based ones.
   // Except maybe lifetime intrinsics.
   bool runOnFunction(llvm::Function &F);
+  bool replaceMemmove(llvm::Module &M);
   bool replaceMemset(llvm::Module &M);
   bool replaceMemcpy(llvm::Module &M);
   bool removeIntrinsicDeclaration(llvm::Function &F);

--- a/test/LLVMIntrinsics/memmove.ll
+++ b/test/LLVMIntrinsics/memmove.ll
@@ -1,33 +1,55 @@
-; RUN: clspv -x=ir %s --spv-version=1.4 -o %t.spv
-; RUN: spirv-val %t.spv --target-env spv1.4
-; RUN: spirv-dis -o %t2.spvasm %t.spv
-; RUN: FileCheck %s < %t2.spvasm
+; RUN: clspv --physical-storage-buffers --arch=spir64 -x=ir %s -o %t.spv
+; RUN: spirv-val %t.spv
 
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
-target triple = "spirv32-unknown-vulkan"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spirv64-unknown-vulkan"
 
-define dso_local spir_kernel void @fct1(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
-  tail call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 64, i1 false)
-  ret void
-}
-define dso_local spir_kernel void @fct2(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 %len) {
-  tail call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 %len, i1 false)
+define dso_local spir_kernel void @static_global_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+  tail call void @llvm.memmove.p1.p1.i64(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 64, i1 false)
   ret void
 }
 
-; CHECK: [[fct1_dst_arg:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} StorageBuffer
-; CHECK: [[fct1_src_arg:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} StorageBuffer
-; CHECK: [[fct1_arr_var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Function
-; CHECK: [[src_gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_src_arg]]
-; CHECK: [[src_load:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[src_gep]]
-; CHECK: [[src_copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[src_load]]
-; CHECK: [[arr_gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_arr_var]]
-; CHECK: OpStore [[arr_gep1]] [[src_copy]]
-; CHECK: [[arr_gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_arr_var]]
-; CHECK: [[arr_load:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[arr_gep2]]
-; CHECK: [[dst_gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_dst_arg]]
-; CHECK: [[arr_copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[arr_load]]
-; CHECK: OpStore [[dst_gep]] [[arr_copy]]
-; CHECK: OpReturn
+define dso_local spir_kernel void @large_static_global_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+  tail call void @llvm.memmove.p1.p1.i64(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 512, i1 false)
+  ret void
+}
 
-declare void @llvm.memmove.p1.p1.i32(ptr addrspace(1), ptr addrspace(1), i32, i1)
+define dso_local spir_kernel void @dynamic_global_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 %len) {
+  tail call void @llvm.memmove.p1.p1.i64(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 %len, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @static_private_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+  %a = alloca [4 x i32], align 16
+  call void @llvm.memcpy.p0.p1.i64(ptr align 16 %a, ptr addrspace(1) %src, i64 16, i1 false)
+  %gep = getelementptr inbounds i8, ptr %a, i64 4
+  call void @llvm.memmove.p0.p0.i64(ptr align 16 %a, ptr align 4 %gep, i64 12, i1 false)
+  call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dst, ptr align 4 %gep, i64 16, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @static_local_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src, ptr addrspace(3) %scratch) {
+  call void @llvm.memcpy.p3.p1.i64(ptr addrspace(3) %scratch, ptr addrspace(1) %src, i64 16, i1 false)
+  %gep = getelementptr inbounds i8, ptr addrspace(3) %scratch, i64 4
+  call void @llvm.memmove.p3.p3.i64(ptr addrspace(3) %scratch, ptr addrspace(3) %scratch, i64 12, i1 false)
+  call void @llvm.memcpy.p1.p3.i64(ptr addrspace(1) %dst, ptr addrspace(3) %scratch, i64 16, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @dynamic_local_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src, ptr addrspace(3) %scratch, i64 %len) {
+  call void @llvm.memcpy.p3.p1.i64(ptr addrspace(3) %scratch, ptr addrspace(1) %src, i64 16, i1 false)
+  %gep = getelementptr inbounds i8, ptr addrspace(3) %scratch, i64 4
+  call void @llvm.memmove.p3.p3.i64(ptr addrspace(3) %scratch, ptr addrspace(3) %scratch, i64 %len, i1 false)
+  call void @llvm.memcpy.p1.p3.i64(ptr addrspace(1) %dst, ptr addrspace(3) %scratch, i64 16, i1 false)
+  ret void
+}
+
+declare void @llvm.memmove.p1.p1.i64(ptr addrspace(1), ptr addrspace(1), i64, i1)
+
+declare void @llvm.memmove.p3.p3.i64(ptr addrspace(3), ptr addrspace(3), i64, i1)
+
+declare void @llvm.memmove.p0.p0.i64(ptr, ptr, i64, i1)
+
+declare void @llvm.memcpy.p0.p1.i64(ptr, ptr addrspace(1), i64, i1)
+
+declare void @llvm.memcpy.p1.p0.i64(ptr addrspace(1), ptr, i64, i1)

--- a/test/LLVMIntrinsics/memmove.ll
+++ b/test/LLVMIntrinsics/memmove.ll
@@ -1,5 +1,8 @@
-; RUN: clspv --physical-storage-buffers --arch=spir64 -x=ir %s -o %t.spv
+; RUN: clspv --spv-version=1.4 -x=ir %s -o %t.spv
 ; RUN: spirv-val %t.spv
+
+; RUN: clspv --physical-storage-buffers --arch=spir64 -x=ir %s -o %t_phys.spv
+; RUN: spirv-val %t_phys.spv
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
 target triple = "spirv64-unknown-vulkan"
@@ -24,6 +27,15 @@ define dso_local spir_kernel void @static_private_ptr(ptr addrspace(1) %dst, ptr
   call void @llvm.memcpy.p0.p1.i64(ptr align 16 %a, ptr addrspace(1) %src, i64 16, i1 false)
   %gep = getelementptr inbounds i8, ptr %a, i64 4
   call void @llvm.memmove.p0.p0.i64(ptr align 16 %a, ptr align 4 %gep, i64 12, i1 false)
+  call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dst, ptr align 4 %gep, i64 16, i1 false)
+  ret void
+}
+
+define dso_local spir_kernel void @static_dynamic_ptr(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 %len) {
+  %a = alloca [4 x i32], align 16
+  call void @llvm.memcpy.p0.p1.i64(ptr align 16 %a, ptr addrspace(1) %src, i64 16, i1 false)
+  %gep = getelementptr inbounds i8, ptr %a, i64 4
+  call void @llvm.memmove.p0.p0.i64(ptr align 16 %a, ptr align 4 %gep, i64 %len, i1 false)
   call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dst, ptr align 4 %gep, i64 16, i1 false)
   ret void
 }

--- a/test/LLVMIntrinsics/memmove.ll
+++ b/test/LLVMIntrinsics/memmove.ll
@@ -1,0 +1,33 @@
+; RUN: clspv -x=ir %s --spv-version=1.4 -o %t.spv
+; RUN: spirv-val %t.spv --target-env spv1.4
+; RUN: spirv-dis -o %t2.spvasm %t.spv
+; RUN: FileCheck %s < %t2.spvasm
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @fct1(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+  tail call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 64, i1 false)
+  ret void
+}
+define dso_local spir_kernel void @fct2(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 %len) {
+  tail call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %dst, ptr addrspace(1) %src, i32 %len, i1 false)
+  ret void
+}
+
+; CHECK: [[fct1_dst_arg:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} StorageBuffer
+; CHECK: [[fct1_src_arg:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} StorageBuffer
+; CHECK: [[fct1_arr_var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} Function
+; CHECK: [[src_gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_src_arg]]
+; CHECK: [[src_load:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[src_gep]]
+; CHECK: [[src_copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[src_load]]
+; CHECK: [[arr_gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_arr_var]]
+; CHECK: OpStore [[arr_gep1]] [[src_copy]]
+; CHECK: [[arr_gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_arr_var]]
+; CHECK: [[arr_load:%[a-zA-Z0-9_]+]] = OpLoad {{.*}} [[arr_gep2]]
+; CHECK: [[dst_gep:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[fct1_dst_arg]]
+; CHECK: [[arr_copy:%[a-zA-Z0-9_]+]] = OpCopyLogical {{.*}} [[arr_load]]
+; CHECK: OpStore [[dst_gep]] [[arr_copy]]
+; CHECK: OpReturn
+
+declare void @llvm.memmove.p1.p1.i32(ptr addrspace(1), ptr addrspace(1), i32, i1)


### PR DESCRIPTION
The [llvm.memmove](https://llvm.org/docs/LangRef.html#llvm-memmove-intrinsic) intrinsic can exist in input LLVM IR generated from the following OpenCL-C code, but is not currently handled by clspv.

```c
$ cat /tmp/memmove.cl
__kernel void foo(__global int* a, int size) {
  for (int i=0; i < size-1; i++) {
    a[i] = a[i+1];
  }
}

$ clang-19 -S -emit-llvm /tmp/memmove.cl -o /tmp/memmove.ll && cat /tmp/memmove.ll
; ModuleID = '/tmp/memmove.cl'
source_filename = "/tmp/memmove.cl"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"

; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite) uwtable
define dso_local spir_kernel void @foo(ptr nocapture noundef align 4 %0, i32 noundef %1) local_unnamed_addr #0 !kernel_arg_addr_space !7 !kernel_arg_access_qual !8 !kernel_arg_type !9 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 {
  %3 = icmp sgt i32 %1, 1
  br i1 %3, label %4, label %9

4:                                                ; preds = %2
  %5 = add nsw i32 %1, -1
  %6 = getelementptr i8, ptr %0, i64 4
  %7 = zext nneg i32 %5 to i64
  %8 = shl nuw nsw i64 %7, 2
  tail call void @llvm.memmove.p0.p0.i64(ptr align 4 %0, ptr align 4 %6, i64 %8, i1 false), !tbaa !11
  br label %9

9:                                                ; preds = %4, %2
  ret void
}

; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
declare void @llvm.memmove.p0.p0.i64(ptr nocapture writeonly, ptr nocapture readonly, i64, i1 immarg) #1
```

This patch expands the memmove intrinsic in `ReplaceLLVMIntrinsicPass` by copying to an intermediate alloca byte array when the number of bytes is known at compile time. When the number of bytes to copy isn't known at compile time, then we fallback to LLVMs utility for creating loops to do the copy. The same strategy as [SPIRVLowerMemmove.cpp](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/main/lib/SPIRV/SPIRVLowerMemmove.cpp) in the SPIRV-LLVM-Translator.