### PR TITLE
Compiler: Fix MSVC separate heap assert/crash

### DIFF
--- a/include/clspv/Compiler.h
+++ b/include/clspv/Compiler.h
@@ -104,13 +104,7 @@ EXPORT ClspvError clspvCompileFromSourcesString(
 //
 // |output_binary|      - Handle to spv
 // |output_log|         - Handle to compiler build log
-static inline void clspvFreeOutputBuildObjs(char *output_binary,
-                                            char *output_log) {
-  free(output_binary);
-  output_binary = NULL;
-  free(output_log);
-  output_log = NULL;
-}
+EXPORT void clspvFreeOutputBuildObjs(char *output_binary, char *output_log);
 
 #ifdef __cplusplus
 }

--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -1482,3 +1482,10 @@ ClspvError clspvCompileFromSourcesString(
 
   return CLSPV_SUCCESS;
 }
+
+void clspvFreeOutputBuildObjs(char *output_binary, char *output_log) {
+  free(output_binary);
+  output_binary = NULL;
+  free(output_log);
+  output_log = NULL;
+}


### PR DESCRIPTION
Assert/crash triggers on clspvFreeOutputBuildObjs
for windows builds due to API call being a
static inline declaration. Windows DLL's have
separate CRT heaps - free leads to heap boundary issue.

Fix is to remove static inline and define routine in the source compiler file (as well as export it).

Tests-Passing: oclcts.test_api_enqueue_task (Win32)