### PR TITLE
Prefer OptionalPassInfoMixin

### DIFF
--- a/lib/AddFunctionAttributesPass.h
+++ b/lib/AddFunctionAttributesPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct AddFunctionAttributesPass
-    : llvm::OptionalOptionalPassInfoMixin<AddFunctionAttributesPass> {
+    : llvm::OptionalPassInfoMixin<AddFunctionAttributesPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/AddFunctionAttributesPass.h
+++ b/lib/AddFunctionAttributesPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct AddFunctionAttributesPass
-    : llvm::PassInfoMixin<AddFunctionAttributesPass> {
+    : llvm::OptionalOptionalPassInfoMixin<AddFunctionAttributesPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/AllocateDescriptorsPass.h
+++ b/lib/AllocateDescriptorsPass.h
@@ -21,7 +21,8 @@
 #define _CLSPV_LIB_ALLOCATE_DESCRIPTORS_PASS_H
 
 namespace clspv {
-struct AllocateDescriptorsPass : llvm::PassInfoMixin<AllocateDescriptorsPass> {
+struct AllocateDescriptorsPass
+    : llvm::OptionalPassInfoMixin<AllocateDescriptorsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   using SamplerMapType = llvm::ArrayRef<std::pair<unsigned, std::string>>;

--- a/lib/AnnotationToMetadataPass.h
+++ b/lib/AnnotationToMetadataPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct AnnotationToMetadataPass
-    : llvm::PassInfoMixin<AnnotationToMetadataPass> {
+    : llvm::OptionalPassInfoMixin<AnnotationToMetadataPass> {
   // read the annotations produced by the PrintAttrsConsumer and store in the
   // entry point annotations in metadata
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);

--- a/lib/AutoPodArgsPass.h
+++ b/lib/AutoPodArgsPass.h
@@ -21,7 +21,7 @@
 #define _CLSPV_LIB_AUTO_POD_ARGS_PASS_H
 
 namespace clspv {
-struct AutoPodArgsPass : llvm::PassInfoMixin<AutoPodArgsPass> {
+struct AutoPodArgsPass : llvm::OptionalPassInfoMixin<AutoPodArgsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/ClusterConstants.h
+++ b/lib/ClusterConstants.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct ClusterModuleScopeConstantVars
-    : llvm::PassInfoMixin<ClusterModuleScopeConstantVars> {
+    : llvm::OptionalPassInfoMixin<ClusterModuleScopeConstantVars> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/ClusterPodKernelArgumentsPass.h
+++ b/lib/ClusterPodKernelArgumentsPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct ClusterPodKernelArgumentsPass
-    : llvm::PassInfoMixin<ClusterPodKernelArgumentsPass> {
+    : llvm::OptionalPassInfoMixin<ClusterPodKernelArgumentsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:
@@ -30,7 +30,6 @@ private:
   // packed structs propoerly. AutoPodArgsPass would also need updates to
   // support packed structs.
   llvm::StructType *GetTypeMangledPodArgsStruct(llvm::Module &M);
-
 };
 } // namespace clspv
 

--- a/lib/DeclarePushConstantsPass.h
+++ b/lib/DeclarePushConstantsPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct DeclarePushConstantsPass
-    : llvm::PassInfoMixin<DeclarePushConstantsPass> {
+    : llvm::OptionalPassInfoMixin<DeclarePushConstantsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/DefineOpenCLWorkItemBuiltinsPass.h
+++ b/lib/DefineOpenCLWorkItemBuiltinsPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct DefineOpenCLWorkItemBuiltinsPass
-    : llvm::PassInfoMixin<DefineOpenCLWorkItemBuiltinsPass> {
+    : llvm::OptionalPassInfoMixin<DefineOpenCLWorkItemBuiltinsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   llvm::GlobalVariable *createGlobalVariable(llvm::Module &M,

--- a/lib/DestructurizeGEPPass.h
+++ b/lib/DestructurizeGEPPass.h
@@ -19,7 +19,8 @@
 #include "llvm/IR/PassManager.h"
 
 namespace clspv {
-struct DestructurizeGEPPass : llvm::PassInfoMixin<DestructurizeGEPPass> {
+struct DestructurizeGEPPass
+    : llvm::OptionalPassInfoMixin<DestructurizeGEPPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/DirectResourceAccessPass.h
+++ b/lib/DirectResourceAccessPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct DirectResourceAccessPass
-    : llvm::PassInfoMixin<DirectResourceAccessPass> {
+    : llvm::OptionalPassInfoMixin<DirectResourceAccessPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/FixupBuiltinsPass.h
+++ b/lib/FixupBuiltinsPass.h
@@ -21,7 +21,7 @@
 namespace clspv {
 // This pass performs transformations on calls to builtin functions without
 // erasing them from the module.
-struct FixupBuiltinsPass : llvm::PassInfoMixin<FixupBuiltinsPass> {
+struct FixupBuiltinsPass : llvm::OptionalPassInfoMixin<FixupBuiltinsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/FixupStructuredCFGPass.h
+++ b/lib/FixupStructuredCFGPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_FIXUP_STRUCTURED_CFG_PASS_H
 
 namespace clspv {
-struct FixupStructuredCFGPass : llvm::PassInfoMixin<FixupStructuredCFGPass> {
+struct FixupStructuredCFGPass
+    : llvm::OptionalPassInfoMixin<FixupStructuredCFGPass> {
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &FAM);
 

--- a/lib/FunctionInternalizerPass.h
+++ b/lib/FunctionInternalizerPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct FunctionInternalizerPass
-    : llvm::PassInfoMixin<FunctionInternalizerPass> {
+    : llvm::OptionalPassInfoMixin<FunctionInternalizerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/HideConstantLoadsPass.h
+++ b/lib/HideConstantLoadsPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_HIDE_CONSTANT_LOADS_PASS_H
 
 namespace clspv {
-struct HideConstantLoadsPass : llvm::PassInfoMixin<HideConstantLoadsPass> {
+struct HideConstantLoadsPass
+    : llvm::OptionalPassInfoMixin<HideConstantLoadsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:
@@ -29,7 +30,8 @@ private:
   llvm::DenseMap<llvm::Type *, std::string> function_for_type_;
 };
 
-struct UnhideConstantLoadsPass : llvm::PassInfoMixin<UnhideConstantLoadsPass> {
+struct UnhideConstantLoadsPass
+    : llvm::OptionalPassInfoMixin<UnhideConstantLoadsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/InlineEntryPointsPass.h
+++ b/lib/InlineEntryPointsPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_INLINE_ENTRY_POINTS_PASS_H
 
 namespace clspv {
-struct InlineEntryPointsPass : llvm::PassInfoMixin<InlineEntryPointsPass> {
+struct InlineEntryPointsPass
+    : llvm::OptionalPassInfoMixin<InlineEntryPointsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/InlineFuncWithImageMetadataGetterPass.h
+++ b/lib/InlineFuncWithImageMetadataGetterPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct InlineFuncWithImageMetadataGetterPass
-    : llvm::PassInfoMixin<InlineFuncWithImageMetadataGetterPass> {
+    : llvm::OptionalPassInfoMixin<InlineFuncWithImageMetadataGetterPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   bool InlineFunctions(llvm::Module &M);

--- a/lib/InlineFuncWithPointerBitCastArgPass.h
+++ b/lib/InlineFuncWithPointerBitCastArgPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct InlineFuncWithPointerBitCastArgPass
-    : llvm::PassInfoMixin<InlineFuncWithPointerBitCastArgPass> {
+    : llvm::OptionalPassInfoMixin<InlineFuncWithPointerBitCastArgPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   bool InlineFunctions(llvm::Module &M);

--- a/lib/InlineFuncWithPointerToFunctionArgPass.h
+++ b/lib/InlineFuncWithPointerToFunctionArgPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct InlineFuncWithPointerToFunctionArgPass
-    : llvm::PassInfoMixin<InlineFuncWithPointerToFunctionArgPass> {
+    : llvm::OptionalPassInfoMixin<InlineFuncWithPointerToFunctionArgPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   bool InlineFunctions(llvm::Module &M);

--- a/lib/InlineFuncWithReadImage3DNonLiteralSampler.h
+++ b/lib/InlineFuncWithReadImage3DNonLiteralSampler.h
@@ -22,7 +22,8 @@
 namespace clspv {
 
 struct InlineFuncWithReadImage3DNonLiteralSamplerPass
-    : llvm::PassInfoMixin<InlineFuncWithReadImage3DNonLiteralSamplerPass> {
+    : llvm::OptionalPassInfoMixin<
+          InlineFuncWithReadImage3DNonLiteralSamplerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   bool InlineFunctions(llvm::Module &M);

--- a/lib/InlineFuncWithSingleCallSitePass.h
+++ b/lib/InlineFuncWithSingleCallSitePass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct InlineFuncWithSingleCallSitePass
-    : llvm::PassInfoMixin<InlineFuncWithSingleCallSitePass> {
+    : llvm::OptionalPassInfoMixin<InlineFuncWithSingleCallSitePass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/KernelArgNamesToMetadataPass.h
+++ b/lib/KernelArgNamesToMetadataPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct KernelArgNamesToMetadataPass
-    : llvm::PassInfoMixin<KernelArgNamesToMetadataPass> {
+    : llvm::OptionalPassInfoMixin<KernelArgNamesToMetadataPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/LogicalPointerToIntPass.h
+++ b/lib/LogicalPointerToIntPass.h
@@ -21,7 +21,8 @@
 #define _CLSPV_LIB_LOGICAL_POINTER_TO_INT_PASS_H
 
 namespace clspv {
-struct LogicalPointerToIntPass : llvm::PassInfoMixin<LogicalPointerToIntPass> {
+struct LogicalPointerToIntPass
+    : llvm::OptionalPassInfoMixin<LogicalPointerToIntPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/LongVectorLoweringPass.h
+++ b/lib/LongVectorLoweringPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct LongVectorLoweringPass
-    : llvm::PassInfoMixin<LongVectorLoweringPass>,
+    : llvm::OptionalPassInfoMixin<LongVectorLoweringPass>,
       llvm::InstVisitor<LongVectorLoweringPass, llvm::Value *> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 

--- a/lib/LowerAddrSpaceCastPass.h
+++ b/lib/LowerAddrSpaceCastPass.h
@@ -24,7 +24,7 @@
 
 namespace clspv {
 struct LowerAddrSpaceCastPass
-    : llvm::PassInfoMixin<LowerAddrSpaceCastPass>,
+    : llvm::OptionalPassInfoMixin<LowerAddrSpaceCastPass>,
       llvm::InstVisitor<LowerAddrSpaceCastPass, llvm::Value *> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 

--- a/lib/LowerPrivatePointerPHIPass.h
+++ b/lib/LowerPrivatePointerPHIPass.h
@@ -27,7 +27,7 @@
 
 namespace clspv {
 struct LowerPrivatePointerPHIPass
-    : llvm::PassInfoMixin<LowerPrivatePointerPHIPass> {
+    : llvm::OptionalPassInfoMixin<LowerPrivatePointerPHIPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/MultiVersionUBOFunctionsPass.h
+++ b/lib/MultiVersionUBOFunctionsPass.h
@@ -22,7 +22,7 @@
 
 namespace clspv {
 struct MultiVersionUBOFunctionsPass
-    : llvm::PassInfoMixin<MultiVersionUBOFunctionsPass> {
+    : llvm::OptionalPassInfoMixin<MultiVersionUBOFunctionsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/NativeMathPass.h
+++ b/lib/NativeMathPass.h
@@ -19,7 +19,7 @@
 #define _CLSPV_LIB_NATIVE_MATH_PASS_H
 
 namespace clspv {
-struct NativeMathPass : llvm::PassInfoMixin<NativeMathPass> {
+struct NativeMathPass : llvm::OptionalPassInfoMixin<NativeMathPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/NormalizeGlobalVariable.h
+++ b/lib/NormalizeGlobalVariable.h
@@ -28,7 +28,7 @@ namespace clspv {
 void NormalizeGlobalVariables(llvm::Module &M);
 
 struct NormalizeGlobalVariablesPass
-    : llvm::PassInfoMixin<NormalizeGlobalVariablesPass> {
+    : llvm::OptionalPassInfoMixin<NormalizeGlobalVariablesPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 

--- a/lib/OpenCLInlinerPass.h
+++ b/lib/OpenCLInlinerPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_OPENCL_INLINER_PASS_H
 
 namespace clspv {
-struct OpenCLInlinerPass : llvm::PassInfoMixin<OpenCLInlinerPass> {
+struct OpenCLInlinerPass : llvm::OptionalPassInfoMixin<OpenCLInlinerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/PhysicalPointerArgsPass.h
+++ b/lib/PhysicalPointerArgsPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_PHYSICAL_POINTER_ARGS_PASS_H
 
 namespace clspv {
-struct PhysicalPointerArgsPass : llvm::PassInfoMixin<PhysicalPointerArgsPass> {
+struct PhysicalPointerArgsPass
+    : llvm::OptionalPassInfoMixin<PhysicalPointerArgsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/PrintfPass.h
+++ b/lib/PrintfPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_PRINTF_PASS_H
 
 namespace clspv {
-struct PrintfPass : llvm::PassInfoMixin<PrintfPass> {
+struct PrintfPass : llvm::OptionalPassInfoMixin<PrintfPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/RemoveUnusedArguments.h
+++ b/lib/RemoveUnusedArguments.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_REMOVE_UNUSED_ARGUMENTS_PASS_H
 
 namespace clspv {
-struct RemoveUnusedArguments : llvm::PassInfoMixin<RemoveUnusedArguments> {
+struct RemoveUnusedArguments
+    : llvm::OptionalPassInfoMixin<RemoveUnusedArguments> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/ReorderBasicBlocksPass.h
+++ b/lib/ReorderBasicBlocksPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_REORDER_BASIC_BLOCKS_PASS_H
 
 namespace clspv {
-struct ReorderBasicBlocksPass : llvm::PassInfoMixin<ReorderBasicBlocksPass> {
+struct ReorderBasicBlocksPass
+    : llvm::OptionalPassInfoMixin<ReorderBasicBlocksPass> {
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &);
 };

--- a/lib/ReplaceLLVMIntrinsicsPass.h
+++ b/lib/ReplaceLLVMIntrinsicsPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct ReplaceLLVMIntrinsicsPass
-    : llvm::PassInfoMixin<ReplaceLLVMIntrinsicsPass> {
+    : llvm::OptionalPassInfoMixin<ReplaceLLVMIntrinsicsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   // TODO: update module-based funtions to work like function-based ones.

--- a/lib/ReplaceOpenCLBuiltinPass.h
+++ b/lib/ReplaceOpenCLBuiltinPass.h
@@ -29,7 +29,7 @@
 
 namespace clspv {
 struct ReplaceOpenCLBuiltinPass
-    : llvm::PassInfoMixin<ReplaceOpenCLBuiltinPass> {
+    : llvm::OptionalPassInfoMixin<ReplaceOpenCLBuiltinPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/ReplacePointerBitcastPass.h
+++ b/lib/ReplacePointerBitcastPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct ReplacePointerBitcastPass
-    : llvm::PassInfoMixin<ReplacePointerBitcastPass> {
+    : llvm::OptionalPassInfoMixin<ReplacePointerBitcastPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/RewriteInsertsPass.h
+++ b/lib/RewriteInsertsPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_REWRITE_INSERTS_PASS_H
 
 namespace clspv {
-struct RewriteInsertsPass : llvm::PassInfoMixin<RewriteInsertsPass> {
+struct RewriteInsertsPass : llvm::OptionalPassInfoMixin<RewriteInsertsPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/RewritePackedStructs.h
+++ b/lib/RewritePackedStructs.h
@@ -20,7 +20,8 @@
 #define _CLSPV_LIB_RewritePackedStructs_PASS_H
 
 namespace clspv {
-struct RewritePackedStructs : llvm::PassInfoMixin<RewritePackedStructs> {
+struct RewritePackedStructs
+    : llvm::OptionalPassInfoMixin<RewritePackedStructs> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/SPIRVProducerPass.h
+++ b/lib/SPIRVProducerPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_SPIRV_PRODUCER_PASS_H
 
 namespace clspv {
-struct SPIRVProducerPass : llvm::PassInfoMixin<SPIRVProducerPass> {
+struct SPIRVProducerPass : llvm::OptionalPassInfoMixin<SPIRVProducerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   SPIRVProducerPass(llvm::raw_pwrite_stream *out, bool outputCInitList)

--- a/lib/ScalarizePass.h
+++ b/lib/ScalarizePass.h
@@ -19,7 +19,7 @@
 #define _CLSPV_LIB_SCALARIZE_PASS_H
 
 namespace clspv {
-struct ScalarizePass : llvm::PassInfoMixin<ScalarizePass> {
+struct ScalarizePass : llvm::OptionalPassInfoMixin<ScalarizePass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/SetImageMetadataPass.h
+++ b/lib/SetImageMetadataPass.h
@@ -24,7 +24,8 @@
 // This is done by the InlineFuncWithImageMetadataGetterPass
 
 namespace clspv {
-struct SetImageMetadataPass : llvm::PassInfoMixin<SetImageMetadataPass> {
+struct SetImageMetadataPass
+    : llvm::OptionalPassInfoMixin<SetImageMetadataPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/ShareModuleScopeVariables.h
+++ b/lib/ShareModuleScopeVariables.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct ShareModuleScopeVariablesPass
-    : llvm::PassInfoMixin<ShareModuleScopeVariablesPass> {
+    : llvm::OptionalPassInfoMixin<ShareModuleScopeVariablesPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   typedef llvm::DenseMap<llvm::Function *, llvm::UniqueVector<llvm::Function *>>

--- a/lib/SignedCompareFixupPass.h
+++ b/lib/SignedCompareFixupPass.h
@@ -22,7 +22,8 @@
 #define _CLSPV_LIB_SIGNED_COMPARE_FIXUP_PASS_H
 
 namespace clspv {
-struct SignedCompareFixupPass : llvm::PassInfoMixin<SignedCompareFixupPass> {
+struct SignedCompareFixupPass
+    : llvm::OptionalPassInfoMixin<SignedCompareFixupPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/SimplifyPointerBitcastPass.h
+++ b/lib/SimplifyPointerBitcastPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct SimplifyPointerBitcastPass
-    : llvm::PassInfoMixin<SimplifyPointerBitcastPass> {
+    : llvm::OptionalPassInfoMixin<SimplifyPointerBitcastPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   void runOnInstFromCstExpr(llvm::Module &M) const;

--- a/lib/SpecializeImageTypes.h
+++ b/lib/SpecializeImageTypes.h
@@ -24,7 +24,7 @@
 
 namespace clspv {
 struct SpecializeImageTypesPass
-    : llvm::PassInfoMixin<SpecializeImageTypesPass> {
+    : llvm::OptionalPassInfoMixin<SpecializeImageTypesPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   enum ResultType { kNotImage, kNotSpecialized, kSpecialized };

--- a/lib/SplatArgPass.h
+++ b/lib/SplatArgPass.h
@@ -21,7 +21,7 @@
 #define _CLSPV_LIB_SPLAT_ARG_PASS_PASS_H
 
 namespace clspv {
-struct SplatArgPass : llvm::PassInfoMixin<SplatArgPass> {
+struct SplatArgPass : llvm::OptionalPassInfoMixin<SplatArgPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   std::string getSplatName(const Builtins::FunctionInfo &func_info,

--- a/lib/SplatSelectCondition.h
+++ b/lib/SplatSelectCondition.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct SplatSelectConditionPass
-    : llvm::PassInfoMixin<SplatSelectConditionPass> {
+    : llvm::OptionalPassInfoMixin<SplatSelectConditionPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/StripFreezePass.h
+++ b/lib/StripFreezePass.h
@@ -19,7 +19,7 @@
 #define _CLSPV_LIB_STRIP_FREEZE_PASS_H
 
 namespace clspv {
-struct StripFreezePass : llvm::PassInfoMixin<StripFreezePass> {
+struct StripFreezePass : llvm::OptionalPassInfoMixin<StripFreezePass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/StructurizeGEPPass.h
+++ b/lib/StructurizeGEPPass.h
@@ -19,7 +19,7 @@
 #include "llvm/IR/PassManager.h"
 
 namespace clspv {
-struct StructurizeGEPPass : llvm::PassInfoMixin<StructurizeGEPPass> {
+struct StructurizeGEPPass : llvm::OptionalPassInfoMixin<StructurizeGEPPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/ThreeElementVectorLoweringPass.h
+++ b/lib/ThreeElementVectorLoweringPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct ThreeElementVectorLoweringPass
-    : llvm::PassInfoMixin<ThreeElementVectorLoweringPass>,
+    : llvm::OptionalPassInfoMixin<ThreeElementVectorLoweringPass>,
       llvm::InstVisitor<ThreeElementVectorLoweringPass, llvm::Value *> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 

--- a/lib/UBOTypeTransformPass.h
+++ b/lib/UBOTypeTransformPass.h
@@ -19,7 +19,8 @@
 #define _CLSPV_LIB_UBO_TYPE_TRANSFORM_PASS_H
 
 namespace clspv {
-struct UBOTypeTransformPass : llvm::PassInfoMixin<UBOTypeTransformPass> {
+struct UBOTypeTransformPass
+    : llvm::OptionalPassInfoMixin<UBOTypeTransformPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/UndoBoolPass.h
+++ b/lib/UndoBoolPass.h
@@ -19,7 +19,7 @@
 #define _CLSPV_LIB_UNDO_BOOL_PASS_H
 
 namespace clspv {
-struct UndoBoolPass : llvm::PassInfoMixin<UndoBoolPass> {
+struct UndoBoolPass : llvm::OptionalPassInfoMixin<UndoBoolPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/UndoByvalPass.h
+++ b/lib/UndoByvalPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_UNDO_BYVAL_PASS_H
 
 namespace clspv {
-struct UndoByvalPass : llvm::PassInfoMixin<UndoByvalPass> {
+struct UndoByvalPass : llvm::OptionalPassInfoMixin<UndoByvalPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/UndoGetElementPtrConstantExprPass.h
+++ b/lib/UndoGetElementPtrConstantExprPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct UndoGetElementPtrConstantExprPass
-    : llvm::PassInfoMixin<UndoGetElementPtrConstantExprPass> {
+    : llvm::OptionalPassInfoMixin<UndoGetElementPtrConstantExprPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
   bool replaceGetElementPtrConstantExpr(llvm::ConstantExpr *CE);

--- a/lib/UndoInstCombinePass.h
+++ b/lib/UndoInstCombinePass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_UNDO_INST_COMBINE_PASS_H
 
 namespace clspv {
-struct UndoInstCombinePass : llvm::PassInfoMixin<UndoInstCombinePass> {
+struct UndoInstCombinePass : llvm::OptionalPassInfoMixin<UndoInstCombinePass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/UndoSRetPass.h
+++ b/lib/UndoSRetPass.h
@@ -20,7 +20,7 @@
 #define _CLSPV_LIB_UNDO_SRET_PASS_H
 
 namespace clspv {
-struct UndoSRetPass : llvm::PassInfoMixin<UndoSRetPass> {
+struct UndoSRetPass : llvm::OptionalPassInfoMixin<UndoSRetPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/UndoTranslateSamplerFoldPass.h
+++ b/lib/UndoTranslateSamplerFoldPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct UndoTranslateSamplerFoldPass
-    : llvm::PassInfoMixin<UndoTranslateSamplerFoldPass> {
+    : llvm::OptionalPassInfoMixin<UndoTranslateSamplerFoldPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv

--- a/lib/UndoTruncateToOddIntegerPass.h
+++ b/lib/UndoTruncateToOddIntegerPass.h
@@ -21,7 +21,7 @@
 
 namespace clspv {
 struct UndoTruncateToOddIntegerPass
-    : llvm::PassInfoMixin<UndoTruncateToOddIntegerPass> {
+    : llvm::OptionalPassInfoMixin<UndoTruncateToOddIntegerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
 private:

--- a/lib/ZeroInitializeAllocasPass.h
+++ b/lib/ZeroInitializeAllocasPass.h
@@ -20,7 +20,7 @@
 
 namespace clspv {
 struct ZeroInitializeAllocasPass
-    : llvm::PassInfoMixin<ZeroInitializeAllocasPass> {
+    : llvm::OptionalPassInfoMixin<ZeroInitializeAllocasPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 };
 } // namespace clspv


### PR DESCRIPTION
PassInfoMixin in upstream LLVM will soon be moved to a detail namespace with users expected to use RequiredPassInfoMixin or OptionalPassInfoMixin depending upon the behavior they want. Given none of these passes explicitly set isRequired to true, move them all to OptionalPassInfoMixin.