### PR TITLE
[CMake] Use libclc spirv-vulkan cache file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,7 @@ else()
     endif()
     use_component(${CLSPV_LIBCLC_SOURCE_DIR})
 
-    set(RUNTIMES_spirv32-unknown-vulkan_LLVM_ENABLE_RUNTIMES "libclc" CACHE STRING "")
-    set(RUNTIMES_spirv64-unknown-vulkan_LLVM_ENABLE_RUNTIMES "libclc" CACHE STRING "")
-    set(LLVM_RUNTIME_TARGETS spirv32-unknown-vulkan;spirv64-unknown-vulkan CACHE STRING "")
+    include(${CLSPV_LIBCLC_SOURCE_DIR}/cmake/caches/spirv-vulkan.cmake)
 
     # Tell LLVM to build the native target (needed to build libclc).
     set(CLSPV_LLVM_TARGETS_TO_BUILD "Native")

--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "0220c07a94012b9dce9250addac6a8ee1f674b21"
+      "commit" : "d34b0ab0434285bad750b5da1af3d7c9c2492f3a"
     },
     {
       "name" : "SPIRV-Headers",


### PR DESCRIPTION
Simplify configuration by including spirv-vulkan.cmake instead of manually setting RUNTIMES_* and LLVM_RUNTIME_TARGETS.

https://github.com/llvm/llvm-project/pull/201480