### PR TITLE
Add support for OpenCL compliant FP16 division

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -5831,6 +5831,32 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
           Ops << Ty << RID << c;
           RID = addSPIRVInst(spv::OpFMul, Ops);
         }
+      } else if (I.getOpcode() == Instruction::FDiv &&
+                 I.getType()->getScalarType()->isHalfTy() &&
+                 !clspv::Option::UnsafeMath()) {
+        Type *FP16Ty = I.getType();
+        Type *FP32Ty = Type::getFloatTy(Context);
+        if (FP16Ty->isVectorTy()) {
+          FP32Ty = FixedVectorType::get(
+              FP32Ty, dyn_cast<FixedVectorType>(FP16Ty)->getNumElements());
+        }
+
+        SPIRVOperandVec Ops;
+        Ops.clear();
+        Ops << FP32Ty << I.getOperand(0);
+        auto a_f32 = addSPIRVInst(spv::OpFConvert, Ops);
+
+        Ops.clear();
+        Ops << FP32Ty << I.getOperand(1);
+        auto b_f32 = addSPIRVInst(spv::OpFConvert, Ops);
+
+        Ops.clear();
+        Ops << FP32Ty << a_f32 << b_f32;
+        auto div_f32 = addSPIRVInst(spv::OpFDiv, Ops);
+
+        Ops.clear();
+        Ops << FP16Ty << div_f32;
+        RID = addSPIRVInst(spv::OpFConvert, Ops);
       } else {
         // Ops[0] = Result Type ID
         // Ops[1] = Operand 0

--- a/test/div/half4_div.cl
+++ b/test/div/half4_div.cl
@@ -1,0 +1,37 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.spv -cl-unsafe-math-optimizations
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK-UNSAFE %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpCapability Float16
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-DAG: %[[VEC_HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[VEC_FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_HALF_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_HALF_TYPE_ID]]
+// CHECK: %[[CVTA_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[VEC_FLOAT_TYPE_ID]] %[[LOADA_ID]]
+// CHECK: %[[CVTB_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[VEC_FLOAT_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[DIV_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[VEC_FLOAT_TYPE_ID]] %[[CVTA_ID]] %[[CVTB_ID]]
+// CHECK: %[[CVTDIV_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[VEC_HALF_TYPE_ID]] %[[DIV_ID]]
+// CHECK: OpStore {{.*}} %[[CVTDIV_ID]]
+
+// CHECK-UNSAFE: OpCapability Float16
+// CHECK-UNSAFE-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-UNSAFE-DAG: %[[VEC_HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[HALF_TYPE_ID]] 4
+// CHECK-UNSAFE: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_HALF_TYPE_ID]]
+// CHECK-UNSAFE: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[VEC_HALF_TYPE_ID]]
+// CHECK-UNSAFE: %[[DIV_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[VEC_HALF_TYPE_ID]] %[[LOADA_ID]] %[[LOADB_ID]]
+// CHECK-UNSAFE: OpStore {{.*}} %[[DIV_ID]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half4* a, global half4* b)
+{
+  *a /= *b;
+}

--- a/test/div/half_div.cl
+++ b/test/div/half_div.cl
@@ -1,0 +1,34 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.spv -cl-unsafe-math-optimizations
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck --check-prefix=CHECK-UNSAFE %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK: OpCapability Float16
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[CVTA_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[FLOAT_TYPE_ID]] %[[LOADA_ID]]
+// CHECK: %[[CVTB_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[FLOAT_TYPE_ID]] %[[LOADB_ID]]
+// CHECK: %[[DIV_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[FLOAT_TYPE_ID]] %[[CVTA_ID]] %[[CVTB_ID]]
+// CHECK: %[[CVTDIV_ID:[a-zA-Z0-9_]*]] = OpFConvert %[[HALF_TYPE_ID]] %[[DIV_ID]]
+// CHECK: OpStore {{.*}} %[[CVTDIV_ID]]
+
+// CHECK-UNSAFE: OpCapability Float16
+// CHECK-UNSAFE-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-UNSAFE: %[[LOADB_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-UNSAFE: %[[LOADA_ID:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-UNSAFE: %[[DIV_ID:[a-zA-Z0-9_]*]] = OpFDiv %[[HALF_TYPE_ID]] %[[LOADA_ID]] %[[LOADB_ID]]
+// CHECK-UNSAFE: OpStore {{.*}} %[[DIV_ID]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* a, global half* b)
+{
+  *a /= *b;
+}


### PR DESCRIPTION
To satisfy OpenCL conformance requirements for half-precision floating-point division, evaluate FP16 division in single-precision (FP32) when unsafe math optimizations are not enabled.