### PR TITLE
UndoInstCombine: Undo narrowed integer divisions and remainders

### DIFF
--- a/lib/UndoInstCombinePass.cpp
+++ b/lib/UndoInstCombinePass.cpp
@@ -63,6 +63,7 @@ bool clspv::UndoInstCombinePass::runOnFunction(Function &F) {
     for (auto &I : BB) {
       changed |= UndoWideVectorExtractCast(&I);
       changed |= UndoWideVectorShuffleCast(&I);
+      changed |= UndoNarrowedIntDiv(&I);
     }
   }
 
@@ -248,6 +249,72 @@ bool clspv::UndoInstCombinePass::UndoWideVectorShuffleCast(Instruction *inst) {
   dead_.push_back(shuffle);
   if (in1_cast)
     potentially_dead_.insert(in1_cast);
+
+  return true;
+}
+
+bool clspv::UndoInstCombinePass::UndoNarrowedIntDiv(Instruction *inst) {
+  auto cast = dyn_cast<CastInst>(inst);
+  if (!cast)
+    return false;
+
+  auto opcode = cast->getOpcode();
+  if (opcode != Instruction::SExt && opcode != Instruction::ZExt)
+    return false;
+
+  auto src = cast->getOperand(0);
+  auto binop = dyn_cast<BinaryOperator>(src);
+  if (!binop)
+    return false;
+
+  auto binop_code = binop->getOpcode();
+  bool is_signed = (opcode == Instruction::SExt);
+  if (is_signed) {
+    if (binop_code != Instruction::SDiv && binop_code != Instruction::SRem)
+      return false;
+  } else {
+    if (binop_code != Instruction::UDiv && binop_code != Instruction::URem)
+      return false;
+  }
+
+  auto dst_ty = cast->getType();
+  auto src_ty = binop->getType();
+  if (dst_ty == src_ty)
+    return false;
+
+  auto dst_elem_ty = dst_ty->getScalarType();
+  auto src_elem_ty = src_ty->getScalarType();
+  if (!dst_elem_ty->isIntegerTy() || !src_elem_ty->isIntegerTy())
+    return false;
+
+  if (dst_elem_ty->getIntegerBitWidth() <= src_elem_ty->getIntegerBitWidth())
+    return false;
+
+  IRBuilder<> builder(cast);
+  Value *lhs = binop->getOperand(0);
+  Value *rhs = binop->getOperand(1);
+
+  auto get_widened_operand = [&](Value *val) -> Value * {
+    if (auto *trunc = dyn_cast<TruncInst>(val)) {
+      if (trunc->getOperand(0)->getType() == dst_ty) {
+        if ((is_signed && trunc->hasNoSignedWrap()) ||
+            (!is_signed && trunc->hasNoUnsignedWrap())) {
+          potentially_dead_.insert(trunc);
+          return trunc->getOperand(0);
+        }
+      }
+    }
+    return is_signed ? builder.CreateSExt(val, dst_ty)
+                     : builder.CreateZExt(val, dst_ty);
+  };
+
+  Value *new_lhs = get_widened_operand(lhs);
+  Value *new_rhs = get_widened_operand(rhs);
+  Value *new_binop = builder.CreateBinOp(binop_code, new_lhs, new_rhs);
+
+  cast->replaceAllUsesWith(new_binop);
+  dead_.push_back(cast);
+  potentially_dead_.insert(binop);
 
   return true;
 }

--- a/lib/UndoInstCombinePass.h
+++ b/lib/UndoInstCombinePass.h
@@ -74,6 +74,16 @@ private:
   //  %in1 = insertelement <2 x i16> %in0, i16 %trunc1, i32 1
   bool UndoWideVectorShuffleCast(llvm::Instruction *inst);
 
+  // Undoes narrowed integer divisions and remainders that are extended back,
+  // for example:
+  //  %1 = trunc nsw i32 %a to i16
+  //  %2 = sdiv i16 %1, 3
+  //  %3 = sext i16 %2 to i32
+  //
+  // With:
+  //  %3 = sdiv i32 %a, 3
+  bool UndoNarrowedIntDiv(llvm::Instruction *inst);
+
   llvm::UniqueVector<llvm::Value *> potentially_dead_;
   std::vector<llvm::Instruction *> dead_;
 };

--- a/test/MathBuiltins/cbrt/float_cbrt.cl
+++ b/test/MathBuiltins/cbrt/float_cbrt.cl
@@ -1,0 +1,11 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: FileCheck %s < %t.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// CHECK-NOT: OpCapability Int16
+
+__kernel void test_cbrt(__global float *out, __global float *in) {
+  int gid = get_global_id(0);
+  out[gid] = cbrt(in[gid]);
+}

--- a/test/UndoInstCombine/undo_narrowed_sdiv.ll
+++ b/test/UndoInstCombine/undo_narrowed_sdiv.ll
@@ -1,0 +1,31 @@
+; RUN: clspv-opt %s -o %t.ll --passes=undo-instcombine
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define void @test_sdiv(i32 %in, ptr addrspace(1) %out) {
+entry:
+  ; CHECK-LABEL: @test_sdiv
+  ; CHECK: [[div:%[a-zA-Z0-9_.]+]] = sdiv i32 %in, 3
+  ; CHECK: store i32 [[div]]
+  ; CHECK-NOT: sdiv i16
+  %trunc = trunc nsw i32 %in to i16
+  %sdiv = sdiv i16 %trunc, 3
+  %sext = sext i16 %sdiv to i32
+  store i32 %sext, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+define void @test_udiv(i32 %in, ptr addrspace(1) %out) {
+entry:
+  ; CHECK-LABEL: @test_udiv
+  ; CHECK: [[div:%[a-zA-Z0-9_.]+]] = udiv i32 %in, 3
+  ; CHECK: store i32 [[div]]
+  ; CHECK-NOT: udiv i16
+  %trunc = trunc nuw i32 %in to i16
+  %udiv = udiv i16 %trunc, 3
+  %zext = zext i16 %udiv to i32
+  store i32 %zext, ptr addrspace(1) %out, align 4
+  ret void
+}


### PR DESCRIPTION
LLVM's InstCombine pass can narrow integer divisions (SDiv, UDiv) and remainders (SRem, URem) to smaller integer types (such as i16 or i8) when value range analysis proves that the operands and result fit into the narrower type, sign/zero-extending the result back to the original integer type.

In clspv, when these narrowed operations remain in the IR, SPIRVProducerPass emits optional capabilities such as `OpCapability Int16` even if the kernel did not use 16-bit integer types (for example in libclc builtins like `cbrt(float)`). On devices without native 16-bit integer support (e.g., SwiftShader), such shaders fail validation.

This change adds `UndoNarrowedIntDiv` to `UndoInstCombinePass` to widen these narrowed divisions and remainders back to the destination integer type (such as i32), avoiding unnecessary OpCapability Int16 emissions.