### PR TITLE
Update LLVM

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "d34b0ab0434285bad750b5da1af3d7c9c2492f3a"
+      "commit" : "d4c19355521fe0d7af54dd80c766fa00d1c6a278"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/ClusterConstants.cpp
+++ b/lib/ClusterConstants.cpp
@@ -64,7 +64,8 @@ clspv::ClusterModuleScopeConstantVars::run(Module &M, ModuleAnalysisManager &) {
       } else {
         global_constants.push_back(&GV);
         initializers.insert(GV.getInitializer());
-        initializers_alignment[GV.getInitializer()] = GV.getAlignment();
+        initializers_alignment[GV.getInitializer()] =
+            GV.getAlign().valueOrOne().value();
       }
     }
   }


### PR DESCRIPTION
Contains https://github.com/llvm/llvm-project/pull/217240

Note that this llvm version is a bit ahead of google3, so we will have to wait a bit to import it.