### PR TITLE
Make EXTERNAL_LLVM a boolean CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(ENABLE_CLSPV_OPT "Enable the clspv-opt driver." ON)
 
-if (NOT DEFINED EXTERNAL_LLVM)
-  set(EXTERNAL_LLVM 0)
-endif()
-if (${EXTERNAL_LLVM} EQUAL 1)
+option(EXTERNAL_LLVM "Use an externally built LLVM instead of the LLVM monorepo" OFF)
+if (${EXTERNAL_LLVM})
   if (NOT DEFINED CLSPV_LLVM_SOURCE_DIR)
     message(FATAL_ERROR "External LLVM requires CLSPV_LLVM_SOURCE_DIR to be specified")
   endif()


### PR DESCRIPTION
## Summary

`EXTERNAL_LLVM` in the root `CMakeLists.txt` was defined as an integer:

```cmake
if (NOT DEFINED EXTERNAL_LLVM)
  set(EXTERNAL_LLVM 0)
endif()
if (${EXTERNAL_LLVM} EQUAL 1)
```

This breaks the standard CMake convention for enabling options. Passing `-DEXTERNAL_LLVM=ON` (or `TRUE`), which is what most users would expect, evaluates to `0` in the `EQUAL 1` numeric comparison and therefore *silently* falls back to building the bundled LLVM monorepo instead of using the external LLVM.

## Change

Replace the integer handling with a real boolean option, consistent with the other options in the same file (e.g. `ENABLE_CLSPV_OPT`, `CLSPV_SHARED_LIB`):

```cmake
option(EXTERNAL_LLVM "Use an externally built LLVM instead of the LLVM monorepo" OFF)
if (${EXTERNAL_LLVM})
```

With `option()`, `ON`/`TRUE`/`1` all enable external LLVM, and `OFF`/`FALSE`/`0`/unset all keep the default monorepo build. No default behavior changes.

Fixes #1466.