### PR TITLE
Add option to set execution mode SignedZeroInfNanPreserve

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -201,6 +201,10 @@ enum class FloatingPointType : uint32_t {
 // floating point type.
 bool ExecutionModeRoundingModeRTE(FloatingPointType rm);
 
+// Returns true when the execution mode SignedZeroInfNanPreserve should be set
+// for a floating point type.
+bool ExecutionModeSignedZeroInfNanPreserve(FloatingPointType fpty);
+
 enum class DenormMode : uint32_t {
   error,
   preserve,

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -311,6 +311,22 @@ static llvm::cl::list<clspv::Option::FloatingPointType> rounding_mode_rte(
         clEnumValN(clspv::Option::FloatingPointType::fp64, "64",
                    "Set execution mode RoundingModeRTE for fp64")));
 
+static llvm::cl::list<clspv::Option::FloatingPointType>
+    signed_zero_inf_nan_preserve(
+        "signed-zero-inf-nan-preserve",
+        llvm::cl::desc("Set execution mode SignedZeroInfNanPreserve for a "
+                       "floating point type"),
+        llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
+        llvm::cl::values(
+            clEnumValN(clspv::Option::FloatingPointType::fp16, "16",
+                       "Set execution mode SignedZeroInfNanPreserve for fp16")),
+        llvm::cl::values(
+            clEnumValN(clspv::Option::FloatingPointType::fp32, "32",
+                       "Set execution mode SignedZeroInfNanPreserve for fp32")),
+        llvm::cl::values(clEnumValN(
+            clspv::Option::FloatingPointType::fp64, "64",
+            "Set execution mode SignedZeroInfNanPreserve for fp64")));
+
 static llvm::cl::list<clspv::Option::FloatingPointType> denorm_preserve(
     "denorm-preserve",
     llvm::cl::desc(
@@ -556,6 +572,15 @@ bool ClusterPodKernelArgs() { return cluster_non_pointer_kernel_args; }
 
 bool ExecutionModeRoundingModeRTE(FloatingPointType fp) {
   for (auto type : rounding_mode_rte) {
+    if (type == fp) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ExecutionModeSignedZeroInfNanPreserve(FloatingPointType fp) {
+  for (auto type : signed_zero_inf_nan_preserve) {
     if (type == fp) {
       return true;
     }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3394,6 +3394,11 @@ void SPIRVProducerPassImpl::GenerateModuleInfo() {
        DenormMode::flush_to_zero)) {
     addCapability(spv::CapabilityDenormFlushToZero);
   }
+  if (ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp16) ||
+      ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp32) ||
+      ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp64)) {
+    addCapability(spv::CapabilitySignedZeroInfNanPreserve);
+  }
 
   SPIRVOperandVec Ops;
 
@@ -3434,8 +3439,13 @@ void SPIRVProducerPassImpl::GenerateModuleInfo() {
       (clspv::Option::ExecutionModeDenorm(FloatingPointType::fp64) !=
        DenormMode::unspecified);
 
+  bool hasSignedZero =
+      ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp16) ||
+      ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp32) ||
+      ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp64);
+
   if (SpvVersion() < SPIRVVersion::SPIRV_1_4 &&
-      (hasConvertToF() || hasDenorms)) {
+      (hasConvertToF() || hasDenorms || hasSignedZero)) {
     addSPIRVInst<kExtensions>(spv::OpExtension, "SPV_KHR_float_controls");
   }
 
@@ -3643,6 +3653,28 @@ void SPIRVProducerPassImpl::GenerateModuleInfo() {
     } else if (FP64() && mode == DenormMode::flush_to_zero) {
       Ops.clear();
       Ops << EntryPoint.second << spv::ExecutionModeDenormFlushToZero << 64;
+      addSPIRVInst<kExecutionModes>(spv::OpExecutionMode, Ops);
+    }
+
+    // Emit SignedZeroInfNanPreserve execution modes
+    if (FP16() &&
+        ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp16)) {
+      Ops.clear();
+      Ops << EntryPoint.second << spv::ExecutionModeSignedZeroInfNanPreserve
+          << 16;
+      addSPIRVInst<kExecutionModes>(spv::OpExecutionMode, Ops);
+    }
+    if (ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp32)) {
+      Ops.clear();
+      Ops << EntryPoint.second << spv::ExecutionModeSignedZeroInfNanPreserve
+          << 32;
+      addSPIRVInst<kExecutionModes>(spv::OpExecutionMode, Ops);
+    }
+    if (FP64() &&
+        ExecutionModeSignedZeroInfNanPreserve(FloatingPointType::fp64)) {
+      Ops.clear();
+      Ops << EntryPoint.second << spv::ExecutionModeSignedZeroInfNanPreserve
+          << 64;
       addSPIRVInst<kExecutionModes>(spv::OpExecutionMode, Ops);
     }
   }

--- a/test/signed_zero_inf_nan_preserve.cl
+++ b/test/signed_zero_inf_nan_preserve.cl
@@ -1,0 +1,36 @@
+// RUN: clspv %s -o %t.preserve.spv -signed-zero-inf-nan-preserve=16,32,64
+// RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+// RUN: FileCheck %s --check-prefix=PRESERVE < %t.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// RUN: clspv %s -o %t.none.spv
+// RUN: spirv-dis %t.none.spv -o %t.none.spvasm
+// RUN: FileCheck %s --check-prefix=NONE < %t.none.spvasm
+// RUN: spirv-val %t.none.spv
+
+// RUN: clspv %s -o %t.preserve14.spv -signed-zero-inf-nan-preserve=16,32,64 -spv-version 1.4
+// RUN: spirv-dis %t.preserve14.spv -o %t.preserve14.spvasm
+// RUN: FileCheck %s --check-prefix=PRESERVE14 < %t.preserve14.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve14.spv
+
+// PRESERVE: OpCapability SignedZeroInfNanPreserve
+// PRESERVE: OpExtension "SPV_KHR_float_controls"
+// PRESERVE: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 16
+// PRESERVE: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 32
+// PRESERVE: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 64
+
+// NONE-NOT: OpCapability SignedZeroInfNanPreserve
+// NONE-NOT: OpExtension "SPV_KHR_float_controls"
+// NONE-NOT: OpExecutionMode {{.*}} SignedZeroInfNanPreserve
+
+// PRESERVE14: OpCapability SignedZeroInfNanPreserve
+// PRESERVE14-NOT: OpExtension "SPV_KHR_float_controls"
+// PRESERVE14: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 16
+// PRESERVE14: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 32
+// PRESERVE14: OpExecutionMode {{.*}} SignedZeroInfNanPreserve 64
+
+void kernel foo(global int *input, global float *output)
+{
+    uint gid = get_global_id(0);
+    output[gid] = input[gid];
+}


### PR DESCRIPTION
Introduce the `-signed-zero-inf-nan-preserve` option to clspv. This option allows specifying which floating-point types (fp16, fp32, fp64) should enable the SignedZeroInfNanPreserve execution mode.

The new option:
- Emits the `SignedZeroInfNanPreserve` capability when enabled.
- Adds `SPV_KHR_float_controls` extension for SPIR-V versions prior to 1.4.
- Emits `OpExecutionMode SignedZeroInfNanPreserve <width>` on entry points for supported floating-point types.