### PR TITLE
Canonicalize operands of FMin/FMax/NMin/NMax when FTZ is enabled

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -4927,9 +4927,8 @@ SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
   };
   Type *IntegerTy;
   if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
-    IntegerTy =
-        FixedVectorType::get(getSameSizeIntegerTy(VecTy->getElementType()),
-                             VecTy->getNumElements());
+    IntegerTy = FixedVectorType::get(
+        getSameSizeIntegerTy(VecTy->getElementType()), VecTy->getNumElements());
   } else {
     IntegerTy = getSameSizeIntegerTy(InputTy);
   }

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -490,6 +490,8 @@ struct SPIRVProducerPassImpl {
                                    Value *Mask);
   SPIRVID GeneratePopcount(Type *Ty, Value *BaseValue, LLVMContext &Context);
   SPIRVID GenerateFabs(Value *Input);
+  SPIRVID GenerateCanonicalize(Value *val);
+  bool ShouldFlushDenorms(Type *Ty) const;
   SPIRVID GenerateIntegerDot(CallInst *Call, const FunctionInfo &func_info);
   void GenerateInstruction(Instruction &I);
   void GenerateFuncEpilogue();
@@ -4900,6 +4902,83 @@ SPIRVID SPIRVProducerPassImpl::GenerateFabs(Value *Input) {
   return addSPIRVInst(spv::OpBitcast, Ops);
 }
 
+bool SPIRVProducerPassImpl::ShouldFlushDenorms(Type *Ty) const {
+  Type *ScalarTy = Ty->getScalarType();
+  if (ScalarTy->isHalfTy()) {
+    return clspv::Option::ExecutionModeDenorm(
+               clspv::Option::FloatingPointType::fp16) ==
+           clspv::Option::DenormMode::flush_to_zero;
+  } else if (ScalarTy->isFloatTy()) {
+    return clspv::Option::ExecutionModeDenorm(
+               clspv::Option::FloatingPointType::fp32) !=
+           clspv::Option::DenormMode::preserve;
+  } else if (ScalarTy->isDoubleTy()) {
+    return clspv::Option::ExecutionModeDenorm(
+               clspv::Option::FloatingPointType::fp64) !=
+           clspv::Option::DenormMode::preserve;
+  }
+  return false;
+}
+
+SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
+  Type *InputTy = val->getType();
+  auto getSameSizeIntegerTy = [](Type *FpTy) {
+    return Type::getIntNTy(FpTy->getContext(), FpTy->getScalarSizeInBits());
+  };
+  Type *IntegerTy;
+  if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
+    IntegerTy =
+        FixedVectorType::get(getSameSizeIntegerTy(VecTy->getElementType()),
+                             VecTy->getNumElements());
+  } else {
+    IntegerTy = getSameSizeIntegerTy(InputTy);
+  }
+
+  SPIRVOperandVec Ops;
+  Ops << IntegerTy << val;
+  auto bitcast_val = addSPIRVInst(spv::OpBitcast, Ops);
+
+  APInt sign_mask_val = APInt::getSignMask(InputTy->getScalarSizeInBits());
+  Constant *SignMask =
+      ConstantInt::get(IntegerTy->getScalarType(), sign_mask_val);
+  if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
+    SignMask = ConstantVector::getSplat(VecTy->getElementCount(), SignMask);
+  }
+
+  Ops.clear();
+  Ops << IntegerTy << bitcast_val << SignMask;
+  auto copysign_zero_int = addSPIRVInst(spv::OpBitwiseAnd, Ops);
+
+  Ops.clear();
+  Ops << InputTy << copysign_zero_int;
+  auto copysign_zero = addSPIRVInst(spv::OpBitcast, Ops);
+
+  auto abs_val = GenerateFabs(val);
+
+  auto flt_min_ap = llvm::APFloat::getSmallestNormalized(
+      InputTy->getScalarType()->getFltSemantics());
+  Constant *flt_min_cnst =
+      ConstantFP::get(InputTy->getScalarType(), flt_min_ap);
+  if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
+    flt_min_cnst =
+        ConstantVector::getSplat(VecTy->getElementCount(), flt_min_cnst);
+  }
+
+  LLVMContext &Context = val->getContext();
+  Type *BoolTy = Type::getInt1Ty(Context);
+  if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
+    BoolTy = FixedVectorType::get(BoolTy, VecTy->getNumElements());
+  }
+
+  Ops.clear();
+  Ops << BoolTy << abs_val << flt_min_cnst;
+  auto cmp = addSPIRVInst(spv::OpFOrdLessThan, Ops);
+
+  Ops.clear();
+  Ops << InputTy << cmp << copysign_zero << val;
+  return addSPIRVInst(spv::OpSelect, Ops);
+}
+
 SPIRVID
 SPIRVProducerPassImpl::GenerateIntegerDot(CallInst *Call,
                                           const FunctionInfo &func_info) {
@@ -5129,15 +5208,25 @@ SPIRVID SPIRVProducerPassImpl::GenerateInstructionFromCall(CallInst *Call) {
   case Intrinsic::minimumnum: {
     SPIRVOperandVec Ops;
     Ops << Call->getType() << getOpExtInstImportID()
-        << glsl::ExtInst::ExtInstFMin << Call->getArgOperand(0)
-        << Call->getArgOperand(1);
+        << glsl::ExtInst::ExtInstFMin;
+    if (ShouldFlushDenorms(Call->getType())) {
+      Ops << GenerateCanonicalize(Call->getArgOperand(0))
+          << GenerateCanonicalize(Call->getArgOperand(1));
+    } else {
+      Ops << Call->getArgOperand(0) << Call->getArgOperand(1);
+    }
     return addSPIRVInst(spv::OpExtInst, Ops);
   }
   case Intrinsic::maximumnum: {
     SPIRVOperandVec Ops;
     Ops << Call->getType() << getOpExtInstImportID()
-        << glsl::ExtInst::ExtInstFMax << Call->getArgOperand(0)
-        << Call->getArgOperand(1);
+        << glsl::ExtInst::ExtInstFMax;
+    if (ShouldFlushDenorms(Call->getType())) {
+      Ops << GenerateCanonicalize(Call->getArgOperand(0))
+          << GenerateCanonicalize(Call->getArgOperand(1));
+    } else {
+      Ops << Call->getArgOperand(0) << Call->getArgOperand(1);
+    }
     return addSPIRVInst(spv::OpExtInst, Ops);
   }
   case Intrinsic::memcpy: {
@@ -5191,69 +5280,7 @@ SPIRVID SPIRVProducerPassImpl::GenerateInstructionFromCall(CallInst *Call) {
     return addSPIRVInst(spv::OpCopyMemorySized, Ops);
   }
   case Intrinsic::canonicalize: {
-    // canonicalize(x) {
-    //   if (fabs(x) < flt_min)
-    //     return copysign(0.0, x);
-    //   else
-    //      return x;
-    // }
-    auto val = Call->getArgOperand(0);
-    Type *InputTy = Call->getType();
-
-    auto getSameSizeIntegerTy = [](Type *FpTy) {
-      return Type::getIntNTy(FpTy->getContext(), FpTy->getScalarSizeInBits());
-    };
-    Type *IntegerTy;
-    if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
-      IntegerTy =
-          FixedVectorType::get(getSameSizeIntegerTy(VecTy->getElementType()),
-                               VecTy->getNumElements());
-    } else {
-      IntegerTy = getSameSizeIntegerTy(InputTy);
-    }
-
-    SPIRVOperandVec Ops;
-    Ops << IntegerTy << val;
-    auto bitcast_val = addSPIRVInst(spv::OpBitcast, Ops);
-
-    APInt sign_mask_val = APInt::getSignMask(InputTy->getScalarSizeInBits());
-    Constant *SignMask =
-        ConstantInt::get(IntegerTy->getScalarType(), sign_mask_val);
-    if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
-      SignMask = ConstantVector::getSplat(VecTy->getElementCount(), SignMask);
-    }
-
-    Ops.clear();
-    Ops << IntegerTy << bitcast_val << SignMask;
-    auto copysign_zero_int = addSPIRVInst(spv::OpBitwiseAnd, Ops);
-
-    Ops.clear();
-    Ops << InputTy << copysign_zero_int;
-    auto copysign_zero = addSPIRVInst(spv::OpBitcast, Ops);
-
-    auto abs_val = GenerateFabs(val);
-
-    auto flt_min_ap = llvm::APFloat::getSmallestNormalized(
-        InputTy->getScalarType()->getFltSemantics());
-    Constant *flt_min_cnst =
-        ConstantFP::get(InputTy->getScalarType(), flt_min_ap);
-    if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
-      flt_min_cnst =
-          ConstantVector::getSplat(VecTy->getElementCount(), flt_min_cnst);
-    }
-
-    Type *BoolTy = Type::getInt1Ty(Context);
-    if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
-      BoolTy = FixedVectorType::get(BoolTy, VecTy->getNumElements());
-    }
-
-    Ops.clear();
-    Ops << BoolTy << abs_val << flt_min_cnst;
-    auto cmp = addSPIRVInst(spv::OpFOrdLessThan, Ops);
-
-    Ops.clear();
-    Ops << InputTy << cmp << copysign_zero << val;
-    return addSPIRVInst(spv::OpSelect, Ops);
+    return GenerateCanonicalize(Call->getArgOperand(0));
   }
 
   default:
@@ -5371,6 +5398,21 @@ SPIRVID SPIRVProducerPassImpl::GenerateInstructionFromCall(CallInst *Call) {
         // code.
         Ops << Call->getOperand(0);
         break;
+      case glsl::ExtInst::ExtInstFMin:
+      case glsl::ExtInst::ExtInstFMax:
+      case glsl::ExtInst::ExtInstNMin:
+      case glsl::ExtInst::ExtInstNMax: {
+        if (ShouldFlushDenorms(Call->getType())) {
+          for (auto &use : Call->args()) {
+            Ops << GenerateCanonicalize(use.get());
+          }
+          break;
+        }
+        for (auto &use : Call->args()) {
+          Ops << use.get();
+        }
+        break;
+      }
       default:
         for (auto &use : Call->args()) {
           Ops << use.get();

--- a/test/CommonBuiltins/max/float2_max.cl
+++ b/test/CommonBuiltins/max/float2_max.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/max/float3_max.cl
+++ b/test/CommonBuiltins/max/float3_max.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/max/float3_max_novec3.cl
+++ b/test/CommonBuiltins/max/float3_max_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/max/float4_max.cl
+++ b/test/CommonBuiltins/max/float4_max.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/max/float_max.cl
+++ b/test/CommonBuiltins/max/float_max.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/max/half_fmax_denorm.cl
+++ b/test/CommonBuiltins/max/half_fmax_denorm.cl
@@ -1,0 +1,31 @@
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=16,64
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=16,64
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-FLUSH: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-FLUSH: %[[CMP:[a-zA-Z0-9_]*]] = OpFOrdLessThan
+// CHECK-FLUSH: %[[SEL:[a-zA-Z0-9_]*]] = OpSelect %[[HALF_TYPE_ID]] %[[CMP]]
+// CHECK-FLUSH: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] NMax %[[SEL]]
+// CHECK-FLUSH: OpStore {{.*}} %[[OP]]
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] NMax %[[LOAD0]] %[[LOAD1]]
+// CHECK-PRESERVE: OpStore {{.*}} %[[OP]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* in, global half* out)
+{
+  *out = fmax(in[0], in[1]);
+}

--- a/test/CommonBuiltins/min/float2_min.cl
+++ b/test/CommonBuiltins/min/float2_min.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/min/float3_min.cl
+++ b/test/CommonBuiltins/min/float3_min.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/min/float3_min_novec3.cl
+++ b/test/CommonBuiltins/min/float3_min_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/min/float4_min.cl
+++ b/test/CommonBuiltins/min/float4_min.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/min/float_min.cl
+++ b/test/CommonBuiltins/min/float_min.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/CommonBuiltins/min/half_fmin_denorm.cl
+++ b/test/CommonBuiltins/min/half_fmin_denorm.cl
@@ -1,0 +1,31 @@
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=16,64
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=16,64
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-FLUSH: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-FLUSH: %[[CMP:[a-zA-Z0-9_]*]] = OpFOrdLessThan
+// CHECK-FLUSH: %[[SEL:[a-zA-Z0-9_]*]] = OpSelect %[[HALF_TYPE_ID]] %[[CMP]]
+// CHECK-FLUSH: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] NMin %[[SEL]]
+// CHECK-FLUSH: OpStore {{.*}} %[[OP]]
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] NMin %[[LOAD0]] %[[LOAD1]]
+// CHECK-PRESERVE: OpStore {{.*}} %[[OP]]
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* in, global half* out)
+{
+  *out = fmin(in[0], in[1]);
+}

--- a/test/MathBuiltins/fmax/float2_fmax.cl
+++ b/test/MathBuiltins/fmax/float2_fmax.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmax/float3_fmax.cl
+++ b/test/MathBuiltins/fmax/float3_fmax.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmax/float3_fmax_novec3.cl
+++ b/test/MathBuiltins/fmax/float3_fmax_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmax/float4_fmax.cl
+++ b/test/MathBuiltins/fmax/float4_fmax.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmax/float_fmax.cl
+++ b/test/MathBuiltins/fmax/float_fmax.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmax/float_fmax_denorm.cl
+++ b/test/MathBuiltins/fmax/float_fmax_denorm.cl
@@ -1,0 +1,29 @@
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=32
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-FLUSH: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-FLUSH: %[[CMP:[a-zA-Z0-9_]*]] = OpFOrdLessThan
+// CHECK-FLUSH: %[[SEL:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_TYPE_ID]] %[[CMP]]
+// CHECK-FLUSH: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMax %[[SEL]]
+// CHECK-FLUSH: OpStore {{.*}} %[[OP]]
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE-DAG: %[[CST1:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-PRESERVE: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMax %[[LOADB]] %[[CST1]]
+// CHECK-PRESERVE: OpStore {{.*}} %[[OP]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
+{
+  *a = fmax(*b, 1.0f);
+}

--- a/test/MathBuiltins/fmin/float2_fmin.cl
+++ b/test/MathBuiltins/fmin/float2_fmin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmin/float3_fmin.cl
+++ b/test/MathBuiltins/fmin/float3_fmin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmin/float3_fmin_novec3.cl
+++ b/test/MathBuiltins/fmin/float3_fmin_novec3.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -vec3-to-vec4
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -vec3-to-vec4
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmin/float4_fmin.cl
+++ b/test/MathBuiltins/fmin/float4_fmin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmin/float_fmin.cl
+++ b/test/MathBuiltins/fmin/float_fmin.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fmin/float_fmin_denorm.cl
+++ b/test/MathBuiltins/fmin/float_fmin_denorm.cl
@@ -1,0 +1,29 @@
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=32
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-FLUSH: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-FLUSH: %[[CMP:[a-zA-Z0-9_]*]] = OpFOrdLessThan
+// CHECK-FLUSH: %[[SEL:[a-zA-Z0-9_]*]] = OpSelect %[[FLOAT_TYPE_ID]] %[[CMP]]
+// CHECK-FLUSH: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMin %[[SEL]]
+// CHECK-FLUSH: OpStore {{.*}} %[[OP]]
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE-DAG: %[[CST1:[a-zA-Z0-9_]*]] = OpConstant %[[FLOAT_TYPE_ID]] 1
+// CHECK-PRESERVE: %[[LOADB:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] NMin %[[LOADB]] %[[CST1]]
+// CHECK-PRESERVE: OpStore {{.*}} %[[OP]]
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b)
+{
+  *a = fmin(*b, 1.0f);
+}

--- a/test/MathBuiltins/fract/float2_fract_private.cl
+++ b/test/MathBuiltins/fract/float2_fract_private.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -cl-native-math
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -cl-native-math
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fract/float3_fract_private.cl
+++ b/test/MathBuiltins/fract/float3_fract_private.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -cl-native-math
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -cl-native-math
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fract/float4_fract_private.cl
+++ b/test/MathBuiltins/fract/float4_fract_private.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -cl-native-math
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -cl-native-math
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/fract/float_fract_private.cl
+++ b/test/MathBuiltins/fract/float_fract_private.cl
@@ -1,4 +1,4 @@
-// RUN: clspv %target %s -o %t.spv -cl-native-math
+// RUN: clspv %target -denorm-preserve=32 %s -o %t.spv -cl-native-math
 // RUN: spirv-dis -o %t2.spvasm %t.spv
 // RUN: FileCheck %s < %t2.spvasm
 // RUN: spirv-val --target-env vulkan1.0 %t.spv

--- a/test/MathBuiltins/maxmag/float4_maxmag.cl
+++ b/test/MathBuiltins/maxmag/float4_maxmag.cl
@@ -1,0 +1,44 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK: %[[RES:[a-zA-Z0-9_]*]] = OpCompositeConstruct %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: OpStore {{.*}}
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-PRESERVE: %[[E0_0:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 0
+// CHECK-PRESERVE: %[[E1_0:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 0
+// CHECK-PRESERVE: %[[M0:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[E0_0]] %[[E1_0]]
+// CHECK-PRESERVE: %[[E0_1:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 1
+// CHECK-PRESERVE: %[[E1_1:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 1
+// CHECK-PRESERVE: %[[M1:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[E0_1]] %[[E1_1]]
+// CHECK-PRESERVE: %[[E0_2:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 2
+// CHECK-PRESERVE: %[[E1_2:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 2
+// CHECK-PRESERVE: %[[M2:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[E0_2]] %[[E1_2]]
+// CHECK-PRESERVE: %[[E0_3:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 3
+// CHECK-PRESERVE: %[[E1_3:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 3
+// CHECK-PRESERVE: %[[M3:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[E0_3]] %[[E1_3]]
+// CHECK-PRESERVE: %[[RES:[a-zA-Z0-9_]*]] = OpCompositeConstruct %[[FLOAT_VECTOR_TYPE_ID]] %[[M0]] %[[M1]] %[[M2]] %[[M3]]
+// CHECK-PRESERVE: OpStore {{.*}}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b, global float4* out)
+{
+  *out = maxmag(*a, *b);
+}

--- a/test/MathBuiltins/maxmag/float_maxmag.cl
+++ b/test/MathBuiltins/maxmag/float_maxmag.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK: OpStore {{.*}}
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMax %[[LOAD0]] %[[LOAD1]]
+// CHECK-PRESERVE: OpStore {{.*}}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b, global float* out)
+{
+  *out = maxmag(*a, *b);
+}

--- a/test/MathBuiltins/maxmag/half_maxmag.cl
+++ b/test/MathBuiltins/maxmag/half_maxmag.cl
@@ -1,0 +1,28 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=16,64
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] FMax %[[LOAD0]] %[[LOAD1]]
+// CHECK: OpStore {{.*}}
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-FLUSH: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] FMax
+// CHECK-FLUSH: OpStore {{.*}}
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* a, global half* b, global half* out)
+{
+  *out = maxmag(*a, *b);
+}

--- a/test/MathBuiltins/minmag/float4_minmag.cl
+++ b/test/MathBuiltins/minmag/float4_minmag.cl
@@ -1,0 +1,44 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK: OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK: %[[RES:[a-zA-Z0-9_]*]] = OpCompositeConstruct %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK: OpStore {{.*}}
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE-DAG: %[[FLOAT_VECTOR_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeVector %[[FLOAT_TYPE_ID]] 4
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_VECTOR_TYPE_ID]]
+// CHECK-PRESERVE: %[[E0_0:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 0
+// CHECK-PRESERVE: %[[E1_0:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 0
+// CHECK-PRESERVE: %[[M0:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[E0_0]] %[[E1_0]]
+// CHECK-PRESERVE: %[[E0_1:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 1
+// CHECK-PRESERVE: %[[E1_1:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 1
+// CHECK-PRESERVE: %[[M1:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[E0_1]] %[[E1_1]]
+// CHECK-PRESERVE: %[[E0_2:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 2
+// CHECK-PRESERVE: %[[E1_2:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 2
+// CHECK-PRESERVE: %[[M2:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[E0_2]] %[[E1_2]]
+// CHECK-PRESERVE: %[[E0_3:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD0]] 3
+// CHECK-PRESERVE: %[[E1_3:[a-zA-Z0-9_]*]] = OpCompositeExtract %[[FLOAT_TYPE_ID]] %[[LOAD1]] 3
+// CHECK-PRESERVE: %[[M3:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[E0_3]] %[[E1_3]]
+// CHECK-PRESERVE: %[[RES:[a-zA-Z0-9_]*]] = OpCompositeConstruct %[[FLOAT_VECTOR_TYPE_ID]] %[[M0]] %[[M1]] %[[M2]] %[[M3]]
+// CHECK-PRESERVE: OpStore {{.*}}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float4* a, global float4* b, global float4* out)
+{
+  *out = minmag(*a, *b);
+}

--- a/test/MathBuiltins/minmag/float_minmag.cl
+++ b/test/MathBuiltins/minmag/float_minmag.cl
@@ -1,0 +1,26 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.preserve.spv -denorm-preserve=32
+// RUN: spirv-dis -o %t2.preserve.spvasm %t.preserve.spv
+// RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t2.preserve.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK: OpStore {{.*}}
+
+// CHECK-PRESERVE: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-PRESERVE-DAG: %[[FLOAT_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 32
+// CHECK-PRESERVE: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[FLOAT_TYPE_ID]]
+// CHECK-PRESERVE: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[FLOAT_TYPE_ID]] %[[EXT_INST]] FMin %[[LOAD0]] %[[LOAD1]]
+// CHECK-PRESERVE: OpStore {{.*}}
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global float* a, global float* b, global float* out)
+{
+  *out = minmag(*a, *b);
+}

--- a/test/MathBuiltins/minmag/half_minmag.cl
+++ b/test/MathBuiltins/minmag/half_minmag.cl
@@ -1,0 +1,28 @@
+// RUN: clspv %target %s -o %t.spv
+// RUN: spirv-dis -o %t2.spvasm %t.spv
+// RUN: FileCheck %s < %t2.spvasm
+// RUN: spirv-val --target-env vulkan1.0 %t.spv
+
+// RUN: clspv %target %s -o %t.flush.spv -denorm-flush-to-zero=16,64
+// RUN: spirv-dis -o %t2.flush.spvasm %t.flush.spv
+// RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t2.flush.spvasm
+// RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+// CHECK: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK: %[[LOAD0:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[LOAD1:[a-zA-Z0-9_]*]] = OpLoad %[[HALF_TYPE_ID]]
+// CHECK: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] FMin %[[LOAD0]] %[[LOAD1]]
+// CHECK: OpStore {{.*}}
+
+// CHECK-FLUSH: %[[EXT_INST:[a-zA-Z0-9_]*]] = OpExtInstImport "GLSL.std.450"
+// CHECK-FLUSH-DAG: %[[HALF_TYPE_ID:[a-zA-Z0-9_]*]] = OpTypeFloat 16
+// CHECK-FLUSH: %[[OP_ID:[a-zA-Z0-9_]*]] = OpExtInst %[[HALF_TYPE_ID]] %[[EXT_INST]] FMin
+// CHECK-FLUSH: OpStore {{.*}}
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+void kernel __attribute__((reqd_work_group_size(1, 1, 1))) foo(global half* a, global half* b, global half* out)
+{
+  *out = minmag(*a, *b);
+}

--- a/test/SPIRVProducer/fmax.ll
+++ b/test/SPIRVProducer/fmax.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[float]]
+; CHECK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+; CHECK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+; CHECK-DAG: [[one:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+; CHECK-DAG: [[two:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2{{$}}
+; CHECK-DAG: [[mask_sign:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+; CHECK-DAG: [[mask_abs:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+; CHECK-DAG: [[float_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 1.17549435e-38
+; CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[one]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK: [[cast1_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and1_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_0]] [[mask_sign]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_0]]
+; CHECK: [[cast2_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and2_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_0]] [[mask_abs]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_0]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[float_min_norm]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[cast1_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and1_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_1]] [[mask_sign]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_1]]
+; CHECK: [[cast2_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and2_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_1]] [[mask_abs]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_1]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[float_min_norm]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} NMax [[canon0]] [[canon1]]
+; CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[two]]
+; CHECK: OpStore [[gep2]] [[min]]
+
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float:%[a-zA-Z0-9_]+]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} NMax [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load float, ptr addrspace(1) %1, align 4
+  %2 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load float, ptr addrspace(1) %2, align 4
+  %res = call spir_func float @_Z4fmaxff(float %ld1, float %ld2)
+  %3 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store float %res, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
+declare spir_func float @_Z4fmaxff(float, float)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/fmax_half.ll
+++ b/test/SPIRVProducer/fmax_half.ll
@@ -1,0 +1,53 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.flush.ll --passes=spirv-producer -producer-out-file %t.flush.spv -denorm-flush-to-zero=16,64
+; RUN: spirv-dis %t.flush.spv -o %t.flush.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t.flush.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+; CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[half]] %{{.*}} NMax [[ld0]] [[ld1]]
+; CHECK: OpStore {{.*}} [[min]]
+
+; CHECK-FLUSH-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+; CHECK-FLUSH-DAG: [[ushort:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
+; CHECK-FLUSH-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-FLUSH-DAG: [[half_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[half]] 0x1p-14
+; CHECK-FLUSH: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK-FLUSH: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK-FLUSH: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[half_min_norm]]
+; CHECK-FLUSH: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[half]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK-FLUSH: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[half_min_norm]]
+; CHECK-FLUSH: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[half]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK-FLUSH: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[half]] %{{.*}} NMax [[canon0]] [[canon1]]
+; CHECK-FLUSH: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 2 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x half] } zeroinitializer)
+  %1 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load half, ptr addrspace(1) %1, align 2
+  %2 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load half, ptr addrspace(1) %2, align 2
+  %res = call spir_func half @_Z4fmaxDhDh(half %ld1, half %ld2)
+  %3 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store half %res, ptr addrspace(1) %3, align 2
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x half] })
+declare spir_func half @_Z4fmaxDhDh(half, half)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/fmax_vector.ll
+++ b/test/SPIRVProducer/fmax_vector.ll
@@ -1,0 +1,56 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
+; CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[v2uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 2
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[v2bool:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 2
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[v2bool]] [[abs0]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[v2float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[v2bool]] [[abs1]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[v2float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[v2float]] %{{.*}} NMax [[canon0]] [[canon1]]
+; CHECK: OpStore {{.*}} [[min]]
+
+; CHECK-PRESERVE-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-PRESERVE-DAG: [[v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[v2float]] %{{.*}} NMax [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 8 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <2 x float>] } zeroinitializer)
+  %1 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load <2 x float>, ptr addrspace(1) %1, align 8
+  %2 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load <2 x float>, ptr addrspace(1) %2, align 8
+  %res = call spir_func <2 x float> @_Z4fmaxDv2_fS_(<2 x float> %ld1, <2 x float> %ld2)
+  %3 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store <2 x float> %res, ptr addrspace(1) %3, align 8
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <2 x float>] })
+declare spir_func <2 x float> @_Z4fmaxDv2_fS_(<2 x float>, <2 x float>)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/fmin.ll
+++ b/test/SPIRVProducer/fmin.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[float]]
+; CHECK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+; CHECK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+; CHECK-DAG: [[one:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+; CHECK-DAG: [[two:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2{{$}}
+; CHECK-DAG: [[mask_sign:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+; CHECK-DAG: [[mask_abs:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+; CHECK-DAG: [[float_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 1.17549435e-38
+; CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[one]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK: [[cast1_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and1_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_0]] [[mask_sign]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_0]]
+; CHECK: [[cast2_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and2_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_0]] [[mask_abs]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_0]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[float_min_norm]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[cast1_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and1_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_1]] [[mask_sign]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_1]]
+; CHECK: [[cast2_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and2_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_1]] [[mask_abs]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_1]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[float_min_norm]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} NMin [[canon0]] [[canon1]]
+; CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[two]]
+; CHECK: OpStore [[gep2]] [[min]]
+
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float:%[a-zA-Z0-9_]+]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} NMin [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load float, ptr addrspace(1) %1, align 4
+  %2 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load float, ptr addrspace(1) %2, align 4
+  %res = call spir_func float @_Z4fminff(float %ld1, float %ld2)
+  %3 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store float %res, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
+declare spir_func float @_Z4fminff(float, float)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/fmin_half.ll
+++ b/test/SPIRVProducer/fmin_half.ll
@@ -1,0 +1,53 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.flush.ll --passes=spirv-producer -producer-out-file %t.flush.spv -denorm-flush-to-zero=16,64
+; RUN: spirv-dis %t.flush.spv -o %t.flush.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-FLUSH < %t.flush.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.flush.spv
+
+; CHECK-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[half]] %{{.*}} NMin [[ld0]] [[ld1]]
+; CHECK: OpStore {{.*}} [[min]]
+
+; CHECK-FLUSH-DAG: [[half:%[a-zA-Z0-9_]+]] = OpTypeFloat 16
+; CHECK-FLUSH-DAG: [[ushort:%[a-zA-Z0-9_]+]] = OpTypeInt 16 0
+; CHECK-FLUSH-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-FLUSH-DAG: [[half_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[half]] 0x1p-14
+; CHECK-FLUSH: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK-FLUSH: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[half]]
+; CHECK-FLUSH: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[half_min_norm]]
+; CHECK-FLUSH: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[half]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK-FLUSH: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[half]]
+; CHECK-FLUSH: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[half_min_norm]]
+; CHECK-FLUSH: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[half]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK-FLUSH: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[half]] %{{.*}} NMin [[canon0]] [[canon1]]
+; CHECK-FLUSH: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 2 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x half] } zeroinitializer)
+  %1 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load half, ptr addrspace(1) %1, align 2
+  %2 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load half, ptr addrspace(1) %2, align 2
+  %res = call spir_func half @_Z4fminDhDh(half %ld1, half %ld2)
+  %3 = getelementptr { [0 x half] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store half %res, ptr addrspace(1) %3, align 2
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x half] })
+declare spir_func half @_Z4fminDhDh(half, half)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/fmin_vector.ll
+++ b/test/SPIRVProducer/fmin_vector.ll
@@ -1,0 +1,56 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
+; CHECK-DAG: [[uint:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[v2uint:%[a-zA-Z0-9_]+]] = OpTypeVector [[uint]] 2
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[v2bool:%[a-zA-Z0-9_]+]] = OpTypeVector [[bool]] 2
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[v2bool]] [[abs0]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[v2float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[v2float]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[v2bool]] [[abs1]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[v2float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[v2float]] %{{.*}} NMin [[canon0]] [[canon1]]
+; CHECK: OpStore {{.*}} [[min]]
+
+; CHECK-PRESERVE-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-PRESERVE-DAG: [[v2float:%[a-zA-Z0-9_]+]] = OpTypeVector [[float]] 2
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[v2float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[v2float]] %{{.*}} NMin [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 8 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x <2 x float>] } zeroinitializer)
+  %1 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load <2 x float>, ptr addrspace(1) %1, align 8
+  %2 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load <2 x float>, ptr addrspace(1) %2, align 8
+  %res = call spir_func <2 x float> @_Z4fminDv2_fS_(<2 x float> %ld1, <2 x float> %ld2)
+  %3 = getelementptr { [0 x <2 x float>] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store <2 x float> %res, ptr addrspace(1) %3, align 8
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x <2 x float>] })
+declare spir_func <2 x float> @_Z4fminDv2_fS_(<2 x float>, <2 x float>)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/maximumnum.ll
+++ b/test/SPIRVProducer/maximumnum.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv -denorm-preserve=32
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val %t.spv

--- a/test/SPIRVProducer/maxnum.ll
+++ b/test/SPIRVProducer/maxnum.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[float]]
+; CHECK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+; CHECK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+; CHECK-DAG: [[one:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+; CHECK-DAG: [[two:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2{{$}}
+; CHECK-DAG: [[mask_sign:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+; CHECK-DAG: [[mask_abs:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+; CHECK-DAG: [[float_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 1.17549435e-38
+; CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[one]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK: [[cast1_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and1_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_0]] [[mask_sign]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_0]]
+; CHECK: [[cast2_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and2_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_0]] [[mask_abs]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_0]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[float_min_norm]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[cast1_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and1_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_1]] [[mask_sign]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_1]]
+; CHECK: [[cast2_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and2_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_1]] [[mask_abs]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_1]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[float_min_norm]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} FMax [[canon0]] [[canon1]]
+; CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[two]]
+; CHECK: OpStore [[gep2]] [[min]]
+
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float:%[a-zA-Z0-9_]+]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} FMax [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load float, ptr addrspace(1) %1, align 4
+  %2 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load float, ptr addrspace(1) %2, align 4
+  %res = call float @llvm.maxnum.f32(float %ld1, float %ld2)
+  %3 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store float %res, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
+declare float @llvm.maxnum.f32(float, float)
+
+!8 = !{i32 2}

--- a/test/SPIRVProducer/minimumnum.ll
+++ b/test/SPIRVProducer/minimumnum.ll
@@ -1,4 +1,4 @@
-; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv -denorm-preserve=32
 ; RUN: spirv-dis %t.spv -o %t.spvasm
 ; RUN: FileCheck %s < %t.spvasm
 ; RUN: spirv-val %t.spv

--- a/test/SPIRVProducer/minnum.ll
+++ b/test/SPIRVProducer/minnum.ll
@@ -1,0 +1,73 @@
+; RUN: clspv-opt %s -o %t.ll --passes=spirv-producer -producer-out-file %t.spv
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s < %t.spvasm
+; RUN: spirv-val %t.spv
+
+; RUN: clspv-opt %s -o %t.preserve.ll --passes=spirv-producer -producer-out-file %t.preserve.spv -denorm-preserve=32
+; RUN: spirv-dis %t.preserve.spv -o %t.preserve.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-PRESERVE < %t.preserve.spvasm
+; RUN: spirv-val --target-env spv1.4 %t.preserve.spv
+
+; CHECK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[float]]
+; CHECK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+; CHECK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0
+; CHECK-DAG: [[one:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1
+; CHECK-DAG: [[two:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2{{$}}
+; CHECK-DAG: [[mask_sign:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+; CHECK-DAG: [[mask_abs:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+; CHECK-DAG: [[float_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 1.17549435e-38
+; CHECK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep0]]
+; CHECK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[one]]
+; CHECK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK: [[cast1_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and1_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_0]] [[mask_sign]]
+; CHECK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_0]]
+; CHECK: [[cast2_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK: [[and2_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_0]] [[mask_abs]]
+; CHECK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_0]]
+; CHECK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[float_min_norm]]
+; CHECK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK: [[cast1_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and1_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_1]] [[mask_sign]]
+; CHECK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_1]]
+; CHECK: [[cast2_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK: [[and2_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_1]] [[mask_abs]]
+; CHECK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_1]]
+; CHECK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[float_min_norm]]
+; CHECK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} FMin [[canon0]] [[canon1]]
+; CHECK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[two]]
+; CHECK: OpStore [[gep2]] [[min]]
+
+; CHECK-PRESERVE: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float:%[a-zA-Z0-9_]+]]
+; CHECK-PRESERVE: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]]
+; CHECK-PRESERVE: [[min:%[a-zA-Z0-9_]+]] = OpExtInst [[float]] %{{.*}} FMin [[ld0]] [[ld1]]
+; CHECK-PRESERVE: OpStore {{.*}} [[min]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld1 = load float, ptr addrspace(1) %1, align 4
+  %2 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld2 = load float, ptr addrspace(1) %2, align 4
+  %res = call float @llvm.minnum.f32(float %ld1, float %ld2)
+  %3 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store float %res, ptr addrspace(1) %3, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
+declare float @llvm.minnum.f32(float, float)
+
+!8 = !{i32 2}


### PR DESCRIPTION
In OpenCL, math builtins such as fmax, fmin, maxmag, and minmag require correct handling of subnormal values and signed zeros. When Flush-To-Zero (FTZ) mode is active (default for single/double precision unless preserved, and optional for half precision), subnormals must be treated as signed zeros (+0.0 / -0.0) before min/max comparisons and magnitude equality checks.

This change canonicalizes floating-point inputs to:
- llvm.minimumnum and llvm.maximumnum intrinsics (mapped to FMin/FMax)
- GLSL extended instructions FMin, FMax, NMin, and NMax

when denormals should be flushed to zero according to the configured DenormMode.