### PR TITLE
Fix infinite loop/assert in SimplifyPointerBitcastPass

### DIFF
--- a/lib/SimplifyPointerBitcastPass.cpp
+++ b/lib/SimplifyPointerBitcastPass.cpp
@@ -915,15 +915,14 @@ bool clspv::SimplifyPointerBitcastPass::runOnUpgradeableConstantCasts(
             }
             size_t dest_ty_size = SizeInBits(DL, dest_ty);
             dest_ty_size /= 2;
-            dest_ty = Type::getIntNTy(context, dest_ty_size);
 
-            while (dest_ty != source_ty) {
+            while (dest_ty_size > SizeInBits(DL, source_ty)) {
+              dest_ty = Type::getIntNTy(context, dest_ty_size);
               if (gepIndicesCanBeUpgradedTo(dest_ty, gep, cstVal, dynVal,
                                             smallerBitWidths)) {
                 return dest_ty;
               }
               dest_ty_size /= 2;
-              dest_ty = Type::getIntNTy(context, dest_ty_size);
             }
 
             return source_ty;

--- a/test/PointerCasts/issue-1632.cl
+++ b/test/PointerCasts/issue-1632.cl
@@ -1,0 +1,14 @@
+// RUN: clspv %s -o %t.spv
+// RUN: spirv-dis %t.spv -o %t.spvasm
+// RUN: spirv-val %t.spv --target-env spv1.0
+
+struct S16 { float4 v; };
+
+__kernel void kern(__global struct S16 *in, __global long *out) {
+    size_t lid = get_local_id(0);
+    size_t gid = get_group_id(0);
+    __global struct S16 *s1 = in + lid;
+    __global uchar *s2 = (__global uchar *)s1 + gid;
+    long v = *(__global long *)s2;
+    out[lid] = v;
+}

--- a/test/PointerCasts/issue-1632.ll
+++ b/test/PointerCasts/issue-1632.ll
@@ -1,0 +1,20 @@
+; RUN: clspv-opt %s -o %t.ll --passes=simplify-pointer-bitcast
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: getelementptr %struct.S16, ptr addrspace(1) %in, i32 %lid, i32 0, i32 %gid
+; CHECK: load i64, ptr addrspace(1)
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+%struct.S16 = type { <4 x float> }
+
+define spir_kernel void @kern(ptr addrspace(1) %in, ptr addrspace(1) %out, i32 %lid, i32 %gid) {
+entry:
+  %s1 = getelementptr %struct.S16, ptr addrspace(1) %in, i32 %lid
+  %s2 = getelementptr float, ptr addrspace(1) %s1, i32 %gid
+  %v = load i64, ptr addrspace(1) %s2, align 8
+  %out_ptr = getelementptr i64, ptr addrspace(1) %out, i32 %lid
+  store i64 %v, ptr addrspace(1) %out_ptr, align 8
+  ret void
+}


### PR DESCRIPTION
`findBiggerTyToUpdate` assumed `dest_ty` would eventually match `source_ty` when halved. If `source_ty` is not an integer (e.g. float), `dest_ty_size` would drop to 0, triggering an infinite loop or assertion failure in `getIntNTy`.

Fixes #1632