### PR TITLE
Add support for LLVM PtrToAddr instruction

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -6,7 +6,7 @@
       "subrepo" : "llvm/llvm-project",
       "branch" : "main",
       "subdir" : "third_party/llvm",
-      "commit" : "d4c19355521fe0d7af54dd80c766fa00d1c6a278"
+      "commit" : "ab547095ead5464dc024d66264d9b8a987f429f3"
     },
     {
       "name" : "SPIRV-Headers",

--- a/lib/LogicalPointerToIntPass.cpp
+++ b/lib/LogicalPointerToIntPass.cpp
@@ -53,7 +53,8 @@ static bool IsTargetAddrSpace(unsigned AS) {
 static bool FunctionShouldBeInlined(Function &F) {
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
-      if (isa<IntToPtrInst>(I) || isa<PtrToIntInst>(I)) {
+      if (isa<IntToPtrInst>(I) || isa<PtrToIntInst>(I) ||
+          isa<PtrToAddrInst>(I)) {
         return true;
       }
     }
@@ -106,7 +107,8 @@ clspv::LogicalPointerToIntPass::run(Module &M, ModuleAnalysisManager &MAM) {
     for (auto &BB : F) {
       for (auto &I : BB) {
         if (auto *Cast = dyn_cast<CastInst>(&I)) {
-          if (Cast->getOpcode() == Instruction::PtrToInt) {
+          if (Cast->getOpcode() == Instruction::PtrToInt ||
+              Cast->getOpcode() == Instruction::PtrToAddr) {
             if (auto *PtrTy =
                     cast<PointerType>(Cast->getOperand(0)->getType())) {
               if (IsTargetAddrSpace(PtrTy->getAddressSpace())) {

--- a/lib/LongVectorLoweringPass.cpp
+++ b/lib/LongVectorLoweringPass.cpp
@@ -949,6 +949,11 @@ Value *clspv::LongVectorLoweringPass::visitCastInst(CastInst &I) {
     V = B.CreatePtrToInt(EquivalentValue, EquivalentDestTy, I.getName());
     break;
   }
+  case Instruction::PtrToAddr: {
+    IRBuilder<> B(&I);
+    V = B.CreatePtrToAddr(EquivalentValue, I.getName());
+    break;
+  }
   case Instruction::IntToPtr: {
     IRBuilder<> B(&I);
     V = B.CreateIntToPtr(EquivalentValue, EquivalentDestTy, I.getName());
@@ -1381,6 +1386,9 @@ bool clspv::LongVectorLoweringPass::handlingRequired(User &U) {
     if (getEquivalentType(gep->getSourceElementType()) != nullptr)
       return true;
   } else if (auto *ptr = dyn_cast<PtrToIntInst>(&U)) {
+    if (visit(ptr->getPointerOperand()) != nullptr)
+      return true;
+  } else if (auto *ptr = dyn_cast<PtrToAddrInst>(&U)) {
     if (visit(ptr->getPointerOperand()) != nullptr)
       return true;
   }

--- a/lib/LowerAddrSpaceCastPass.cpp
+++ b/lib/LowerAddrSpaceCastPass.cpp
@@ -338,6 +338,18 @@ Value *clspv::LowerAddrSpaceCastPass::visitPtrToIntInst(PtrToIntInst &I) {
   return ptrToInt;
 }
 
+Value *clspv::LowerAddrSpaceCastPass::visitPtrToAddrInst(PtrToAddrInst &I) {
+  auto ptr = visit(I.getPointerOperand());
+
+  IRBuilder<> B(&I);
+  auto ptrToAddr = B.CreatePtrToAddr(ptr);
+
+  registerReplacement(&I, ptrToAddr);
+  I.replaceAllUsesWith(ptrToAddr);
+
+  return ptrToAddr;
+}
+
 static bool DependsOnPhiNode(const Value *V, const PHINode *PhiNode) {
   DenseSet<const llvm::Value *> Visited;
   if (!isa<Instruction>(V)) {

--- a/lib/LowerAddrSpaceCastPass.h
+++ b/lib/LowerAddrSpaceCastPass.h
@@ -45,6 +45,7 @@ private:
   llvm::Value *visitCallInst(llvm::CallInst &I);
   llvm::Value *visitIntToPtrInst(llvm::IntToPtrInst &I);
   llvm::Value *visitPtrToIntInst(llvm::PtrToIntInst &I);
+  llvm::Value *visitPtrToAddrInst(llvm::PtrToAddrInst &I);
   llvm::Value *visitPHINode(llvm::PHINode &I);
   llvm::Value *visitInstruction(llvm::Instruction &I);
 

--- a/lib/LowerPrivatePointerPHIPass.cpp
+++ b/lib/LowerPrivatePointerPHIPass.cpp
@@ -322,6 +322,14 @@ void clspv::LowerPrivatePointerPHIPass::runOnFunction(Function &F) {
         auto newPtrToInt = B.CreatePtrToInt(gep, ptrtoint->getDestTy());
         ptrtoint->replaceAllUsesWith(newPtrToInt);
         ToBeErased.push_back(ptrtoint);
+      } else if (auto ptrtoaddr = dyn_cast<PtrToAddrInst>(node)) {
+        IRBuilder<> B(ptrtoaddr);
+        auto gep = makeNewGEP(DL, B, alloca, alloca->getAllocatedType(),
+                              B.getIntNTy(SmallerBitWidths), CstVal, DynVal,
+                              SmallerBitWidths);
+        auto newPtrToAddr = B.CreatePtrToAddr(gep);
+        ptrtoaddr->replaceAllUsesWith(newPtrToAddr);
+        ToBeErased.push_back(ptrtoaddr);
       } else if (auto icmp = dyn_cast<ICmpInst>(node)) {
         int opId = -1;
         int otherOpIsIntToPtr = -1;

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -3872,8 +3872,9 @@ spv::Op SPIRVProducerPassImpl::GetSPIRVCastOpcode(Instruction &I) {
       {Instruction::FPExt, spv::OpFConvert},
       {Instruction::BitCast, spv::OpBitcast},
       {Instruction::PtrToInt, spv::OpConvertPtrToU},
+      {Instruction::PtrToAddr, spv::OpConvertPtrToU},
       {Instruction::IntToPtr, spv::OpConvertUToPtr},
-      };
+  };
 
   assert(0 != Map.count(I.getOpcode()));
 

--- a/test/LogicalPtrToInt/ptrtoaddr.ll
+++ b/test/LogicalPtrToInt/ptrtoaddr.ll
@@ -1,0 +1,22 @@
+; RUN: clspv-opt %s -o %t.ll --passes=logical-pointer-to-int
+; RUN: FileCheck %s < %t.ll
+
+; We expect a base of 1152921504606846976 (0x1000000000000000) plus an offset
+; of 4 x 4 + 4 + 8 * %i = 20 + (%i << 3) => 1152921504606846996 (0x1000000000000014)
+
+; CHECK:  [[shl0:%[^ ]+]] = shl i64 %i, 1
+; CHECK:  [[shl1:%[^ ]+]] = shl i64 [[shl0]], 2
+; CHECK:  [[add:%[^ ]+]] = add i64 1152921504606846996, [[shl1]]
+; CHECK:  store i64 [[add]], ptr %dst, align 4
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-vulkan"
+
+define dso_local spir_kernel void @foo(ptr %dst, i64 %i) {
+entry:
+  %gep = getelementptr i32, ptr %dst, i64 4
+  %gep2 = getelementptr <2 x i32>, ptr %gep, i64 %i, i64 1
+  %ptrtoaddr = ptrtoaddr ptr %gep2 to i64
+  store i64 %ptrtoaddr, ptr %dst, align 4
+  ret void
+}


### PR DESCRIPTION
Recent versions of LLVM generate `ptrtoaddr` instructions for pointer subtraction and address calculations. Support `Instruction::PtrToAddr` across passes that handle pointer casts:
- Lower `PtrToAddr` in `LogicalPointerToIntPass` alongside `PtrToInt`.
- Map `Instruction::PtrToAddr` to `spv::OpConvertPtrToU` in `SPIRVProducerPass`.
- Support `PtrToAddr` in `LowerAddrSpaceCastPass`, `LowerPrivatePointerPHIPass`, and `LongVectorLoweringPass`.

Fixes OpenCL CTS regression in `vec_align_packed_struct_arr`.