### PR TITLE
Emit error on undefined function call instead of crashing

### DIFF
--- a/lib/Compiler.cpp
+++ b/lib/Compiler.cpp
@@ -567,7 +567,8 @@ int SetCompilerInstanceOptions(
   return 0;
 }
 
-int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
+int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream,
+                    std::string *output_log) {
   llvm::LoopAnalysisManager lam;
   llvm::FunctionAnalysisManager fam;
   llvm::CGSCCAnalysisManager cgam;
@@ -607,6 +608,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     return -1;
   }
 
+  bool has_error = false;
   // Run the following optimizations prior to the standard LLVM pass pipeline.
   pb.registerPipelineStartEPCallback([](llvm::ModulePassManager &pm,
                                         llvm::OptimizationLevel level) {
@@ -743,9 +745,10 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
   });
 
   // Run the following passes after the default LLVM pass pipeline.
-  pb.registerOptimizerLastEPCallback([binaryStream](llvm::ModulePassManager &pm,
-                                                    llvm::OptimizationLevel,
-                                                    llvm::ThinOrFullLTOPhase) {
+  pb.registerOptimizerLastEPCallback([binaryStream, &has_error,
+                                      output_log](llvm::ModulePassManager &pm,
+                                                  llvm::OptimizationLevel,
+                                                  llvm::ThinOrFullLTOPhase) {
     pm.addPass(clspv::DestructurizeGEPPass());
     // No point attempting to handle freeze currently so strip them from the
     // IR.
@@ -863,8 +866,8 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
       pm.addPass(clspv::LongVectorLoweringPass());
     }
 
-    pm.addPass(
-        clspv::SPIRVProducerPass(binaryStream, OutputFormat == OutputFormatC));
+    pm.addPass(clspv::SPIRVProducerPass(
+        binaryStream, OutputFormat == OutputFormatC, &has_error, output_log));
   });
 
   // Add the default optimizations for the requested optimization level.
@@ -876,7 +879,7 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
     mpm.run(M, mam);
   }
 
-  return 0;
+  return has_error ? -1 : 0;
 }
 
 int ParseOptions(const int argc, const char *const argv[]) {
@@ -1298,7 +1301,7 @@ int CompileModule(const llvm::StringRef &input_filename,
   }
 
   // Run the passes to produce SPIR-V.
-  if (RunPassPipeline(*module, &binaryStream) != 0) {
+  if (RunPassPipeline(*module, &binaryStream, output_log) != 0) {
     return -1;
   }
 

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -307,7 +307,8 @@ struct SPIRVProducerPassImpl {
       GlobalConstFuncMapType;
 
   SPIRVProducerPassImpl(raw_pwrite_stream *out, bool outputCInitList,
-                        ModuleAnalysisManager &MAM)
+                        ModuleAnalysisManager &MAM, bool *HasErrorOut,
+                        std::string *OutputLog)
       : module(nullptr), MAM(&MAM), out(out),
         binaryTempOut(binaryTempUnderlyingVector), binaryOut(out),
         outputCInitList(outputCInitList), patchBoundOffset(0), nextID(1),
@@ -315,25 +316,11 @@ struct SPIRVProducerPassImpl {
         HasVariablePointers(false), HasNonUniformPointers(false),
         HasConvertToF(false), HasIntegerDot(false), SamplerPointerTy(nullptr),
         SamplerDataTy(nullptr), WorkgroupSizeValueID(0), WorkgroupSizeVarID(0),
-        TestOutput(out == nullptr) {
+        TestOutput(out == nullptr), HasErrorOut(HasErrorOut),
+        OutputLog(OutputLog), HasError(false) {
     addCapability(spv::CapabilityShader);
     if (clspv::Option::PhysicalStorageBuffers())
       addCapability(spv::CapabilityPhysicalStorageBufferAddresses);
-    Ptr = this;
-  }
-
-  SPIRVProducerPassImpl()
-      : module(nullptr), out(nullptr),
-        binaryTempOut(binaryTempUnderlyingVector), binaryOut(nullptr),
-        outputCInitList(false), patchBoundOffset(0), nextID(1),
-        OpExtInstImportID(0), HasVariablePointersStorageBuffer(false),
-        HasVariablePointers(false), HasNonUniformPointers(false),
-        HasConvertToF(false), HasIntegerDot(false), SamplerPointerTy(nullptr),
-        SamplerDataTy(nullptr), WorkgroupSizeValueID(0), WorkgroupSizeVarID(0),
-        TestOutput(true) {
-    if (clspv::Option::PhysicalStorageBuffers())
-      addCapability(spv::CapabilityPhysicalStorageBufferAddresses);
-    addCapability(spv::CapabilityShader);
     Ptr = this;
   }
 
@@ -748,6 +735,9 @@ private:
   SPIRVID WorkgroupSizeVarID;
 
   bool TestOutput;
+  bool *HasErrorOut;
+  std::string *OutputLog;
+  bool HasError;
 
   // Bookkeeping for mapping kernel arguments to resource variables.
   struct ResourceVarInfo {
@@ -871,7 +861,7 @@ void SPIRVProducerPassImpl::ReadFunctionAttributes() {
 
 PreservedAnalyses SPIRVProducerPass::run(Module &M,
                                          ModuleAnalysisManager &MAM) {
-  SPIRVProducerPassImpl impl(out, outputCInitList, MAM);
+  SPIRVProducerPassImpl impl(out, outputCInitList, MAM, has_error, output_log);
   impl.runOnModule(M);
   PreservedAnalyses PA;
   return PA;
@@ -946,6 +936,10 @@ bool SPIRVProducerPassImpl::runOnModule(Module &M) {
   }
 
   HandleDeferredInstruction();
+  if (HasError) {
+    *HasErrorOut = true;
+    return false;
+  }
   HandleDeferredDecorations();
 
   // Generate SPIRV module information.
@@ -2615,6 +2609,9 @@ SPIRVID SPIRVProducerPassImpl::getSPIRVValue(Value *V, Type *TyHint) {
   if (II != ValueMap.end()) {
     assert(II->second.isValid());
     return II->second;
+  }
+  if (isa<Function>(V)) {
+    return SPIRVID();
   }
   if (Constant *Cst = dyn_cast<Constant>(V)) {
     return getSPIRVConstant(Cst, TyHint);
@@ -6965,12 +6962,15 @@ void SPIRVProducerPassImpl::HandleDeferredInstruction() {
 
         SPIRVID CalleeID = getSPIRVValue(Callee);
         if (!CalleeID.isValid()) {
-          errs() << "Can't translate function call.  Missing builtin? "
-                 << callee_name << " in: " << *Call << "\n";
-          // TODO(dneto): Can we error out?  Enabling this llvm_unreachable
-          // causes an infinite loop.  Instead, go ahead and generate
-          // the bad function call.  A validator will catch the 0-Id.
-          // llvm_unreachable("Can't translate function call");
+          std::string err_msg =
+              "error: undefined reference to '" + callee_name.str() + "'\n";
+          if (OutputLog) {
+            OutputLog->append(err_msg);
+          } else {
+            errs() << err_msg;
+          }
+          HasError = true;
+          return;
         }
 
         Ops << CalleeID;

--- a/lib/SPIRVProducerPass.h
+++ b/lib/SPIRVProducerPass.h
@@ -23,14 +23,20 @@ namespace clspv {
 struct SPIRVProducerPass : llvm::OptionalPassInfoMixin<SPIRVProducerPass> {
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
 
-  SPIRVProducerPass(llvm::raw_pwrite_stream *out, bool outputCInitList)
-      : out(out), outputCInitList(outputCInitList) {}
+  SPIRVProducerPass(llvm::raw_pwrite_stream *out, bool outputCInitList,
+                    bool *has_error, std::string *output_log)
+      : out(out), outputCInitList(outputCInitList), has_error(has_error),
+        output_log(output_log) {}
 
-  SPIRVProducerPass() : out(nullptr), outputCInitList(false) {}
+  SPIRVProducerPass()
+      : out(nullptr), outputCInitList(false), has_error(nullptr),
+        output_log(nullptr) {}
 
 private:
   llvm::raw_pwrite_stream *out;
   bool outputCInitList;
+  bool *has_error;
+  std::string *output_log;
 };
 } // namespace clspv
 

--- a/test/undefined_function.cl
+++ b/test/undefined_function.cl
@@ -1,0 +1,8 @@
+// RUN: not clspv %target %s -o %t.spv 2>&1 | FileCheck %s
+// CHECK: error: undefined reference to 'undefined_function'
+
+int undefined_function(int a);
+
+kernel void test_kernel(global int *out, int in) {
+  *out = undefined_function(in);
+}


### PR DESCRIPTION
When a kernel contains a call to an undefined function (declaration without definition), clspv previously crashed with an `llvm_unreachable` assertion failure in `getSPIRVConstant` because `Function` inherits from `Constant` and was unhandled when resolving callee IDs.

This change:
- Returns an invalid `SPIRVID` in `getSPIRVValue` for unmapped `Function` values instead of falling through to constant emission.
- In `HandleDeferredInstruction`, reports a clear error message: `error: undefined reference to '<func_name>'` to `output_log` or `errs()` and aborts SPIR-V generation cleanly.
- Propagates the error code out of `SPIRVProducerPass` and `RunPassPipeline` so the compiler driver and API callers return a failure status.
- Adds a regression test in `test/undefined_function.cl`.

Fixes #712