### PR TITLE
Fix infinite recursion on AddrSpaceCastOperator in type inference

### DIFF
--- a/lib/Types.cpp
+++ b/lib/Types.cpp
@@ -46,6 +46,8 @@ Type *InferUserType(User *user, bool &isPointerTy, unsigned operand,
   };
   if (auto *GEP = dyn_cast<GEPOperator>(user)) {
     return GEP->getSourceElementType();
+  } else if (dyn_cast<AddrSpaceCastOperator>(user)) {
+    isPointerTy = true;
   } else if (auto *load = dyn_cast<LoadInst>(user)) {
     if (!load->getType()->isPointerTy()) {
       return load->getType();
@@ -395,6 +397,9 @@ Type *clspv::InferType(Value *v, LLVMContext &context,
     auto false_ty = InferType(select->getFalseValue(), context, cache);
     auto true_ty = InferType(select->getTrueValue(), context, cache);
     return CacheType(SmallerTypeNotAliasing(DL, false_ty, true_ty));
+  } else if (auto *asc = dyn_cast<AddrSpaceCastOperator>(v)) {
+    CacheType(nullptr);
+    return CacheType(InferType(asc->getPointerOperand(), context, cache));
   }
 
   // Special resource-related functions. The last parameter of each function

--- a/test/AddressSpaceCast/infer_type.ll
+++ b/test/AddressSpaceCast/infer_type.ll
@@ -1,0 +1,19 @@
+; RUN: clspv-opt %s -o %t.ll --passes=replace-llvm-intrinsics
+; RUN: FileCheck %s < %t.ll
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+declare void @llvm.memset.p1.i32(ptr addrspace(1), i8, i32, i1)
+
+define spir_kernel void @test() {
+entry:
+  %0 = alloca float, align 4
+  %dst = addrspacecast ptr %0 to ptr addrspace(1)
+  call void @llvm.memset.p1.i32(ptr addrspace(1) %dst, i8 0, i32 4, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: @test
+; CHECK: %[[gep:[a-zA-Z0-9_]+]] = getelementptr float, ptr addrspace(1) %dst, i32 0
+; CHECK: store float 0.000000e+00, ptr addrspace(1) %[[gep]]


### PR DESCRIPTION
When an AddrSpaceCastOperator is encountered during type inference, InferType and InferUserType could recursively call each other indefinitely.

Mark AddrSpaceCastOperator as a pointer type in InferUserType, cache the type in clspv::InferType, and provide an integer pointer fallback in SPIRVProducerPass when an inferred type cannot be determined.