### PR TITLE
Preserve sign and support OpFConvert in -hack-convert-to-float

### DIFF
--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -480,6 +480,7 @@ struct SPIRVProducerPassImpl {
   SPIRVID GeneratePopcount(Type *Ty, Value *BaseValue, LLVMContext &Context);
   SPIRVID GenerateFabs(Value *Input);
   SPIRVID GenerateCanonicalize(Value *val);
+  SPIRVID GenerateCopySignZero(SPIRVID val, Type *InputTy);
   bool ShouldFlushDenorms(Type *Ty) const;
   SPIRVID GenerateIntegerDot(CallInst *Call, const FunctionInfo &func_info);
   void GenerateInstruction(Instruction &I);
@@ -5057,8 +5058,8 @@ bool SPIRVProducerPassImpl::ShouldFlushDenorms(Type *Ty) const {
   return false;
 }
 
-SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
-  Type *InputTy = val->getType();
+SPIRVID SPIRVProducerPassImpl::GenerateCopySignZero(SPIRVID val,
+                                                    Type *InputTy) {
   auto getSameSizeIntegerTy = [](Type *FpTy) {
     return Type::getIntNTy(FpTy->getContext(), FpTy->getScalarSizeInBits());
   };
@@ -5087,8 +5088,12 @@ SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
 
   Ops.clear();
   Ops << InputTy << copysign_zero_int;
-  auto copysign_zero = addSPIRVInst(spv::OpBitcast, Ops);
+  return addSPIRVInst(spv::OpBitcast, Ops);
+}
 
+SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
+  Type *InputTy = val->getType();
+  auto copysign_zero = GenerateCopySignZero(getSPIRVValue(val), InputTy);
   auto abs_val = GenerateFabs(val);
 
   auto flt_min_ap = llvm::APFloat::getSmallestNormalized(
@@ -5106,6 +5111,7 @@ SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
     BoolTy = FixedVectorType::get(BoolTy, VecTy->getNumElements());
   }
 
+  SPIRVOperandVec Ops;
   Ops.clear();
   Ops << BoolTy << abs_val << flt_min_cnst;
   auto cmp = addSPIRVInst(spv::OpFOrdLessThan, Ops);
@@ -5802,10 +5808,11 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         }
 
         if (clspv::Option::HackConvertToFloat() &&
-            (Op == spv::OpConvertSToF || Op == spv::OpConvertUToF)) {
+            (Op == spv::OpConvertSToF || Op == spv::OpConvertUToF ||
+             Op == spv::OpFConvert)) {
+          auto copysign_zero = GenerateCopySignZero(RID, I.getType());
           Ops.clear();
-          Ops << I.getType() << RID
-              << getSPIRVConstant(Constant::getNullValue(I.getType()));
+          Ops << I.getType() << RID << copysign_zero;
           RID = addSPIRVInst(spv::OpFAdd, Ops);
         }
       }

--- a/test/ConvertBuiltins/hack_convert_to_half.ll
+++ b/test/ConvertBuiltins/hack_convert_to_half.ll
@@ -3,12 +3,13 @@
 ; RUN: spirv-val --target-env spv1.0 %t.spv
 ; RUN: FileCheck %s < %t.spvasm
 
-; CHECK: OpConvertSToF
+; CHECK: OpCapability Float16
+; CHECK: OpFConvert
 ; CHECK-NEXT: OpBitcast
 ; CHECK-NEXT: OpBitwiseAnd
 ; CHECK-NEXT: OpBitcast
 ; CHECK-NEXT: OpFAdd
-; CHECK-NEXT: OpConvertFToS
+; CHECK-NEXT: OpStore
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-vulkan"
@@ -16,22 +17,21 @@ target triple = "spirv32-unknown-vulkan"
 @__spirv_WorkgroupSize = local_unnamed_addr addrspace(8) global <3 x i32> zeroinitializer
 
 ; Function Attrs: nofree norecurse nosync nounwind memory(argmem: readwrite)
-define dso_local spir_kernel void @foo(ptr addrspace(1) nocapture readonly align 4 %src, ptr addrspace(1) nocapture writeonly align 4 %dest) local_unnamed_addr #0 !kernel_arg_addr_space !7 !kernel_arg_access_qual !8 !kernel_arg_type !9 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !clspv.pod_args_impl !11 {
+define dso_local spir_kernel void @foo(ptr addrspace(1) nocapture readonly align 4 %src, ptr addrspace(1) nocapture writeonly align 2 %dest) local_unnamed_addr #0 !kernel_arg_addr_space !7 !kernel_arg_access_qual !8 !kernel_arg_type !9 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !clspv.pod_args_impl !11 {
 entry:
-  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x i32] } zeroinitializer)
-  %1 = getelementptr { [0 x i32] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
-  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x i32] } zeroinitializer)
-  %3 = getelementptr { [0 x i32] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
-  %4 = load i32, ptr addrspace(1) %1, align 4
-  %5 = sitofp i32 %4 to float
-  %6 = fptosi float %5 to i32
-  store i32 %6, ptr addrspace(1) %3, align 4
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %2 = call ptr addrspace(1) @_Z14clspv.resource.1(i32 0, i32 1, i32 0, i32 1, i32 1, i32 0, { [0 x half] } zeroinitializer)
+  %3 = getelementptr { [0 x half] }, ptr addrspace(1) %2, i32 0, i32 0, i32 0
+  %4 = load float, ptr addrspace(1) %1, align 4
+  %5 = fptrunc float %4 to half
+  store half %5, ptr addrspace(1) %3, align 2
   ret void
 }
 
-declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
 
-declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x i32] })
+declare ptr addrspace(1) @_Z14clspv.resource.1(i32, i32, i32, i32, i32, i32, { [0 x half] })
 
 attributes #0 = { nofree norecurse nosync nounwind memory(argmem: readwrite) "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="0" "stackrealign" "uniform-work-group-size"="true" }
 attributes #1 = { nofree nosync memory(none) }
@@ -52,7 +52,6 @@ attributes #2 = { nounwind }
 !6 = !{i32 1}
 !7 = !{i32 1, i32 1}
 !8 = !{!"none", !"none"}
-!9 = !{!"int*", !"float*"}
+!9 = !{!"float*", !"half*"}
 !10 = !{!"", !""}
 !11 = !{i32 2}
-


### PR DESCRIPTION
Previously, -hack-convert-to-float inserted an OpFAdd with +0.0 after conversions to prevent driver optimizations from eliminating them. However, in IEEE 754 arithmetic, -0.0 + (+0.0) yields +0.0, which incorrectly clobbered the sign when conversions resulted in -0.0.

In addition, the workaround only applied to integer-to-float conversions omitting floating-point conversions such as float-to-half.