### PR TITLE
Fix Workgroup variable descriptor allocation for array types

### DIFF
--- a/lib/AllocateDescriptorsPass.cpp
+++ b/lib/AllocateDescriptorsPass.cpp
@@ -784,8 +784,11 @@ bool clspv::AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
         auto fn_name =
             clspv::WorkgroupAccessorFunction() + "." + std::to_string(spec_id);
         Function *var_fn = M.getFunction(fn_name);
-        auto *zero = Builder.getInt32(0);
-        Type *array_ty = ArrayType::get(inferred_ty, 0);
+        Type *elem_ty = inferred_ty;
+        while (auto *array_type = dyn_cast<ArrayType>(elem_ty)) {
+          elem_ty = array_type->getElementType();
+        }
+        Type *array_ty = ArrayType::get(elem_ty, 0);
         auto *data_ty = array_ty;
         if (Option::UntypedPointerAddressSpace(
                 argTy->getPointerAddressSpace())) {
@@ -812,12 +815,17 @@ bool clspv::AllocateDescriptorsPass::AllocateLocalKernelArgSpecIds(Module &M) {
 
         // Add the correct gep. Since the workgroup variable is [ <type> x 0 ]
         // addrspace(3)*, generate two zero indices for the gep.
+        auto *zero = Builder.getInt32(0);
         SmallVector<Value *, 3> zeroes(2, zero);
         if (Option::UntypedPointerAddressSpace(
                 argTy->getPointerAddressSpace())) {
           zeroes.push_back(zero);
         }
-        auto *replacement = Builder.CreateGEP(data_ty, call, zeroes);
+        Value *replacement = Builder.CreateGEP(data_ty, call, zeroes);
+        if (replacement->getType() != Arg.getType()) {
+          replacement = Builder.CreatePointerBitCastOrAddrSpaceCast(
+              replacement, Arg.getType());
+        }
         Arg.replaceAllUsesWith(replacement);
 
         // We record the assignment of the spec id for this particular argument

--- a/test/AllocateDescriptors/array_local_arg.ll
+++ b/test/AllocateDescriptors/array_local_arg.ll
@@ -1,0 +1,18 @@
+; RUN: clspv-opt %s -o %t.ll --passes=allocate-descriptors
+; RUN: FileCheck %s < %t.ll
+
+; CHECK: call ptr addrspace(3) @_Z11clspv.local.3(i32 3, [0 x i32] zeroinitializer)
+; CHECK: getelementptr [0 x i32], ptr addrspace(3) {{.*}}, i32 0, i32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define spir_kernel void @test(ptr addrspace(3) %wg, ptr addrspace(1) %out) !clspv.pod_args_impl !1 {
+entry:
+  %gep = getelementptr inbounds [4 x i32], ptr addrspace(3) %wg, i32 0, i32 1
+  %ld = load i32, ptr addrspace(3) %gep, align 4
+  store i32 %ld, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+!1 = !{i32 1}


### PR DESCRIPTION
When allocating descriptors for Workgroup variables whose inferred type is already an array type, unwrap nested ArrayType layers to obtain the underlying element type for the [0 x Type] workgroup accessor variable. Also ensure replacement GEP is cast if its type differs from the argument.