### PR TITLE
Add -hack-fmul-flush-to-zero option to workaround driver bugs

### DIFF
--- a/include/clspv/Option.h
+++ b/include/clspv/Option.h
@@ -197,6 +197,10 @@ enum class FloatingPointType : uint32_t {
   fp64,
 };
 
+// Returns true if subnormal floating point values should be flushed to zero to
+// workaround driver bugs.
+bool HackFMulFlushToZero(FloatingPointType fpty);
+
 // Returns true when the execution mode RoundingModeRTE should be set for a
 // floating point type.
 bool ExecutionModeRoundingModeRTE(FloatingPointType rm);

--- a/lib/Option.cpp
+++ b/lib/Option.cpp
@@ -354,6 +354,18 @@ static llvm::cl::list<clspv::Option::FloatingPointType> denorm_flush_to_zero(
         clEnumValN(clspv::Option::FloatingPointType::fp64, "64",
                    "Set execution mode DenormFlushToZero for fp64")));
 
+static llvm::cl::list<clspv::Option::FloatingPointType> hack_fmul_flush_to_zero(
+    "hack-fmul-flush-to-zero",
+    llvm::cl::desc("Flush subnormal floating point values to zero to "
+                   "workaround driver bugs"),
+    llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore,
+    llvm::cl::values(clEnumValN(clspv::Option::FloatingPointType::fp16, "16",
+                                "Enable hack-fmul-flush-to-zero for fp16")),
+    llvm::cl::values(clEnumValN(clspv::Option::FloatingPointType::fp32, "32",
+                                "Enable hack-fmul-flush-to-zero for fp32")),
+    llvm::cl::values(clEnumValN(clspv::Option::FloatingPointType::fp64, "64",
+                                "Enable hack-fmul-flush-to-zero for fp64")));
+
 static llvm::cl::list<clspv::Option::StorageClass> no_16bit_storage(
     "no-16bit-storage",
     llvm::cl::desc("Disable fine-grained 16-bit storage capabilities."),
@@ -612,6 +624,15 @@ DenormMode ExecutionModeDenorm(FloatingPointType fpty) {
     }
   }
   return modes[fpty];
+}
+
+bool HackFMulFlushToZero(FloatingPointType fpty) {
+  for (auto type : hack_fmul_flush_to_zero) {
+    if (type == fpty) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool Supports16BitStorageClass(StorageClass sc) {

--- a/lib/SPIRVProducerPass.cpp
+++ b/lib/SPIRVProducerPass.cpp
@@ -479,9 +479,12 @@ struct SPIRVProducerPassImpl {
                                    Value *Mask);
   SPIRVID GeneratePopcount(Type *Ty, Value *BaseValue, LLVMContext &Context);
   SPIRVID GenerateFabs(Value *Input);
+  SPIRVID GenerateFabs(SPIRVID Input, Type *InputTy);
   SPIRVID GenerateCanonicalize(Value *val);
+  SPIRVID GenerateCanonicalize(SPIRVID val, Type *InputTy);
   SPIRVID GenerateCopySignZero(SPIRVID val, Type *InputTy);
   bool ShouldFlushDenorms(Type *Ty) const;
+  bool ShouldHackFMulFlushToZero(Type *Ty) const;
   SPIRVID GenerateIntegerDot(CallInst *Call, const FunctionInfo &func_info);
   void GenerateInstruction(Instruction &I);
   void GenerateFuncEpilogue();
@@ -5006,8 +5009,7 @@ SPIRVID SPIRVProducerPassImpl::GeneratePopcount(Type *Ty, Value *BaseValue,
   return RID;
 }
 
-SPIRVID SPIRVProducerPassImpl::GenerateFabs(Value *Input) {
-  Type *InputTy = Input->getType();
+SPIRVID SPIRVProducerPassImpl::GenerateFabs(SPIRVID Input, Type *InputTy) {
   SPIRVOperandVec Ops;
 
   auto nativeBuiltins = clspv::Option::UseNativeBuiltins();
@@ -5030,14 +5032,20 @@ SPIRVID SPIRVProducerPassImpl::GenerateFabs(Value *Input) {
   Ops << IntegerTy << Input;
   auto bitcast = addSPIRVInst(spv::OpBitcast, Ops);
   Ops.clear();
-  Constant *Mask = InputTy->getScalarType()->isHalfTy()
-                       ? ConstantInt::get(IntegerTy, 0x7fff)
-                       : ConstantInt::get(IntegerTy, 0x7fffffff);
+  APInt abs_mask_val = ~APInt::getSignMask(InputTy->getScalarSizeInBits());
+  Constant *Mask = ConstantInt::get(IntegerTy->getScalarType(), abs_mask_val);
+  if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
+    Mask = ConstantVector::getSplat(VecTy->getElementCount(), Mask);
+  }
   Ops << IntegerTy << bitcast << Mask;
   auto bitwiseand = addSPIRVInst(spv::OpBitwiseAnd, Ops);
   Ops.clear();
   Ops << InputTy << bitwiseand;
   return addSPIRVInst(spv::OpBitcast, Ops);
+}
+
+SPIRVID SPIRVProducerPassImpl::GenerateFabs(Value *Input) {
+  return GenerateFabs(getSPIRVValue(Input), Input->getType());
 }
 
 bool SPIRVProducerPassImpl::ShouldFlushDenorms(Type *Ty) const {
@@ -5091,10 +5099,11 @@ SPIRVID SPIRVProducerPassImpl::GenerateCopySignZero(SPIRVID val,
   return addSPIRVInst(spv::OpBitcast, Ops);
 }
 
-SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
-  Type *InputTy = val->getType();
-  auto copysign_zero = GenerateCopySignZero(getSPIRVValue(val), InputTy);
-  auto abs_val = GenerateFabs(val);
+SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(SPIRVID val,
+                                                    Type *InputTy) {
+  auto &Context = InputTy->getContext();
+  auto copysign_zero = GenerateCopySignZero(val, InputTy);
+  auto abs_val = GenerateFabs(val, InputTy);
 
   auto flt_min_ap = llvm::APFloat::getSmallestNormalized(
       InputTy->getScalarType()->getFltSemantics());
@@ -5105,20 +5114,22 @@ SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
         ConstantVector::getSplat(VecTy->getElementCount(), flt_min_cnst);
   }
 
-  LLVMContext &Context = val->getContext();
   Type *BoolTy = Type::getInt1Ty(Context);
   if (auto VecTy = dyn_cast<FixedVectorType>(InputTy)) {
     BoolTy = FixedVectorType::get(BoolTy, VecTy->getNumElements());
   }
 
   SPIRVOperandVec Ops;
-  Ops.clear();
   Ops << BoolTy << abs_val << flt_min_cnst;
   auto cmp = addSPIRVInst(spv::OpFOrdLessThan, Ops);
 
   Ops.clear();
   Ops << InputTy << cmp << copysign_zero << val;
   return addSPIRVInst(spv::OpSelect, Ops);
+}
+
+SPIRVID SPIRVProducerPassImpl::GenerateCanonicalize(Value *val) {
+  return GenerateCanonicalize(getSPIRVValue(val), val->getType());
 }
 
 SPIRVID
@@ -5626,6 +5637,48 @@ SPIRVID SPIRVProducerPassImpl::GenerateInstructionFromCall(CallInst *Call) {
   return RID;
 }
 
+static bool isPowerOfTwo(Value *v) {
+  auto isScalarPowerOfTwo = [](Value *val) -> bool {
+    if (auto *CFP = dyn_cast<ConstantFP>(val)) {
+      const auto &APF = CFP->getValueAPF();
+      return APF.isNormal() && APF.getExactLog2Abs() != INT_MIN;
+    }
+    return false;
+  };
+  if (!v) {
+    return false;
+  }
+  if (auto *VecTy = dyn_cast<FixedVectorType>(v->getType())) {
+    auto *C = dyn_cast<Constant>(v);
+    if (!C) {
+      return false;
+    }
+    for (unsigned i = 0; i < VecTy->getNumElements(); ++i) {
+      Constant *Elt = C->getAggregateElement(i);
+      if (!Elt || !isScalarPowerOfTwo(Elt)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return isScalarPowerOfTwo(v);
+}
+
+bool SPIRVProducerPassImpl::ShouldHackFMulFlushToZero(Type *Ty) const {
+  Type *ScalarTy = Ty->getScalarType();
+  if (ScalarTy->isHalfTy()) {
+    return clspv::Option::HackFMulFlushToZero(
+        clspv::Option::FloatingPointType::fp16);
+  } else if (ScalarTy->isFloatTy()) {
+    return clspv::Option::HackFMulFlushToZero(
+        clspv::Option::FloatingPointType::fp32);
+  } else if (ScalarTy->isDoubleTy()) {
+    return clspv::Option::HackFMulFlushToZero(
+        clspv::Option::FloatingPointType::fp64);
+  }
+  return false;
+}
+
 void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
   ValueMapType &VMap = getValueMap();
   DIFileMap &DbgDIFileMap = getDebugDIFileMap();
@@ -6051,10 +6104,22 @@ void SPIRVProducerPassImpl::GenerateInstruction(Instruction &I) {
         // Ops[2] = Operand 1
         SPIRVOperandVec Ops;
 
-        Ops << I.getType() << I.getOperand(0) << I.getOperand(1);
-
         auto opcode = GetSPIRVBinaryOpcode(I);
+        auto a = getSPIRVValue(I.getOperand(0));
+        auto b = getSPIRVValue(I.getOperand(1));
+        bool shouldCanonicalize =
+            opcode == spv::OpFMul && ShouldHackFMulFlushToZero(I.getType()) &&
+            !isPowerOfTwo(I.getOperand(0)) && !isPowerOfTwo(I.getOperand(1));
+        if (shouldCanonicalize) {
+          a = GenerateCanonicalize(a, I.getType());
+          b = GenerateCanonicalize(b, I.getType());
+        }
+
+        Ops << I.getType() << a << b;
         RID = addSPIRVInst(opcode, Ops);
+        if (shouldCanonicalize) {
+          RID = GenerateCanonicalize(RID, I.getType());
+        }
       }
     } else if (I.getOpcode() == Instruction::FNeg) {
       // The only unary operator.

--- a/test/SPIRVProducer/hack_fmul_flush_to_zero.ll
+++ b/test/SPIRVProducer/hack_fmul_flush_to_zero.ll
@@ -1,0 +1,95 @@
+; RUN: clspv-opt %s -o %t.hack.ll --passes=spirv-producer -producer-out-file %t.hack.spv -hack-fmul-flush-to-zero=32
+; RUN: spirv-dis %t.hack.spv -o %t.hack.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-HACK < %t.hack.spvasm
+; RUN: spirv-val %t.hack.spv
+
+; RUN: clspv-opt %s -o %t.nohack.ll --passes=spirv-producer -producer-out-file %t.nohack.spv
+; RUN: spirv-dis %t.nohack.spv -o %t.nohack.spvasm
+; RUN: FileCheck %s --check-prefix=CHECK-NOHACK < %t.nohack.spvasm
+; RUN: spirv-val %t.nohack.spv
+
+; CHECK-HACK-DAG: [[int:%[a-zA-Z0-9_]+]] = OpTypeInt 32 0
+; CHECK-HACK-DAG: [[float:%[a-zA-Z0-9_]+]] = OpTypeFloat 32
+; CHECK-HACK-DAG: [[bool:%[a-zA-Z0-9_]+]] = OpTypeBool
+; CHECK-HACK-DAG: [[array:%[a-zA-Z0-9_]+]] = OpTypeRuntimeArray [[float]]
+; CHECK-HACK-DAG: [[block:%[a-zA-Z0-9_]+]] = OpTypeStruct [[array]]
+; CHECK-HACK-DAG: [[block_ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[block]]
+; CHECK-HACK-DAG: [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer StorageBuffer [[float]]
+; CHECK-HACK-DAG: [[zero:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 0{{$}}
+; CHECK-HACK-DAG: [[one:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 1{{$}}
+; CHECK-HACK-DAG: [[two:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2{{$}}
+; CHECK-HACK-DAG: [[three:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 3{{$}}
+; CHECK-HACK-DAG: [[mask_sign:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483648
+; CHECK-HACK-DAG: [[mask_abs:%[a-zA-Z0-9_]+]] = OpConstant [[int]] 2147483647
+; CHECK-HACK-DAG: [[float_min_norm:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 1.17549435e-38
+; CHECK-HACK-DAG: [[const_two:%[a-zA-Z0-9_]+]] = OpConstant [[float]] 2{{$}}
+; CHECK-HACK: [[var:%[a-zA-Z0-9_]+]] = OpVariable [[block_ptr]] StorageBuffer
+; CHECK-HACK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[zero]]
+; CHECK-HACK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep0]]
+; CHECK-HACK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[one]]
+; CHECK-HACK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK-HACK: [[cast1_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK-HACK: [[and1_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_0]] [[mask_sign]]
+; CHECK-HACK: [[sign0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_0]]
+; CHECK-HACK: [[cast2_0:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld0]]
+; CHECK-HACK: [[and2_0:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_0]] [[mask_abs]]
+; CHECK-HACK: [[abs0:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_0]]
+; CHECK-HACK: [[cond0:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs0]] [[float_min_norm]]
+; CHECK-HACK: [[canon0:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond0]] [[sign0]] [[ld0]]
+; CHECK-HACK: [[cast1_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK-HACK: [[and1_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_1]] [[mask_sign]]
+; CHECK-HACK: [[sign1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_1]]
+; CHECK-HACK: [[cast2_1:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[ld1]]
+; CHECK-HACK: [[and2_1:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_1]] [[mask_abs]]
+; CHECK-HACK: [[abs1:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_1]]
+; CHECK-HACK: [[cond1:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs1]] [[float_min_norm]]
+; CHECK-HACK: [[canon1:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond1]] [[sign1]] [[ld1]]
+; CHECK-HACK: [[mul:%[a-zA-Z0-9_]+]] = OpFMul [[float]] [[canon0]] [[canon1]]
+; CHECK-HACK: [[cast1_res:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[mul]]
+; CHECK-HACK: [[and1_res:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast1_res]] [[mask_sign]]
+; CHECK-HACK: [[sign_res:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and1_res]]
+; CHECK-HACK: [[cast2_res:%[a-zA-Z0-9_]+]] = OpBitcast [[int]] [[mul]]
+; CHECK-HACK: [[and2_res:%[a-zA-Z0-9_]+]] = OpBitwiseAnd [[int]] [[cast2_res]] [[mask_abs]]
+; CHECK-HACK: [[abs_res:%[a-zA-Z0-9_]+]] = OpBitcast [[float]] [[and2_res]]
+; CHECK-HACK: [[cond_res:%[a-zA-Z0-9_]+]] = OpFOrdLessThan [[bool]] [[abs_res]] [[float_min_norm]]
+; CHECK-HACK: [[canon_res:%[a-zA-Z0-9_]+]] = OpSelect [[float]] [[cond_res]] [[sign_res]] [[mul]]
+; CHECK-HACK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[two]]
+; CHECK-HACK: OpStore [[gep2]] [[canon_res]]
+; CHECK-HACK: [[mul_p2:%[a-zA-Z0-9_]+]] = OpFMul [[float]] [[ld0]] [[const_two]]
+; CHECK-HACK: [[gep3:%[a-zA-Z0-9_]+]] = OpAccessChain [[ptr]] [[var]] [[zero]] [[three]]
+; CHECK-HACK: OpStore [[gep3]] [[mul_p2]]
+
+; CHECK-NOHACK: [[var:%[a-zA-Z0-9_]+]] = OpVariable {{.*}} StorageBuffer
+; CHECK-NOHACK: [[gep0:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] {{.*}}
+; CHECK-NOHACK: [[ld0:%[a-zA-Z0-9_]+]] = OpLoad [[float:%[a-zA-Z0-9_]+]] [[gep0]]
+; CHECK-NOHACK: [[gep1:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] {{.*}}
+; CHECK-NOHACK: [[ld1:%[a-zA-Z0-9_]+]] = OpLoad [[float]] [[gep1]]
+; CHECK-NOHACK: [[mul:%[a-zA-Z0-9_]+]] = OpFMul [[float]] [[ld0]] [[ld1]]
+; CHECK-NOHACK: [[gep2:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] {{.*}}
+; CHECK-NOHACK: OpStore [[gep2]] [[mul]]
+; CHECK-NOHACK: [[mul_p2:%[a-zA-Z0-9_]+]] = OpFMul [[float]] [[ld0]]
+; CHECK-NOHACK: [[gep3:%[a-zA-Z0-9_]+]] = OpAccessChain {{.*}} [[var]] {{.*}}
+; CHECK-NOHACK: OpStore [[gep3]] [[mul_p2]]
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv32-unknown-vulkan"
+
+define dso_local spir_kernel void @test(ptr addrspace(1) nocapture writeonly align 4 %out) !clspv.pod_args_impl !8 {
+entry:
+  %0 = call ptr addrspace(1) @_Z14clspv.resource.0(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, { [0 x float] } zeroinitializer)
+  %1 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 0
+  %ld0 = load float, ptr addrspace(1) %1, align 4
+  %2 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 1
+  %ld1 = load float, ptr addrspace(1) %2, align 4
+  %res_mul = fmul float %ld0, %ld1
+  %3 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 2
+  store float %res_mul, ptr addrspace(1) %3, align 4
+  %res_p2 = fmul float %ld0, 2.000000e+00
+  %4 = getelementptr { [0 x float] }, ptr addrspace(1) %0, i32 0, i32 0, i32 3
+  store float %res_p2, ptr addrspace(1) %4, align 4
+  ret void
+}
+
+declare ptr addrspace(1) @_Z14clspv.resource.0(i32, i32, i32, i32, i32, i32, { [0 x float] })
+
+!8 = !{i32 2}


### PR DESCRIPTION
Some drivers do not correctly flush subnormal floating-point values to zero during floating-point multiplication (OpFMul) or have bugs when handling denormals in FMul.

This commit introduces the `-hack-fmul-flush-to-zero=16,32,64` option:
- In SPIRVProducerPass, when the option is enabled for the floating-point type, canonicalizes (flushes subnormals to signed zero) both operands before OpFMul and canonicalizes the result.
- Multiplications involving power-of-two constants bypass canonicalization to avoid breaking math algorithms (such as in libclc) that rely on power-of-two scaling for denormal processing.
- Generalizes GenerateFabs to compute bit masks using APInt sign masks, fixing support for vector types and fp64.
- Overloads GenerateCanonicalize to accept SPIRVID inputs.
- Adds test coverage in test/SPIRVProducer/hack_fmul_flush_to_zero.ll.